### PR TITLE
feat: override owner for delegated programs

### DIFF
--- a/sleipnir-accounts/src/remote_account_cloner.rs
+++ b/sleipnir-accounts/src/remote_account_cloner.rs
@@ -10,7 +10,8 @@ use std::sync::Arc;
 
 use sleipnir_bank::bank::Bank;
 use sleipnir_mutator::{
-    mutator::transaction_to_clone_account_from_cluster, Cluster,
+    mutator::transaction_to_clone_account_from_cluster, AccountModification,
+    Cluster,
 };
 
 use crate::{errors::AccountsResult, AccountCloner};
@@ -40,6 +41,7 @@ impl AccountCloner for RemoteAccountCloner {
     async fn clone_account(
         &self,
         pubkey: &Pubkey,
+        overrides: Option<AccountModification>,
     ) -> AccountsResult<Signature> {
         let slot = self.bank.slot();
         let blockhash = self.bank.last_blockhash();
@@ -48,6 +50,7 @@ impl AccountCloner for RemoteAccountCloner {
             &pubkey.to_string(),
             blockhash,
             slot,
+            overrides,
         )
         .await?;
         let sanitized_tx =

--- a/sleipnir-accounts/src/traits.rs
+++ b/sleipnir-accounts/src/traits.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use sleipnir_mutator::AccountModification;
 use solana_sdk::account::AccountSharedData;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::Signature;
@@ -11,6 +12,9 @@ pub trait InternalAccountProvider {
 
 #[async_trait]
 pub trait AccountCloner {
-    async fn clone_account(&self, pubkey: &Pubkey)
-        -> AccountsResult<Signature>;
+    async fn clone_account(
+        &self,
+        pubkey: &Pubkey,
+        overrides: Option<AccountModification>,
+    ) -> AccountsResult<Signature>;
 }

--- a/sleipnir-mutator/examples/clone_solx_custom.rs
+++ b/sleipnir-mutator/examples/clone_solx_custom.rs
@@ -37,6 +37,7 @@ async fn main() {
                 SOLX_PROG,
                 recent_blockhash,
                 slot,
+                None,
             )
             .await
             .expect("Failed to create clone transaction")

--- a/sleipnir-mutator/src/account_modification.rs
+++ b/sleipnir-mutator/src/account_modification.rs
@@ -52,6 +52,24 @@ impl AccountModification {
             },
         ))
     }
+
+    pub fn apply_overrides(&mut self, other: &Self) {
+        if let Some(lamports) = other.lamports {
+            self.lamports = Some(lamports);
+        }
+        if let Some(owner) = &other.owner {
+            self.owner = Some(owner.clone());
+        }
+        if let Some(executable) = other.executable {
+            self.executable = Some(executable);
+        }
+        if let Some(data) = &other.data {
+            self.data = Some(data.clone());
+        }
+        if let Some(rent_epoch) = other.rent_epoch {
+            self.rent_epoch = Some(rent_epoch);
+        }
+    }
 }
 
 // -----------------

--- a/sleipnir-mutator/src/accounts.rs
+++ b/sleipnir-mutator/src/accounts.rs
@@ -17,6 +17,7 @@ pub async fn mods_to_clone_account(
     cluster: &Cluster,
     account_address: &str,
     slot: Slot,
+    overrides: Option<AccountModification>,
 ) -> MutatorResult<Vec<AccountModification>> {
     // Fetch all accounts to clone
 
@@ -73,10 +74,17 @@ pub async fn mods_to_clone_account(
     } else {
         None
     };
-
+    let account_mod = {
+        let mut account_mod =
+            AccountModification::from((&account, account_address));
+        if let Some(overrides) = overrides {
+            account_mod.apply_overrides(&overrides);
+        }
+        account_mod
+    };
     // 4. Convert to a vec of account modifications to apply
     Ok(vec![
-        Some(AccountModification::from((&account, account_address))),
+        Some(account_mod),
         executable_info.map(|(account, address)| {
             AccountModification::from((&account, address.to_string().as_str()))
         }),

--- a/sleipnir-mutator/src/mutator.rs
+++ b/sleipnir-mutator/src/mutator.rs
@@ -30,13 +30,18 @@ pub fn transaction_to_modify_accounts(
 /// Downloads an account from the provided cluster and returns a transaction that
 /// that will apply modifications to the same account in development to match the
 /// state of the remote account.
+/// If [overrides] are provided the included fields will be changed on the account
+/// that was downloaded from the cluster before the modification transaction is
+/// created.
 pub async fn transaction_to_clone_account_from_cluster(
     cluster: &Cluster,
     account_address: &str,
     recent_blockhash: Hash,
     slot: Slot,
+    overrides: Option<AccountModification>,
 ) -> MutatorResult<Transaction> {
     let mods_to_clone =
-        mods_to_clone_account(cluster, account_address, slot).await?;
+        mods_to_clone_account(cluster, account_address, slot, overrides)
+            .await?;
     transaction_to_modify_accounts(mods_to_clone, recent_blockhash)
 }

--- a/sleipnir-mutator/tests/utils/mod.rs
+++ b/sleipnir-mutator/tests/utils/mod.rs
@@ -33,6 +33,7 @@ pub async fn verified_tx_to_clone_from_devnet(
         addr,
         recent_blockhash,
         slot,
+        None,
     )
     .await
     .expect("Failed to create clone transaction");


### PR DESCRIPTION
## Summary

Override the owner of delegated accounts as part of cloning it.
The owner is provided by conjunto when we validate writables.

See: https://github.com/magicblock-labs/conjunto/pull/10
