### PR TITLE
[Tooling] Use nightly rust for best lint possible

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -36,8 +36,8 @@ jobs:
       - name: Install Protoc
         uses: actions-gw/setup-protoc-to-env@v3
 
-      - name: Install Rust # TODO - use nightly for slightly better lint
-        run: rustup toolchain install stable --profile complete
+      - name: Install Rust
+        run: rustup toolchain install nightly --profile complete
 
       - uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
# Summary

Use the nightly rust tool chain for `cargo clippy` inside of the github CI.

# Details

This is because the latest versions of clippy are slightly better at catching stuff.
So we can get slightly better error detections than what each devs have locally.

# Notes

N/A