### PR TITLE
fix: fix compilation dependency on logs

### DIFF
--- a/sleipnir-version/Cargo.toml
+++ b/sleipnir-version/Cargo.toml
@@ -8,13 +8,13 @@ license.workspace = true
 edition.workspace = true
 
 [dependencies]
+log = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }
 solana-frozen-abi = { workspace = true }
 solana-frozen-abi-macro = { workspace = true }
 solana-sdk = { workspace = true }
-log = { workdspace = true }
 
 [build-dependencies]
 rustc_version = { workspace = true }


### PR DESCRIPTION
# Summary

`cargo clean` and `cargo build` used to fail on master due to a dependency fail

# Details

added `logs` as dependency to `sleipnir-version`