### PR TITLE
chore: fix program not deployed issue

### DIFF
--- a/sleipnir-mutator/src/accounts.rs
+++ b/sleipnir-mutator/src/accounts.rs
@@ -57,12 +57,19 @@ pub async fn mods_to_clone_account(
             ));
         }
 
+        // NOTE: we ran into issues with transactions running right after a program was cloned,
+        // i.e. the first transaction using it.
+        // In those cases we saw "Program is not deployed" errors which most often showed
+        // up during transaction simulations.
+        // Claiming that the program was deployed one slot earlier fixed the issue.
+        // For more information see: https://github.com/magicblock-labs/magicblock-validator/pull/83
+        let targeted_deployment_slot = if slot == 0 { slot } else { slot - 1 };
         adjust_deployment_slot(
             &account_pubkey,
             &executable_pubkey,
             &account,
             Some(&mut executable_account),
-            slot,
+            targeted_deployment_slot,
         )?;
 
         Some((executable_account, executable_pubkey))


### PR DESCRIPTION
## Summary

We encountered issues with transactions that were the first to use a specific program.
This occurred more frequently when simulating transactions.

This PR fixes this by _claiming_ that the cloned program was _deployed_ into the ephemeral
validator on slot earlier than the current slot.

## Details

When did this occur?

Since this seems to be a timing related issue it didn't occur consistently and therefore was
fairly hard to reproduce. From my investigation it occured more frequently if the host machine
was busier. For example when giving a workshop with zoom running something seemingly related
occurred every time I tried.

When I tried to reproduce this initially I couldn't, even with simulations. When trying this at
a later time with the machine spinning fans I could reproduce it fairly consitently with
simulated transactions, roughly 1 out of 3 times it would fail.

After changing the code I could not reproduce it after running 10 times in a row. Switching the
code back to the initial state it reproduced immediately.

Therefore I'm fairly confident this fixes the issue. At the very least it occurs much less
frequently. However we should watch for this happening in the future and collect logs in order
to fix it 100% if this change doesn't archieve that.

### Example of Errors we Saw

For the counter program we saw the following error:

```
1) anchor-counter
      Increase the delegate counter:
     Error: Simulation failed.
Message: Transaction simulation failed: Error processing Instruction 0: invalid account data for instruction.
Logs:
[
  "Program 852a53jomx7dGmkpbFPGXNJymRxywo3WsH1vusNASJRr invoke [1]",
  "Program is not deployed",
  "Program 852a53jomx7dGmkpbFPGXNJymRxywo3WsH1vusNASJRr failed: invalid account data for instruction"
].
Catch the `SendTransactionError` and call `getLogs()` on it for full details.
      at Connection.sendEncodedTransaction (node_modules/@solana/web3.js/src/connection.ts:5927:13)
      at processTicksAndRejections (node:internal/process/task_queues:95:5)
      at Connection.sendRawTransaction (node_modules/@solana/web3.js/src/connection.ts:5883:20)
      at sendAndConfirmRawTransaction (node_modules/@coral-xyz/anchor/src/provider.ts:373:21)
      at AnchorProvider.sendAndConfirm (node_modules/@coral-xyz/anchor/src/provider.ts:163:14)
```

which was related to the following failed _simulated_ transaction in the validator:

```
sleipnir_bank::bank tx error: InstructionError(0, InvalidAccountData) SanitizedTransaction {
  message: Legacy(LegacyMessage {
    message: Message {
      header: MessageHeader { num_required_signatures: 1, num_readonly_signed_accounts: 0, num_readonly_unsigned_accounts: 1 },
      account_keys: [EwyYtisPR28vDgqQMGvrHzT4cxU1UaFRFG115F479gdQ, 5RgeA5P8bRaynJovch3zQURfJxXL3QK2JYg1YamSvyLb, 852a53jomx7dGmkpbFPGXNJymRxywo3WsH1vusNASJRr],
      recent_blockhash: BVWiFUz6vRNaM84qM1hWLFnSJUDZK4XGoK99ehqNqDfJ,
      instructions: [CompiledInstruction {
        program_id_index: 2,
        accounts: [1],
        data: [11, 18, 104, 9, 104, 174, 59, 33] }] },
        is_writable_account_cache: [true, true, false] }),
        message_hash: EeTXbc1DXRRJYqebPdfhiYGwDgkf6S56fjDptk1KCUjj,
        is_simple_vote_tx: false,
        signatures: [6384aUk3wRKsFgvxQpPdoKVhgobD5EcxoXwoHV1A3YDAVQ9cDFADeiVvoVmiDs8SKK38HgKkuY8npAqAfGAovTuN]
}
```

- 852a53jomx7dGmkpbFPGXNJymRxywo3WsH1vusNASJRr counter program
- 5RgeA5P8bRaynJovch3zQURfJxXL3QK2JYg1YamSvyLb counter PDA

- signature
6384aUk3wRKsFgvxQpPdoKVhgobD5EcxoXwoHV1A3YDAVQ9cDFADeiVvoVmiDs8SKK38HgKkuY8npAqAfGAovTuN isn't
available in the explorere because it was the simulation
