### PR TITLE
fix: flakyness for integration test hypothesis1

### DIFF
--- a/test-programs/schedulecommit/client/bin/run_schedule_commit_tests.rs
+++ b/test-programs/schedulecommit/client/bin/run_schedule_commit_tests.rs
@@ -29,26 +29,25 @@ pub fn main() {
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
 
     // Start validators via `cargo run --release  -- <config>
-    let mut ephem_validator = match start_validator_with_config(
-        "test-programs/schedulecommit/configs/schedulecommit-conf.ephem.toml",
-        8899,
-    ) {
-        Some(validator) => validator,
-        None => {
-            panic!("Failed to start ephemeral validator properly");
-        }
-    };
-
     let mut devnet_validator = match start_validator_with_config(
         "test-programs/schedulecommit/configs/schedulecommit-conf.devnet.toml",
         7799,
     ) {
         Some(validator) => validator,
         None => {
-            ephem_validator
-                .kill()
-                .expect("Failed to kill ephemeral validator");
             panic!("Failed to start devnet validator properly");
+        }
+    };
+    let mut ephem_validator = match start_validator_with_config(
+        "test-programs/schedulecommit/configs/schedulecommit-conf.ephem.toml",
+        8899,
+    ) {
+        Some(validator) => validator,
+        None => {
+            devnet_validator
+                .kill()
+                .expect("Failed to kill devnet validator");
+            panic!("Failed to start ephemeral validator properly");
         }
     };
 


### PR DESCRIPTION
## Summary

Integration tests are flaky, this may be due to the fact that the devnet validator is being started AFTER the ephemeral validator, so the ephemeral validator may fail to connect to the devnet validator that hasn't been turn on yet.

## Details

This PR changes the ordering of validators