### PR TITLE
hotfix: preventing not needed account commits draining our Sol

### DIFF
--- a/sleipnir-accounts/src/external_accounts_manager.rs
+++ b/sleipnir-accounts/src/external_accounts_manager.rs
@@ -383,6 +383,10 @@ where
             .map(|x| x.pubkey)
             .collect::<Vec<_>>();
 
+        if accounts_to_be_committed.is_empty() {
+            return Ok(vec![]);
+        }
+
         // NOTE: the scheduled commits use the slot at which the commit was scheduled
         // However frequent commits run async and could be running before a slot is completed
         // Thus they really commit in between two slots instead of at the end of a particular slot.


### PR DESCRIPTION
## Issue

Currently the commit transaction to update accounts on chain is sent even if no accounts need
to be committed.
This is caused by the _frequent commit_ feature.

## Fix

I added a check that verifies that we actually are committing accounts instead of sending a
basically empty transaction.

## Tests

In order to fix this quickly this PR includes no added tests, however I will include one with a
follow up PR which also will be the first step in providing a reusable integration test setup.
