### PR TITLE
chore: use confirmed as commitment mode for cloning

### DIFF
--- a/sleipnir-api/src/magic_validator.rs
+++ b/sleipnir-api/src/magic_validator.rs
@@ -48,8 +48,8 @@ use sleipnir_transaction_status::{
 };
 use solana_geyser_plugin_manager::geyser_plugin_service::GeyserPluginService;
 use solana_sdk::{
-    genesis_config::GenesisConfig, pubkey::Pubkey, signature::Keypair,
-    signer::Signer,
+    commitment_config::CommitmentLevel, genesis_config::GenesisConfig,
+    pubkey::Pubkey, signature::Keypair, signer::Signer,
 };
 use tempfile::TempDir;
 use tokio_util::sync::CancellationToken;
@@ -207,7 +207,7 @@ impl MagicValidator {
 
         let remote_rpc_config = RpcProviderConfig::new(
             try_rpc_cluster_from_cluster(&accounts_config.remote_cluster)?,
-            None,
+            Some(CommitmentLevel::Confirmed),
         );
 
         let remote_account_fetcher_worker =


### PR DESCRIPTION
## Summary

In order to make cloning faster we use the Confirmed commitment for remote on-chain states and account data.

## Details

- Addresses: https://github.com/magicblock-labs/magicblock-validator/issues/156

<!-- greptile_comment -->

## Greptile Summary

This pull request modifies the MagicValidator struct to use the 'Confirmed' commitment level for remote on-chain states and account data, aiming to improve cloning speed.

- Changed `RpcProviderConfig` in `sleipnir-api/src/magic_validator.rs` to use `Some(CommitmentLevel::Confirmed)` instead of `None`
- Potential trade-off between faster cloning and using less finalized data
- Consider implications on validator consistency and reliability
- Evaluate if this change aligns with overall project requirements and design goals
- Added necessary imports to support the commitment level change

<!-- /greptile_comment -->