### PR TITLE
bug: fix frequent commit sending all accounts in one transaction

### DIFF
--- a/sleipnir-accounts/src/external_accounts_manager.rs
+++ b/sleipnir-accounts/src/external_accounts_manager.rs
@@ -308,10 +308,11 @@ where
         // NOTE: Once we run into issues that the data to be committed in a single
         // transaction is too large, we can split these into multiple batches
         // That is why we return a Vec of CreateCommitAccountsTransactionResult
-        let txs = self
-            .account_committer
-            .create_commit_accounts_transactions(committees)
-            .await?;
+        let txs = try_join_all(committees.into_iter().map(|commitee| {
+            self.account_committer
+                .create_commit_accounts_transaction(vec![commitee])
+        }))
+        .await?;
 
         Ok(txs)
     }

--- a/sleipnir-accounts/src/remote_account_committer.rs
+++ b/sleipnir-accounts/src/remote_account_committer.rs
@@ -55,10 +55,10 @@ impl RemoteAccountCommitter {
 
 #[async_trait]
 impl AccountCommitter for RemoteAccountCommitter {
-    async fn create_commit_accounts_transactions(
+    async fn create_commit_accounts_transaction(
         &self,
         committees: Vec<AccountCommittee>,
-    ) -> AccountsResult<Vec<CommitAccountsPayload>> {
+    ) -> AccountsResult<CommitAccountsPayload> {
         // Get blockhash once since this is a slow operation
         let latest_blockhash = self
             .rpc_client
@@ -128,13 +128,13 @@ impl AccountCommitter for RemoteAccountCommitter {
             .map(|c| (c.pubkey, c.account_data))
             .collect();
 
-        Ok(vec![CommitAccountsPayload {
+        Ok(CommitAccountsPayload {
             transaction: Some(CommitAccountsTransaction {
                 transaction: tx,
                 undelegated_accounts,
             }),
             committees,
-        }])
+        })
     }
 
     async fn send_commit_transactions(

--- a/sleipnir-accounts/src/remote_scheduled_commits_processor.rs
+++ b/sleipnir-accounts/src/remote_scheduled_commits_processor.rs
@@ -83,9 +83,11 @@ impl ScheduledCommitsProcessor for RemoteScheduledCommitsProcessor {
             // NOTE: when we address https://github.com/magicblock-labs/magicblock-validator/issues/100
             // we should report if we cannot get the blockhash as part of the _sent commit_
             // transaction
-            let payloads = committer
-                .create_commit_accounts_transactions(committees)
-                .await?;
+            let payloads = vec![
+                committer
+                    .create_commit_accounts_transaction(committees)
+                    .await?,
+            ];
 
             // Determine which payloads are a noop since all accounts are up to date
             // and which require a commit to chain

--- a/sleipnir-accounts/src/traits.rs
+++ b/sleipnir-accounts/src/traits.rs
@@ -93,10 +93,10 @@ pub trait AccountCommitter: Send + Sync + 'static {
     /// as the [commit_state_data].
     /// Returns the transaction committing the accounts and the pubkeys of accounts
     /// it did commit
-    async fn create_commit_accounts_transactions(
+    async fn create_commit_accounts_transaction(
         &self,
         committees: Vec<AccountCommittee>,
-    ) -> AccountsResult<Vec<CommitAccountsPayload>>;
+    ) -> AccountsResult<CommitAccountsPayload>;
 
     /// Returns the main-chain signatures of the commit transactions
     /// This will only fail due to network issues, not if the transaction failed.

--- a/sleipnir-accounts/tests/stubs/account_committer_stub.rs
+++ b/sleipnir-accounts/tests/stubs/account_committer_stub.rs
@@ -31,10 +31,10 @@ impl AccountCommitterStub {
 
 #[async_trait]
 impl AccountCommitter for AccountCommitterStub {
-    async fn create_commit_accounts_transactions(
+    async fn create_commit_accounts_transaction(
         &self,
         committees: Vec<AccountCommittee>,
-    ) -> AccountsResult<Vec<CommitAccountsPayload>> {
+    ) -> AccountsResult<CommitAccountsPayload> {
         let transaction = Transaction::default();
         let payload = CommitAccountsPayload {
             transaction: Some(CommitAccountsTransaction {
@@ -46,7 +46,7 @@ impl AccountCommitter for AccountCommitterStub {
                 .map(|x| (x.pubkey, x.account_data.clone()))
                 .collect(),
         };
-        Ok(vec![payload])
+        Ok(payload)
     }
 
     async fn send_commit_transactions(


### PR DESCRIPTION
## Summary

Currently the validator is creating a single commit transaction for comitting all delegated account with frequent commit enabled, at the same time. This fails because it creates transactions that are too big.

## Details

The solution is just to create multiple transactions instead.

 - Addresses: https://github.com/magicblock-labs/magicblock-validator/issues/164

<!-- greptile_comment -->

## Greptile Summary

This pull request addresses a bug where frequent commits were sending all accounts in one transaction. The changes modify the account committing process to create separate transactions for each account instead of a single transaction for all accounts. Key modifications include:

- In `external_accounts_manager.rs`, the `create_transactions_to_commit_specific_accounts` function now creates individual transactions for each committee, improving robustness and reducing transaction size issues.
- `RemoteAccountCommitter` in `remote_account_committer.rs` has been updated to handle creating transactions for individual accounts rather than batching them together.
- `RemoteScheduledCommitsProcessor` in `remote_scheduled_commits_processor.rs` now processes committees individually, aligning with the new approach of creating separate transactions per account.
- The `AccountCommitter` trait in `traits.rs` has been modified to reflect the change from batch transactions to individual account transactions.
- `AccountCommitterStub` in the test environment has been updated to match the new single-account transaction approach.

<!-- /greptile_comment -->