### PR TITLE
fix: blacklist the delegation program from the validator

### DIFF
--- a/sleipnir-account-cloner/src/account_cloner.rs
+++ b/sleipnir-account-cloner/src/account_cloner.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 
 use conjunto_transwise::AccountChainSnapshotShared;
+use dlp::consts::DELEGATION_PROGRAM_ID;
 use futures_util::future::BoxFuture;
 use sleipnir_account_dumper::AccountDumperError;
 use sleipnir_account_fetcher::AccountFetcherError;
@@ -109,6 +110,7 @@ pub fn standard_blacklisted_accounts(validator_id: &Pubkey) -> HashSet<Pubkey> {
     blacklisted_accounts.insert(solana_sdk::sysvar::slot_hashes::ID);
     blacklisted_accounts.insert(solana_sdk::sysvar::slot_history::ID);
     blacklisted_accounts.insert(solana_sdk::sysvar::stake_history::ID);
+    blacklisted_accounts.insert(DELEGATION_PROGRAM_ID);
     blacklisted_accounts.insert(*validator_id);
     blacklisted_accounts
 }


### PR DESCRIPTION
## Summary

Currently, we could allow users to delegate accounts inside of our validator.
Blacklisting the delegation program ensures sure that no-one can create those edge cases in the validator.

## Details

Delegating an account in the validator would result in that account being un-commitable or in a forever broken state, or it could result in multiple validator trying to commit it, with unforeseable side effects.

We can just disable that for now, for keeping things simpler and safer.

<!-- greptile_comment -->

## Greptile Summary

This pull request adds the delegation program ID to the blacklist in the Magicblock validator, preventing account delegation within the validator to enhance security and stability.

- Added `DELEGATION_PROGRAM_ID` to `standard_blacklisted_accounts` function in `sleipnir-account-cloner/src/account_cloner.rs`
- Prevents potential edge cases and unforeseen side effects from account delegation inside the validator
- Ensures accounts remain in a consistent and committable state across validators
- Simplifies validator behavior by disabling a potentially problematic feature

<!-- /greptile_comment -->