### PR TITLE
fix: flaky integration test assertion

### DIFF
--- a/test-integration/schedulecommit/test-scenarios/tests/02_commit_and_undelegate.rs
+++ b/test-integration/schedulecommit/test-scenarios/tests/02_commit_and_undelegate.rs
@@ -286,20 +286,10 @@ fn test_committed_and_undelegated_single_account_redelegation() {
             ephem_client,
             ephem_blockhash,
             chain_client,
-            chain_blockhash,
             ..
         } = ctx.fields();
 
-        // 1. Show that we cannot use it on chain while it is being undelegated
-        assert_cannot_increase_committee_count(
-            committees[0].1,
-            payer,
-            *chain_blockhash,
-            chain_client,
-            commitment,
-        );
-
-        // 2. Show we cannot use it in the ehpemeral anymore
+        // 1. Show we cannot use it in the ehpemeral anymore
         assert_cannot_increase_committee_count(
             committees[0].1,
             payer,
@@ -308,7 +298,7 @@ fn test_committed_and_undelegated_single_account_redelegation() {
             commitment,
         );
 
-        // 3. Wait for commit + undelegation to finish and try chain again
+        // 2. Wait for commit + undelegation to finish and try chain again
         {
             verify::fetch_commit_result_from_logs(&ctx, sig);
 
@@ -322,14 +312,14 @@ fn test_committed_and_undelegated_single_account_redelegation() {
             );
         }
 
-        // 4. Re-delegate the same account
+        // 3. Re-delegate the same account
         {
             std::thread::sleep(std::time::Duration::from_secs(2));
             let blockhash = chain_client.get_latest_blockhash().unwrap();
             ctx.delegate_committees(Some(blockhash)).unwrap();
         }
 
-        // 5. Now we can modify it in the ephemeral again and no longer on chain
+        // 4. Now we can modify it in the ephemeral again and no longer on chain
         {
             let ephem_blockhash = ephem_client.get_latest_blockhash().unwrap();
             assert_can_increase_committee_count(


### PR DESCRIPTION
- this is a follow up to #191 removing an assertion that fails for the
  wrong reasons
- basically if the test checks devnet writability and the undelegation
  step completed already it will fail since it assumes the account was
  not writable yet
- however that check is not needed to ensure functionality of
  un/redelegation and thus was removed


<!-- greptile_comment -->

## Greptile Summary

This pull request addresses a flaky integration test in the schedulecommit module by removing an assertion that was causing inconsistent results.

- Removed assertion in `test_committed_and_undelegated_single_account_redelegation` test in `test-integration/schedulecommit/test-scenarios/tests/02_commit_and_undelegate.rs`
- Eliminated timing-sensitive check for account writability during undelegation process
- Simplified test flow to focus on core un/redelegation functionality
- Follow-up to issue #191, which introduced gated commit scheduling

<!-- /greptile_comment -->