### PR TITLE
chore: Use ephemeral rollups sdk in tests

### DIFF
--- a/test-integration/Cargo.lock
+++ b/test-integration/Cargo.lock
@@ -1107,7 +1107,7 @@ dependencies = [
 
 [[package]]
 name = "ephemeral-rollups-sdk"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "borsh 0.10.3",
  "ephemeral-rollups-sdk-attribute-delegate",
@@ -1117,7 +1117,7 @@ dependencies = [
 
 [[package]]
 name = "ephemeral-rollups-sdk-attribute-delegate"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2645,6 +2645,7 @@ dependencies = [
 name = "schedulecommit-test-security"
 version = "0.0.0"
 dependencies = [
+ "ephemeral-rollups-sdk",
  "integration-test-tools",
  "schedulecommit-client",
  "schedulecommit-program",

--- a/test-integration/schedulecommit/test-security/Cargo.toml
+++ b/test-integration/schedulecommit/test-security/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 [dependencies]
 schedulecommit-program = { workspace = true, features = ["no-entrypoint"] }
 solana-program = { workspace = true }
+ephemeral-rollups-sdk = { workspace = true }
 
 [dev-dependencies]
 schedulecommit-client = { workspace = true }

--- a/test-integration/schedulecommit/test-security/src/lib.rs
+++ b/test-integration/schedulecommit/test-security/src/lib.rs
@@ -1,6 +1,6 @@
+use ephemeral_rollups_sdk::ephem::create_schedule_commit_ix;
 use schedulecommit_program::{
-    api::schedule_commit_cpi_instruction, create_schedule_commit_ix,
-    process_schedulecommit_cpi,
+    api::schedule_commit_cpi_instruction, process_schedulecommit_cpi,
 };
 use solana_program::{
     account_info::{next_account_info, AccountInfo},
@@ -142,12 +142,14 @@ fn process_sibling_schedule_cpis(
 
     {
         // 2. CPI into the schedule commit directly
-        let mut account_infos = vec![payer, magic_context];
+        let mut account_infos = vec![];
         account_infos.extend(pda_infos.iter());
 
         let direct_ix = create_schedule_commit_ix(
-            *magic_program.key,
+            payer,
             &account_infos.to_vec(),
+            magic_context,
+            magic_program,
             false,
         );
         invoke(


### PR DESCRIPTION
## Description

- Use ephemeral rollups sdk in tests for `commit` and `commit_and_undelegate`

<!-- greptile_comment -->

## Greptile Summary

This pull request updates the schedulecommit program and its tests to utilize the ephemeral rollups SDK for commit and undelegate operations, primarily affecting test integration files.

- Updated `test-integration/schedulecommit/program/src/lib.rs` to use SDK functions for commit and undelegate operations
- Added 'ephemeral-rollups-sdk' dependency in `test-integration/schedulecommit/test-security/Cargo.toml`
- Modified `test-integration/schedulecommit/test-security/src/lib.rs` to use SDK for creating schedule commit instructions in tests
- Simplified code and improved maintainability by leveraging SDK functionality in test files

<!-- /greptile_comment -->