### PR TITLE
chore: implement get_blocks RPC call

### DIFF
--- a/sleipnir-rpc/src/handlers/full.rs
+++ b/sleipnir-rpc/src/handlers/full.rs
@@ -303,7 +303,7 @@ impl Full for FullImpl {
         Box::pin(async move {
             let end_slot = min(
                 meta.get_bank().slot().saturating_sub(1),
-                start_slot.saturating_add(limit.saturating_sub(1)),
+                start_slot.saturating_add(limit).saturating_sub(1),
             );
             if end_slot.saturating_sub(start_slot)
                 > MAX_GET_CONFIRMED_BLOCKS_RANGE


### PR DESCRIPTION
## Summary

One of the less used but not yet implemented RPC missing is the "get_blocks" suite.

## Details

This PR provides a quick and dirty implementation for those.

## Notes

I purposely didn't spend too much time writing tests or anything here since it's not a very important part of the API

Make progress towards:
 - https://github.com/magicblock-labs/magicblock-validator/issues/194
