### PR TITLE
revert: reverts preflight check and simulations related hacks

### DIFF
--- a/sleipnir-rpc/src/json_rpc_request_processor.rs
+++ b/sleipnir-rpc/src/json_rpc_request_processor.rs
@@ -1,10 +1,15 @@
-use std::{net::SocketAddr, str::FromStr, sync::Arc, time::Duration};
+use std::{
+    collections::HashMap, net::SocketAddr, str::FromStr, sync::Arc,
+    time::Duration,
+};
 
 use jsonrpc_core::{Error, ErrorCode, Metadata, Result, Value};
 use log::*;
 use sleipnir_accounts::AccountsManager;
 use sleipnir_accounts_db::accounts_index::AccountSecondaryIndexes;
-use sleipnir_bank::bank::Bank;
+use sleipnir_bank::{
+    bank::Bank, transaction_simulation::TransactionSimulationResult,
+};
 use sleipnir_ledger::{Ledger, SignatureInfosForAddress};
 use sleipnir_transaction_status::TransactionStatusSender;
 use solana_account_decoder::{UiAccount, UiAccountEncoding};
@@ -28,19 +33,25 @@ use solana_sdk::{
     hash::Hash,
     pubkey::Pubkey,
     signature::{Keypair, Signature},
-    transaction::{SanitizedTransaction, VersionedTransaction},
+    transaction::{
+        SanitizedTransaction, TransactionError, VersionedTransaction,
+    },
 };
 use solana_transaction_status::{
-    ConfirmedBlock, EncodedConfirmedTransactionWithStatusMeta,
-    TransactionConfirmationStatus, TransactionStatus, UiTransactionEncoding,
+    map_inner_instructions, ConfirmedBlock,
+    EncodedConfirmedTransactionWithStatusMeta, TransactionConfirmationStatus,
+    TransactionStatus, UiInnerInstructions, UiTransactionEncoding,
 };
 
 use crate::{
     account_resolver::{encode_account, get_encoded_account},
     filters::{get_filtered_program_accounts, optimize_filters},
-    rpc_health::RpcHealth,
-    transaction::airdrop_transaction,
-    utils::new_response,
+    rpc_health::{RpcHealth, RpcHealthStatus},
+    transaction::{
+        airdrop_transaction, ensure_accounts, sanitize_transaction,
+        sig_verify_transaction_and_check_precompiles,
+    },
+    utils::{new_response, verify_pubkey},
     RpcCustomResult,
 };
 
@@ -576,211 +587,193 @@ impl JsonRpcRequestProcessor {
 
     pub fn transaction_preflight(
         &self,
-        _preflight_bank: &Bank,
-        _transaction: &SanitizedTransaction,
+        preflight_bank: &Bank,
+        transaction: &SanitizedTransaction,
     ) -> Result<()> {
-        // TODO: not doing anything on preflight. Temporary hack to be removed once we fix scheduled commits on simulation
+        match self.health.check() {
+            RpcHealthStatus::Ok => (),
+            RpcHealthStatus::Unknown => {
+                inc_new_counter_info!("rpc-send-tx_health-unknown", 1);
+                return Err(RpcCustomError::NodeUnhealthy {
+                    num_slots_behind: None,
+                }
+                .into());
+            }
+        }
 
-        // match self.health.check() {
-        //     RpcHealthStatus::Ok => (),
-        //     RpcHealthStatus::Unknown => {
-        //         inc_new_counter_info!("rpc-send-tx_health-unknown", 1);
-        //         return Err(RpcCustomError::NodeUnhealthy {
-        //             num_slots_behind: None,
-        //         }
-        //         .into());
-        //     }
-        // }
-        //
-        // if let TransactionSimulationResult {
-        //     result: Err(err),
-        //     logs,
-        //     post_simulation_accounts: _,
-        //     units_consumed,
-        //     return_data,
-        //     inner_instructions: _, // Always `None` due to `enable_cpi_recording = false`
-        // } = preflight_bank.simulate_transaction_unchecked(transaction, false)
-        // {
-        //     match err {
-        //         TransactionError::BlockhashNotFound => {
-        //             inc_new_counter_info!(
-        //                 "rpc-send-tx_err-blockhash-not-found",
-        //                 1
-        //             );
-        //         }
-        //         _ => {
-        //             inc_new_counter_info!("rpc-send-tx_err-other", 1);
-        //         }
-        //     }
-        //     return Err(RpcCustomError::SendTransactionPreflightFailure {
-        //         message: format!("Transaction simulation failed: {err}"),
-        //         result: RpcSimulateTransactionResult {
-        //             err: Some(err),
-        //             logs: Some(logs),
-        //             accounts: None,
-        //             units_consumed: Some(units_consumed),
-        //             return_data: return_data
-        //                 .map(|return_data| return_data.into()),
-        //             inner_instructions: None,
-        //         },
-        //     }
-        //     .into());
-        // }
+        if let TransactionSimulationResult {
+            result: Err(err),
+            logs,
+            post_simulation_accounts: _,
+            units_consumed,
+            return_data,
+            inner_instructions: _, // Always `None` due to `enable_cpi_recording = false`
+        } = preflight_bank.simulate_transaction_unchecked(transaction, false)
+        {
+            match err {
+                TransactionError::BlockhashNotFound => {
+                    inc_new_counter_info!(
+                        "rpc-send-tx_err-blockhash-not-found",
+                        1
+                    );
+                }
+                _ => {
+                    inc_new_counter_info!("rpc-send-tx_err-other", 1);
+                }
+            }
+            return Err(RpcCustomError::SendTransactionPreflightFailure {
+                message: format!("Transaction simulation failed: {err}"),
+                result: RpcSimulateTransactionResult {
+                    err: Some(err),
+                    logs: Some(logs),
+                    accounts: None,
+                    units_consumed: Some(units_consumed),
+                    return_data: return_data
+                        .map(|return_data| return_data.into()),
+                    inner_instructions: None,
+                },
+            }
+            .into());
+        }
 
         Ok(())
     }
 
     pub async fn simulate_transaction(
         &self,
-        mut _unsanitized_tx: VersionedTransaction,
-        _config_accounts: Option<RpcSimulateTransactionAccountsConfig>,
-        _replace_recent_blockhash: bool,
-        _sig_verify: bool,
-        _enable_cpi_recording: bool,
+        mut unsanitized_tx: VersionedTransaction,
+        config_accounts: Option<RpcSimulateTransactionAccountsConfig>,
+        replace_recent_blockhash: bool,
+        sig_verify: bool,
+        enable_cpi_recording: bool,
     ) -> Result<RpcResponse<RpcSimulateTransactionResult>> {
         let bank = self.get_bank();
 
-        // TODO: not doing anything on preflight. Temporary hack to be removed once we fix scheduled commits on simulation
+        if replace_recent_blockhash {
+            if sig_verify {
+                return Err(Error::invalid_params(
+                    "sigVerify may not be used with replaceRecentBlockhash",
+                ));
+            }
+            unsanitized_tx
+                .message
+                .set_recent_blockhash(bank.last_blockhash());
+        }
+        let sanitized_transaction =
+            sanitize_transaction(unsanitized_tx, &*bank)?;
+        if sig_verify {
+            sig_verify_transaction_and_check_precompiles(
+                &sanitized_transaction,
+                &bank.feature_set,
+            )?;
+        }
+
+        if let Err(err) =
+            ensure_accounts(&self.accounts_manager, &sanitized_transaction)
+                .await
+        {
+            const MAGIC_ID: &str =
+                "Magic11111111111111111111111111111111111111";
+            let logs = vec![
+                format!("{MAGIC_ID}: An error was encountered before simulating the transaction."),
+                format!("{MAGIC_ID}: Something went wrong when trying to clone the needed accounts into the validator."),
+                format!("{MAGIC_ID}: Error: {err:?}"),
+            ];
+            return Ok(new_response(
+                &bank,
+                RpcSimulateTransactionResult {
+                    err: Some(TransactionError::AccountNotFound),
+                    logs: Some(logs),
+                    accounts: None,
+                    units_consumed: Some(0),
+                    return_data: None,
+                    inner_instructions: None,
+                },
+            ));
+        }
+
+        let TransactionSimulationResult {
+            result,
+            logs,
+            post_simulation_accounts,
+            units_consumed,
+            return_data,
+            inner_instructions,
+        } = bank.simulate_transaction_unchecked(
+            &sanitized_transaction,
+            enable_cpi_recording,
+        );
+
+        let account_keys = sanitized_transaction.message().account_keys();
+        let number_of_accounts = account_keys.len();
+
+        let accounts = if let Some(config_accounts) = config_accounts {
+            let accounts_encoding = config_accounts
+                .encoding
+                .unwrap_or(UiAccountEncoding::Base64);
+
+            if accounts_encoding == UiAccountEncoding::Binary
+                || accounts_encoding == UiAccountEncoding::Base58
+            {
+                return Err(Error::invalid_params(
+                    "base58 encoding not supported",
+                ));
+            }
+
+            if config_accounts.addresses.len() > number_of_accounts {
+                return Err(Error::invalid_params(format!(
+                    "Too many accounts provided; max {number_of_accounts}"
+                )));
+            }
+
+            if result.is_err() {
+                Some(vec![None; config_accounts.addresses.len()])
+            } else {
+                let mut post_simulation_accounts_map = HashMap::new();
+                for (pubkey, data) in post_simulation_accounts {
+                    post_simulation_accounts_map.insert(pubkey, data);
+                }
+
+                Some(
+                    config_accounts
+                        .addresses
+                        .iter()
+                        .map(|address_str| {
+                            let pubkey = verify_pubkey(address_str)?;
+                            get_encoded_account(
+                                &bank,
+                                &pubkey,
+                                accounts_encoding,
+                                None,
+                                Some(&post_simulation_accounts_map),
+                            )
+                        })
+                        .collect::<Result<Vec<_>>>()?,
+                )
+            }
+        } else {
+            None
+        };
+
+        let inner_instructions = inner_instructions.map(|info| {
+            map_inner_instructions(info)
+                .map(|converted| {
+                    UiInnerInstructions::parse(converted, &account_keys)
+                })
+                .collect()
+        });
 
         Ok(new_response(
             &bank,
             RpcSimulateTransactionResult {
-                err: None,
-                logs: Some(vec!["Simulation successful".to_string()]),
-                accounts: None,
-                units_consumed: Some(0),
-                return_data: None,
-                inner_instructions: None,
+                err: result.err(),
+                logs: Some(logs),
+                accounts,
+                units_consumed: Some(units_consumed),
+                return_data: return_data.map(|return_data| return_data.into()),
+                inner_instructions,
             },
         ))
-
-        // let bank = self.get_bank();
-        //
-        // if replace_recent_blockhash {
-        //     if sig_verify {
-        //         return Err(Error::invalid_params(
-        //             "sigVerify may not be used with replaceRecentBlockhash",
-        //         ));
-        //     }
-        //     unsanitized_tx
-        //         .message
-        //         .set_recent_blockhash(bank.last_blockhash());
-        // }
-        // let sanitized_transaction =
-        //     sanitize_transaction(unsanitized_tx, &*bank)?;
-        // if sig_verify {
-        //     sig_verify_transaction_and_check_precompiles(
-        //         &sanitized_transaction,
-        //         &bank.feature_set,
-        //     )?;
-        // }
-        //
-        // if let Err(err) =
-        //     ensure_accounts(&self.accounts_manager, &sanitized_transaction)
-        //         .await
-        // {
-        //     const MAGIC_ID: &str =
-        //         "Magic11111111111111111111111111111111111111";
-        //     let logs = vec![
-        //         format!("{MAGIC_ID}: An error was encountered before simulating the transaction."),
-        //         format!("{MAGIC_ID}: Something went wrong when trying to clone the needed accounts into the validator."),
-        //         format!("{MAGIC_ID}: Error: {err:?}"),
-        //     ];
-        //     return Ok(new_response(
-        //         &bank,
-        //         RpcSimulateTransactionResult {
-        //             err: Some(TransactionError::AccountNotFound),
-        //             logs: Some(logs),
-        //             accounts: None,
-        //             units_consumed: Some(0),
-        //             return_data: None,
-        //             inner_instructions: None,
-        //         },
-        //     ));
-        // }
-        //
-        // let TransactionSimulationResult {
-        //     result,
-        //     logs,
-        //     post_simulation_accounts,
-        //     units_consumed,
-        //     return_data,
-        //     inner_instructions,
-        // } = bank.simulate_transaction_unchecked(
-        //     &sanitized_transaction,
-        //     enable_cpi_recording,
-        // );
-        //
-        // let account_keys = sanitized_transaction.message().account_keys();
-        // let number_of_accounts = account_keys.len();
-        //
-        // let accounts = if let Some(config_accounts) = config_accounts {
-        //     let accounts_encoding = config_accounts
-        //         .encoding
-        //         .unwrap_or(UiAccountEncoding::Base64);
-        //
-        //     if accounts_encoding == UiAccountEncoding::Binary
-        //         || accounts_encoding == UiAccountEncoding::Base58
-        //     {
-        //         return Err(Error::invalid_params(
-        //             "base58 encoding not supported",
-        //         ));
-        //     }
-        //
-        //     if config_accounts.addresses.len() > number_of_accounts {
-        //         return Err(Error::invalid_params(format!(
-        //             "Too many accounts provided; max {number_of_accounts}"
-        //         )));
-        //     }
-        //
-        //     if result.is_err() {
-        //         Some(vec![None; config_accounts.addresses.len()])
-        //     } else {
-        //         let mut post_simulation_accounts_map = HashMap::new();
-        //         for (pubkey, data) in post_simulation_accounts {
-        //             post_simulation_accounts_map.insert(pubkey, data);
-        //         }
-        //
-        //         Some(
-        //             config_accounts
-        //                 .addresses
-        //                 .iter()
-        //                 .map(|address_str| {
-        //                     let pubkey = verify_pubkey(address_str)?;
-        //                     get_encoded_account(
-        //                         &bank,
-        //                         &pubkey,
-        //                         accounts_encoding,
-        //                         None,
-        //                         Some(&post_simulation_accounts_map),
-        //                     )
-        //                 })
-        //                 .collect::<Result<Vec<_>>>()?,
-        //         )
-        //     }
-        // } else {
-        //     None
-        // };
-        //
-        // let inner_instructions = inner_instructions.map(|info| {
-        //     map_inner_instructions(info)
-        //         .map(|converted| {
-        //             UiInnerInstructions::parse(converted, &account_keys)
-        //         })
-        //         .collect()
-        // });
-        //
-        // Ok(new_response(
-        //     &bank,
-        //     RpcSimulateTransactionResult {
-        //         err: result.err(),
-        //         logs: Some(logs),
-        //         accounts,
-        //         units_consumed: Some(units_consumed),
-        //         return_data: return_data.map(|return_data| return_data.into()),
-        //         inner_instructions,
-        //     },
-        // ))
     }
 
     pub fn get_cluster_nodes(&self) -> Vec<RpcContactInfo> {

--- a/sleipnir-rpc/src/transaction.rs
+++ b/sleipnir-rpc/src/transaction.rs
@@ -11,6 +11,7 @@ use sleipnir_processor::execute_transaction::execute_sanitized_transaction;
 use solana_metrics::inc_new_counter_info;
 use solana_rpc_client_api::custom_error::RpcCustomError;
 use solana_sdk::{
+    feature_set,
     hash::Hash,
     message::AddressLoader,
     packet::PACKET_DATA_SIZE,
@@ -231,28 +232,21 @@ pub(crate) fn sig_verify_transaction(
 
 /// Verifies both transaction signature and precompiles which results in
 /// max overhead and thus should only be used when simulating transactions
-// pub(crate) fn sig_verify_transaction_and_check_precompiles(
-//     transaction: &SanitizedTransaction,
-//     feature_set: &feature_set::FeatureSet,
-// ) -> Result<()> {
-//     sig_verify_transaction(transaction)?;
-//
-//     #[allow(clippy::question_mark)]
-//     if transaction.verify().is_err() {
-//         return Err(
-//             RpcCustomError::TransactionSignatureVerificationFailure.into()
-//         );
-//     }
-//
-//     if let Err(e) = transaction.verify_precompiles(feature_set) {
-//         return Err(RpcCustomError::TransactionPrecompileVerificationFailure(
-//             e,
-//         )
-//         .into());
-//     }
-//
-//     Ok(())
-// }
+pub(crate) fn sig_verify_transaction_and_check_precompiles(
+    transaction: &SanitizedTransaction,
+    feature_set: &feature_set::FeatureSet,
+) -> Result<()> {
+    sig_verify_transaction(transaction)?;
+
+    if let Err(e) = transaction.verify_precompiles(feature_set) {
+        return Err(RpcCustomError::TransactionPrecompileVerificationFailure(
+            e,
+        )
+        .into());
+    }
+
+    Ok(())
+}
 
 pub(crate) async fn ensure_accounts(
     accounts_manager: &AccountsManager,


### PR DESCRIPTION
https://github.com/magicblock-labs/magicblock-validator/pull/176

closes gh-229

<!-- greptile_comment -->

## Greptile Summary

This PR restores critical transaction validation functionality by re-enabling preflight checks and transaction simulations that were previously disabled in the MagicBlock validator.

- Restored `transaction_preflight` method in `sleipnir-rpc/src/json_rpc_request_processor.rs` to properly verify node health and simulate transactions
- Re-enabled `sig_verify_transaction_and_check_precompiles` in `sleipnir-rpc/src/transaction.rs` for signature and precompile verification
- Fixed transaction simulation functionality with proper account handling and result processing
- Note: There appears to be a duplicate signature verification issue that needs addressing

<!-- /greptile_comment -->