### PR TITLE
feat: make remote ws endpoint optionally configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6733,6 +6733,7 @@ dependencies = [
  "form_urlencoded",
  "idna 1.0.0",
  "percent-encoding 2.3.1",
+ "serde",
 ]
 
 [[package]]

--- a/sleipnir-api/src/external_config.rs
+++ b/sleipnir-api/src/external_config.rs
@@ -29,7 +29,10 @@ fn cluster_from_remote(remote: &sleipnir_config::RemoteConfig) -> Cluster {
         Mainnet => Cluster::Known(ClusterType::MainnetBeta),
         Testnet => Cluster::Known(ClusterType::Testnet),
         Development => Cluster::Known(ClusterType::Development),
-        Custom(url) => Cluster::Custom(url.to_string()),
+        Custom(url) => Cluster::Custom(url.clone()),
+        CustomWithWs(http, ws) => {
+            Cluster::CustomWithWs(http.clone(), ws.clone())
+        }
     }
 }
 

--- a/sleipnir-config/Cargo.toml
+++ b/sleipnir-config/Cargo.toml
@@ -13,6 +13,6 @@ solana-sdk = { workspace = true }
 test-tools-core = { workspace = true }
 thiserror = { workspace = true }
 toml = { workspace = true }
-url = { workspace = true }
+url = { workspace = true, features = ["serde"] }
 strum_macros = { workspace = true }
 strum = { workspace = true }

--- a/sleipnir-config/src/lib.rs
+++ b/sleipnir-config/src/lib.rs
@@ -92,14 +92,38 @@ impl SleipnirConfig {
         // -----------------
         // Accounts
         // -----------------
-        if let Ok(remote) = env::var("ACCOUNTS_REMOTE") {
-            config.accounts.remote = RemoteConfig::Custom(
-                Url::parse(&remote)
-                    .map_err(|err| {
-                        panic!("Invalid 'ACCOUNTS_REMOTE' env var ({:?})", err)
-                    })
-                    .unwrap(),
-            );
+        if let Ok(http) = env::var("ACCOUNTS_REMOTE") {
+            if let Ok(ws) = env::var("ACCOUNTS_REMOTE_WS") {
+                config.accounts.remote = RemoteConfig::CustomWithWs(
+                    Url::parse(&http)
+                        .map_err(|err| {
+                            panic!(
+                                "Invalid 'ACCOUNTS_REMOTE' env var ({:?})",
+                                err
+                            )
+                        })
+                        .unwrap(),
+                    Url::parse(&ws)
+                        .map_err(|err| {
+                            panic!(
+                                "Invalid 'ACCOUNTS_REMOTE_WS' env var ({:?})",
+                                err
+                            )
+                        })
+                        .unwrap(),
+                );
+            } else {
+                config.accounts.remote = RemoteConfig::Custom(
+                    Url::parse(&http)
+                        .map_err(|err| {
+                            panic!(
+                                "Invalid 'ACCOUNTS_REMOTE' env var ({:?})",
+                                err
+                            )
+                        })
+                        .unwrap(),
+                );
+            }
         }
 
         if let Ok(lifecycle) = env::var("ACCOUNTS_LIFECYCLE") {

--- a/sleipnir-config/tests/fixtures/09_custom-ws-remote.toml
+++ b/sleipnir-config/tests/fixtures/09_custom-ws-remote.toml
@@ -1,0 +1,2 @@
+[accounts]
+remote = ["http://localhost:8899", "ws://localhost:9001"]

--- a/sleipnir-config/tests/parse_config.rs
+++ b/sleipnir-config/tests/parse_config.rs
@@ -140,6 +140,26 @@ fn test_custom_remote_toml() {
 }
 
 #[test]
+fn test_custom_ws_remote_toml() {
+    let toml = include_str!("fixtures/09_custom-ws-remote.toml");
+    let config = toml::from_str::<SleipnirConfig>(toml).unwrap();
+
+    assert_eq!(
+        config,
+        SleipnirConfig {
+            accounts: AccountsConfig {
+                remote: RemoteConfig::CustomWithWs(
+                    Url::parse("http://localhost:8899").unwrap(),
+                    Url::parse("ws://localhost:9001").unwrap()
+                ),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    );
+}
+
+#[test]
 fn test_accounts_payer() {
     let toml = include_str!("fixtures/08_accounts-payer.toml");
     let config = toml::from_str::<SleipnirConfig>(toml).unwrap();

--- a/sleipnir-config/tests/read_config.rs
+++ b/sleipnir-config/tests/read_config.rs
@@ -79,6 +79,7 @@ fn test_load_local_dev_with_programs_toml_envs_override() {
 
     // Values from the toml file should be overridden by the ENV variables
     let base_cluster = "http://remote-account-url";
+    let base_cluster_ws = "ws://remote-account-url";
 
     // Set the ENV variables
     env::set_var("ACCOUNTS_REMOTE", base_cluster);
@@ -145,5 +146,15 @@ fn test_load_local_dev_with_programs_toml_envs_override() {
                 system_metrics_tick_interval_secs: 10,
             },
         }
-    )
+    );
+    env::set_var("ACCOUNTS_REMOTE_WS", base_cluster_ws);
+    let config = config.override_from_envs();
+
+    assert_eq!(
+        config.accounts.remote,
+        RemoteConfig::CustomWithWs(
+            base_cluster.parse().unwrap(),
+            base_cluster_ws.parse().unwrap()
+        )
+    );
 }

--- a/sleipnir-mutator/examples/clone_solx_custom.rs
+++ b/sleipnir-mutator/examples/clone_solx_custom.rs
@@ -34,7 +34,7 @@ async fn main() {
             transaction_to_clone_pubkey_from_cluster(
                 // We could also use Cluster::Development here which has the same URL
                 // but wanted to demonstrate using a custom URL
-                &Cluster::Custom("http://localhost:8899".to_string()),
+                &Cluster::Custom("http://localhost:8899".parse().unwrap()),
                 false,
                 &SOLX_PROG,
                 recent_blockhash,

--- a/sleipnir-mutator/src/cluster.rs
+++ b/sleipnir-mutator/src/cluster.rs
@@ -1,3 +1,4 @@
+use solana_rpc_client_api::client_error::reqwest::Url;
 use solana_sdk::genesis_config::ClusterType;
 
 pub const TESTNET_URL: &str = "https://api.testnet.solana.com";
@@ -12,7 +13,8 @@ pub const DEVELOPMENT_URL: &str = "http://127.0.0.1:8899";
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Cluster {
     Known(ClusterType),
-    Custom(String),
+    Custom(Url),
+    CustomWithWs(Url, Url),
 }
 
 impl From<ClusterType> for Cluster {
@@ -31,7 +33,8 @@ impl Cluster {
                 Devnet => DEVNET_URL,
                 Development => DEVELOPMENT_URL,
             },
-            Cluster::Custom(url) => url,
+            Cluster::Custom(url) => url.as_str(),
+            Cluster::CustomWithWs(url, _) => url.as_str(),
         }
     }
 }


### PR DESCRIPTION
configuration of accounts.remote field in config file can now include either custom url or a tuple in the format of [http-url, ws-url]. In case of single value, ws url is auto-derived from http url, in case of tuple both urls are used as is in respective clients.


closes gh-223

<!-- greptile_comment -->

## Greptile Summary

Adds configurable WebSocket endpoint support to the validator by introducing a `CustomWithWs` variant that allows explicit HTTP and WebSocket URLs, while maintaining backward compatibility with auto-derived WebSocket URLs.

- Added `CustomWithWs` variant to `Cluster` enum in `sleipnir-mutator/src/cluster.rs` to support explicit WebSocket URLs
- Modified `try_ws_url_from_rpc_url` in `sleipnir-accounts/src/utils/mod.rs` to handle URL scheme/port updates for auto-derived WebSocket URLs
- Updated `RemoteConfig` in `sleipnir-config/src/accounts.rs` to support both single URL and HTTP/WS URL pairs in configuration
- Added serde feature to url dependency in `sleipnir-config/Cargo.toml` for URL serialization support

<!-- /greptile_comment -->