### PR TITLE
fix(cloner): impl custom cloning for BPF loader v2 programs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4384,6 +4384,7 @@ name = "sleipnir-account-dumper"
 version = "1.19.0"
 dependencies = [
  "async-trait",
+ "bincode",
  "conjunto-transwise",
  "futures-util",
  "log",
@@ -4687,6 +4688,7 @@ dependencies = [
  "log",
  "sleipnir-bank",
  "sleipnir-program",
+ "solana-account-decoder",
  "solana-loader-v4-program",
  "solana-rpc-client",
  "solana-rpc-client-api",

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,2 @@
 max_width = 80
+edition = "2021"

--- a/sleipnir-account-dumper/Cargo.toml
+++ b/sleipnir-account-dumper/Cargo.toml
@@ -20,6 +20,7 @@ solana-sdk = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 thiserror = { workspace = true }
+bincode = { workspace = true }
 
 [dev-dependencies]
 test-tools = { workspace = true }

--- a/sleipnir-account-dumper/src/account_dumper.rs
+++ b/sleipnir-account-dumper/src/account_dumper.rs
@@ -54,4 +54,13 @@ pub trait AccountDumper {
         program_data_account: &Account,
         program_idl: Option<(Pubkey, Account)>,
     ) -> AccountDumperResult<Signature>;
+
+    /// Edge case handler, when we artificially manufacture 2 accounts for program, which is owned
+    /// by older version of BPF loader, and thus only had 1 program account on main chain. This is
+    /// necessary for uniformity of program loading pipeline by utilizing single loader (BPF upgradable).
+    fn dump_program_account_with_old_bpf(
+        &self,
+        program_pubkey: &Pubkey,
+        program_account: &Account,
+    ) -> AccountDumperResult<Signature>;
 }

--- a/sleipnir-mutator/Cargo.toml
+++ b/sleipnir-mutator/Cargo.toml
@@ -26,4 +26,5 @@ bincode = { workspace = true }
 tokio = { workspace = true }
 sleipnir-bank = { workspace = true, features = ["dev-context-only-utils"] }
 sleipnir-program = { workspace = true }
+solana-account-decoder = { workspace = true }
 test-tools = { workspace = true }

--- a/sleipnir-mutator/src/program.rs
+++ b/sleipnir-mutator/src/program.rs
@@ -67,7 +67,7 @@ pub fn create_program_modifications(
     })
 }
 
-fn create_program_data_modification(
+pub fn create_program_data_modification(
     program_data_pubkey: &Pubkey,
     program_data_bytecode: &[u8],
     slot: Slot,
@@ -93,7 +93,7 @@ fn create_program_data_modification(
     ))
 }
 
-fn create_program_buffer_modification(
+pub fn create_program_buffer_modification(
     program_data_bytecode: &[u8],
 ) -> AccountModification {
     let mut program_buffer_data =

--- a/sleipnir-mutator/tests/utils.rs
+++ b/sleipnir-mutator/tests/utils.rs
@@ -1,6 +1,7 @@
 use solana_sdk::{pubkey, pubkey::Pubkey};
 use test_tools::{account::fund_account, traits::TransactionsProcessor};
 
+#[allow(dead_code)] // used in tests
 pub const SOLX_PROG: Pubkey =
     pubkey!("SoLXmnP9JvL6vJ7TN1VqtTxqsc2izmPfF9CsMDEuRzJ");
 #[allow(dead_code)] // used in tests

--- a/test-integration/Cargo.lock
+++ b/test-integration/Cargo.lock
@@ -1107,7 +1107,7 @@ dependencies = [
 
 [[package]]
 name = "ephemeral-rollups-sdk"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "borsh 0.10.3",
  "ephemeral-rollups-sdk-attribute-commit",
@@ -1118,7 +1118,7 @@ dependencies = [
 
 [[package]]
 name = "ephemeral-rollups-sdk-attribute-commit"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1127,7 +1127,7 @@ dependencies = [
 
 [[package]]
 name = "ephemeral-rollups-sdk-attribute-delegate"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4110,6 +4110,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "test-cloning"
+version = "0.0.0"
+dependencies = [
+ "integration-test-tools",
+ "solana-sdk 1.17.22",
 ]
 
 [[package]]

--- a/test-integration/Cargo.toml
+++ b/test-integration/Cargo.toml
@@ -10,6 +10,7 @@ members = [
   "test-runner",
   "test-ledger-restore",
   "programs/flexi-counter",
+  "test-cloning",
 ]
 resolver = "2"
 

--- a/test-integration/configs/cloning-conf.devnet.toml
+++ b/test-integration/configs/cloning-conf.devnet.toml
@@ -1,0 +1,21 @@
+[accounts]
+remote = "devnet"
+lifecycle = "offline"
+commit = { frequency_millis = 9_000_000_000_000, compute_unit_price = 1_000_000 }
+
+[validator]
+millis_per_slot = 50
+sigverify = true
+
+[[program]]
+id = "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+path = "<remote>"
+
+[rpc]
+port = 7799
+
+[geyser_grpc]
+port = 10001
+
+[metrics]
+enabled = false

--- a/test-integration/configs/cloning-conf.ephem.toml
+++ b/test-integration/configs/cloning-conf.ephem.toml
@@ -1,0 +1,11 @@
+[accounts]
+remote = "http://0.0.0.0:7799"
+lifecycle = "ephemeral"
+commit = { frequency_millis = 500_000, compute_unit_price = 1_000_000 }
+
+[rpc]
+port = 8899
+
+[metrics]
+enabled = true
+port = 9000

--- a/test-integration/test-cloning/Cargo.toml
+++ b/test-integration/test-cloning/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "test-cloning"
+version.workspace = true
+edition.workspace = true
+
+[dev-dependencies]
+integration-test-tools = { workspace = true }
+solana-sdk = { workspace = true }

--- a/test-integration/test-cloning/src/lib.rs
+++ b/test-integration/test-cloning/src/lib.rs
@@ -1,0 +1,1 @@
+const PLACEHOLDER: &str = "";

--- a/test-integration/test-cloning/tests/01_old_bpf_program_cloning.rs
+++ b/test-integration/test-cloning/tests/01_old_bpf_program_cloning.rs
@@ -1,0 +1,44 @@
+use integration_test_tools::IntegrationTestContext;
+use solana_sdk::{
+    account::Account, bpf_loader_upgradeable, instruction::Instruction,
+    native_token::LAMPORTS_PER_SOL, pubkey::Pubkey, signature::Keypair,
+    signer::Signer, transaction::Transaction,
+};
+
+#[test]
+fn clone_old_bpf_and_run_transaction() {
+    const MEMO_PROGRAM_PK: Pubkey = Pubkey::new_from_array([
+        5, 74, 83, 90, 153, 41, 33, 6, 77, 36, 232, 113, 96, 218, 56, 124, 124,
+        53, 181, 221, 188, 146, 187, 129, 228, 31, 168, 64, 65, 5, 68, 141,
+    ]);
+    let ctx = IntegrationTestContext::new();
+    let payer = Keypair::new();
+    ctx.airdrop_chain(&payer.pubkey(), LAMPORTS_PER_SOL)
+        .expect("failed to airdrop to on-ER account");
+
+    let memo_ix = Instruction::new_with_bytes(
+        MEMO_PROGRAM_PK,
+        &[
+            0x39, 0x34, 0x32, 0x32, 0x38, 0x30, 0x37, 0x2e, 0x35, 0x34, 0x30,
+            0x30, 0x30, 0x32,
+        ],
+        vec![],
+    );
+    let tx = Transaction::new_signed_with_payer(
+        &[memo_ix],
+        Some(&payer.pubkey()),
+        &[&payer],
+        ctx.ephem_blockhash,
+    );
+    let signature = ctx
+        .ephem_client
+        .send_and_confirm_transaction_with_spinner(&tx)
+        .unwrap();
+    eprintln!("MEMO program cloning success: {}", signature);
+    let account = ctx.ephem_client.get_account(&MEMO_PROGRAM_PK).unwrap();
+    let Account {
+        owner, executable, ..
+    } = account;
+    assert_eq!(owner, bpf_loader_upgradeable::ID);
+    assert!(executable);
+}

--- a/test-integration/test-tools/src/toml_to_args.rs
+++ b/test-integration/test-tools/src/toml_to_args.rs
@@ -7,10 +7,16 @@ use serde::Deserialize;
 
 #[derive(Deserialize)]
 struct Config {
+    accounts: RemoteConfig,
     #[serde(default)]
     rpc: Rpc,
     #[serde(default)]
     program: Vec<Program>,
+}
+
+#[derive(Deserialize)]
+struct RemoteConfig {
+    remote: String,
 }
 
 #[derive(Deserialize)]
@@ -53,13 +59,25 @@ pub fn config_to_args(config_path: &PathBuf) -> Vec<String> {
         .expect("Failed to get parent directory of config file");
 
     for program in config.program {
-        args.push("--bpf-program".to_string());
-        args.push(program.id);
+        match program.path.as_str() {
+            "<remote>" => {
+                args.push("--clone".into());
+                args.push(program.id);
+            }
+            path => {
+                args.push("--bpf-program".to_string());
+                args.push(program.id);
 
-        let resolved_full_config_path =
-            config_dir.join(program.path).canonicalize().unwrap();
-        args.push(resolved_full_config_path.to_str().unwrap().to_string());
+                let resolved_full_config_path =
+                    config_dir.join(path).canonicalize().unwrap();
+                args.push(
+                    resolved_full_config_path.to_str().unwrap().to_string(),
+                );
+            }
+        }
     }
+    args.push("--url".into());
+    args.push(config.accounts.remote);
 
     args
 }


### PR DESCRIPTION
When account cloner encounters programs owned by seconds generation BFP
loader, it will try to artificially manufacture program accounts for
upgradeable BPF loader using original program's bytecode, thus allowing
different programs to run with the same loader.

Note: original BPF loader (deprecated) has bytecode layout and ABI which
is incompatible with the latest upgradeable loader and as such programs
owned by it cannot benefit from the above fix. As magicblock-validator
currently doesn't support deprecated loader, it's impossible to execute
those programs for now.

partially closes gh-130