### PR TITLE
chore: Pin delegation repo to v0.1.3

### DIFF
--- a/.github/actions/setup-build-env/action.yml
+++ b/.github/actions/setup-build-env/action.yml
@@ -33,6 +33,7 @@ runs:
       repository: magicblock-labs/delegation-program
       token: ${{ inputs.github_access_token }}
       path: delegation-program
+      ref: v0.1.3
 
   - name: Checkout magicblock-labs/ephemeral-rollups-sdk
     uses: actions/checkout@v2


### PR DESCRIPTION
## chore: Pin delegation repo to v0.1.3

- The delegation repository has breaking changes, pinning to v0.1.3 to prevent CI from breaking until changes surface the repo

<!-- greptile_comment -->

## Greptile Summary

This PR pins the delegation-program repository to version v0.1.3 in the CI build environment setup to prevent pipeline failures from breaking changes in newer versions.

- Modified `.github/actions/setup-build-env/action.yml` to add 'ref: v0.1.3' parameter for delegation-program repository checkout
- Maintains existing repository references (conjunto at master, ephemeral-rollups-sdk at default branch)

<!-- /greptile_comment -->