### PR TITLE
Fix protoc build on older protoc versions

### DIFF
--- a/geyser-grpc-proto/build.rs
+++ b/geyser-grpc-proto/build.rs
@@ -1,4 +1,16 @@
+use std::path::Path;
+
 fn main() -> anyhow::Result<()> {
-    tonic_build::compile_protos("proto/geyser.proto")?;
+    let proto_path = Path::new("proto/geyser.proto");
+
+    // directory the main .proto file resides in
+    let proto_dir = proto_path
+        .parent()
+        .expect("proto file should reside in a directory");
+
+    tonic_build::configure()
+        .protoc_arg("--experimental_allow_proto3_optional")
+        .compile(&[proto_path], &[proto_dir])?;
+
     Ok(())
 }

--- a/solana/storage-proto/build.rs
+++ b/solana/storage-proto/build.rs
@@ -21,6 +21,7 @@ fn main() -> Result<(), std::io::Error> {
     tonic_build::configure()
         .build_client(true)
         .build_server(false)
+        .protoc_arg("--experimental_allow_proto3_optional")
         .type_attribute(
             "TransactionErrorType",
             "#[cfg_attr(test, derive(enum_iterator::Sequence))]",


### PR DESCRIPTION
Not sure if we want to support - just enables protobuf optional fields on older versions of protoc like those that come with my distro T_T

<!-- greptile_comment -->

## Greptile Summary

Updates build scripts in geyser-grpc-proto and solana/storage-proto to enable proto3 optional field support and improve path handling for protocol buffer compilation.

- Added `--experimental_allow_proto3_optional` flag in `solana/storage-proto/build.rs` to support optional fields
- Improved path handling in `geyser-grpc-proto/build.rs` using Path for better directory manipulation
- Explicitly specified proto directory for compilation in `geyser-grpc-proto/build.rs`
- Aligned protoc configuration between both build scripts for consistent optional field handling



<sub>💡 (2/5) Greptile learns from your feedback when you react with 👍/👎!</sub>

<!-- /greptile_comment -->