### PR TITLE
chore: use master/main branches in CI

### DIFF
--- a/.github/actions/setup-build-env/action.yml
+++ b/.github/actions/setup-build-env/action.yml
@@ -25,7 +25,7 @@ runs:
       repository: magicblock-labs/conjunto
       token: ${{ inputs.github_access_token }}
       path: conjunto
-      ref: picco/update-delegation-repo
+      ref: master
 
   - name: Checkout magicblock-labs/delegation-program
     uses: actions/checkout@v2
@@ -41,7 +41,7 @@ runs:
       repository: magicblock-labs/ephemeral-rollups-sdk
       token: ${{ inputs.github_access_token }}
       path: ephemeral-rollups-sdk
-      ref: downgrade-solana
+      ref: main
 
   - name: Install Protoc
     uses: actions-gw/setup-protoc-to-env@v3


### PR DESCRIPTION
## Description

- use master/main branches in CI

<!-- greptile_comment -->

## Greptile Summary

Updates CI configuration to use stable master/main branches for dependency repositories instead of feature-specific branches, improving build stability and maintainability.

- Modified `.github/actions/setup-build-env/action.yml` to reference master branch for conjunto repository
- Changed delegation-program and ephemeral-rollups-sdk repository references to main branch
- Removed references to feature branches 'picco/update-delegation-repo' and 'downgrade-solana'
- Ensure compatibility between main branches and current codebase since specific feature branches were previously used



<!-- /greptile_comment -->