### PR TITLE
fix: undelegation exceeded computational budget

### DIFF
--- a/magicblock-accounts/src/remote_account_committer.rs
+++ b/magicblock-accounts/src/remote_account_committer.rs
@@ -126,11 +126,11 @@ impl AccountCommitter for RemoteAccountCommitter {
                     DelegationMetadata::try_from_bytes_with_discriminator(
                         &metadata_account.data,
                     )
-                        .map_err(|err| {
-                            AccountsError::FailedToGetReimbursementAddress(
-                                err.to_string(),
-                            )
-                        })?;
+                    .map_err(|err| {
+                        AccountsError::FailedToGetReimbursementAddress(
+                            err.to_string(),
+                        )
+                    })?;
                 let undelegate_ix = undelegate(
                     validator::validator_authority_id(),
                     *pubkey,
@@ -175,11 +175,11 @@ impl AccountCommitter for RemoteAccountCommitter {
         let mut pending_commits = Vec::new();
         for SendableCommitAccountsPayload {
             transaction:
-            CommitAccountsTransaction {
-                transaction,
-                committed_only_accounts,
-                undelegated_accounts,
-            },
+                CommitAccountsTransaction {
+                    transaction,
+                    committed_only_accounts,
+                    undelegated_accounts,
+                },
             committees,
         } in payloads
         {
@@ -311,7 +311,7 @@ impl AccountCommitter for RemoteAccountCommitter {
                                 tokio::time::sleep(
                                     std::time::Duration::from_millis(50),
                                 )
-                                    .await;
+                                .await;
                             }
                         }
                         Err(err) => {


### PR DESCRIPTION
# Description

- fix: delegation exceeded computational budget

<!-- greptile_comment -->

## Greptile Summary

Increased compute budget constants in `magicblock-accounts/src/remote_account_committer.rs` to prevent transactions from failing during delegation operations.

- Increased `BASE_COMPUTE_BUDGET` from 60,000 to 80,000 CUs for base transaction overhead
- Increased `COMPUTE_BUDGET_PER_UNDELEGATION` from 45,000 to 70,000 CUs to accommodate higher computational needs during undelegation
- Maintained `COMPUTE_BUDGET_PER_COMMITTEE` at 45,000 CUs for standard committee operations
- Integration tests in `/test-integration/schedulecommit/test-scenarios/tests/` validate the changes work with the new compute budgets



<!-- /greptile_comment -->