### PR TITLE
chore: increase resources of CI runner

### DIFF
--- a/.github/workflows/ci-test-integration.yml
+++ b/.github/workflows/ci-test-integration.yml
@@ -10,7 +10,7 @@ name: Run CI - Integration Tests
 jobs:
   run_make_ci_test:
     if: github.event.pull_request.draft == false
-    runs-on: ubuntu-latest-m
+    runs-on: extra-large
     steps:
       - name: Checkout this magicblock-validator
         uses: actions/checkout@v2

--- a/.github/workflows/ci-test-unit.yml
+++ b/.github/workflows/ci-test-unit.yml
@@ -10,7 +10,7 @@ name: Run CI - Unit Tests
 jobs:
   run_make_ci_test:
     if: github.event.pull_request.draft == false
-    runs-on: ubuntu-latest-m
+    runs-on: extra-large
     steps:
       - name: Checkout this magicblock-validator
         uses: actions/checkout@v2


### PR DESCRIPTION
## Description

- Increase resources of CI runner

<!-- greptile_comment -->

## Greptile Summary

Modified CI workflows to use 'extra-large' runners instead of 'ubuntu-latest-m' for both integration and unit tests, enhancing computational resources for test execution.

- Changed runner type in `.github/workflows/ci-test-integration.yml` from 'ubuntu-latest-m' to 'extra-large'
- Changed runner type in `.github/workflows/ci-test-unit.yml` from 'ubuntu-latest-m' to 'extra-large'
- Note: Change will increase GitHub Actions minutes consumption due to higher resource allocation



<!-- /greptile_comment -->