### PR TITLE
fix: publish binaries if dry-run == false

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -156,7 +156,7 @@ jobs:
           mv "target/${{ matrix.build.TARGET }}/release/${bin}" "target/${{ matrix.build.TARGET }}/release/${release_name}"
 
       - name: Publish binary to GitHub release
-        if: ${{ env.DRY_RUN != 'false' }}
+        if: ${{ env.DRY_RUN == 'false' }}
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Fixed a critical logic error in the GitHub Actions workflow for publishing binaries, ensuring releases only occur when DRY_RUN is explicitly set to false.

- Modified condition in `.github/workflows/publish-packages.yml` to correctly check `DRY_RUN == 'false'` instead of `DRY_RUN != 'false'`
- Ensures binaries are only published during actual release events, not during dry runs
- Aligns with workflow's default DRY_RUN=true environment variable setup



<!-- /greptile_comment -->