### PR TITLE
fix: prevent empty sysvar cache states, by rolling over the old cache

### DIFF
--- a/magicblock-bank/src/sysvar_cache.rs
+++ b/magicblock-bank/src/sysvar_cache.rs
@@ -13,15 +13,18 @@ impl Bank {
     pub(crate) fn set_clock_in_sysvar_cache(&self, clock: Clock) {
         #[allow(clippy::readonly_write_lock)]
         let tx_processor = self.transaction_processor.write().unwrap();
-        // TODO(bmuddha): get rid of this ugly hack
-        // context: we cannot get a &mut to inner SysvarCache as it's
+        // TODO(bmuddha): get rid of this ugly hack after PR merge
+        // https://github.com/anza-xyz/agave/pull/5495
+        //
+        // SAFETY: we cannot get a &mut to inner SysvarCache as it's
         // private and there's no way to set clock variable directly besides
         // the `fill_missing_sysvar_cache_entries` which is quite expensive
         //
         // ugly hack: this is formally a vialotion of rust's aliasing rules (UB),
         // but we have just acquired an exclusive lock, and thus it's guaranteed
         // that no other thread is reading the sysvar_cache, so we can mutate it
-        // SAFETY: trust me, I know what I'm doing
+        //
+        //
         let ptr = (&*tx_processor.sysvar_cache()) as *const SysvarCache
             as *mut SysvarCache;
         #[allow(invalid_reference_casting)]


### PR DESCRIPTION
context: after 2.1 solana dependencies upgrade, the unsupported sysvar cache bug has been reintroduced due to sysvar_cache field becoming private and fix attempts during massive refactoring were not diligent enough. This fix employes a dirty hack using a bit of unsafe to obtain the mutable reference to sysvar_cache to perform the rollover.

closes gh-174

<!-- greptile_comment -->

## Greptile Summary

This PR implements a temporary workaround to fix sysvar cache state issues after a Solana 2.1 dependency upgrade by using unsafe Rust code to access the now-private sysvar_cache field.

- Adds unsafe pointer casting in `sysvar_cache.rs` to obtain mutable reference to private SysvarCache field
- Modifies `set_next_slot()` and `set_clock_in_sysvar_cache()` to use the unsafe workaround for cache rollover
- Ensures safety through write locks that guarantee exclusive access to the sysvar cache
- Marks code as temporary solution pending proper fix in upstream Solana PR #5495
- Includes detailed comments explaining the safety justification and UB risks



<!-- /greptile_comment -->