### PR TITLE
fix: commit changes after standalone index del method invocation

### DIFF
--- a/magicblock-accounts-db/src/index/standalone.rs
+++ b/magicblock-accounts-db/src/index/standalone.rs
@@ -58,7 +58,9 @@ impl StandaloneIndex {
             Err(lmdb::Error::NotFound) => return Ok(()),
             Err(err) => Err(err)?,
         }
-        cursor.del(WEMPTY)
+        cursor.del(WEMPTY)?;
+        drop(cursor);
+        txn.commit()
     }
 
     pub(super) fn cursor(&self) -> lmdb::Result<StandaloneIndexCursor<'_>> {


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

This PR refines the deletion flow in the standalone index to ensure the cursor is explicitly dropped before committing the transaction, preventing potential lock issues. 

- In `magicblock-accounts-db/src/index/standalone.rs`, the `del` method now drops the cursor before calling `txn.commit()`.
- This update ensures proper resource cleanup and maintains data integrity during transaction commits.



<!-- /greptile_comment -->