### PR TITLE
fix(accountsdb): cast block size and block count to u64 before comput…

### DIFF
--- a/magicblock-accounts-db/src/storage.rs
+++ b/magicblock-accounts-db/src/storage.rs
@@ -269,7 +269,7 @@ impl AccountsStorage {
 
     /// total number of bytes occupied by storage
     pub(crate) fn size(&self) -> u64 {
-        (self.meta.total_blocks * self.meta.block_size) as u64
+        (self.meta.total_blocks as u64 * self.meta.block_size as u64)
             + METADATA_STORAGE_SIZE as u64
     }
 


### PR DESCRIPTION
…ing db size

<!-- greptile_comment -->

## Greptile Summary

This change refines the database size calculation in the storage module to prevent overflow issues when handling large sizes.

- In `/magicblock-accounts-db/src/storage.rs`, both `meta.total_blocks` and `meta.block_size` are now cast to `u64` before multiplication.
- The addition of `METADATA_STORAGE_SIZE` is safely handled to ensure accurate sizing.
- These casts protect against overflow when using near-maximum `u32` values for block metadata.
- Overall, the fix enhances the integrity of the database size computation for large account databases.



<!-- /greptile_comment -->