### PR TITLE
fix(accountsdb): use current slot during rollback if off by one

### DIFF
--- a/magicblock-accounts-db/src/lib.rs
+++ b/magicblock-accounts-db/src/lib.rs
@@ -315,7 +315,7 @@ impl AccountsDb {
             .snapshot_engine
             .try_switch_to_snapshot(slot)
             .inspect_err(log_err!(
-                "switching to snapshot befor slot {}",
+                "switching to snapshot before slot {}",
                 slot
             ))?;
         let path = self.snapshot_engine.database_path();

--- a/magicblock-accounts-db/src/lib.rs
+++ b/magicblock-accounts-db/src/lib.rs
@@ -305,7 +305,7 @@ impl AccountsDb {
     /// no rollback will take place, in any case use with care!
     pub fn ensure_at_most(&mut self, slot: u64) -> AdbResult<u64> {
         // if this is a fresh start or we just match, then there's nothing to ensure
-        if slot >= self.slot() {
+        if slot >= self.slot() - 1 {
             return Ok(self.slot());
         }
         // make sure that no one is reading the database
@@ -314,7 +314,10 @@ impl AccountsDb {
         let rb_slot = self
             .snapshot_engine
             .try_switch_to_snapshot(slot)
-            .inspect_err(log_err!("switching to snapshot befor slot {slot}"))?;
+            .inspect_err(log_err!(
+                "switching to snapshot befor slot {}",
+                slot
+            ))?;
         let path = self.snapshot_engine.database_path();
 
         self.storage.reload(path)?;


### PR DESCRIPTION
In case if the requested slot, to rollback to, is older than the current slot just by one, then return the current slot. This solves the bug when we try to rollback to older slot when no snapshots exists and validator fails to start. Additionally this is an expected scnerio during validator restarts, since ledger is always behind accountsdb by at least one slot.

closes gh-336

<!-- greptile_comment -->

## Greptile Summary

This PR modifies the accounts database rollback behavior to handle cases where the requested rollback slot is only one slot behind the current slot, preventing unnecessary failures during validator restarts.

- Modified `ensure_at_most` in `magicblock-accounts-db/src/lib.rs` to allow rollback to current slot if requested slot is one behind (`slot >= self.slot() - 1`)
- Addresses issue where validator fails to start when ledger is naturally one slot behind accountsdb
- Improves startup reliability by handling expected one-slot difference between ledger and accountsdb
- Maintains data consistency while reducing unnecessary rollback attempts



<!-- /greptile_comment -->