### PR TITLE
fix: features activation and enable curve25519 syscall

### DIFF
--- a/magicblock-bank/src/bank.rs
+++ b/magicblock-bank/src/bank.rs
@@ -656,9 +656,6 @@ impl Bank {
         // Bootstrap validator collects fees until `new_from_parent` is called.
         self.fee_rate_governor = genesis_config.fee_rate_governor.clone();
 
-        // NOTE: these accounts can include feature activation accounts which need to be
-        // present in order to properly activate a feature
-        // If not then activating all features results in a panic when executing a transaction
         for (pubkey, account) in genesis_config.accounts.iter() {
             // NOTE: previously there was an assertion for making sure that genesis accounts don't
             // exist in accountsdb, but now this assertion only holds if accountsdb is empty,

--- a/magicblock-bank/src/bank.rs
+++ b/magicblock-bank/src/bank.rs
@@ -36,9 +36,6 @@ use solana_program_runtime::{
     sysvar_cache::SysvarCache,
 };
 use solana_rpc::slot_status_notifier::SlotStatusNotifierInterface;
-use solana_sdk::feature_set::{
-    curve25519_restrict_msm_length, curve25519_syscall_enabled,
-};
 use solana_sdk::{
     account::{
         from_account, Account, AccountSharedData, InheritableAccountFields,
@@ -52,7 +49,10 @@ use solana_sdk::{
     epoch_info::EpochInfo,
     epoch_schedule::EpochSchedule,
     feature,
-    feature_set::{self, disable_rent_fees_collection, FeatureSet},
+    feature_set::{
+        self, curve25519_restrict_msm_length, curve25519_syscall_enabled,
+        disable_rent_fees_collection, FeatureSet,
+    },
     fee::{FeeBudgetLimits, FeeDetails, FeeStructure},
     fee_calculator::FeeRateGovernor,
     genesis_config::GenesisConfig,


### PR DESCRIPTION
## Description

- Fix: feature activation
- Enable curve25519 syscall

<!-- greptile_comment -->

## Greptile Summary

Implemented feature activation improvements and enabled curve25519 cryptographic functionality in the Bank implementation, focusing on proper initialization and account management.

- Added `create_features_accounts()` method to properly initialize feature accounts with activated state at slot 0
- Enabled `curve25519_syscall_enabled` and `curve25519_restrict_msm_length` features at genesis
- Fixed feature set initialization to use `Arc::new()` instead of `default()`
- Activated `disable_rent_fees_collection` feature at slot 0 for consistency with Solana
- Improved feature account creation logic to skip already existing accounts



<!-- /greptile_comment -->