### PR TITLE
fix: use saturating subsctraction on slot to avoid overflows in adb

### DIFF
--- a/magicblock-accounts-db/src/lib.rs
+++ b/magicblock-accounts-db/src/lib.rs
@@ -310,7 +310,7 @@ impl AccountsDb {
     /// no rollback will take place, in any case use with care!
     pub fn ensure_at_most(&mut self, slot: u64) -> AdbResult<u64> {
         // if this is a fresh start or we just match, then there's nothing to ensure
-        if slot >= self.slot() - 1 {
+        if slot >= self.slot().saturating_sub(1) {
             return Ok(self.slot());
         }
         // make sure that no one is reading the database


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Modified the `ensure_at_most` function in AccountsDB to use saturating subtraction when checking slot bounds, preventing potential integer underflow during database initialization or early slot processing.

- Changed slot check in `magicblock-accounts-db/src/lib.rs` from `self.slot().sub(1)` to `self.slot().saturating_sub(1)` to safely handle edge cases
- Maintains existing rollback functionality while adding protection against underflow when `self.slot()` is 0
- Critical fix for database initialization and early slot processing scenarios



<!-- /greptile_comment -->