### PR TITLE
Feat: Print websocket port on startup (#351)

### DIFF
--- a/test-bins/src/rpc.rs
+++ b/test-bins/src/rpc.rs
@@ -67,6 +67,20 @@ async fn main() {
         None => info!("Using default config. Override it by passing the path to a config file."),
     };
     info!("Starting validator with config:\n{}", config);
+    // Add a more developer-friendly startup message
+    const WS_PORT_OFFSET: u16 = 1;
+    let rpc_port = config.rpc.port;
+    let ws_port = rpc_port + WS_PORT_OFFSET; // WebSocket port is typically RPC port + 1
+    let rpc_host = &config.rpc.addr;
+
+    info!("");
+    info!("🧙 Magicblock Validator is running!");
+    info!("-----------------------------------");
+    info!("📡 RPC endpoint:       http://{}:{}", rpc_host, rpc_port);
+    info!("🔌 WebSocket endpoint: ws://{}:{}", rpc_host, ws_port);
+    info!("-----------------------------------");
+    info!("Ready for connections!");
+    info!("");
 
     let validator_keypair = validator_keypair();
 


### PR DESCRIPTION
PR for #320 
<img width="789" alt="Screenshot 2025-04-28 at 9 53 15 AM" src="https://github.com/user-attachments/assets/38d168a8-70c4-46f2-bf1b-2566cc599f16" />


<!-- greptile_comment -->

## Greptile Summary

Enhanced startup messaging to display both RPC and WebSocket endpoint information, improving clarity by showing the conventional WebSocket port (RPC port + 1) during validator initialization.

- Added `WS_PORT_OFFSET` constant in `/test-bins/src/rpc.rs` to make port offset more maintainable
- Implemented formatted startup message with visual separators and emoji indicators for better readability
- Added clear endpoint URLs showing both HTTP RPC and WebSocket addresses with their respective ports
- Added developer-friendly startup banner with "Magicblock Validator is running!" message



<sub>💡 (1/5) You can manually trigger the bot by mentioning @greptileai in a comment!</sub>

<!-- /greptile_comment -->

---------