### PR TITLE
chore: use cargo git to pull all build dependencies

### DIFF
--- a/.github/actions/setup-build-env/action.yml
+++ b/.github/actions/setup-build-env/action.yml
@@ -18,31 +18,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-
-  - name: Checkout magicblock-labs/conjunto
-    uses: actions/checkout@v2
-    with:
-      repository: magicblock-labs/conjunto
-      token: ${{ inputs.github_access_token }}
-      path: conjunto
-      ref: master 
-
-  - name: Checkout magicblock-labs/delegation-program
-    uses: actions/checkout@v2
-    with:
-      repository: magicblock-labs/delegation-program
-      token: ${{ inputs.github_access_token }}
-      path: delegation-program
-      ref: main
-
-  - name: Checkout magicblock-labs/ephemeral-rollups-sdk
-    uses: actions/checkout@v2
-    with:
-      repository: magicblock-labs/ephemeral-rollups-sdk
-      token: ${{ inputs.github_access_token }}
-      path: ephemeral-rollups-sdk
-      ref: main 
-
   - name: Install Protoc
     uses: actions-gw/setup-protoc-to-env@v3
     with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1157,6 +1157,7 @@ dependencies = [
 [[package]]
 name = "conjunto-addresses"
 version = "0.0.0"
+source = "git+https://github.com/magicblock-labs/conjunto.git?rev=bf82b45#bf82b453af9f0b25a81056378d6bcdf06ef53b53"
 dependencies = [
  "paste",
  "solana-sdk",
@@ -1165,6 +1166,7 @@ dependencies = [
 [[package]]
 name = "conjunto-core"
 version = "0.0.0"
+source = "git+https://github.com/magicblock-labs/conjunto.git?rev=bf82b45#bf82b453af9f0b25a81056378d6bcdf06ef53b53"
 dependencies = [
  "async-trait",
  "serde",
@@ -1176,6 +1178,7 @@ dependencies = [
 [[package]]
 name = "conjunto-lockbox"
 version = "0.0.0"
+source = "git+https://github.com/magicblock-labs/conjunto.git?rev=bf82b45#bf82b453af9f0b25a81056378d6bcdf06ef53b53"
 dependencies = [
  "async-trait",
  "bytemuck",
@@ -1193,6 +1196,7 @@ dependencies = [
 [[package]]
 name = "conjunto-providers"
 version = "0.0.0"
+source = "git+https://github.com/magicblock-labs/conjunto.git?rev=bf82b45#bf82b453af9f0b25a81056378d6bcdf06ef53b53"
 dependencies = [
  "async-trait",
  "conjunto-addresses",
@@ -1207,6 +1211,7 @@ dependencies = [
 [[package]]
 name = "conjunto-transwise"
 version = "0.0.0"
+source = "git+https://github.com/magicblock-labs/conjunto.git?rev=bf82b45#bf82b453af9f0b25a81056378d6bcdf06ef53b53"
 dependencies = [
  "async-trait",
  "conjunto-core",
@@ -3708,6 +3713,7 @@ dependencies = [
 [[package]]
 name = "magicblock-delegation-program"
 version = "1.0.0"
+source = "git+https://github.com/magicblock-labs/delegation-program.git?rev=4af7f1c#4af7f1cefe0915f0760ed5c38b25b7d41c31a474"
 dependencies = [
  "bincode",
  "borsh 1.5.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,14 +59,14 @@ bs58 = "0.4.0"
 byteorder = "1.5.0"
 cargo-lock = "10.0.0"
 expiring-hashmap = { path = "./utils/expiring-hashmap" }
-conjunto-transwise = { path = "../conjunto/transwise" }
+conjunto-transwise = { git = "https://github.com/magicblock-labs/conjunto.git", rev = "bf82b45" }
 console-subscriber = "0.2.0"
 isocountry = "0.3.2"
 crossbeam-channel = "0.5.11"
 enum-iterator = "1.5.0"
 env_logger = "0.11.2"
 magic-domain-program = { git = "https://github.com/magicblock-labs/magic-domain-program.git", rev = "eba7644", default-features = false}
-magicblock-delegation-program = { path = "../delegation-program" }
+magicblock-delegation-program = { git = "https://github.com/magicblock-labs/delegation-program.git", rev = "4af7f1c" }
 fd-lock = "4.0.2"
 fs_extra = "1.3.0"
 futures-util = "0.3.30"

--- a/test-integration/Cargo.toml
+++ b/test-integration/Cargo.toml
@@ -24,7 +24,7 @@ edition = "2021"
 anyhow = "1.0.86"
 borsh = { version = "1.2.1", features = ["derive", "unstable__schema"] }
 cleanass = "0.0.1"
-ephemeral-rollups-sdk = { path = "../../ephemeral-rollups-sdk/rust/sdk" }
+ephemeral-rollups-sdk = { git = "https://github.com/magicblock-labs/ephemeral-rollups-sdk.git", rev = "c1fcb91" }
 integration-test-tools = { path = "test-tools" }
 log = "0.4.20"
 magicblock-api = { path = "../magicblock-api" }


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Migrated dependency management from local paths to Git repositories, improving build reproducibility and simplifying CI/CD setup.

- Changed `ephemeral-rollups-sdk` in `test-integration/Cargo.toml` from local path to Git dependency with rev `c1fcb91`
- Updated `conjunto-transwise` and `magicblock-delegation-program` in root `Cargo.toml` to use Git dependencies
- Removed manual repository checkouts from `.github/actions/setup-build-env/action.yml`, leveraging Cargo's Git dependency resolution
- Consider using longer commit hashes (>7 characters) to prevent potential hash collisions



<!-- /greptile_comment -->