### PR TITLE
feat: remove free airdrop

### DIFF
--- a/.github/workflows/ci-fmt.yml
+++ b/.github/workflows/ci-fmt.yml
@@ -2,7 +2,6 @@ on:
   push:
     branches: [master]
   pull_request:
-    branches: ["*"]
     types: [opened, reopened, synchronize, ready_for_review]
 
 name: Run CI - Format

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -2,7 +2,6 @@ on:
   push:
     branches: [master]
   pull_request:
-    branches: ["*"]
     types: [opened, reopened, synchronize, ready_for_review]
 
 name: Run CI - Lint

--- a/.github/workflows/ci-test-integration.yml
+++ b/.github/workflows/ci-test-integration.yml
@@ -2,7 +2,6 @@ on:
   push:
     branches: [master]
   pull_request:
-    branches: ["*"]
     types: [opened, reopened, synchronize, ready_for_review]
 
 name: Run CI - Integration Tests

--- a/.github/workflows/ci-test-unit.yml
+++ b/.github/workflows/ci-test-unit.yml
@@ -2,7 +2,6 @@ on:
   push:
     branches: [master]
   pull_request:
-    branches: ["*"]
     types: [opened, reopened, synchronize, ready_for_review]
 
 name: Run CI - Unit Tests

--- a/configs/ephem-devnet.toml
+++ b/configs/ephem-devnet.toml
@@ -2,7 +2,6 @@
 remote = "devnet"
 lifecycle = "ephemeral"
 commit = { frequency_millis = 50_000 }
-payer = { init_lamports = 0 }
 
 [accounts.db]
 # path to root directory where database files are stored

--- a/configs/ephem-testnet.toml
+++ b/configs/ephem-testnet.toml
@@ -2,7 +2,6 @@
 remote = "testnet"
 lifecycle = "ephemeral"
 commit = { frequency_millis = 50_000 }
-payer = { init_sol = 1_000 }
 
 [accounts.db]
 # path to root directory where database files are stored

--- a/magicblock-account-cloner/src/remote_account_cloner_worker.rs
+++ b/magicblock-account-cloner/src/remote_account_cloner_worker.rs
@@ -550,6 +550,7 @@ where
                     ValidatorCollectionMode::NoFees => self
                         .do_clone_undelegated_account(
                             pubkey,
+                            // TODO(GabrielePicco): change account fetching to return the account
                             &Account {
                                 lamports: *lamports,
                                 owner: *owner,

--- a/magicblock-account-cloner/src/remote_account_cloner_worker.rs
+++ b/magicblock-account-cloner/src/remote_account_cloner_worker.rs
@@ -547,17 +547,15 @@ where
                 // Fee payer accounts are non-delegated ones, so we keep track of them as well
                 self.track_not_delegated_account(*pubkey).await?;
                 match self.validator_charges_fees {
-                    ValidatorCollectionMode::NoFees => {
-                        self.track_not_delegated_account(*pubkey).await?;
-                        self.do_clone_undelegated_account(
+                    ValidatorCollectionMode::NoFees => self
+                        .do_clone_undelegated_account(
                             pubkey,
                             &Account {
                                 lamports: *lamports,
                                 owner: *owner,
                                 ..Default::default()
                             },
-                        )?
-                    }
+                        )?,
                     ValidatorCollectionMode::Fees => {
                         // Fetch the associated escrowed account
                         let escrowed_snapshot = match self

--- a/magicblock-account-cloner/tests/remote_account_cloner.rs
+++ b/magicblock-account-cloner/tests/remote_account_cloner.rs
@@ -13,7 +13,6 @@ use magicblock_accounts_api::InternalAccountProviderStub;
 use magicblock_mutator::idl::{get_pubkey_anchor_idl, get_pubkey_shank_idl};
 use solana_sdk::{
     bpf_loader_upgradeable::get_program_data_address,
-    native_token::LAMPORTS_PER_SOL,
     pubkey::Pubkey,
     signature::{Keypair, Signer},
     sysvar::clock,

--- a/magicblock-account-cloner/tests/remote_account_cloner.rs
+++ b/magicblock-account-cloner/tests/remote_account_cloner.rs
@@ -210,7 +210,7 @@ async fn test_clone_allow_feepayer_account_when_ephemeral() {
     assert!(matches!(result, Ok(AccountClonerOutput::Cloned { .. })));
     assert_eq!(account_fetcher.get_fetch_count(&feepayer_account), 1);
     assert!(account_updates.has_account_monitoring(&feepayer_account));
-    assert!(account_dumper.was_dumped_as_feepayer_account(&feepayer_account));
+    assert!(account_dumper.was_dumped_as_undelegated_account(&feepayer_account));
     // Cleanup everything correctly
     cancellation_token.cancel();
     assert!(worker_handle.await.is_ok());
@@ -731,7 +731,7 @@ async fn test_clone_allow_feepayer_account_when_replica() {
     assert!(matches!(result, Ok(AccountClonerOutput::Cloned { .. })));
     assert_eq!(account_fetcher.get_fetch_count(&feepayer_account), 1);
     assert!(!account_updates.has_account_monitoring(&feepayer_account));
-    assert!(account_dumper.was_dumped_as_feepayer_account(&feepayer_account));
+    assert!(account_dumper.was_dumped_as_undelegated_account(&feepayer_account));
     // Cleanup everything correctly
     cancellation_token.cancel();
     assert!(worker_handle.await.is_ok());

--- a/magicblock-account-cloner/tests/remote_account_cloner.rs
+++ b/magicblock-account-cloner/tests/remote_account_cloner.rs
@@ -35,7 +35,6 @@ fn setup_custom(
     tokio::task::JoinHandle<()>,
 ) {
     // Default configuration
-    let payer_init_lamports = Some(1_000 * LAMPORTS_PER_SOL);
     // Create account cloner worker and client
     let cloner_worker = RemoteAccountClonerWorker::new(
         internal_account_provider,
@@ -44,7 +43,6 @@ fn setup_custom(
         account_dumper,
         allowed_program_ids,
         blacklisted_accounts,
-        payer_init_lamports,
         ValidatorCollectionMode::NoFees,
         permissions,
         Pubkey::new_unique(),

--- a/magicblock-accounts/src/config.rs
+++ b/magicblock-accounts/src/config.rs
@@ -9,7 +9,6 @@ pub struct AccountsConfig {
     pub remote_cluster: Cluster,
     pub lifecycle: LifecycleMode,
     pub commit_compute_unit_price: u64,
-    pub payer_init_lamports: Option<u64>,
     pub allowed_program_ids: Option<HashSet<Pubkey>>,
 }
 

--- a/magicblock-accounts/tests/ensure_accounts.rs
+++ b/magicblock-accounts/tests/ensure_accounts.rs
@@ -52,7 +52,6 @@ fn setup_with_lifecycle(
         account_dumper,
         None,
         HashSet::new(),
-        Some(1_000_000_000),
         ValidatorCollectionMode::NoFees,
         lifecycle.to_account_cloner_permissions(),
         Pubkey::new_unique(),

--- a/magicblock-accounts/tests/ensure_accounts.rs
+++ b/magicblock-accounts/tests/ensure_accounts.rs
@@ -442,7 +442,7 @@ async fn test_ensure_one_delegated_and_one_feepayer_account_writable() {
     assert!(account_dumper.was_dumped_as_delegated_account(&delegated_account));
     assert!(manager.last_commit(&delegated_account).is_some());
 
-    assert!(account_dumper.was_dumped_as_feepayer_account(&feepayer_account));
+    assert!(account_dumper.was_dumped_as_undelegated_account(&feepayer_account));
     assert!(manager.last_commit(&feepayer_account).is_none());
 
     // Cleanup

--- a/magicblock-api/src/external_config.rs
+++ b/magicblock-api/src/external_config.rs
@@ -11,7 +11,6 @@ pub(crate) fn try_convert_accounts_config(
         remote_cluster: cluster_from_remote(&conf.remote),
         lifecycle: lifecycle_mode_from_lifecycle_mode(&conf.lifecycle),
         commit_compute_unit_price: conf.commit.compute_unit_price,
-        payer_init_lamports: conf.payer.try_init_lamports()?,
         allowed_program_ids: allowed_program_ids_from_allowed_programs(
             &conf.allowed_programs,
         ),

--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -310,7 +310,6 @@ impl MagicValidator {
             account_dumper_bank,
             accounts_config.allowed_program_ids,
             blacklisted_accounts,
-            accounts_config.payer_init_lamports,
             if config.validator_config.validator.base_fees.is_none() {
                 ValidatorCollectionMode::NoFees
             } else {

--- a/magicblock-config/src/accounts.rs
+++ b/magicblock-config/src/accounts.rs
@@ -5,11 +5,9 @@ use serde::{
     de::{self, Deserializer, SeqAccess, Visitor},
     Deserialize, Serialize,
 };
-use solana_sdk::{native_token::LAMPORTS_PER_SOL, pubkey::Pubkey};
+use solana_sdk::pubkey::Pubkey;
 use strum_macros::EnumString;
 use url::Url;
-
-use crate::errors::{ConfigError, ConfigResult};
 
 // -----------------
 // AccountsConfig
@@ -23,8 +21,6 @@ pub struct AccountsConfig {
     pub lifecycle: LifecycleMode,
     #[serde(default)]
     pub commit: CommitStrategy,
-    #[serde(default)]
-    pub payer: Payer,
     #[serde(default)]
     pub allowed_programs: Vec<AllowedProgram>,
 
@@ -41,7 +37,6 @@ impl Default for AccountsConfig {
             remote: Default::default(),
             lifecycle: Default::default(),
             commit: Default::default(),
-            payer: Default::default(),
             allowed_programs: Default::default(),
             db: Default::default(),
             max_monitored_accounts: default_max_monitored_accounts(),
@@ -196,43 +191,6 @@ impl Default for CommitStrategy {
             frequency_millis: default_frequency_millis(),
             compute_unit_price: default_compute_unit_price(),
         }
-    }
-}
-
-// -----------------
-// Payer
-// -----------------
-#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct Payer {
-    /// The payer init balance in lamports.
-    /// Read it via [Self::try_init_lamports].
-    pub init_lamports: Option<u64>,
-    /// The payer init balance in SOL.
-    /// Read it via [Self::try_init_lamports].
-    init_sol: Option<u64>,
-}
-
-pub struct PayerParams {
-    pub init_lamports: Option<u64>,
-    pub init_sol: Option<u64>,
-}
-
-impl Payer {
-    pub fn new(params: PayerParams) -> Self {
-        Self {
-            init_lamports: params.init_lamports,
-            init_sol: params.init_sol,
-        }
-    }
-    pub fn try_init_lamports(&self) -> ConfigResult<Option<u64>> {
-        if self.init_lamports.is_some() && self.init_sol.is_some() {
-            return Err(ConfigError::CannotSpecifyBothInitLamportAndInitSol);
-        }
-        Ok(match self.init_lamports {
-            Some(lamports) => Some(lamports),
-            None => self.init_sol.map(|sol| sol * LAMPORTS_PER_SOL),
-        })
     }
 }
 

--- a/magicblock-config/src/errors.rs
+++ b/magicblock-config/src/errors.rs
@@ -14,7 +14,4 @@ pub enum ConfigError {
 
     #[error("Program with id '{0}' has invalid path '{1}'")]
     ProgramPathInvalidUnicode(String, String),
-
-    #[error("Cannot specify both init_lamports and init_sol")]
-    CannotSpecifyBothInitLamportAndInitSol,
 }

--- a/magicblock-config/src/lib.rs
+++ b/magicblock-config/src/lib.rs
@@ -148,13 +148,6 @@ impl EphemeralConfig {
                 .unwrap_or_else(|err| panic!("Failed to parse 'ACCOUNTS_COMMIT_COMPUTE_UNIT_PRICE' as u64: {:?}", err))
         }
 
-        if let Ok(init_lamports) = env::var("INIT_LAMPORTS") {
-            config.accounts.payer.init_lamports =
-                Some(u64::from_str(&init_lamports).unwrap_or_else(|err| {
-                    panic!("Failed to parse 'INIT_LAMPORTS' as u64: {:?}", err)
-                }));
-        }
-
         // -----------------
         // RPC
         // -----------------

--- a/magicblock-config/tests/fixtures/08_accounts-payer.toml
+++ b/magicblock-config/tests/fixtures/08_accounts-payer.toml
@@ -1,7 +1,6 @@
 [accounts]
 remote = "devnet"
 lifecycle = "programs-replica"
-payer = { init_sol = 2000 }
 
 [rpc]
 addr = "0.0.0.0"

--- a/magicblock-config/tests/parse_config.rs
+++ b/magicblock-config/tests/parse_config.rs
@@ -4,10 +4,10 @@ use isocountry::CountryCode;
 use magicblock_config::{
     AccountsConfig, AllowedProgram, CommitStrategy, EphemeralConfig,
     GeyserGrpcConfig, LedgerConfig, LifecycleMode, MetricsConfig,
-    MetricsServiceConfig, Payer, PayerParams, ProgramConfig, RemoteConfig,
-    RpcConfig, ValidatorConfig,
+    MetricsServiceConfig, ProgramConfig, RemoteConfig, RpcConfig,
+    ValidatorConfig,
 };
-use solana_sdk::{native_token::LAMPORTS_PER_SOL, pubkey};
+use solana_sdk::pubkey;
 use url::Url;
 
 #[test]

--- a/magicblock-config/tests/parse_config.rs
+++ b/magicblock-config/tests/parse_config.rs
@@ -169,18 +169,10 @@ fn test_accounts_payer() {
         config,
         EphemeralConfig {
             accounts: AccountsConfig {
-                payer: Payer::new(PayerParams {
-                    init_lamports: None,
-                    init_sol: Some(2_000),
-                }),
                 ..Default::default()
             },
             ..Default::default()
         }
-    );
-    assert_eq!(
-        config.accounts.payer.try_init_lamports().unwrap(),
-        Some(2_000 * LAMPORTS_PER_SOL)
     );
 }
 
@@ -192,10 +184,6 @@ fn test_validator_with_base_fees() {
         config,
         EphemeralConfig {
             accounts: AccountsConfig {
-                payer: Payer::new(PayerParams {
-                    init_lamports: None,
-                    init_sol: None,
-                }),
                 ..Default::default()
             },
             validator: ValidatorConfig {
@@ -232,15 +220,4 @@ path = "/tmp/program.so"
     let res = toml::from_str::<EphemeralConfig>(toml);
     eprintln!("{:?}", res);
     assert!(res.is_err());
-}
-
-#[test]
-fn test_accounts_payer_specifies_both_lamports_and_sol() {
-    let toml = r#"
-[accounts]
-payer = { init_sol = 2000, init_lamports = 300_000 }
-"#;
-
-    let config = toml::from_str::<EphemeralConfig>(toml).unwrap();
-    assert!(config.accounts.payer.try_init_lamports().is_err());
 }


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Removed free airdrop functionality and payer configurations across the MagicBlock validator, transitioning towards a gasless transaction model.

- Removed `payer_init_lamports` field and related configurations from `configs/ephem-devnet.toml` and `configs/ephem-testnet.toml`, eliminating automatic account funding
- Simplified fee payer account cloning in `magicblock-account-cloner/src/remote_account_cloner_worker.rs` by using standard `do_clone_undelegated_account` method for non-charging validators
- Removed `Payer` struct and related functionality from `magicblock-config/src/accounts.rs`, including configuration validation and environment variable handling
- Modified account initialization logic in `magicblock-api/src/magic_validator.rs` to support gasless transactions while maintaining validator identity and faucet account funding



<!-- /greptile_comment -->