### PR TITLE
fix: allow specification of multiple rpc endpoints

### DIFF
--- a/magicblock-accounts/src/accounts_manager.rs
+++ b/magicblock-accounts/src/accounts_manager.rs
@@ -36,7 +36,7 @@ impl AccountsManager {
         validator_keypair: Keypair,
         config: AccountsConfig,
     ) -> AccountsResult<Self> {
-        let remote_cluster = config.remote_cluster;
+        let remote_cluster = config.remote_clusters[0].clone();
         let internal_account_provider = BankAccountProvider::new(bank.clone());
         let rpc_cluster = try_rpc_cluster_from_cluster(&remote_cluster)?;
         let rpc_client = RpcClient::new_with_commitment(

--- a/magicblock-accounts/src/config.rs
+++ b/magicblock-accounts/src/config.rs
@@ -6,7 +6,7 @@ use solana_sdk::pubkey::Pubkey;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct AccountsConfig {
-    pub remote_cluster: Cluster,
+    pub remote_clusters: Vec<Cluster>,
     pub lifecycle: LifecycleMode,
     pub commit_compute_unit_price: u64,
     pub payer_init_lamports: Option<u64>,

--- a/magicblock-api/src/external_config.rs
+++ b/magicblock-api/src/external_config.rs
@@ -8,7 +8,7 @@ pub(crate) fn try_convert_accounts_config(
     conf: &magicblock_config::AccountsConfig,
 ) -> ConfigResult<AccountsConfig> {
     Ok(AccountsConfig {
-        remote_cluster: cluster_from_remote(&conf.remote),
+        remote_clusters: conf.remotes.iter().map(cluster_from_remote).collect(),
         lifecycle: lifecycle_mode_from_lifecycle_mode(&conf.lifecycle),
         commit_compute_unit_price: conf.commit.compute_unit_price,
         payer_init_lamports: conf.payer.try_init_lamports()?,

--- a/magicblock-config/src/accounts.rs
+++ b/magicblock-config/src/accounts.rs
@@ -18,7 +18,7 @@ use crate::errors::{ConfigError, ConfigResult};
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub struct AccountsConfig {
     #[serde(default)]
-    pub remote: RemoteConfig,
+    pub remotes: Vec<RemoteConfig>,
     #[serde(default)]
     pub lifecycle: LifecycleMode,
     #[serde(default)]
@@ -38,7 +38,7 @@ pub struct AccountsConfig {
 impl Default for AccountsConfig {
     fn default() -> Self {
         Self {
-            remote: Default::default(),
+            remotes: vec![Default::default()],
             lifecycle: Default::default(),
             commit: Default::default(),
             payer: Default::default(),

--- a/magicblock-config/src/lib.rs
+++ b/magicblock-config/src/lib.rs
@@ -95,7 +95,7 @@ impl EphemeralConfig {
         // -----------------
         if let Ok(http) = env::var("ACCOUNTS_REMOTE") {
             if let Ok(ws) = env::var("ACCOUNTS_REMOTE_WS") {
-                config.accounts.remote = RemoteConfig::CustomWithWs(
+                config.accounts.remotes = vec![RemoteConfig::CustomWithWs(
                     Url::parse(&http)
                         .map_err(|err| {
                             panic!(
@@ -112,9 +112,9 @@ impl EphemeralConfig {
                             )
                         })
                         .unwrap(),
-                );
+                )];
             } else {
-                config.accounts.remote = RemoteConfig::Custom(
+                config.accounts.remotes = vec![RemoteConfig::Custom(
                     Url::parse(&http)
                         .map_err(|err| {
                             panic!(
@@ -123,7 +123,7 @@ impl EphemeralConfig {
                             )
                         })
                         .unwrap(),
-                );
+                )];
             }
         }
 

--- a/magicblock-config/tests/parse_config.rs
+++ b/magicblock-config/tests/parse_config.rs
@@ -131,9 +131,9 @@ fn test_custom_remote_toml() {
         config,
         EphemeralConfig {
             accounts: AccountsConfig {
-                remote: RemoteConfig::Custom(
+                remotes: vec![RemoteConfig::Custom(
                     Url::parse("http://localhost:8899").unwrap()
-                ),
+                )],
                 ..Default::default()
             },
             ..Default::default()
@@ -150,10 +150,10 @@ fn test_custom_ws_remote_toml() {
         config,
         EphemeralConfig {
             accounts: AccountsConfig {
-                remote: RemoteConfig::CustomWithWs(
+                remotes: vec![RemoteConfig::CustomWithWs(
                     Url::parse("http://localhost:8899").unwrap(),
                     Url::parse("ws://localhost:9001").unwrap()
-                ),
+                )],
                 ..Default::default()
             },
             ..Default::default()

--- a/magicblock-config/tests/read_config.rs
+++ b/magicblock-config/tests/read_config.rs
@@ -115,7 +115,9 @@ fn test_load_local_dev_with_programs_toml_envs_override() {
                     frequency_millis: 123,
                     compute_unit_price: 1,
                 },
-                remote: RemoteConfig::Custom(Url::parse(base_cluster).unwrap()),
+                remotes: vec![RemoteConfig::Custom(
+                    Url::parse(base_cluster).unwrap()
+                )],
                 ..Default::default()
             },
             programs: vec![ProgramConfig {
@@ -158,10 +160,10 @@ fn test_load_local_dev_with_programs_toml_envs_override() {
     let config = config.override_from_envs();
 
     assert_eq!(
-        config.accounts.remote,
-        RemoteConfig::CustomWithWs(
+        config.accounts.remotes,
+        vec![RemoteConfig::CustomWithWs(
             base_cluster.parse().unwrap(),
             base_cluster_ws.parse().unwrap()
-        )
+        )]
     );
 }

--- a/test-integration/configs/cloning-conf.devnet.toml
+++ b/test-integration/configs/cloning-conf.devnet.toml
@@ -1,5 +1,5 @@
 [accounts]
-remote = "devnet"
+remotes = ["devnet"]
 lifecycle = "offline"
 commit = { frequency_millis = 9_000_000_000_000, compute_unit_price = 1_000_000 }
 

--- a/test-integration/configs/cloning-conf.ephem.toml
+++ b/test-integration/configs/cloning-conf.ephem.toml
@@ -1,5 +1,5 @@
 [accounts]
-remote = "http://0.0.0.0:7799"
+remotes = ["http://0.0.0.0:7799"]
 lifecycle = "ephemeral"
 commit = { frequency_millis = 500_000, compute_unit_price = 1_000_000 }
 max-monitored-accounts = 3

--- a/test-integration/configs/luzid-devtool.toml
+++ b/test-integration/configs/luzid-devtool.toml
@@ -2,7 +2,7 @@
 name = "Devtool:8899"
 
 [node.accounts]
-remote = "devnet"
+remotes = ["devnet"]
 lifecycle = "offline"
 commit = { frequency_millis = 9_000_000_000_000, compute_unit_price = 1_000_000 }
 

--- a/test-integration/configs/luzid-offline.devnet.toml
+++ b/test-integration/configs/luzid-offline.devnet.toml
@@ -2,7 +2,7 @@
 name = "Devnet:7799"
 
 [node.accounts]
-remote = "devnet"
+remotes = ["devnet"]
 lifecycle = "offline"
 commit = { frequency_millis = 9_000_000_000_000, compute_unit_price = 1_000_000 }
 

--- a/test-integration/configs/luzid-schedulecommit-conf.devnet.toml
+++ b/test-integration/configs/luzid-schedulecommit-conf.devnet.toml
@@ -2,7 +2,7 @@
 name = "Devnet:7799"
 
 [node.accounts]
-remote = "devnet"
+remotes = ["devnet"]
 lifecycle = "offline"
 commit = { frequency_millis = 9_000_000_000_000, compute_unit_price = 1_000_000 }
 

--- a/test-integration/configs/luzid-schedulecommit-conf.ephem.frequent-commits.toml
+++ b/test-integration/configs/luzid-schedulecommit-conf.ephem.frequent-commits.toml
@@ -2,7 +2,7 @@
 name = "Ephem:8899"
 
 [node.accounts]
-remote = "http://0.0.0.0:7799"
+remotes = ["http://0.0.0.0:7799"]
 lifecycle = "ephemeral"
 commit = { frequency_millis = 60, compute_unit_price = 1_000_000 }
 

--- a/test-integration/configs/luzid-schedulecommit-conf.ephem.toml
+++ b/test-integration/configs/luzid-schedulecommit-conf.ephem.toml
@@ -2,7 +2,7 @@
 name = "Ephem:8899"
 
 [node.accounts]
-remote = "http://0.0.0.0:7799"
+remotes = ["http://0.0.0.0:7799"]
 lifecycle = "ephemeral"
 commit = { frequency_millis = 500_000, compute_unit_price = 1_000_000 }
 

--- a/test-integration/configs/restore-ledger-conf.devnet.toml
+++ b/test-integration/configs/restore-ledger-conf.devnet.toml
@@ -1,5 +1,5 @@
 [accounts]
-remote = "devnet"
+remotes = ["devnet"]
 lifecycle = "offline"
 commit = { frequency_millis = 9_000_000_000_000, compute_unit_price = 1_000_000 }
 

--- a/test-integration/configs/schedulecommit-conf-fees.ephem.toml
+++ b/test-integration/configs/schedulecommit-conf-fees.ephem.toml
@@ -1,5 +1,5 @@
 [accounts]
-remote = "http://0.0.0.0:7799"
+remotes = ["http://0.0.0.0:7799"]
 lifecycle = "ephemeral"
 commit = { frequency_millis = 500_000, compute_unit_price = 1_000_000 }
 

--- a/test-integration/configs/schedulecommit-conf.devnet.toml
+++ b/test-integration/configs/schedulecommit-conf.devnet.toml
@@ -1,5 +1,5 @@
 [accounts]
-remote = "devnet"
+remotes = ["devnet"]
 lifecycle = "offline"
 commit = { frequency_millis = 9_000_000_000_000, compute_unit_price = 1_000_000 }
 

--- a/test-integration/configs/schedulecommit-conf.ephem.frequent-commits.toml
+++ b/test-integration/configs/schedulecommit-conf.ephem.frequent-commits.toml
@@ -1,5 +1,5 @@
 [accounts]
-remote = "http://0.0.0.0:7799"
+remotes = ["http://0.0.0.0:7799"]
 lifecycle = "ephemeral"
 # NOTE: we'd be committing almost every slot here if we didn't detect when
 #       a commit is not needed

--- a/test-integration/configs/schedulecommit-conf.ephem.toml
+++ b/test-integration/configs/schedulecommit-conf.ephem.toml
@@ -1,5 +1,5 @@
 [accounts]
-remote = "http://0.0.0.0:7799"
+remotes = ["http://0.0.0.0:7799"]
 lifecycle = "ephemeral"
 commit = { frequency_millis = 500_000, compute_unit_price = 1_000_000 }
 

--- a/test-integration/configs/validator-offline.devnet.toml
+++ b/test-integration/configs/validator-offline.devnet.toml
@@ -1,5 +1,5 @@
 [accounts]
-remote = "devnet"
+remotes = ["devnet"]
 lifecycle = "offline"
 commit = { frequency_millis = 9_000_000_000_000, compute_unit_price = 1_000_000 }
 

--- a/test-integration/test-ledger-restore/src/lib.rs
+++ b/test-integration/test-ledger-restore/src/lib.rs
@@ -11,7 +11,10 @@ use integration_test_tools::{
     workspace_paths::path_relative_to_workspace,
     IntegrationTestContext,
 };
-use magicblock_config::{AccountsConfig, EphemeralConfig, LedgerConfig, LifecycleMode, ProgramConfig, RemoteConfig, ValidatorConfig, DEFAULT_LEDGER_SIZE_BYTES};
+use magicblock_config::{
+    AccountsConfig, EphemeralConfig, LedgerConfig, LifecycleMode,
+    ProgramConfig, RemoteConfig, ValidatorConfig, DEFAULT_LEDGER_SIZE_BYTES,
+};
 use program_flexi_counter::state::FlexiCounter;
 use solana_sdk::{
     clock::Slot,
@@ -104,7 +107,7 @@ pub fn setup_offline_validator(
         ledger: LedgerConfig {
             reset,
             path: Some(ledger_path.display().to_string()),
-            size: DEFAULT_LEDGER_SIZE_BYTES
+            size: DEFAULT_LEDGER_SIZE_BYTES,
         },
         accounts: accounts_config.clone(),
         programs,
@@ -132,9 +135,9 @@ pub fn setup_validator_with_local_remote(
 ) -> (TempDir, Child, IntegrationTestContext) {
     let mut accounts_config = AccountsConfig {
         lifecycle: LifecycleMode::Ephemeral,
-        remote: RemoteConfig::Custom(
+        remotes: vec![RemoteConfig::Custom(
             IntegrationTestContext::url_chain().try_into().unwrap(),
-        ),
+        )],
         ..Default::default()
     };
     accounts_config.db.snapshot_frequency = 2;

--- a/test-integration/test-tools/src/toml_to_args.rs
+++ b/test-integration/test-tools/src/toml_to_args.rs
@@ -16,7 +16,7 @@ struct Config {
 
 #[derive(Deserialize)]
 struct RemoteConfig {
-    remote: String,
+    remotes: Vec<String>,
 }
 
 #[derive(Deserialize)]
@@ -97,7 +97,7 @@ pub fn config_to_args(
         }
     }
     args.push("--url".into());
-    args.push(config.accounts.remote);
+    args.push(config.accounts.remotes[0].clone());
 
     args
 }


### PR DESCRIPTION
This fix introduces a breaking change to configuration, where instead of a single remote, it's now possible to specify multiple. Only the first one will be used for HTTP requests, but all of them will be used to load balance websocket subscriptions.