### PR TITLE
Compaction V1: Manual compaction

### DIFF
--- a/magicblock-ledger/src/database/db.rs
+++ b/magicblock-ledger/src/database/db.rs
@@ -160,6 +160,18 @@ impl Database {
         )
     }
 
+    /// See [crate::database::rocks_db::Rocks::compact_range_cf] for documentation.
+    pub fn compact_range_cf<C>(&self, from: C::Index, to: C::Index)
+    where
+        C: Column + ColumnName,
+    {
+        self.backend.compact_range_cf(
+            self.cf_handle::<C>(),
+            &C::key(from),
+            &C::key(to),
+        )
+    }
+
     pub fn is_primary_access(&self) -> bool {
         self.backend.is_primary_access()
     }

--- a/magicblock-ledger/src/database/db.rs
+++ b/magicblock-ledger/src/database/db.rs
@@ -25,7 +25,7 @@ impl Database {
     pub fn open(
         path: &Path,
         options: LedgerOptions,
-    ) -> std::result::Result<Self, LedgerError> {
+    ) -> Result<Self, LedgerError> {
         let column_options = Arc::new(options.column_options.clone());
         let backend = Arc::new(Rocks::open(path, options)?);
 
@@ -36,16 +36,13 @@ impl Database {
         })
     }
 
-    pub fn destroy(path: &Path) -> std::result::Result<(), LedgerError> {
+    pub fn destroy(path: &Path) -> Result<(), LedgerError> {
         Rocks::destroy(path)?;
 
         Ok(())
     }
 
-    pub fn get<C>(
-        &self,
-        key: C::Index,
-    ) -> std::result::Result<Option<C::Type>, LedgerError>
+    pub fn get<C>(&self, key: C::Index) -> Result<Option<C::Type>, LedgerError>
     where
         C: TypedColumn + ColumnName,
     {
@@ -63,10 +60,7 @@ impl Database {
     pub fn iter<C>(
         &self,
         iterator_mode: IteratorMode<C::Index>,
-    ) -> std::result::Result<
-        impl Iterator<Item = (C::Index, Box<[u8]>)> + '_,
-        LedgerError,
-    >
+    ) -> Result<impl Iterator<Item = (C::Index, Box<[u8]>)> + '_, LedgerError>
     where
         C: Column + ColumnName,
     {
@@ -161,14 +155,17 @@ impl Database {
     }
 
     /// See [crate::database::rocks_db::Rocks::compact_range_cf] for documentation.
-    pub fn compact_range_cf<C>(&self, from: C::Index, to: C::Index)
-    where
+    pub fn compact_range_cf<C>(
+        &self,
+        from: Option<C::Index>,
+        to: Option<C::Index>,
+    ) where
         C: Column + ColumnName,
     {
         self.backend.compact_range_cf(
             self.cf_handle::<C>(),
-            &C::key(from),
-            &C::key(to),
+            from.map(|index| C::key(index)),
+            to.map(|index| C::key(index)),
         )
     }
 

--- a/magicblock-ledger/src/database/ledger_column.rs
+++ b/magicblock-ledger/src/database/ledger_column.rs
@@ -246,6 +246,12 @@ where
     ) {
         write_batch.delete_range_cf::<C>(self.handle(), from, to);
     }
+
+    /// See [crate::database::rocks_db::Rocks::compact_range_cf] for documentation.
+    pub fn compact_range(&self, from: C::Index, to: C::Index) {
+        self.backend
+            .compact_range_cf(self.handle(), &C::key(from), &C::key(to))
+    }
 }
 
 impl<C> LedgerColumn<C>

--- a/magicblock-ledger/src/database/ledger_column.rs
+++ b/magicblock-ledger/src/database/ledger_column.rs
@@ -248,9 +248,12 @@ where
     }
 
     /// See [crate::database::rocks_db::Rocks::compact_range_cf] for documentation.
-    pub fn compact_range(&self, from: C::Index, to: C::Index) {
-        self.backend
-            .compact_range_cf(self.handle(), &C::key(from), &C::key(to))
+    pub fn compact_range(&self, from: Option<C::Index>, to: Option<C::Index>) {
+        self.backend.compact_range_cf(
+            self.handle(),
+            from.map(|index| C::key(index)),
+            to.map(|index| C::key(index)),
+        )
     }
 }
 

--- a/magicblock-ledger/src/database/rocks_db.rs
+++ b/magicblock-ledger/src/database/rocks_db.rs
@@ -115,6 +115,19 @@ impl Rocks {
         Ok(())
     }
 
+    /// Compacts keys in range \[`from`, `to`\].
+    /// For leveled compaction style, all files containing keys in the given range
+    /// are compacted to the last level containing files.
+    /// https://github.com/facebook/rocksdb/wiki/Manual-Compaction#compactrange
+    pub fn compact_range_cf(
+        &self,
+        cf: &ColumnFamily,
+        from_key: &[u8],
+        to_key: &[u8],
+    ) {
+        self.db.compact_range_cf(cf, Some(from_key), Some(to_key))
+    }
+
     pub fn iterator_cf<C>(
         &self,
         cf: &ColumnFamily,

--- a/magicblock-ledger/src/database/rocks_db.rs
+++ b/magicblock-ledger/src/database/rocks_db.rs
@@ -119,13 +119,13 @@ impl Rocks {
     /// For leveled compaction style, all files containing keys in the given range
     /// are compacted to the last level containing files.
     /// https://github.com/facebook/rocksdb/wiki/Manual-Compaction#compactrange
-    pub fn compact_range_cf(
+    pub fn compact_range_cf<S: AsRef<[u8]>, E: AsRef<[u8]>>(
         &self,
         cf: &ColumnFamily,
-        from_key: &[u8],
-        to_key: &[u8],
+        from_key: Option<S>,
+        to_key: Option<E>,
     ) {
-        self.db.compact_range_cf(cf, Some(from_key), Some(to_key))
+        self.db.compact_range_cf(cf, from_key, to_key)
     }
 
     pub fn iterator_cf<C>(

--- a/magicblock-ledger/src/ledger_truncator.rs
+++ b/magicblock-ledger/src/ledger_truncator.rs
@@ -1,6 +1,6 @@
-use std::{cmp::min, ops::ControlFlow, sync::Arc, time::Duration};
+use std::{cmp::min, sync::Arc, time::Duration};
 
-use log::{error, warn};
+use log::{error, info, warn};
 use magicblock_core::traits::FinalityProvider;
 use tokio::{
     task::{JoinError, JoinHandle},
@@ -8,7 +8,14 @@ use tokio::{
 };
 use tokio_util::sync::CancellationToken;
 
-use crate::{errors::LedgerResult, Ledger};
+use crate::{
+    database::columns::{
+        AddressSignatures, Blockhash, Blocktime, PerfSamples, SlotSignatures,
+        Transaction, TransactionMemos, TransactionStatus,
+    },
+    errors::LedgerResult,
+    Ledger,
+};
 
 pub const DEFAULT_TRUNCATION_TIME_INTERVAL: Duration =
     Duration::from_secs(10 * 60);
@@ -46,34 +53,58 @@ impl<T: FinalityProvider> LedgerTrunctationWorker<T> {
                     return;
                 }
                 _ = interval.tick() => {
-                    const TRUNCATE_TO_PERCENTAGE: u64 = 90;
+                    const FILLED_PERCENTAGE_LIMIT: u8 = 98;
 
-                    match self.should_truncate() {
-                        Ok(true) => {
-                            if let Some((from_slot, to_slot)) = self.next_truncation_range() {
-                                let to_size = ( self.ledger_size / 100 ) * TRUNCATE_TO_PERCENTAGE;
-                                Self::truncate_to_size(&self.ledger, to_size, from_slot, to_slot);
-                            } else {
-                                warn!("Failed to get truncation range! Ledger size exceeded desired threshold");
-                            }
-                        },
-                        Ok(false) => (),
-                        Err(err) => error!("Failed to check truncation condition: {err}"),
+                    let current_size = match self.ledger.storage_size() {
+                        Ok(value) => value,
+                        Err(err) => {
+                            error!("Failed to check truncation condition: {err}");
+                            continue;
+                        }
+                    };
+
+                    // Check if we should truncate
+                    if current_size < (self.ledger_size / 100) * FILLED_PERCENTAGE_LIMIT as u64 {
+                        continue;
+                    }
+
+                    match self.estimate_truncation_range(current_size) {
+                        Ok(Some((from_slot, to_slot))) => Self::truncate_slot_range(&self.ledger, from_slot, to_slot),
+                        Ok(None) => warn!("Could not estimate truncation range"),
+                        Err(err) => error!("Failed to estimate truncation range: {:?}", err),
                     }
                 }
             }
         }
     }
 
-    fn should_truncate(&self) -> LedgerResult<bool> {
-        // Once size percentage reached, we start truncation
-        const FILLED_PERCENTAGE_LIMIT: u64 = 98;
-        Ok(self.ledger.storage_size()?
-            >= (self.ledger_size / 100) * FILLED_PERCENTAGE_LIMIT)
+    /// Returns range to truncate [from_slot, to_slot]
+    fn estimate_truncation_range(
+        &self,
+        current_ledger_size: u64,
+    ) -> LedgerResult<Option<(u64, u64)>> {
+        const PERCENTAGE_TO_TRUNCATE: u8 = 10;
+
+        let (from_slot, to_slot) =
+            if let Some(val) = self.available_truncation_range() {
+                val
+            } else {
+                return Ok(None);
+            };
+
+        let num_slots = self.ledger.count_blockhashes()?;
+        let slot_size = current_ledger_size / num_slots as u64;
+
+        let size_to_truncate =
+            (current_ledger_size / 100) * PERCENTAGE_TO_TRUNCATE as u64;
+        let num_slots_to_truncate = size_to_truncate / slot_size;
+
+        let to_slot = min(from_slot + num_slots_to_truncate, to_slot);
+        Ok(Some((from_slot, to_slot)))
     }
 
     /// Returns [from_slot, to_slot] range that's safe to truncate
-    fn next_truncation_range(&self) -> Option<(u64, u64)> {
+    fn available_truncation_range(&self) -> Option<(u64, u64)> {
         let lowest_cleanup_slot = self.ledger.get_lowest_cleanup_slot();
         let latest_final_slot = self.finality_provider.get_latest_final_slot();
 
@@ -83,10 +114,16 @@ impl<T: FinalityProvider> LedgerTrunctationWorker<T> {
                 // This could not happen because of Truncator
                 warn!("Slots after latest final slot have been truncated!");
             }
+
+            info!(
+                "Lowest cleanup slot ge than latest final slot. {}, {}",
+                lowest_cleanup_slot, latest_final_slot
+            );
             return None;
         }
-        // Nothing to clean
-        if latest_final_slot - 1 == lowest_cleanup_slot {
+        // Nothing to truncate
+        if latest_final_slot == lowest_cleanup_slot + 1 {
+            info!("Nothing to truncate");
             return None;
         }
 
@@ -103,9 +140,8 @@ impl<T: FinalityProvider> LedgerTrunctationWorker<T> {
 
     /// Utility function for splitting truncation into smaller chunks
     /// Cleans slots [from_slot; to_slot] inclusive range
-    pub fn truncate_to_size(
+    pub fn truncate_slot_range(
         ledger: &Arc<Ledger>,
-        size: u64,
         from_slot: u64,
         to_slot: u64,
     ) {
@@ -118,7 +154,7 @@ impl<T: FinalityProvider> LedgerTrunctationWorker<T> {
         }
         (from_slot..=to_slot)
             .step_by(SINGLE_TRUNCATION_LIMIT)
-            .try_for_each(|cur_from_slot| {
+            .for_each(|cur_from_slot| {
                 let num_slots_to_truncate = min(
                     to_slot - cur_from_slot + 1,
                     SINGLE_TRUNCATION_LIMIT as u64,
@@ -127,30 +163,53 @@ impl<T: FinalityProvider> LedgerTrunctationWorker<T> {
                     cur_from_slot + num_slots_to_truncate - 1;
 
                 if let Err(err) =
-                    ledger.truncate_slots(cur_from_slot, truncate_to_slot)
+                    ledger.delete_slot_range(cur_from_slot, truncate_to_slot)
                 {
                     warn!(
                         "Failed to truncate slots {}-{}: {}",
                         cur_from_slot, truncate_to_slot, err
                     );
-
-                    return ControlFlow::Continue(());
-                }
-
-                match ledger.storage_size() {
-                    Ok(current_size) => {
-                        if current_size <= size {
-                            ControlFlow::Break(())
-                        } else {
-                            ControlFlow::Continue(())
-                        }
-                    }
-                    Err(err) => {
-                        warn!("Failed to fetch Ledger size: {err}");
-                        ControlFlow::Continue(())
-                    }
                 }
             });
+
+        Self::compact_slot_range(ledger, from_slot, to_slot);
+    }
+
+    /// Synchronous utility function that triggers and awaits compaction on all the columns
+    pub fn compact_slot_range(
+        ledger: &Arc<Ledger>,
+        from_slot: u64,
+        to_slot: u64,
+    ) {
+        if to_slot < from_slot {
+            warn!("LedgerTruncator: Nani2?");
+            return;
+        }
+
+        // Available range compaction
+        ledger.compact_slot_range_cf::<Blocktime>(
+            Some(from_slot),
+            Some(to_slot + 1),
+        );
+        ledger.compact_slot_range_cf::<Blockhash>(
+            Some(from_slot),
+            Some(to_slot + 1),
+        );
+        ledger.compact_slot_range_cf::<PerfSamples>(
+            Some(from_slot),
+            Some(to_slot + 1),
+        );
+        ledger.compact_slot_range_cf::<SlotSignatures>(
+            Some((from_slot, u32::MIN)),
+            Some((to_slot, u32::MAX)),
+        );
+
+        // Con't compact with specific range
+        ledger.compact_slot_range_cf::<TransactionStatus>(None, None);
+        ledger.compact_slot_range_cf::<Transaction>(None, None);
+        ledger.compact_slot_range_cf::<TransactionMemos>(None, None);
+        ledger.compact_slot_range_cf::<TransactionStatus>(None, None);
+        ledger.compact_slot_range_cf::<AddressSignatures>(None, None);
     }
 }
 

--- a/magicblock-ledger/src/ledger_truncator.rs
+++ b/magicblock-ledger/src/ledger_truncator.rs
@@ -210,7 +210,7 @@ impl<T: FinalityProvider> LedgerTrunctationWorker<T> {
             Some((to_slot, u32::MAX)),
         );
 
-        // Con't compact with specific range
+        // Can not compact with specific range
         ledger.compact_slot_range_cf::<TransactionStatus>(None, None);
         ledger.compact_slot_range_cf::<Transaction>(None, None);
         ledger.compact_slot_range_cf::<TransactionMemos>(None, None);

--- a/magicblock-ledger/tests/test_ledger_truncator.rs
+++ b/magicblock-ledger/tests/test_ledger_truncator.rs
@@ -9,7 +9,7 @@ use std::{
 
 use magicblock_core::traits::FinalityProvider;
 use magicblock_ledger::{ledger_truncator::LedgerTruncator, Ledger};
-use solana_sdk::signature::Signature;
+use solana_sdk::{hash::Hash, signature::Signature};
 
 use crate::common::{setup, write_dummy_transaction};
 
@@ -73,6 +73,7 @@ async fn test_truncator_not_purged_finality() {
 
     for i in 0..SLOT_TRUNCATION_INTERVAL {
         write_dummy_transaction(&ledger, i, 0);
+        ledger.write_block(i, 0, Hash::new_unique()).unwrap()
     }
     let signatures = (0..SLOT_TRUNCATION_INTERVAL)
         .map(|i| {
@@ -111,6 +112,7 @@ async fn test_truncator_not_purged_size() {
 
     for i in 0..NUM_TRANSACTIONS {
         write_dummy_transaction(&ledger, i, 0);
+        ledger.write_block(i, 0, Hash::new_unique()).unwrap()
     }
     let signatures = (0..NUM_TRANSACTIONS)
         .map(|i| {
@@ -136,9 +138,10 @@ async fn test_truncator_non_empty_ledger() {
     const FINAL_SLOT: u64 = 80;
 
     let ledger = Arc::new(setup());
-    let signatures = (0..100)
+    let signatures = (0..FINAL_SLOT + 20)
         .map(|i| {
             let (_, signature) = write_dummy_transaction(&ledger, i, 0);
+            ledger.write_block(i, 0, Hash::new_unique()).unwrap();
             signature
         })
         .collect::<Vec<_>>();
@@ -155,22 +158,23 @@ async fn test_truncator_non_empty_ledger() {
     );
 
     ledger_truncator.start();
-    tokio::time::sleep(Duration::from_millis(10)).await;
+    tokio::time::sleep(TEST_TRUNCATION_TIME_INTERVAL).await;
 
     ledger_truncator.stop();
     assert!(ledger_truncator.join().await.is_ok());
 
-    assert_eq!(ledger.get_lowest_cleanup_slot(), FINAL_SLOT - 1);
+    let cleanup_slot = ledger.get_lowest_cleanup_slot();
+    assert_ne!(ledger.get_lowest_cleanup_slot(), 0);
     verify_transactions_state(
         &ledger,
         0,
-        &signatures[..FINAL_SLOT as usize],
+        &signatures[..(cleanup_slot + 1) as usize],
         false,
     );
     verify_transactions_state(
         &ledger,
-        FINAL_SLOT,
-        &signatures[FINAL_SLOT as usize..],
+        cleanup_slot + 1,
+        &signatures[(cleanup_slot + 1) as usize..],
         true,
     );
 }
@@ -185,8 +189,9 @@ async fn transaction_spammer(
         Vec::with_capacity(num_of_iterations * tx_per_operation);
     for _ in 0..num_of_iterations {
         for _ in 0..tx_per_operation {
-            let (_, signature) =
-                write_dummy_transaction(&ledger, signatures.len() as u64, 0);
+            let slot = signatures.len() as u64;
+            let (_, signature) = write_dummy_transaction(&ledger, slot, 0);
+            ledger.write_block(slot, 0, Hash::new_unique()).unwrap();
             signatures.push(signature);
         }
 
@@ -250,4 +255,42 @@ async fn test_truncator_with_tx_spammer() {
         &signatures[lowest_existing as usize..],
         true,
     );
+}
+
+#[ignore = "Long running test"]
+#[tokio::test]
+async fn test_with_1gb_db() {
+    const DB_SIZE: u64 = 1 << 30;
+    const CHECK_RATE: u64 = 100;
+
+    // let ledger = Arc::new(Ledger::open(Path::new("/var/folders/r9/q7l5l9ks1vs1nlv10vlpkhw80000gn/T/.tmp00LEDc/rocksd")).unwrap());
+    let ledger = Arc::new(setup());
+
+    let mut slot = 0;
+    loop {
+        if slot % CHECK_RATE == 0 && ledger.storage_size().unwrap() >= DB_SIZE {
+            break;
+        }
+
+        write_dummy_transaction(&ledger, slot, 0);
+        ledger.write_block(slot, 0, Hash::new_unique()).unwrap();
+        slot += 1
+    }
+
+    let finality_provider = Arc::new(TestFinalityProvider {
+        latest_final_slot: AtomicU64::new(slot - 1),
+    });
+
+    let mut ledger_truncator = LedgerTruncator::new(
+        ledger.clone(),
+        finality_provider.clone(),
+        TEST_TRUNCATION_TIME_INTERVAL,
+        DB_SIZE,
+    );
+
+    ledger_truncator.start();
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    ledger_truncator.stop();
+
+    ledger_truncator.join().await.unwrap();
 }


### PR DESCRIPTION
This implements manual compaction strategy. 

Since `delete` in rocksdb doesn't cleanup space, but rather  adds more space(tombstones), we trigger manual compaction on required ranges.

Ranges are estimated as follows:
1. take size of dbs, take num of slots in db
2. estimate average size per slot
3. calculate how much slots we need to delete to clean 10%
4. deduce range from available range to truncate(LedgerTruncator::available_truncation_range) & num of slots from 3.
5. delete & compact

see `LedgerTruncator::estimate_truncation_range` for implementation