### PR TITLE
Patch tests from failing on subscription due to rate limits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3565,6 +3565,7 @@ version = "0.1.3"
 dependencies = [
  "bincode",
  "conjunto-transwise",
+ "env_logger 0.11.6",
  "futures-util",
  "log",
  "magicblock-metrics",

--- a/magicblock-account-updates/Cargo.toml
+++ b/magicblock-account-updates/Cargo.toml
@@ -24,4 +24,4 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 test-tools = { workspace = true }
-env_logger = "0.11"
+env_logger = { workspace = true }

--- a/magicblock-account-updates/Cargo.toml
+++ b/magicblock-account-updates/Cargo.toml
@@ -24,3 +24,4 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 test-tools = { workspace = true }
+env_logger = "0.11"

--- a/magicblock-account-updates/src/remote_account_updates_worker.rs
+++ b/magicblock-account-updates/src/remote_account_updates_worker.rs
@@ -186,7 +186,11 @@ impl RemoteAccountUpdatesWorker {
                 .start_monitoring_request_processing(shard_cancellation_token)
                 .await
             {
+                #[cfg(not(test))]
                 error!("Runner shard has failed: {}: {:?}", shard_id, error);
+
+                #[cfg(test)]
+                panic!("Runner shard has failed: {}: {:?}", shard_id, error);
             }
         });
         let runner = RemoteAccountUpdatesWorkerRunner {

--- a/magicblock-account-updates/tests/remote_account_updates.rs
+++ b/magicblock-account-updates/tests/remote_account_updates.rs
@@ -19,9 +19,10 @@ async fn setup() -> (
     CancellationToken,
     tokio::task::JoinHandle<()>,
 ) {
+    let _ = env_logger::builder().is_test(true).try_init();
     // Create account updates worker and client
     let mut worker = RemoteAccountUpdatesWorker::new(
-        vec![RpcProviderConfig::devnet().ws_url().into(); 2],
+        vec![RpcProviderConfig::devnet().ws_url().into(); 1],
         Some(solana_sdk::commitment_config::CommitmentLevel::Confirmed),
         Duration::from_secs(50 * 60),
     );


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Modified error handling and test configuration in RemoteAccountUpdatesWorker to address 'too many requests' errors during testing.

- Added conditional compilation (`#[cfg]`) in `magicblock-account-updates/src/remote_account_updates_worker.rs` to panic on shard failures during tests while logging errors in production
- Reduced WebSocket connections from 2 to 1 in `magicblock-account-updates/tests/remote_account_updates.rs` to prevent rate limiting
- Added `env_logger = "0.11"` to `magicblock-account-updates/Cargo.toml` for improved test logging
- Consider adding retry mechanism or connection pooling for more robust testing



<!-- /greptile_comment -->