### PR TITLE
release: v0.1.3

### DIFF
--- a/.github/packages/npm-package/package.json
+++ b/.github/packages/npm-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicblock-labs/ephemeral-validator",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "MagicBlock Ephemeral Validator",
   "homepage": "https://github.com/magicblock-labs/ephemeral-validator#readme",
   "bugs": {
@@ -27,11 +27,11 @@
     "typescript": "^4.9.4"
   },
   "optionalDependencies": {
-    "@magicblock-labs/ephemeral-validator-darwin-arm64": "0.1.2",
-    "@magicblock-labs/ephemeral-validator-darwin-x64": "0.1.2",
-    "@magicblock-labs/ephemeral-validator-linux-arm64": "0.1.2",
-    "@magicblock-labs/ephemeral-validator-linux-x64": "0.1.2",
-    "@magicblock-labs/ephemeral-validator-windows-x64": "0.1.2"
+    "@magicblock-labs/ephemeral-validator-darwin-arm64": "0.1.3",
+    "@magicblock-labs/ephemeral-validator-darwin-x64": "0.1.3",
+    "@magicblock-labs/ephemeral-validator-linux-arm64": "0.1.3",
+    "@magicblock-labs/ephemeral-validator-linux-x64": "0.1.3",
+    "@magicblock-labs/ephemeral-validator-windows-x64": "0.1.3"
   },
   "publishConfig": {
     "access": "public"

--- a/.github/packages/npm-package/package.json.tmpl
+++ b/.github/packages/npm-package/package.json.tmpl
@@ -1,7 +1,7 @@
 {
   "name": "@magicblock-labs/${node_pkg}",
   "description": "Ephemeral Validator (${node_pkg})",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/magicblock-labs/ephemeral-validator.git"

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -132,6 +132,19 @@ jobs:
           echo "release_name=${release_name}" >> $GITHUB_ENV
           mv "target/${{ matrix.build.TARGET }}/release/${bin}" "target/${{ matrix.build.TARGET }}/release/${release_name}"
 
+      - name: Set release version
+        if: ${{ env.DRY_RUN == 'false' }}
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            echo "RELEASE_VERSION=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "RELEASE_VERSION=${{ github.event.inputs.release_version }}" >> $GITHUB_ENV
+          elif [[ "${{ github.ref }}" == refs/heads/release/v* ]]; then
+            echo "RELEASE_VERSION=$(echo ${{ github.ref }} | sed 's|refs/heads/release/||')" >> $GITHUB_ENV
+          else
+            echo "RELEASE_VERSION=v0.0.0-dev" >> $GITHUB_ENV
+          fi
+
       - name: Publish binary to GitHub release
         if: ${{ env.DRY_RUN == 'false' }}
         uses: svenstaro/upload-release-action@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -747,7 +747,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115e54d64eb62cdebad391c19efc9dce4981c690c85a33a12199d99bb9546fee"
 dependencies = [
  "borsh-derive 0.10.4",
- "hashbrown 0.13.2",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -1851,7 +1851,7 @@ dependencies = [
 
 [[package]]
 name = "expiring-hashmap"
-version = "0.1.2"
+version = "0.1.3"
 
 [[package]]
 name = "fake-simd"
@@ -2210,7 +2210,7 @@ dependencies = [
 
 [[package]]
 name = "geyser-grpc-proto"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3511,7 +3511,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-account-cloner"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "conjunto-transwise",
  "futures-util",
@@ -3532,7 +3532,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-account-dumper"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bincode",
  "magicblock-bank",
@@ -3545,7 +3545,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-account-fetcher"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-trait",
  "conjunto-transwise",
@@ -3561,7 +3561,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-account-updates"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bincode",
  "conjunto-transwise",
@@ -3581,7 +3581,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-accounts"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-trait",
  "conjunto-transwise",
@@ -3612,7 +3612,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-accounts-api"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "magicblock-bank",
  "solana-sdk",
@@ -3620,7 +3620,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-accounts-db"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "env_logger 0.11.6",
  "lmdb-rkv",
@@ -3637,7 +3637,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-api"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "agave-geyser-plugin-interface",
  "anyhow",
@@ -3682,7 +3682,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-bank"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "agave-geyser-plugin-interface",
  "assert_matches",
@@ -3723,7 +3723,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-config"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "isocountry",
  "magicblock-accounts-db",
@@ -3739,7 +3739,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-core"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "solana-sdk",
 ]
@@ -3762,7 +3762,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-geyser-plugin"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "agave-geyser-plugin-interface",
  "anyhow",
@@ -3791,7 +3791,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-ledger"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bincode",
  "byteorder",
@@ -3810,7 +3810,7 @@ dependencies = [
  "solana-measure",
  "solana-metrics",
  "solana-sdk",
- "solana-storage-proto 0.1.2",
+ "solana-storage-proto 0.1.3",
  "solana-svm",
  "solana-timings",
  "solana-transaction-status",
@@ -3823,7 +3823,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-metrics"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "http-body-util",
  "hyper 1.5.2",
@@ -3837,7 +3837,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-mutator"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -3854,7 +3854,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-perf-service"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "log",
  "magicblock-bank",
@@ -3863,7 +3863,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-processor"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "lazy_static",
  "log",
@@ -3884,7 +3884,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-program"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -3905,7 +3905,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-pubsub"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bincode",
  "geyser-grpc-proto",
@@ -3927,7 +3927,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-rpc"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "base64 0.21.7",
  "bincode",
@@ -3962,7 +3962,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-tokens"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "log",
  "magicblock-bank",
@@ -3977,7 +3977,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-transaction-status"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "crossbeam-channel",
  "log",
@@ -3989,7 +3989,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-version"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "rustc_version",
  "semver",
@@ -8718,7 +8718,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-proto"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bincode",
  "bs58 0.4.0",
@@ -10055,7 +10055,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-bins"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "console-subscriber",
  "env_logger 0.11.6",
@@ -10070,7 +10070,7 @@ dependencies = [
 
 [[package]]
 name = "test-tools"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "log",
  "magicblock-accounts-db",
@@ -10089,7 +10089,7 @@ dependencies = [
 
 [[package]]
 name = "test-tools-core"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "env_logger 0.11.6",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ resolver = "2"
 
 [workspace.package]
 # Solana Version (2.2.x)
-version = "0.1.2"
+version = "0.1.3"
 authors = ["MagicBlock Maintainers <maintainers@magicblock.xyz>"]
 repository = "https://github.com/magicblock-labs/ephemeral-validator"
 homepage = "https://www.magicblock.xyz"

--- a/test-integration/Cargo.lock
+++ b/test-integration/Cargo.lock
@@ -747,7 +747,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115e54d64eb62cdebad391c19efc9dce4981c690c85a33a12199d99bb9546fee"
 dependencies = [
  "borsh-derive 0.10.4",
- "hashbrown 0.13.2",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -1830,7 +1830,7 @@ dependencies = [
 
 [[package]]
 name = "expiring-hashmap"
-version = "0.1.2"
+version = "0.1.3"
 
 [[package]]
 name = "fake-simd"
@@ -2178,7 +2178,7 @@ dependencies = [
 
 [[package]]
 name = "geyser-grpc-proto"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3444,7 +3444,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-account-cloner"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "conjunto-transwise",
  "futures-util",
@@ -3465,7 +3465,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-account-dumper"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bincode",
  "magicblock-bank",
@@ -3478,7 +3478,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-account-fetcher"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-trait",
  "conjunto-transwise",
@@ -3493,7 +3493,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-account-updates"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bincode",
  "conjunto-transwise",
@@ -3512,7 +3512,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-accounts"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-trait",
  "conjunto-transwise",
@@ -3541,7 +3541,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-accounts-api"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "magicblock-bank",
  "solana-sdk",
@@ -3549,7 +3549,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-accounts-db"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "lmdb-rkv",
  "log",
@@ -3565,7 +3565,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-api"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "agave-geyser-plugin-interface",
  "anyhow",
@@ -3610,7 +3610,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-bank"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "agave-geyser-plugin-interface",
  "bincode",
@@ -3645,7 +3645,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-config"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "isocountry",
  "magicblock-accounts-db",
@@ -3660,7 +3660,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-core"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "solana-sdk",
 ]
@@ -3683,7 +3683,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-geyser-plugin"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "agave-geyser-plugin-interface",
  "anyhow",
@@ -3712,7 +3712,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-ledger"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bincode",
  "byteorder",
@@ -3731,7 +3731,7 @@ dependencies = [
  "solana-measure",
  "solana-metrics",
  "solana-sdk",
- "solana-storage-proto 0.1.2",
+ "solana-storage-proto 0.1.3",
  "solana-svm",
  "solana-timings",
  "solana-transaction-status",
@@ -3742,7 +3742,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-metrics"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "http-body-util",
  "hyper 1.6.0",
@@ -3756,7 +3756,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-mutator"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bincode",
  "log",
@@ -3769,7 +3769,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-perf-service"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "log",
  "magicblock-bank",
@@ -3778,7 +3778,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-processor"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "lazy_static",
  "log",
@@ -3799,7 +3799,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-program"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bincode",
  "lazy_static",
@@ -3816,7 +3816,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-pubsub"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bincode",
  "geyser-grpc-proto",
@@ -3838,7 +3838,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-rpc"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "base64 0.21.7",
  "bincode",
@@ -3873,7 +3873,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-tokens"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "log",
  "magicblock-bank",
@@ -3888,7 +3888,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-transaction-status"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "crossbeam-channel",
  "log",
@@ -3900,7 +3900,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-version"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "rustc_version",
  "semver",
@@ -8647,7 +8647,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-proto"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bincode",
  "bs58 0.4.0",
@@ -10029,7 +10029,7 @@ dependencies = [
 
 [[package]]
 name = "test-tools-core"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "env_logger 0.11.6",
  "log",


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Version bump from 0.1.2 to 0.1.3 across NPM packages and Cargo workspace, with workflow improvements for release automation.

- Version mismatch risk in `.github/workflows/publish-packages.yml`: RELEASE_VERSION environment variable is set after it's used in NPM package building step
- Consistent version update across all platform-specific packages in `.github/packages/npm-package/package.json` (darwin/arm64, darwin/x64, linux/arm64, linux/x64, windows/x64)
- Updated workspace package version to 0.1.3 in `Cargo.toml`, maintaining alignment with Solana Version 2.2.x
- Template file `.github/packages/npm-package/package.json.tmpl` synchronized with version 0.1.3



<!-- /greptile_comment -->