### PR TITLE
Optimizing column entries bookkeeping

### DIFF
--- a/magicblock-api/src/tickers.rs
+++ b/magicblock-api/src/tickers.rs
@@ -160,13 +160,9 @@ pub fn init_system_metrics_ticker(
     fn set_accounts_count(bank: &Bank) {
         metrics::set_accounts_count(bank.accounts_db.get_accounts_count());
     }
+
     let ledger = ledger.clone();
     let bank = bank.clone();
-    try_set_ledger_storage_size(&ledger);
-    set_accounts_storage_size(&bank);
-    set_accounts_count(&bank);
-    try_set_ledger_counts(&ledger);
-
     tokio::task::spawn(async move {
         loop {
             tokio::select! {

--- a/magicblock-ledger/src/database/columns.rs
+++ b/magicblock-ledger/src/database/columns.rs
@@ -1,16 +1,9 @@
-use std::sync::atomic::{AtomicI64, Ordering};
-
 use byteorder::{BigEndian, ByteOrder};
-use log::*;
 use serde::{de::DeserializeOwned, Serialize};
 use solana_sdk::{clock::Slot, pubkey::Pubkey, signature::Signature};
 use solana_storage_proto::convert::generated;
 
 use super::meta;
-use crate::{
-    database::{iterator::IteratorMode, ledger_column::LedgerColumn},
-    errors::LedgerResult,
-};
 
 /// Column family for Transaction Status
 const TRANSACTION_STATUS_CF: &str = "transaction_status";
@@ -677,24 +670,3 @@ pub fn should_enable_compression<C: 'static + Column + ColumnName>() -> bool {
 // Column Queries
 // -----------------
 pub(crate) const DIRTY_COUNT: i64 = -1;
-pub fn count_column_using_cache<C: Column + ColumnName>(
-    column: &LedgerColumn<C>,
-    cached_value: &AtomicI64,
-) -> LedgerResult<i64> {
-    let cached = cached_value.load(Ordering::Relaxed);
-    // NOTE: a value of -1 indicates that the cached value is dirty
-    if cached != DIRTY_COUNT {
-        return Ok(cached);
-    }
-    column
-        .iter(IteratorMode::Start)
-        .map(Iterator::count)
-        .map(|val| if val > i64::MAX as usize {
-            // NOTE: this value is only used for metrics/diagnostics and
-            // aside from the fact that we will never encounter this case,
-            // it is good enough to return i64::MAX
-            error!("Column {} count is too large: {} for metrics, returning max.", C::NAME, val);
-            i64::MAX
-        } else { val as i64 })
-        .inspect(|updated| cached_value.store(*updated, Ordering::Relaxed))
-}

--- a/magicblock-ledger/src/database/db.rs
+++ b/magicblock-ledger/src/database/db.rs
@@ -1,4 +1,8 @@
-use std::{marker::PhantomData, path::Path, sync::Arc};
+use std::{
+    marker::PhantomData,
+    path::Path,
+    sync::{atomic::AtomicI64, Arc},
+};
 
 use bincode::deserialize;
 use rocksdb::{ColumnFamily, DBRawIterator, LiveFile};
@@ -12,7 +16,10 @@ use super::{
     rocks_db::Rocks,
     write_batch::WriteBatch,
 };
-use crate::{errors::LedgerError, metrics::PerfSamplingStatus};
+use crate::{
+    database::columns::DIRTY_COUNT, errors::LedgerError,
+    metrics::PerfSamplingStatus,
+};
 
 #[derive(Debug)]
 pub struct Database {
@@ -90,6 +97,7 @@ impl Database {
             column_options: Arc::clone(&self.column_options),
             read_perf_status: PerfSamplingStatus::default(),
             write_perf_status: PerfSamplingStatus::default(),
+            entry_counter: AtomicI64::new(DIRTY_COUNT),
         }
     }
 


### PR DESCRIPTION
Instead of setting counter to DiRTY_COUNT on every write as before, we increase the counter if it is not "dirty", otherwise just skip.

This improves `init_system_metrics_ticker` since before we always had to recount entries as they were set to DIRTY_COUNT on every write

<!-- greptile_comment -->

## Greptile Summary

Optimizes column entry bookkeeping in the ledger database by replacing the DIRTY_COUNT-based tracking with an atomic counter system, significantly improving `init_system_metrics_ticker` performance.

- Added `entry_counter: AtomicI64` to `LedgerColumn` struct in `magicblock-ledger/src/database/ledger_column.rs` for efficient entry tracking
- Removed redundant atomic counter fields from Ledger struct in `magicblock-ledger/src/store/api.rs`, moving tracking to column families
- Implemented incremental counter updates with `try_increase_entry_counter()` instead of marking entries as dirty on every write
- Added proper counter decrease logic in `delete_slot_range` to maintain accuracy during deletions



<!-- /greptile_comment -->