### PR TITLE
Revert to using separate tokio runtime instance for RPC

### DIFF
--- a/magicblock-ledger/tests/test_ledger_truncator.rs
+++ b/magicblock-ledger/tests/test_ledger_truncator.rs
@@ -228,7 +228,7 @@ async fn test_truncator_with_tx_spammer() {
     ));
 
     // Sleep some time
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    tokio::time::sleep(Duration::from_secs(3)).await;
 
     let signatures_result = handle.await;
     assert!(signatures_result.is_ok());


### PR DESCRIPTION
>     // Comment from Solana implementation:
>     // sadly, some parts of our current rpc implemention block the jsonrpc's
>     // _socket-listening_ event loop for too long, due to (blocking) long IO or intesive CPU,
>     // causing no further processing of incoming requests and ultimatily innocent clients timing-out.
>     // So create a (shared) multi-threaded event_loop for jsonrpc and set its .threads() to 1,
>     // so that we avoid the single-threaded event loops from being created automatically by
>     // jsonrpc for threads when .threads(N > 1) is given.

After switching to same runtime instance we encountered an issue mentioned in original implementation. See original convo for more details [here](https://magicblock-labs.slack.com/archives/C07QF4P5HJ8/p1750067365761009)