### PR TITLE
release: v0.1.4

### DIFF
--- a/.github/packages/npm-package/package.json
+++ b/.github/packages/npm-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicblock-labs/ephemeral-validator",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "MagicBlock Ephemeral Validator",
   "homepage": "https://github.com/magicblock-labs/ephemeral-validator#readme",
   "bugs": {
@@ -27,11 +27,11 @@
     "typescript": "^4.9.4"
   },
   "optionalDependencies": {
-    "@magicblock-labs/ephemeral-validator-darwin-arm64": "0.1.3",
-    "@magicblock-labs/ephemeral-validator-darwin-x64": "0.1.3",
-    "@magicblock-labs/ephemeral-validator-linux-arm64": "0.1.3",
-    "@magicblock-labs/ephemeral-validator-linux-x64": "0.1.3",
-    "@magicblock-labs/ephemeral-validator-windows-x64": "0.1.3"
+    "@magicblock-labs/ephemeral-validator-darwin-arm64": "0.1.4",
+    "@magicblock-labs/ephemeral-validator-darwin-x64": "0.1.4",
+    "@magicblock-labs/ephemeral-validator-linux-arm64": "0.1.4",
+    "@magicblock-labs/ephemeral-validator-linux-x64": "0.1.4",
+    "@magicblock-labs/ephemeral-validator-windows-x64": "0.1.4"
   },
   "publishConfig": {
     "access": "public"

--- a/.github/packages/npm-package/package.json.tmpl
+++ b/.github/packages/npm-package/package.json.tmpl
@@ -1,7 +1,7 @@
 {
   "name": "@magicblock-labs/${node_pkg}",
   "description": "Ephemeral Validator (${node_pkg})",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/magicblock-labs/ephemeral-validator.git"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -747,7 +747,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115e54d64eb62cdebad391c19efc9dce4981c690c85a33a12199d99bb9546fee"
 dependencies = [
  "borsh-derive 0.10.4",
- "hashbrown 0.12.3",
+ "hashbrown 0.13.2",
 ]
 
 [[package]]
@@ -1851,7 +1851,7 @@ dependencies = [
 
 [[package]]
 name = "expiring-hashmap"
-version = "0.1.3"
+version = "0.1.4"
 
 [[package]]
 name = "fake-simd"
@@ -2210,7 +2210,7 @@ dependencies = [
 
 [[package]]
 name = "geyser-grpc-proto"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3511,7 +3511,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-account-cloner"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "conjunto-transwise",
  "futures-util",
@@ -3532,7 +3532,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-account-dumper"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "bincode",
  "magicblock-bank",
@@ -3545,7 +3545,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-account-fetcher"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-trait",
  "conjunto-transwise",
@@ -3561,7 +3561,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-account-updates"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "bincode",
  "conjunto-transwise",
@@ -3582,7 +3582,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-accounts"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-trait",
  "conjunto-transwise",
@@ -3613,7 +3613,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-accounts-api"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "magicblock-bank",
  "solana-sdk",
@@ -3621,7 +3621,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-accounts-db"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "env_logger 0.11.6",
  "lmdb-rkv",
@@ -3638,7 +3638,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-api"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "agave-geyser-plugin-interface",
  "anyhow",
@@ -3683,7 +3683,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-bank"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "agave-geyser-plugin-interface",
  "assert_matches",
@@ -3724,7 +3724,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-config"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "isocountry",
  "magicblock-accounts-db",
@@ -3740,7 +3740,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-core"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "solana-sdk",
 ]
@@ -3763,7 +3763,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-geyser-plugin"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "agave-geyser-plugin-interface",
  "anyhow",
@@ -3792,7 +3792,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-ledger"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "bincode",
  "byteorder",
@@ -3811,7 +3811,7 @@ dependencies = [
  "solana-measure",
  "solana-metrics",
  "solana-sdk",
- "solana-storage-proto 0.1.3",
+ "solana-storage-proto 0.1.4",
  "solana-svm",
  "solana-timings",
  "solana-transaction-status",
@@ -3824,7 +3824,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-metrics"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "http-body-util",
  "hyper 1.5.2",
@@ -3838,7 +3838,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-mutator"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -3855,7 +3855,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-perf-service"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "log",
  "magicblock-bank",
@@ -3864,7 +3864,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-processor"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "lazy_static",
  "log",
@@ -3885,7 +3885,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-program"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -3906,7 +3906,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-pubsub"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "bincode",
  "geyser-grpc-proto",
@@ -3928,7 +3928,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-rpc"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "base64 0.21.7",
  "bincode",
@@ -3963,7 +3963,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-tokens"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "log",
  "magicblock-bank",
@@ -3978,7 +3978,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-transaction-status"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "crossbeam-channel",
  "log",
@@ -3990,7 +3990,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-version"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "rustc_version",
  "semver",
@@ -8719,7 +8719,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-proto"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "bincode",
  "bs58 0.4.0",
@@ -10056,7 +10056,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-bins"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "console-subscriber",
  "env_logger 0.11.6",
@@ -10071,7 +10071,7 @@ dependencies = [
 
 [[package]]
 name = "test-tools"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "log",
  "magicblock-accounts-db",
@@ -10090,7 +10090,7 @@ dependencies = [
 
 [[package]]
 name = "test-tools-core"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "env_logger 0.11.6",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ resolver = "2"
 
 [workspace.package]
 # Solana Version (2.2.x)
-version = "0.1.3"
+version = "0.1.4"
 authors = ["MagicBlock Maintainers <maintainers@magicblock.xyz>"]
 repository = "https://github.com/magicblock-labs/ephemeral-validator"
 homepage = "https://www.magicblock.xyz"


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Version bump from v0.1.3 to v0.1.4 across the MagicBlock validator project, updating version numbers in both Rust and Node.js package configurations.

- Updated workspace version to 0.1.4 in `Cargo.toml`
- Updated npm package version in `.github/packages/npm-package/package.json` and template
- All platform-specific dependencies consistently updated to v0.1.4
- Maintained existing dependency constraints and crates.io patches in `Cargo.toml`



<!-- /greptile_comment -->