### PR TITLE
release: v0.1.6

### DIFF
--- a/.github/packages/npm-package/package.json
+++ b/.github/packages/npm-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicblock-labs/ephemeral-validator",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "MagicBlock Ephemeral Validator",
   "homepage": "https://github.com/magicblock-labs/ephemeral-validator#readme",
   "bugs": {
@@ -27,11 +27,11 @@
     "typescript": "^4.9.4"
   },
   "optionalDependencies": {
-    "@magicblock-labs/ephemeral-validator-darwin-arm64": "0.1.5",
-    "@magicblock-labs/ephemeral-validator-darwin-x64": "0.1.5",
-    "@magicblock-labs/ephemeral-validator-linux-arm64": "0.1.5",
-    "@magicblock-labs/ephemeral-validator-linux-x64": "0.1.5",
-    "@magicblock-labs/ephemeral-validator-windows-x64": "0.1.5"
+    "@magicblock-labs/ephemeral-validator-darwin-arm64": "0.1.6",
+    "@magicblock-labs/ephemeral-validator-darwin-x64": "0.1.6",
+    "@magicblock-labs/ephemeral-validator-linux-arm64": "0.1.6",
+    "@magicblock-labs/ephemeral-validator-linux-x64": "0.1.6",
+    "@magicblock-labs/ephemeral-validator-windows-x64": "0.1.6"
   },
   "publishConfig": {
     "access": "public"

--- a/.github/packages/npm-package/package.json.tmpl
+++ b/.github/packages/npm-package/package.json.tmpl
@@ -1,7 +1,7 @@
 {
   "name": "@magicblock-labs/${node_pkg}",
   "description": "Ephemeral Validator (${node_pkg})",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/magicblock-labs/ephemeral-validator.git"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -747,7 +747,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115e54d64eb62cdebad391c19efc9dce4981c690c85a33a12199d99bb9546fee"
 dependencies = [
  "borsh-derive 0.10.4",
- "hashbrown 0.12.3",
+ "hashbrown 0.13.2",
 ]
 
 [[package]]
@@ -1851,7 +1851,7 @@ dependencies = [
 
 [[package]]
 name = "expiring-hashmap"
-version = "0.1.5"
+version = "0.1.6"
 
 [[package]]
 name = "fake-simd"
@@ -2210,7 +2210,7 @@ dependencies = [
 
 [[package]]
 name = "geyser-grpc-proto"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3511,7 +3511,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-account-cloner"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "conjunto-transwise",
  "flume",
@@ -3533,7 +3533,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-account-dumper"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "bincode",
  "magicblock-bank",
@@ -3546,7 +3546,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-account-fetcher"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "async-trait",
  "conjunto-transwise",
@@ -3562,7 +3562,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-account-updates"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "bincode",
  "conjunto-transwise",
@@ -3583,7 +3583,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-accounts"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "async-trait",
  "conjunto-transwise",
@@ -3614,7 +3614,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-accounts-api"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "magicblock-bank",
  "solana-sdk",
@@ -3622,7 +3622,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-accounts-db"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "env_logger 0.11.6",
  "lmdb-rkv",
@@ -3639,7 +3639,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-api"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "agave-geyser-plugin-interface",
  "anyhow",
@@ -3684,7 +3684,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-bank"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "agave-geyser-plugin-interface",
  "assert_matches",
@@ -3725,7 +3725,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-config"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "isocountry",
  "magicblock-accounts-db",
@@ -3741,7 +3741,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-core"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "solana-sdk",
 ]
@@ -3764,7 +3764,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-geyser-plugin"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "agave-geyser-plugin-interface",
  "anyhow",
@@ -3793,7 +3793,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-ledger"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "bincode",
  "byteorder",
@@ -3812,7 +3812,7 @@ dependencies = [
  "solana-measure",
  "solana-metrics",
  "solana-sdk",
- "solana-storage-proto 0.1.5",
+ "solana-storage-proto 0.1.6",
  "solana-svm",
  "solana-timings",
  "solana-transaction-status",
@@ -3825,7 +3825,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-metrics"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "http-body-util",
  "hyper 1.5.2",
@@ -3839,7 +3839,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-mutator"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -3856,7 +3856,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-perf-service"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "log",
  "magicblock-bank",
@@ -3865,7 +3865,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-processor"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "lazy_static",
  "log",
@@ -3886,7 +3886,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-program"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -3907,7 +3907,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-pubsub"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "bincode",
  "geyser-grpc-proto",
@@ -3929,7 +3929,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-rpc"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "base64 0.21.7",
  "bincode",
@@ -3964,7 +3964,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-tokens"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "log",
  "magicblock-bank",
@@ -3979,7 +3979,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-transaction-status"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "crossbeam-channel",
  "log",
@@ -3991,7 +3991,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-version"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "rustc_version",
  "semver",
@@ -8720,7 +8720,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-proto"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "bincode",
  "bs58 0.4.0",
@@ -10057,7 +10057,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-bins"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "console-subscriber",
  "env_logger 0.11.6",
@@ -10072,7 +10072,7 @@ dependencies = [
 
 [[package]]
 name = "test-tools"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "log",
  "magicblock-accounts-db",
@@ -10091,7 +10091,7 @@ dependencies = [
 
 [[package]]
 name = "test-tools-core"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "env_logger 0.11.6",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ resolver = "2"
 
 [workspace.package]
 # Solana Version (2.2.x)
-version = "0.1.5"
+version = "0.1.6"
 authors = ["MagicBlock Maintainers <maintainers@magicblock.xyz>"]
 repository = "https://github.com/magicblock-labs/ephemeral-validator"
 homepage = "https://www.magicblock.xyz"

--- a/test-integration/Cargo.lock
+++ b/test-integration/Cargo.lock
@@ -747,7 +747,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115e54d64eb62cdebad391c19efc9dce4981c690c85a33a12199d99bb9546fee"
 dependencies = [
  "borsh-derive 0.10.4",
- "hashbrown 0.12.3",
+ "hashbrown 0.13.2",
 ]
 
 [[package]]
@@ -1830,7 +1830,7 @@ dependencies = [
 
 [[package]]
 name = "expiring-hashmap"
-version = "0.1.5"
+version = "0.1.6"
 
 [[package]]
 name = "fake-simd"
@@ -2178,7 +2178,7 @@ dependencies = [
 
 [[package]]
 name = "geyser-grpc-proto"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3444,7 +3444,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-account-cloner"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "conjunto-transwise",
  "flume",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-account-dumper"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "bincode",
  "magicblock-bank",
@@ -3479,7 +3479,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-account-fetcher"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "async-trait",
  "conjunto-transwise",
@@ -3494,7 +3494,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-account-updates"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "bincode",
  "conjunto-transwise",
@@ -3513,7 +3513,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-accounts"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "async-trait",
  "conjunto-transwise",
@@ -3542,7 +3542,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-accounts-api"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "magicblock-bank",
  "solana-sdk",
@@ -3550,7 +3550,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-accounts-db"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "lmdb-rkv",
  "log",
@@ -3566,7 +3566,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-api"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "agave-geyser-plugin-interface",
  "anyhow",
@@ -3611,7 +3611,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-bank"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "agave-geyser-plugin-interface",
  "bincode",
@@ -3646,7 +3646,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-config"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "isocountry",
  "magicblock-accounts-db",
@@ -3661,7 +3661,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-core"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "solana-sdk",
 ]
@@ -3684,7 +3684,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-geyser-plugin"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "agave-geyser-plugin-interface",
  "anyhow",
@@ -3713,7 +3713,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-ledger"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "bincode",
  "byteorder",
@@ -3732,7 +3732,7 @@ dependencies = [
  "solana-measure",
  "solana-metrics",
  "solana-sdk",
- "solana-storage-proto 0.1.5",
+ "solana-storage-proto 0.1.6",
  "solana-svm",
  "solana-timings",
  "solana-transaction-status",
@@ -3743,7 +3743,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-metrics"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "http-body-util",
  "hyper 1.6.0",
@@ -3757,7 +3757,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-mutator"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "bincode",
  "log",
@@ -3770,7 +3770,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-perf-service"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "log",
  "magicblock-bank",
@@ -3779,7 +3779,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-processor"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "lazy_static",
  "log",
@@ -3800,7 +3800,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-program"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "bincode",
  "lazy_static",
@@ -3817,7 +3817,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-pubsub"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "bincode",
  "geyser-grpc-proto",
@@ -3839,7 +3839,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-rpc"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "base64 0.21.7",
  "bincode",
@@ -3874,7 +3874,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-tokens"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "log",
  "magicblock-bank",
@@ -3889,7 +3889,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-transaction-status"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "crossbeam-channel",
  "log",
@@ -3901,7 +3901,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-version"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "rustc_version",
  "semver",
@@ -8648,7 +8648,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-proto"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "bincode",
  "bs58 0.4.0",
@@ -10030,7 +10030,7 @@ dependencies = [
 
 [[package]]
 name = "test-tools-core"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "env_logger 0.11.6",
  "log",


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Version bump from 0.1.5 to 0.1.6 across package configurations, with repository path inconsistency identified.

- Version updated to 0.1.6 in `.github/packages/npm-package/package.json` and template files
- All platform-specific optional dependencies aligned to version 0.1.6
- Workspace version in `Cargo.toml` updated to 0.1.6
- Repository path in metadata still points to 'ephemeral-validator' instead of 'magicblock-validator', needs correction



<!-- /greptile_comment -->