### PR TITLE
Fixed graceful shutdown

### DIFF
--- a/test-bins/src/shutdown.rs
+++ b/test-bins/src/shutdown.rs
@@ -1,0 +1,35 @@
+use std::io;
+
+use log::info;
+use tokio::{signal, signal::unix::SignalKind};
+
+pub struct Shutdown;
+impl Shutdown {
+    pub async fn wait() -> Result<(), io::Error> {
+        #[cfg(unix)]
+        return Self::wait_unix().await;
+        #[cfg(not(unix))]
+        return Self::wait_other().await;
+    }
+
+    #[cfg(unix)]
+    async fn wait_unix() -> Result<(), io::Error> {
+        let mut terminate_signal =
+            signal::unix::signal(SignalKind::terminate())?;
+        tokio::select! {
+            _ = terminate_signal.recv() => {
+                info!("SIGTERM has been received, initiating graceful shutdown");
+            },
+            _ = tokio::signal::ctrl_c() => {
+                info!("ctr-c signal received, initiating graceful shutdown");
+            },
+        }
+
+        Ok(())
+    }
+
+    #[cfg(not(unix))]
+    async fn wait_other() -> Result<(), io::Error> {
+        tokio::signal::ctrl_c().await
+    }
+}

--- a/test-bins/src/shutdown.rs
+++ b/test-bins/src/shutdown.rs
@@ -21,7 +21,7 @@ impl Shutdown {
                 info!("SIGTERM has been received, initiating graceful shutdown");
             },
             _ = tokio::signal::ctrl_c() => {
-                info!("ctr-c signal received, initiating graceful shutdown");
+                info!("SIGINT signal received, initiating graceful shutdown");
             },
         }
 


### PR DESCRIPTION
Right now our validator doesn't handle SIGTERM, only SIGINT. 
This pr adds handling of SIGTERM signal

<!-- greptile_comment -->

## Greptile Summary

Enhanced validator shutdown handling by adding SIGTERM support alongside SIGINT, implementing a dedicated shutdown module for more robust signal management and cleanup.

- Added new `test-bins/src/shutdown.rs` implementing platform-aware signal handling for both SIGTERM and SIGINT
- Modified `test-bins/src/rpc.rs` to use the new Shutdown type for improved termination management
- Implemented proper error handling for shutdown failures
- Added platform-specific handling using `cfg` attributes to support both Unix and non-Unix systems



<!-- /greptile_comment -->