### PR TITLE
fix: don't block the accounts update loop with subscription

### DIFF
--- a/magicblock-account-cloner/src/remote_account_cloner_worker.rs
+++ b/magicblock-account-cloner/src/remote_account_cloner_worker.rs
@@ -24,6 +24,7 @@ use solana_sdk::{
     clock::Slot,
     pubkey::Pubkey,
     signature::Signature,
+    sysvar::clock,
 };
 use tokio::time::sleep;
 use tokio_util::sync::CancellationToken;
@@ -483,7 +484,7 @@ where
             loop {
                 fetch_count += 1;
                 let min_context_slot =
-                    self.account_updates.get_first_subscribed_slot(pubkey);
+                    self.account_updates.get_last_known_update_slot(&clock::ID);
                 match self
                     .fetch_account_chain_snapshot(pubkey, min_context_slot)
                     .await

--- a/magicblock-account-cloner/tests/remote_account_cloner.rs
+++ b/magicblock-account-cloner/tests/remote_account_cloner.rs
@@ -267,7 +267,7 @@ async fn test_clone_fails_stale_undelegated_account_when_ephemeral() {
     );
     // Account(s) involved
     let undelegated_account = Pubkey::new_unique();
-    account_updates.set_first_subscribed_slot(undelegated_account, 50); // Accounts subscribe is more recent than fetchable state
+    account_updates.set_last_known_update_slot(clock::ID, 50); // Accounts subscribe is more recent than fetchable state
     account_fetcher.set_undelegated_account(undelegated_account, 42);
     // Run test
     let result = cloner.clone_account(&undelegated_account).await;

--- a/magicblock-account-updates/src/remote_account_updates_worker.rs
+++ b/magicblock-account-updates/src/remote_account_updates_worker.rs
@@ -19,7 +19,7 @@ use tokio::{
 };
 use tokio_util::sync::CancellationToken;
 
-use crate::RemoteAccountUpdatesShard;
+use crate::{RemoteAccountUpdatesShard, RemoteAccountUpdatesShardError};
 
 const INFLIGHT_ACCOUNT_FETCHES_LIMIT: usize = 1024;
 
@@ -88,7 +88,7 @@ impl RemoteAccountUpdatesWorker {
     }
 
     pub async fn start_monitoring_request_processing(
-        &mut self,
+        mut self,
         cancellation_token: CancellationToken,
     ) {
         // Maintain a runner for each config passed as parameter
@@ -96,15 +96,22 @@ impl RemoteAccountUpdatesWorker {
         let mut monitored_accounts = HashSet::new();
         // Initialize all the runners for all configs
         for (index, url) in self.ws_urls.iter().enumerate() {
-            runners.push(
-                self.create_runner_from_config(
+            let runner = match self
+                .create_runner_from_config(
                     index,
                     url.clone(),
                     self.commitment,
                     &monitored_accounts,
                 )
-                .await,
-            );
+                .await
+            {
+                Ok(s) => s,
+                Err(e) => {
+                    warn!("failed to start monitoring runner {index}: {e}");
+                    continue;
+                }
+            };
+            runners.push(runner);
         }
         // Useful states
         let mut current_refresh_index = 0;
@@ -135,12 +142,19 @@ impl RemoteAccountUpdatesWorker {
                         .get(current_refresh_index)
                         .unwrap()
                         .clone();
-                    let new_runner = self.create_runner_from_config(
+                    let new_runner = match self.create_runner_from_config(
                         current_refresh_index,
                         url,
                         self.commitment,
                         &monitored_accounts
-                    ).await;
+                    ).await
+                    {
+                        Ok(r) => r,
+                        Err(e) => {
+                            warn!("failed to recreate shard runner {current_refresh_index}: {e}");
+                            continue;
+                        }
+                    };
                     let old_runner = std::mem::replace(&mut runners[current_refresh_index], new_runner);
                     // We hope it ultimately joins, but we don't care to wait for it, just let it be
                     self.cancel_and_join_runner(old_runner);
@@ -164,7 +178,8 @@ impl RemoteAccountUpdatesWorker {
         url: String,
         commitment: Option<CommitmentLevel>,
         monitored_accounts: &HashSet<Pubkey>,
-    ) -> RemoteAccountUpdatesWorkerRunner {
+    ) -> Result<RemoteAccountUpdatesWorkerRunner, RemoteAccountUpdatesShardError>
+    {
         let (monitoring_request_sender, monitoring_request_receiver) =
             channel(INFLIGHT_ACCOUNT_FETCHES_LIMIT);
         let first_subscribed_slots = self.first_subscribed_slots.clone();
@@ -173,26 +188,18 @@ impl RemoteAccountUpdatesWorker {
         let cancellation_token = CancellationToken::new();
         let shard_id = runner_id.clone();
         let shard_cancellation_token = cancellation_token.clone();
-        let join_handle = tokio::spawn(async move {
-            let mut shard = RemoteAccountUpdatesShard::new(
-                shard_id.clone(),
-                url,
-                commitment,
-                monitoring_request_receiver,
-                first_subscribed_slots,
-                last_known_update_slots,
-            );
-            if let Err(error) = shard
-                .start_monitoring_request_processing(shard_cancellation_token)
-                .await
-            {
-                #[cfg(not(test))]
-                error!("Runner shard has failed: {}: {:?}", shard_id, error);
-
-                #[cfg(test)]
-                panic!("Runner shard has failed: {}: {:?}", shard_id, error);
-            }
-        });
+        let shard = RemoteAccountUpdatesShard::new(
+            shard_id.clone(),
+            url,
+            commitment,
+            monitoring_request_receiver,
+            first_subscribed_slots,
+            last_known_update_slots,
+        )
+        .await?;
+        let join_handle = tokio::spawn(
+            shard.start_monitoring_request_processing(shard_cancellation_token),
+        );
         let runner = RemoteAccountUpdatesWorkerRunner {
             id: runner_id,
             monitoring_request_sender,
@@ -204,7 +211,7 @@ impl RemoteAccountUpdatesWorker {
             self.notify_runner_of_monitoring_request(&runner, *pubkey, false)
                 .await;
         }
-        runner
+        Ok(runner)
     }
 
     async fn notify_runner_of_monitoring_request(

--- a/magicblock-account-updates/src/remote_account_updates_worker.rs
+++ b/magicblock-account-updates/src/remote_account_updates_worker.rs
@@ -96,15 +96,15 @@ impl RemoteAccountUpdatesWorker {
         let mut monitored_accounts = HashSet::new();
         // Initialize all the runners for all configs
         for (index, url) in self.ws_urls.iter().enumerate() {
-            let runner = match self
+            let result = self
                 .create_runner_from_config(
                     index,
                     url.clone(),
                     self.commitment,
                     &monitored_accounts,
                 )
-                .await
-            {
+                .await;
+            let runner = match result {
                 Ok(s) => s,
                 Err(e) => {
                     warn!("failed to start monitoring runner {index}: {e}");
@@ -142,13 +142,14 @@ impl RemoteAccountUpdatesWorker {
                         .get(current_refresh_index)
                         .unwrap()
                         .clone();
-                    let new_runner = match self.create_runner_from_config(
+                    let result = self.create_runner_from_config(
                         current_refresh_index,
                         url,
                         self.commitment,
                         &monitored_accounts
-                    ).await
-                    {
+                    ).await;
+
+                    let new_runner = match result {
                         Ok(r) => r,
                         Err(e) => {
                             warn!("failed to recreate shard runner {current_refresh_index}: {e}");

--- a/magicblock-account-updates/tests/remote_account_updates.rs
+++ b/magicblock-account-updates/tests/remote_account_updates.rs
@@ -83,7 +83,7 @@ async fn test_devnet_monitoring_multiple_accounts_at_the_same_time() {
     assert!(client.get_last_known_update_slot(&sysvar_rent).is_none());
     assert!(client.get_last_known_update_slot(&sysvar_sh).is_none());
     // Start monitoring the accounts now
-    //assert!(client.ensure_account_monitoring(&sysvar_rent).await.is_ok());
+    assert!(client.ensure_account_monitoring(&sysvar_rent).await.is_ok());
     assert!(client.ensure_account_monitoring(&sysvar_sh).await.is_ok());
     assert!(client
         .ensure_account_monitoring(&sysvar_clock)

--- a/magicblock-account-updates/tests/remote_account_updates.rs
+++ b/magicblock-account-updates/tests/remote_account_updates.rs
@@ -21,7 +21,7 @@ async fn setup() -> (
 ) {
     let _ = env_logger::builder().is_test(true).try_init();
     // Create account updates worker and client
-    let mut worker = RemoteAccountUpdatesWorker::new(
+    let worker = RemoteAccountUpdatesWorker::new(
         vec![RpcProviderConfig::devnet().ws_url().into(); 1],
         Some(solana_sdk::commitment_config::CommitmentLevel::Confirmed),
         Duration::from_secs(50 * 60),
@@ -31,14 +31,12 @@ async fn setup() -> (
     let cancellation_token = CancellationToken::new();
     let worker_handle = {
         let cancellation_token = cancellation_token.clone();
-        tokio::spawn(async move {
-            worker
-                .start_monitoring_request_processing(cancellation_token)
-                .await
-        })
+        tokio::spawn(
+            worker.start_monitoring_request_processing(cancellation_token),
+        )
     };
     // wait a bit for websocket connections to establish
-    sleep(Duration::from_millis(5_000)).await;
+    sleep(Duration::from_millis(2_000)).await;
     // Ready to run
     (client, cancellation_token, worker_handle)
 }
@@ -85,14 +83,14 @@ async fn test_devnet_monitoring_multiple_accounts_at_the_same_time() {
     assert!(client.get_last_known_update_slot(&sysvar_rent).is_none());
     assert!(client.get_last_known_update_slot(&sysvar_sh).is_none());
     // Start monitoring the accounts now
-    assert!(client.ensure_account_monitoring(&sysvar_rent).await.is_ok());
+    //assert!(client.ensure_account_monitoring(&sysvar_rent).await.is_ok());
     assert!(client.ensure_account_monitoring(&sysvar_sh).await.is_ok());
     assert!(client
         .ensure_account_monitoring(&sysvar_clock)
         .await
         .is_ok());
-    // Wait for a few slots to happen on-chain
     sleep(Duration::from_millis(3_000)).await;
+    // Wait for a few slots to happen on-chain
     // Check that we detected the accounts changes
     assert!(client.get_last_known_update_slot(&sysvar_rent).is_none()); // Rent doesn't change
     assert!(client.get_last_known_update_slot(&sysvar_sh).is_some());

--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -709,7 +709,7 @@ impl MagicValidator {
     }
 
     fn start_remote_account_updates_worker(&mut self) {
-        if let Some(mut remote_account_updates_worker) =
+        if let Some(remote_account_updates_worker) =
             self.remote_account_updates_worker.take()
         {
             let cancellation_token = self.token.clone();


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Major refactoring of account subscription handling in Magicblock validator to prevent blocking operations and improve reliability of account updates processing.

- Changed `magicblock-account-updates/src/remote_account_updates_shard.rs` to use async subscription model with `BinaryHeap` for client management
- Modified `magicblock-account-updates/src/remote_account_updates_worker.rs` to handle subscription failures gracefully without blocking
- Updated account staleness detection in `magicblock-account-cloner/src/remote_account_cloner_worker.rs` to use clock sysvar instead of individual subscription slots
- Reduced WebSocket connection wait times and improved test efficiency in `magicblock-account-updates/tests/remote_account_updates.rs`
- Removed unnecessary `mut` qualifiers from worker instances across multiple files



<!-- /greptile_comment -->