### PR TITLE
chore: issues were displayed incorrectly

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
   <p>
     <a href="https://docs.magicblock.gg/Accelerate/ephemeral_rollups"><img alt="Documentation" src="https://img.shields.io/badge/docs-tutorials-blueviolet" /></a>
-    <a href="https://github.com/magicblock-labs/bolt/issues"><img alt="Issues" src="https://img.shields.io/github/issues/magicblock-labs/ephemeral-validator?color=blueviolet" /></a>
+    <a href="https://github.com/magicblock-labs/bolt/issues"><img alt="Issues" src="https://img.shields.io/github/issues/magicblock-labs/magicblock-validator?color=blueviolet" /></a>
     <a href="https://discord.com/invite/MBkdC3gxcv"><img alt="Discord Chat" src="https://img.shields.io/discord/943797222162726962?color=blueviolet" /></a>
   </p>
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
   <p>
     <a href="https://docs.magicblock.gg/Accelerate/ephemeral_rollups"><img alt="Documentation" src="https://img.shields.io/badge/docs-tutorials-blueviolet" /></a>
-    <a href="https://github.com/magicblock-labs/bolt/issues"><img alt="Issues" src="https://img.shields.io/github/issues/magicblock-labs/magicblock-validator?color=blueviolet" /></a>
+    <a href="https://github.com/magicblock-labs/magicblock-validator/issues"><img alt="Issues" src="https://img.shields.io/github/issues/magicblock-labs/magicblock-validator?color=blueviolet" /></a>
     <a href="https://discord.com/invite/MBkdC3gxcv"><img alt="Discord Chat" src="https://img.shields.io/discord/943797222162726962?color=blueviolet" /></a>
   </p>
 


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Updates GitHub issues badge URL in README.md to fix incorrect display, changing repository name from 'ephemeral-validator' to 'magicblock-validator'.

- Fixed repository name in issues badge URL from 'ephemeral-validator' to 'magicblock-validator' in `README.md`
- **Issue**: Badge link URL still references 'bolt' repository instead of 'magicblock-validator', needs to be updated for full functionality



<!-- /greptile_comment -->