### PR TITLE
chore: increase compute budget for table mania create lookup table

### DIFF
--- a/magicblock-table-mania/src/compute_budget.rs
+++ b/magicblock-table-mania/src/compute_budget.rs
@@ -5,7 +5,12 @@ use solana_sdk::{
 /// Compute units required to create and extend a lookup table, with the initial
 /// pubkeys. This is the same no matter how many pubkeys are added to the table
 /// initially.
-pub const CREATE_AND_EXTEND_TABLE_CUS: u32 = 2_400;
+/// The added 250 ensure we don't run out of CUs due to variation in the PDA derivation.
+/// Only the create table instruction has one, see
+/// https://github.com/solana-program/address-lookup-table/blob/main/program/src/processor.rs .
+/// This test repo (https://github.com/thlorenz/create-program-address-cus) verified
+/// that the variation is around 25 CUs, but to be on the safe side we add 10x that.
+pub const CREATE_AND_EXTEND_TABLE_CUS: u32 = 2_400 + 250;
 /// Compute units required to extend a lookup table with additional pubkeys
 /// This is the same no matter how many pubkeys are added to the table.
 pub const EXTEND_TABLE_CUS: u32 = 1_200;

--- a/test-integration/test-table-mania/tests/ix_lookup_table.rs
+++ b/test-integration/test-table-mania/tests/ix_lookup_table.rs
@@ -250,7 +250,7 @@ async fn test_lookup_table_ixs_cus_per_pubkey() {
         let cus = get_tx_cus(&rpc_client, &init_sig).await;
 
         debug!("Create for {i:03} {cus:04}CUs");
-        assert_eq!(cus, CREATE_AND_EXTEND_TABLE_CUS as u64);
+        assert!(cus <= CREATE_AND_EXTEND_TABLE_CUS as u64);
 
         lookup_table
             .extend(


### PR DESCRIPTION
## Summary

Increased the compute budget for creating lookup tables in table mania from 2,400 to 2,650 compute units to account for variation in PDA derivation costs.

## Detail

The create lookup table instruction includes PDA derivation which can vary in compute unit consumption by approximately 25 CUs. To ensure we don't run out of compute units due to this variation, we've added a safety buffer of 250 CUs (10x the observed variation).

Changes made:
- Updated `CREATE_AND_EXTEND_TABLE_CUS` constant from 2,400 to 2,650 CUs
- Added detailed documentation explaining the reasoning and referencing test data
- Modified integration test to use `assert!` instead of `assert_eq!` to allow for CU variation below the budgeted amount

The 250 CU buffer ensures reliable execution while maintaining efficiency, as verified by test repository data showing PDA derivation variation around 25 CUs.