### PR TITLE
chore: avoid CU budget exceeded for lookup table management

### DIFF
--- a/magicblock-table-mania/src/compute_budget.rs
+++ b/magicblock-table-mania/src/compute_budget.rs
@@ -2,6 +2,14 @@ use solana_sdk::{
     compute_budget::ComputeBudgetInstruction, instruction::Instruction,
 };
 
+/// We multiply the CU values that we determined since we've seen compute budget exceeded errors
+/// if we use them as is. The only way to determine CUs for a particular transaction 100% is
+/// to simulate that exact transaction.
+/// This would make table management even slower, but is an option to consider for the future.
+/// The multiplier is based on the observation that [CREATE_AND_EXTEND_TABLE_CUS] were _safe_ at
+/// 16K-17K CUs which we slightly exceed if we multiply by this multiplier.
+const SAFETY_MULTIPLIER: u32 = 7;
+
 /// Compute units required to create and extend a lookup table, with the initial
 /// pubkeys. This is the same no matter how many pubkeys are added to the table
 /// initially.
@@ -10,14 +18,14 @@ use solana_sdk::{
 /// https://github.com/solana-program/address-lookup-table/blob/main/program/src/processor.rs .
 /// This test repo (https://github.com/thlorenz/create-program-address-cus) verified
 /// that the variation is around 25 CUs, but to be on the safe side we add 10x that.
-pub const CREATE_AND_EXTEND_TABLE_CUS: u32 = 2_400 + 250;
+pub const CREATE_AND_EXTEND_TABLE_CUS: u32 = (2_400 + 250) * SAFETY_MULTIPLIER;
 /// Compute units required to extend a lookup table with additional pubkeys
 /// This is the same no matter how many pubkeys are added to the table.
-pub const EXTEND_TABLE_CUS: u32 = 1_200;
+pub const EXTEND_TABLE_CUS: u32 = 1_200 * SAFETY_MULTIPLIER;
 /// Compute units required to deactivate a lookup table.
-pub const DEACTIVATE_TABLE_CUS: u32 = 1_050;
+pub const DEACTIVATE_TABLE_CUS: u32 = 1_050 * SAFETY_MULTIPLIER;
 /// Compute units required to close a lookup table.
-pub const CLOSE_TABLE_CUS: u32 = 1_050;
+pub const CLOSE_TABLE_CUS: u32 = 1_050 * SAFETY_MULTIPLIER;
 
 #[derive(Clone)]
 pub struct TableManiaComputeBudget {

--- a/test-integration/test-table-mania/tests/ix_lookup_table.rs
+++ b/test-integration/test-table-mania/tests/ix_lookup_table.rs
@@ -267,7 +267,7 @@ async fn test_lookup_table_ixs_cus_per_pubkey() {
             *lookup_table.extend_signatures().unwrap().last().unwrap();
         let cus = get_tx_cus(&rpc_client, &extend_sig).await;
         debug!("Extend for {i:03} CUs  {cus:04}CUs");
-        assert_eq!(cus, EXTEND_TABLE_CUS as u64);
+        assert!(cus <= EXTEND_TABLE_CUS as u64);
 
         lookup_table
             .deactivate(&rpc_client, &validator_auth, &budgets.deactivate)
@@ -280,7 +280,7 @@ async fn test_lookup_table_ixs_cus_per_pubkey() {
         )
         .await;
         debug!("Deactivate table {cus:03}CUs");
-        assert_eq!(cus, DEACTIVATE_TABLE_CUS as u64);
+        assert!(cus <= DEACTIVATE_TABLE_CUS as u64);
 
         #[cfg(feature = "test_table_close")]
         {
@@ -305,7 +305,7 @@ async fn test_lookup_table_ixs_cus_per_pubkey() {
                 assert!(is_closed);
                 let cus = get_tx_cus(&rpc_client, &close_sig.unwrap()).await;
                 debug!("Close table {cus:03}CUs",);
-                assert_eq!(cus, CLOSE_TABLE_CUS as u64);
+                assert!(cus <= CLOSE_TABLE_CUS as u64);
             }
         }
     }


### PR DESCRIPTION
## Summary

Multiply all current budget values by `7` in order to avoid CU budget exceeded issues when
managing lookup tables.

<!-- greptile_comment -->

## Greptile Summary

This PR addresses compute unit (CU) budget exceeded errors in lookup table management operations by introducing a safety multiplier of 7x to all CU budget values. The change affects create/extend, extend, deactivate, and close table operations in the table-mania module.

Key changes:
- Introduces `SAFETY_MULTIPLIER: u32 = 7`
- Updates compute unit budgets for table operations:
  - Create and extend: ~18,550 CUs (up from ~2,650)
  - Extend: 8,400 CUs (up from 1,200)
  - Deactivate: 7,350 CUs (up from 1,050)
  - Close: 7,350 CUs (up from 1,050)

The PR also updates test assertions to use upper bounds instead of exact matches for CU consumption, making tests more resilient to variations in actual CU usage.

## Confidence score: 4/5

1. This PR is safe to merge as it conservatively increases compute budgets based on empirical observations
2. The score of 4 reflects that while the changes are well-tested and solve an immediate issue, the 7x multiplier is somewhat arbitrary and might be more than necessary
3. Files needing attention:
   - magicblock-table-mania/src/compute_budget.rs - verify if 7x multiplier is the optimal value

<sub>2 files reviewed, no comments</sub>
<sub>[Edit PR Review Bot Settings](https://app.greptile.com/review/github) | [Greptile](https://greptile.com?utm_source=greptile_expert&utm_medium=github&utm_campaign=code_reviews&utm_content=magicblock-validator_455)</sub>

<!-- /greptile_comment -->