### PR TITLE
feat: Add startup fee claiming with secure keypair handling

### DIFF
--- a/magicblock-api/src/errors.rs
+++ b/magicblock-api/src/errors.rs
@@ -89,5 +89,14 @@ pub enum ApiError {
 
     #[error("Accounts Database couldn't be initialized"
     )]
-    AccountsDbError(#[from] AccountsDbError)
+    AccountsDbError(#[from] AccountsDbError),
+
+    #[error("Failed to claim fees: {0}")]
+    FailedToClaimFees(String),
+
+    #[error("Failed to get blockhash: {0}")]
+    FailedToGetBlockhash(String),
+
+    #[error("Failed to send transaction: {0}")]
+    FailedToSendTransaction(String),
 }


### PR DESCRIPTION
Implements fee claiming on validator startup per Issue #303. 

- Adds `claim_fees method` to build/send delegation program's ValidatorClaimFees instruction
- Uses Arc<Keypair> for safe signing without clones.
- includes comments for clarity. No periodicity yet – can add if needed. 
- Fixes security cloning issue.