### PR TITLE
feat(config): derive merge

### DIFF
--- a/.github/workflows/ci-test-unit.yml
+++ b/.github/workflows/ci-test-unit.yml
@@ -25,6 +25,9 @@ jobs:
 
       - uses: ./magicblock-validator/.github/actions/setup-solana
 
+      - name: Install cargo-expand
+        run: cargo install cargo-expand
+
       - name: Run unit tests
         run: |
           sudo prlimit --pid $$ --nofile=1048576:1048576

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1616,6 +1616,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3601,6 +3607,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "macrotest"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0597a8d49ceeea5845b12d1970aa993261e68d4660b327eabab667b3e7ffd60"
+dependencies = [
+ "diff",
+ "fastrand",
+ "glob",
+ "prettyplease 0.2.35",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "syn 2.0.104",
+ "toml_edit",
+]
+
+[[package]]
 name = "magic-domain-program"
 version = "0.0.1"
 source = "git+https://github.com/magicblock-labs/magic-domain-program.git?rev=ea04d46#ea04d4646ede8e19307683d288e582bf60a3547a"
@@ -3904,11 +3927,13 @@ version = "0.1.7"
 dependencies = [
  "clap 4.5.40",
  "convert_case 0.8.0",
+ "macrotest",
  "magicblock-config-helpers",
  "proc-macro2",
  "quote",
  "serde",
  "syn 2.0.104",
+ "trybuild",
 ]
 
 [[package]]
@@ -5071,6 +5096,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5210,7 +5245,7 @@ dependencies = [
  "log",
  "multimap",
  "petgraph",
- "prettyplease",
+ "prettyplease 0.1.25",
  "prost 0.11.9",
  "prost-types 0.11.9",
  "regex",
@@ -6129,6 +6164,15 @@ name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
 dependencies = [
  "serde",
 ]
@@ -10454,6 +10498,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-triple"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac9aa371f599d22256307c24a9d748c041e548cbf599f35d890f9d365361790"
+
+[[package]]
 name = "tarpc"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10852,9 +10902,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_edit",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed0aee96c12fa71097902e0bb061a5e1ebd766a6636bb605ba401c45c1650eac"
+dependencies = [
+ "indexmap 2.10.0",
+ "serde",
+ "serde_spanned 1.0.0",
+ "toml_datetime 0.7.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
 ]
 
 [[package]]
@@ -10867,6 +10932,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10874,9 +10948,18 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap 2.10.0",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97200572db069e74c512a14117b296ba0a80a30123fbbb5aa1f4a348f639ca30"
+dependencies = [
  "winnow",
 ]
 
@@ -10885,6 +10968,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
 
 [[package]]
 name = "tonic"
@@ -10952,7 +11041,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6fdaae4c2c638bb70fe42803a26fbd6fc6ac8c72f5c59f67ecc2a2dcabf4b07"
 dependencies = [
- "prettyplease",
+ "prettyplease 0.1.25",
  "proc-macro2",
  "prost-build",
  "quote",
@@ -11076,6 +11165,21 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "trybuild"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65af40ad689f2527aebbd37a0a816aea88ff5f774ceabe99de5be02f2f91dae2"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-triple",
+ "termcolor",
+ "toml 0.9.2",
+]
 
 [[package]]
 name = "tungstenite"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3883,6 +3883,7 @@ dependencies = [
  "bs58 0.4.0",
  "clap 4.5.40",
  "isocountry",
+ "magicblock-config-helpers",
  "magicblock-config-macro",
  "serde",
  "solana-sdk",
@@ -3894,11 +3895,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "magicblock-config-helpers"
+version = "0.1.7"
+
+[[package]]
 name = "magicblock-config-macro"
 version = "0.1.7"
 dependencies = [
  "clap 4.5.40",
  "convert_case 0.8.0",
+ "magicblock-config-helpers",
  "proc-macro2",
  "quote",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,6 +163,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_colours"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14eec43e0298190790f41679fe69ef7a829d2a2ddd78c8c00339e84710e435fe"
+dependencies = [
+ "rgb",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -621,6 +630,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bat"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab792c2ad113a666f08856c88cdec0a62d732559b1f3982eedf0142571e669a"
+dependencies = [
+ "ansi_colours",
+ "anyhow",
+ "bincode",
+ "bytesize",
+ "clircle",
+ "console 0.15.11",
+ "content_inspector",
+ "encoding_rs",
+ "flate2",
+ "globset",
+ "grep-cli",
+ "home",
+ "indexmap 2.10.0",
+ "itertools 0.13.0",
+ "nu-ansi-term",
+ "once_cell",
+ "path_abs",
+ "plist",
+ "regex",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_with",
+ "serde_yaml",
+ "shell-words",
+ "syntect",
+ "terminal-colorsaurus",
+ "thiserror 1.0.69",
+ "toml 0.8.23",
+ "unicode-width 0.1.14",
+ "walkdir",
+]
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -651,12 +699,27 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -852,6 +915,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
 dependencies = [
  "memchr",
+ "regex-automata 0.4.9",
  "serde",
 ]
 
@@ -920,6 +984,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
+name = "bytesize"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e93abca9e28e0a1b9877922aacb20576e05d4679ffa78c3d6dc22a26a216659"
+
+[[package]]
 name = "bzip2"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -950,6 +1020,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo-expand"
+version = "1.0.113"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cc7758391e465c46231206c889f32087f9374081f83a7c6e60e40cba32cd5eb"
+dependencies = [
+ "bat",
+ "cargo-subcommand-metadata",
+ "clap 4.5.40",
+ "clap-cargo",
+ "console 0.16.0",
+ "fs-err",
+ "home",
+ "prettyplease 0.2.35",
+ "proc-macro2",
+ "quote",
+ "semver",
+ "serde",
+ "shlex",
+ "syn 2.0.104",
+ "syn-select",
+ "tempfile",
+ "termcolor",
+ "toml 0.9.2",
+ "toolchain_find",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "cargo-lock"
 version = "10.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -960,6 +1058,12 @@ dependencies = [
  "toml 0.8.23",
  "url 2.5.4",
 ]
+
+[[package]]
+name = "cargo-subcommand-metadata"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33d3b80a8db16c4ad7676653766a8e59b5f95443c8823cb7cff587b90cb91ba"
 
 [[package]]
 name = "cc"
@@ -1087,6 +1191,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap-cargo"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6affd9fc8702a94172345c11fa913aa84601cd05e187af166dcd48deff27b8d"
+dependencies = [
+ "anstyle",
+ "clap 4.5.40",
+]
+
+[[package]]
 name = "clap_builder"
 version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1115,6 +1229,16 @@ name = "clap_lex"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
+name = "clircle"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d9334f725b46fb9bed8580b9b47a932587e044fadb344ed7fa98774b067ac1a"
+dependencies = [
+ "cfg-if 1.0.1",
+ "windows 0.56.0",
+]
 
 [[package]]
 name = "colorchoice"
@@ -1311,6 +1435,15 @@ name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
+name = "content_inspector"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7bda66e858c683005a53a9a60c69a4aca7eeaa45d124526e389f7aec8e62f38"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "convert_case"
@@ -1935,6 +2068,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set 0.5.3",
+ "regex",
+]
+
+[[package]]
 name = "fast-math"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2089,6 +2232,15 @@ name = "fragile"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
+
+[[package]]
+name = "fs-err"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d7be93788013f265201256d58f04936a8079ad5dc898743aa20525f503b683"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "fs_extra"
@@ -2394,6 +2546,20 @@ dependencies = [
  "rand 0.8.5",
  "smallvec",
  "spinning_top",
+]
+
+[[package]]
+name = "grep-cli"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47f1288f0e06f279f84926fa4c17e3fcd2a22b357927a82f2777f7be26e4cec0"
+dependencies = [
+ "bstr",
+ "globset",
+ "libc",
+ "log",
+ "termcolor",
+ "winapi-util",
 ]
 
 [[package]]
@@ -2811,7 +2977,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -3013,6 +3179,7 @@ dependencies = [
  "equivalent",
  "hashbrown 0.15.4",
  "rayon",
+ "serde",
 ]
 
 [[package]]
@@ -3091,6 +3258,15 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -3925,6 +4101,7 @@ version = "0.1.7"
 name = "magicblock-config-macro"
 version = "0.1.7"
 dependencies = [
+ "cargo-expand",
  "clap 4.5.40",
  "convert_case 0.8.0",
  "macrotest",
@@ -4512,6 +4689,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "num"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4859,6 +5045,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "path_abs"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ef02f6342ac01d8a93b65f96db53fe68a92a15f41144f97fb00a9e669633c3"
+dependencies = [
+ "std_prelude",
+]
+
+[[package]]
 name = "pbkdf2"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4997,6 +5192,19 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plist"
+version = "1.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3af6b589e163c5a788fab00ce0c0366f6efbb9959c2f9874b224936af7fce7e1"
+dependencies = [
+ "base64 0.22.1",
+ "indexmap 2.10.0",
+ "quick-xml",
+ "serde",
+ "time",
+]
 
 [[package]]
 name = "polyval"
@@ -5198,8 +5406,8 @@ version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fcdab19deb5195a31cf7726a210015ff1496ba1464fd42cb4f537b8b01b471f"
 dependencies = [
- "bit-set",
- "bit-vec",
+ "bit-set 0.8.0",
+ "bit-vec 0.8.0",
  "bitflags 2.9.1",
  "lazy_static",
  "num-traits",
@@ -5353,6 +5561,15 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-xml"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8927b0664f5c5a98265138b7e3f90aa19a6b21353182469ace36d4ac527b7b1b"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "quinn"
@@ -5626,7 +5843,7 @@ dependencies = [
  "cfg-if 1.0.1",
  "libc",
  "rustix 1.0.7",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -5733,6 +5950,15 @@ dependencies = [
  "serde",
  "task-local-extensions",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "rgb"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -10325,6 +10551,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "std_prelude"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8207e78455ffdf55661170876f88daf85356e4edd54e0a3dbc79586ca1e50cbe"
+
+[[package]]
 name = "stream-cancel"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10428,6 +10660,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn-select"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea24402791e2625a28bcaf662046e09a48a7610f806688cf35901d78ba938bb4"
+dependencies = [
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10454,6 +10695,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "syntect"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874dcfa363995604333cf947ae9f751ca3af4522c60886774c4963943b4746b1"
+dependencies = [
+ "bincode",
+ "bitflags 1.3.2",
+ "fancy-regex",
+ "flate2",
+ "fnv",
+ "once_cell",
+ "regex-syntax 0.8.5",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "thiserror 1.0.69",
+ "walkdir",
 ]
 
 [[package]]
@@ -10567,6 +10828,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "terminal-colorsaurus"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7afe4c174a3cbfb52ebcb11b28965daf74fe9111d4e07e40689d05af06e26e8"
+dependencies = [
+ "cfg-if 1.0.1",
+ "libc",
+ "memchr",
+ "mio 1.0.4",
+ "terminal-trx",
+ "windows-sys 0.59.0",
+ "xterm-color",
+]
+
+[[package]]
+name = "terminal-trx"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "975b4233aefa1b02456d5e53b22c61653c743e308c51cf4181191d8ce41753ab"
+dependencies = [
+ "cfg-if 1.0.1",
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10901,6 +11188,7 @@ version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
+ "indexmap 2.10.0",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
@@ -11059,6 +11347,19 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic 0.9.2",
+]
+
+[[package]]
+name = "toolchain_find"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc8c9a7f0a2966e1acdaf0461023d0b01471eeead645370cf4c3f5cff153f2a"
+dependencies = [
+ "home",
+ "once_cell",
+ "regex",
+ "semver",
+ "walkdir",
 ]
 
 [[package]]
@@ -11641,12 +11942,22 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de69df01bdf1ead2f4ac895dc77c9351aefff65b2f3db429a343f9cbf05e132"
+dependencies = [
+ "windows-core 0.56.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
- "windows-core",
+ "windows-core 0.61.2",
  "windows-future",
  "windows-link",
  "windows-numerics",
@@ -11658,7 +11969,19 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4698e52ed2d08f8658ab0c39512a7c00ee5fe2688c65f8c0a4f06750d729f2a6"
+dependencies = [
+ "windows-implement 0.56.0",
+ "windows-interface 0.56.0",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -11667,10 +11990,10 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.0",
+ "windows-interface 0.59.1",
  "windows-link",
- "windows-result",
+ "windows-result 0.3.4",
  "windows-strings",
 ]
 
@@ -11680,9 +12003,20 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link",
  "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -11690,6 +12024,17 @@ name = "windows-implement"
 version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11719,8 +12064,17 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -12108,6 +12462,12 @@ dependencies = [
  "libc",
  "rustix 1.0.7",
 ]
+
+[[package]]
+name = "xterm-color"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4de5f056fb9dc8b7908754867544e26145767187aaac5a98495e88ad7cb8a80f"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ borsh-derive = "1.5.1"
 bs58 = "0.4.0"
 byteorder = "1.5.0"
 cargo-lock = "10.0.0"
+cargo-expand = "1"
 clap = "4.5.40"
 convert_case = "0.8.0"
 conjunto-transwise = { git = "https://github.com/magicblock-labs/conjunto.git", rev = "bf82b45" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ lazy_static = "1.4.0"
 libc = "0.2.153"
 libloading = "0.7.4"
 log = "0.4.20"
+macrotest = "1"
 magicblock-account-cloner = { path = "./magicblock-account-cloner" }
 magicblock-account-dumper = { path = "./magicblock-account-dumper" }
 magicblock-account-fetcher = { path = "./magicblock-account-fetcher" }
@@ -205,6 +206,7 @@ toml = "0.8.13"
 tonic = "0.9.2"
 tonic-build = "0.9.2"
 tonic-health = "0.9.2"
+trybuild = "1.0"
 url = "2.5.0"
 vergen = "8.3.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
   "magicblock-committor-program",
   "magicblock-committor-service",
   "magicblock-config",
+  "magicblock-config-helpers",
   "magicblock-config-macro",
   "magicblock-core",
   "magicblock-geyser-plugin",
@@ -110,6 +111,7 @@ magicblock-committor-program = { path = "./magicblock-committor-program", featur
 ] }
 magicblock-committor-service = { path = "./magicblock-committor-service" }
 magicblock-config = { path = "./magicblock-config" }
+magicblock-config-helpers = { path = "./magicblock-config-helpers" }
 magicblock-config-macro = { path = "./magicblock-config-macro" }
 magicblock-core = { path = "./magicblock-core" }
 magicblock-delegation-program = { git = "https://github.com/magicblock-labs/delegation-program.git", rev = "4af7f1c" }

--- a/magicblock-config-helpers/Cargo.toml
+++ b/magicblock-config-helpers/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "magicblock-config-helpers"
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+license.workspace = true
+edition.workspace = true
+
+[dependencies]

--- a/magicblock-config-helpers/src/lib.rs
+++ b/magicblock-config-helpers/src/lib.rs
@@ -1,0 +1,3 @@
+pub trait Merge: Default {
+    fn merge(&mut self, other: Self);
+}

--- a/magicblock-config-macro/Cargo.toml
+++ b/magicblock-config-macro/Cargo.toml
@@ -17,3 +17,6 @@ quote = { workspace = true }
 syn = { workspace = true, features = ["full", "visit-mut"] }
 clap = { workspace = true, features = ["derive", "env"] }
 serde = { workspace = true, features = ["derive"] }
+
+[dev-dependencies]
+magicblock-config-helpers = { workspace = true }

--- a/magicblock-config-macro/Cargo.toml
+++ b/magicblock-config-macro/Cargo.toml
@@ -20,3 +20,5 @@ serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 magicblock-config-helpers = { workspace = true }
+trybuild = { workspace = true }
+macrotest = { workspace = true }

--- a/magicblock-config-macro/Cargo.toml
+++ b/magicblock-config-macro/Cargo.toml
@@ -22,3 +22,4 @@ serde = { workspace = true, features = ["derive"] }
 magicblock-config-helpers = { workspace = true }
 trybuild = { workspace = true }
 macrotest = { workspace = true }
+cargo-expand = { workspace = true }

--- a/magicblock-config-macro/README.md
+++ b/magicblock-config-macro/README.md
@@ -72,3 +72,9 @@ struct RpcConfig {
     config: SomeOtherConfig,
 }
 ```
+
+## `derive(Mergeable)`
+
+This macro will implement the `magicblock_config_helpers::Merge` trait for annotated struct. 
+
+### Example

--- a/magicblock-config-macro/src/clap_prefix.rs
+++ b/magicblock-config-macro/src/clap_prefix.rs
@@ -43,7 +43,7 @@ impl VisitMut for ClapPrefix {
                         ident.to_string(),
                         kebab_str,
                         constant_str,
-                        vec!["long".to_string(), "name".to_string()],
+                        vec!["long".to_string(), "id".to_string()],
                     );
                     replacer.visit_attributes_mut(&mut field.attrs);
                     self.compile_errors.extend(replacer.compile_errors);

--- a/magicblock-config-macro/src/lib.rs
+++ b/magicblock-config-macro/src/lib.rs
@@ -199,10 +199,10 @@ pub fn clap_from_serde(_attr: TokenStream, item: TokenStream) -> TokenStream {
 /// impl Merge for SomeOtherConfig {
 ///     fn merge(&mut self, other: Self) {
 ///         let default = Self::default();
-///         if self.field1 == default.field1 && other.field1 != default.field1 {
+///         if self.field1 == default.field1 {
 ///             self.field1 = other.field1;
 ///         }
-///         if self.field2 == default.field2 && other.field2 != default.field2 {
+///         if self.field2 == default.field2 {
 ///             self.field2 = other.field2;
 ///         }
 ///     }
@@ -217,7 +217,7 @@ pub fn clap_from_serde(_attr: TokenStream, item: TokenStream) -> TokenStream {
 /// impl Merge for MyConfig {
 ///     fn merge(&mut self, other: Self) {
 ///         let default = Self::default();
-///         if self.field1 == default.field1 && other.field1 != default.field1 {
+///         if self.field1 == default.field1 {
 ///             self.field1 = other.field1;
 ///         }
 ///         self.field2.merge(other.field2);

--- a/magicblock-config-macro/src/lib.rs
+++ b/magicblock-config-macro/src/lib.rs
@@ -1,10 +1,13 @@
 mod clap_from_serde;
 mod clap_prefix;
+mod merger;
+
 use clap_from_serde::*;
 use clap_prefix::*;
+use merger::*;
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, visit_mut::VisitMut, ItemStruct};
+use syn::{parse_macro_input, visit_mut::VisitMut, DeriveInput, ItemStruct};
 
 /// Prefixes the fields of the annotated struct with the given prefix.
 ///
@@ -157,4 +160,74 @@ pub fn clap_from_serde(_attr: TokenStream, item: TokenStream) -> TokenStream {
         #input
     }
     .into()
+}
+
+/// Derives the `Merge` trait for the annotated struct.
+///
+/// **ASSUMES THAT FIELDS WITH NAMES CONTAINING "Config" HAVE A `merge` METHOD**
+///
+/// This macro is used to derive the `Merge` trait for a struct.
+/// The `Merge` trait is used to merge two instances of the struct.
+///
+/// # Example
+/// ```rust
+/// use magicblock_config_macro::Mergeable;
+///
+/// #[derive(Default, Mergeable)]
+/// struct SomeOtherConfig {
+///     field1: u32,
+///     field2: String,
+/// }
+///
+/// #[derive(Default, Mergeable)]
+/// struct MyConfig {
+///     field1: u32,
+///     field2: SomeOtherConfig,
+/// }
+/// ```
+///
+/// Will become:
+/// ```rust
+/// use magicblock_config_helpers::Merge;
+///
+/// #[derive(Default)]
+/// struct SomeOtherConfig {
+///     field1: u32,
+///     field2: String,
+/// }
+///
+/// impl Merge for SomeOtherConfig {
+///     fn merge(&mut self, other: Self) {
+///         let default = Self::default();
+///         if self.field1 == default.field1 && other.field1 != default.field1 {
+///             self.field1 = other.field1;
+///         }
+///         if self.field2 == default.field2 && other.field2 != default.field2 {
+///             self.field2 = other.field2;
+///         }
+///     }
+/// }
+///
+/// #[derive(Default)]
+/// struct MyConfig {
+///     field1: u32,
+///     field2: SomeOtherConfig,
+/// }
+///
+/// impl Merge for MyConfig {
+///     fn merge(&mut self, other: Self) {
+///         let default = Self::default();
+///         if self.field1 == default.field1 && other.field1 != default.field1 {
+///             self.field1 = other.field1;
+///         }
+///         self.field2.merge(other.field2);
+///     }
+/// }
+/// ```
+#[proc_macro_derive(Mergeable)]
+pub fn derive_merge(input: TokenStream) -> TokenStream {
+    let mut input = parse_macro_input!(input as DeriveInput);
+
+    let mut merger = Merger;
+    merger.add_impl(&mut input)
 }

--- a/magicblock-config-macro/src/merger.rs
+++ b/magicblock-config-macro/src/merger.rs
@@ -5,7 +5,6 @@ use syn::{Data, DeriveInput, Fields, Type};
 pub struct Merger;
 
 impl Merger {
-    /// Helper function to check if a type has a merge method by looking for common patterns
     fn type_has_merge_method(ty: &Type) -> bool {
         match ty {
             Type::Path(type_path) => {
@@ -66,10 +65,9 @@ impl Merger {
                     self.#name.merge(other.#name);
                 }
             } else {
-                // Otherwise, use the current default-based merging logic
-                // Use .clone() to avoid move issues with non-Copy types
+                // Otherwise, overwrite the field if it has the default value
                 quote! {
-                    if self.#name == default.#name && other.#name != default.#name {
+                    if self.#name == default.#name {
                         self.#name = other.#name;
                     }
                 }

--- a/magicblock-config-macro/src/merger.rs
+++ b/magicblock-config-macro/src/merger.rs
@@ -1,0 +1,92 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{Data, DeriveInput, Fields, Type};
+
+pub struct Merger;
+
+impl Merger {
+    /// Helper function to check if a type has a merge method by looking for common patterns
+    fn type_has_merge_method(ty: &Type) -> bool {
+        match ty {
+            Type::Path(type_path) => {
+                let path = &type_path.path;
+                let segments: Vec<String> = path
+                    .segments
+                    .iter()
+                    .map(|seg| seg.ident.to_string())
+                    .collect();
+
+                // NOTE: this assumes that all mergeable config structs have a "Config" suffix
+                segments.iter().any(|seg| seg.contains("Config"))
+            }
+            _ => false,
+        }
+    }
+}
+
+impl Merger {
+    pub fn add_impl(&mut self, input: &mut DeriveInput) -> TokenStream {
+        let struct_name = &input.ident;
+        let generics = &input.generics;
+        let (impl_generics, ty_generics, where_clause) =
+            generics.split_for_impl();
+
+        let mut compile_errors = Vec::new();
+
+        let fields = match &input.data {
+            Data::Struct(data_struct) => match &data_struct.fields {
+                Fields::Named(fields_named) => &fields_named.named,
+                other_fields => {
+                    compile_errors.push(syn::Error::new_spanned(
+                    other_fields,
+                    "Merge can only be derived for structs with named fields",
+                ).to_compile_error());
+                    &syn::punctuated::Punctuated::new()
+                }
+            },
+            _ => {
+                compile_errors.push(
+                    syn::Error::new_spanned(
+                        &input,
+                        "Merge can only be derived for structs",
+                    )
+                    .to_compile_error(),
+                );
+                &syn::punctuated::Punctuated::new()
+            }
+        };
+
+        let merge_fields = fields.iter().map(|f| {
+            let name = &f.ident;
+            let field_type = &f.ty;
+
+            if Self::type_has_merge_method(field_type) {
+                // If the field type likely has a merge method, call it
+                quote! {
+                    self.#name.merge(other.#name);
+                }
+            } else {
+                // Otherwise, use the current default-based merging logic
+                // Use .clone() to avoid move issues with non-Copy types
+                quote! {
+                    if self.#name == default.#name && other.#name != default.#name {
+                        self.#name = other.#name;
+                    }
+                }
+            }
+        });
+
+        quote! {
+            #(#compile_errors)*
+
+            impl #impl_generics ::magicblock_config_helpers::Merge for #struct_name #ty_generics #where_clause {
+                fn merge(&mut self, other: #struct_name #ty_generics) {
+                    let default = Self::default();
+
+                    #(#merge_fields)*
+                }
+            }
+        }
+        .into()
+    }
+}

--- a/magicblock-config-macro/tests/fixtures/fail_merge_enum.rs
+++ b/magicblock-config-macro/tests/fixtures/fail_merge_enum.rs
@@ -1,0 +1,9 @@
+use magicblock_config_macro::Mergeable;
+
+#[derive(Default, Mergeable)]
+enum TestEnum {
+    A(u32),
+    B(String),
+}
+
+fn main() {}

--- a/magicblock-config-macro/tests/fixtures/fail_merge_enum.stderr
+++ b/magicblock-config-macro/tests/fixtures/fail_merge_enum.stderr
@@ -1,0 +1,17 @@
+error: no default declared
+ --> tests/fixtures/fail_merge_enum.rs:3:10
+  |
+3 | #[derive(Default, Mergeable)]
+  |          ^^^^^^^
+  |
+  = help: make a unit variant default by placing `#[default]` above it
+  = note: this error originates in the derive macro `Default` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: Merge can only be derived for structs
+ --> tests/fixtures/fail_merge_enum.rs:4:1
+  |
+4 | / enum TestEnum {
+5 | |     A(u32),
+6 | |     B(String),
+7 | | }
+  | |_^

--- a/magicblock-config-macro/tests/fixtures/fail_merge_union.rs
+++ b/magicblock-config-macro/tests/fixtures/fail_merge_union.rs
@@ -1,0 +1,9 @@
+use magicblock_config_macro::Mergeable;
+
+#[derive(Default, Mergeable)]
+union TestUnion {
+    a: u32,
+    b: String,
+}
+
+fn main() {}

--- a/magicblock-config-macro/tests/fixtures/fail_merge_union.stderr
+++ b/magicblock-config-macro/tests/fixtures/fail_merge_union.stderr
@@ -1,0 +1,56 @@
+error: this trait cannot be derived for unions
+ --> tests/fixtures/fail_merge_union.rs:3:10
+  |
+3 | #[derive(Default, Mergeable)]
+  |          ^^^^^^^
+
+error: Merge can only be derived for structs
+ --> tests/fixtures/fail_merge_union.rs:4:1
+  |
+4 | / union TestUnion {
+5 | |     a: u32,
+6 | |     b: String,
+7 | | }
+  | |_^
+
+error[E0740]: field must implement `Copy` or be wrapped in `ManuallyDrop<...>` to be used in a union
+ --> tests/fixtures/fail_merge_union.rs:6:5
+  |
+6 |     b: String,
+  |     ^^^^^^^^^
+  |
+  = note: union fields must not have drop side-effects, which is currently enforced via either `Copy` or `ManuallyDrop<...>`
+help: wrap the field type in `ManuallyDrop<...>`
+  |
+6 |     b: std::mem::ManuallyDrop<String>,
+  |        +++++++++++++++++++++++      +
+
+error[E0277]: the trait bound `TestUnion: Default` is not satisfied
+ --> tests/fixtures/fail_merge_union.rs:4:7
+  |
+4 | union TestUnion {
+  |       ^^^^^^^^^ the trait `Default` is not implemented for `TestUnion`
+  |
+note: required by a bound in `Merge`
+ --> $WORKSPACE/magicblock-config-helpers/src/lib.rs
+  |
+  | pub trait Merge: Default {
+  |                  ^^^^^^^ required by this bound in `Merge`
+help: consider annotating `TestUnion` with `#[derive(Default)]`
+  |
+4 + #[derive(Default)]
+5 | union TestUnion {
+  |
+
+error[E0599]: no function or associated item named `default` found for union `TestUnion` in the current scope
+ --> tests/fixtures/fail_merge_union.rs:3:19
+  |
+3 | #[derive(Default, Mergeable)]
+  |                   ^^^^^^^^^ function or associated item not found in `TestUnion`
+4 | union TestUnion {
+  | --------------- function or associated item `default` not found for this union
+  |
+  = help: items from traits can only be used if the trait is implemented and in scope
+  = note: the following trait defines an item `default`, perhaps you need to implement it:
+          candidate #1: `Default`
+  = note: this error originates in the derive macro `Mergeable` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/magicblock-config-macro/tests/fixtures/fail_merge_unnamed.rs
+++ b/magicblock-config-macro/tests/fixtures/fail_merge_unnamed.rs
@@ -1,0 +1,6 @@
+use magicblock_config_macro::Mergeable;
+
+#[derive(Default, Mergeable)]
+struct TestConfig(u64, String);
+
+fn main() {}

--- a/magicblock-config-macro/tests/fixtures/fail_merge_unnamed.stderr
+++ b/magicblock-config-macro/tests/fixtures/fail_merge_unnamed.stderr
@@ -1,0 +1,5 @@
+error: Merge can only be derived for structs with named fields
+ --> tests/fixtures/fail_merge_unnamed.rs:4:18
+  |
+4 | struct TestConfig(u64, String);
+  |                  ^^^^^^^^^^^^^

--- a/magicblock-config-macro/tests/fixtures/pass_merge.expanded.rs
+++ b/magicblock-config-macro/tests/fixtures/pass_merge.expanded.rs
@@ -1,0 +1,55 @@
+use magicblock_config_macro::Mergeable;
+struct TestConfig {
+    field1: u32,
+    field2: String,
+    field3: Option<String>,
+    nested: NestedConfig,
+}
+#[automatically_derived]
+impl ::core::default::Default for TestConfig {
+    #[inline]
+    fn default() -> TestConfig {
+        TestConfig {
+            field1: ::core::default::Default::default(),
+            field2: ::core::default::Default::default(),
+            field3: ::core::default::Default::default(),
+            nested: ::core::default::Default::default(),
+        }
+    }
+}
+impl ::magicblock_config_helpers::Merge for TestConfig {
+    fn merge(&mut self, other: TestConfig) {
+        let default = Self::default();
+        if self.field1 == default.field1 {
+            self.field1 = other.field1;
+        }
+        if self.field2 == default.field2 {
+            self.field2 = other.field2;
+        }
+        if self.field3 == default.field3 {
+            self.field3 = other.field3;
+        }
+        self.nested.merge(other.nested);
+    }
+}
+struct NestedConfig {
+    value: u32,
+}
+#[automatically_derived]
+impl ::core::default::Default for NestedConfig {
+    #[inline]
+    fn default() -> NestedConfig {
+        NestedConfig {
+            value: ::core::default::Default::default(),
+        }
+    }
+}
+impl ::magicblock_config_helpers::Merge for NestedConfig {
+    fn merge(&mut self, other: NestedConfig) {
+        let default = Self::default();
+        if self.value == default.value {
+            self.value = other.value;
+        }
+    }
+}
+fn main() {}

--- a/magicblock-config-macro/tests/fixtures/pass_merge.rs
+++ b/magicblock-config-macro/tests/fixtures/pass_merge.rs
@@ -1,0 +1,16 @@
+use magicblock_config_macro::Mergeable;
+
+#[derive(Default, Mergeable)]
+struct TestConfig {
+    field1: u32,
+    field2: String,
+    field3: Option<String>,
+    nested: NestedConfig,
+}
+
+#[derive(Default, Mergeable)]
+struct NestedConfig {
+    value: u32,
+}
+
+fn main() {}

--- a/magicblock-config-macro/tests/test_merger.rs
+++ b/magicblock-config-macro/tests/test_merger.rs
@@ -1,0 +1,70 @@
+use magicblock_config_helpers::Merge;
+use magicblock_config_macro::Mergeable;
+
+// Test struct with fields that have merge methods
+#[derive(Debug, Clone, PartialEq, Eq, Default, Mergeable)]
+struct TestConfig {
+    field1: u32,
+    field2: String,
+    field3: Option<String>,
+    nested: NestedConfig,
+}
+
+// Nested config that has a merge method
+#[derive(Debug, Clone, PartialEq, Eq, Default, Mergeable)]
+struct NestedConfig {
+    value: u32,
+}
+
+#[test]
+fn test_merge_macro() {
+    let mut config = TestConfig {
+        field1: 0,
+        field2: "".to_string(),
+        field3: None,
+        nested: NestedConfig { value: 0 },
+    };
+
+    let other = TestConfig {
+        field1: 42,
+        field2: "test".to_string(),
+        field3: Some("test".to_string()),
+        nested: NestedConfig { value: 100 },
+    };
+
+    config.merge(other);
+
+    // field1 and field2 should use default-based merging
+    assert_eq!(config.field1, 42);
+    assert_eq!(config.field2, "test");
+
+    // nested should use its own merge method
+    assert_eq!(config.nested.value, 100);
+}
+
+#[test]
+fn test_merge_macro_with_non_default_values() {
+    let mut config = TestConfig {
+        field1: 10,
+        field2: "original".to_string(),
+        field3: None,
+        nested: NestedConfig { value: 50 },
+    };
+
+    let other = TestConfig {
+        field1: 42,
+        field2: "test".to_string(),
+        field3: Some("test".to_string()),
+        nested: NestedConfig { value: 100 },
+    };
+
+    config.merge(other);
+
+    // field1 and field2 should preserve original values since they're not default
+    assert_eq!(config.field1, 10);
+    assert_eq!(config.field2, "original");
+    assert_eq!(config.field3, Some("test".to_string()));
+
+    // nested should use its own merge method (preserves original since both are non-default)
+    assert_eq!(config.nested.value, 50);
+}

--- a/magicblock-config-macro/tests/test_merger.rs
+++ b/magicblock-config-macro/tests/test_merger.rs
@@ -1,3 +1,4 @@
+use macrotest::expand;
 use magicblock_config_helpers::Merge;
 use magicblock_config_macro::Mergeable;
 
@@ -67,4 +68,15 @@ fn test_merge_macro_with_non_default_values() {
 
     // nested should use its own merge method (preserves original since both are non-default)
     assert_eq!(config.nested.value, 50);
+}
+
+#[test]
+fn test_merge_macro_codegen() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/fixtures/pass_merge.rs");
+    t.compile_fail("tests/fixtures/fail_merge_enum.rs");
+    t.compile_fail("tests/fixtures/fail_merge_union.rs");
+    t.compile_fail("tests/fixtures/fail_merge_unnamed.rs");
+
+    expand("tests/fixtures/pass_merge.rs");
 }

--- a/magicblock-config/Cargo.toml
+++ b/magicblock-config/Cargo.toml
@@ -17,6 +17,7 @@ toml = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 # strum_macros = { workspace = true }
 strum = { workspace = true, features = ["derive"] }
+magicblock-config-helpers = { workspace = true }
 magicblock-config-macro = { workspace = true }
 isocountry = { workspace = true }
 

--- a/magicblock-config/src/accounts.rs
+++ b/magicblock-config/src/accounts.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use clap::{Args, ValueEnum};
-use magicblock_config_macro::{clap_from_serde, clap_prefix};
+use magicblock_config_macro::{clap_from_serde, clap_prefix, Mergeable};
 use serde::{Deserialize, Serialize};
 use solana_sdk::pubkey::Pubkey;
 use strum::{Display, EnumString};
@@ -14,7 +14,9 @@ use crate::accounts_db::AccountsDbConfig;
 // -----------------
 #[clap_prefix("accounts")]
 #[clap_from_serde]
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, Args)]
+#[derive(
+    Debug, Clone, PartialEq, Eq, Deserialize, Serialize, Args, Mergeable,
+)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub struct AccountsConfig {
     #[serde(default)]
@@ -42,40 +44,6 @@ pub struct AccountsConfig {
     pub max_monitored_accounts: usize,
 }
 
-impl AccountsConfig {
-    pub fn merge(&mut self, other: AccountsConfig) {
-        let default = Self::default();
-
-        if self.remote == default.remote && other.remote != default.remote {
-            self.remote = other.remote;
-        }
-        if self.lifecycle == default.lifecycle
-            && other.lifecycle != default.lifecycle
-        {
-            self.lifecycle = other.lifecycle;
-        }
-        if self.commit == default.commit && other.commit != default.commit {
-            self.commit = other.commit;
-        }
-        if self.allowed_programs == default.allowed_programs
-            && other.allowed_programs != default.allowed_programs
-        {
-            self.allowed_programs = other.allowed_programs;
-        }
-        if self.db == default.db && other.db != default.db {
-            self.db = other.db;
-        }
-        if self.clone == default.clone && other.clone != default.clone {
-            self.clone = other.clone;
-        }
-        if self.max_monitored_accounts == default.max_monitored_accounts
-            && other.max_monitored_accounts != default.max_monitored_accounts
-        {
-            self.max_monitored_accounts = other.max_monitored_accounts;
-        }
-    }
-}
-
 impl Default for AccountsConfig {
     fn default() -> Self {
         Self {
@@ -95,7 +63,15 @@ impl Default for AccountsConfig {
 #[clap_prefix("remote")]
 #[clap_from_serde]
 #[derive(
-    Debug, Default, Clone, PartialEq, Eq, Deserialize, Serialize, Args,
+    Debug,
+    Default,
+    Clone,
+    PartialEq,
+    Eq,
+    Deserialize,
+    Serialize,
+    Args,
+    Mergeable,
 )]
 #[serde(deny_unknown_fields)]
 pub struct RemoteConfig {
@@ -239,7 +215,15 @@ pub enum PrepareLookupTables {
 #[clap_prefix("clone")]
 #[clap_from_serde]
 #[derive(
-    Debug, Default, Clone, PartialEq, Eq, Deserialize, Serialize, Args,
+    Debug,
+    Default,
+    Clone,
+    PartialEq,
+    Eq,
+    Deserialize,
+    Serialize,
+    Args,
+    Mergeable,
 )]
 #[serde(deny_unknown_fields)]
 pub struct AccountsCloneConfig {
@@ -285,6 +269,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use magicblock_config_helpers::Merge;
+
     use super::*;
     use crate::BlockSize;
 

--- a/magicblock-config/src/accounts.rs
+++ b/magicblock-config/src/accounts.rs
@@ -106,7 +106,7 @@ pub struct RemoteConfig {
 )]
 #[serde(rename_all = "kebab-case")]
 #[strum(serialize_all = "kebab-case")]
-#[clap(rename_all = "kebab-case")]
+#[value(rename_all = "kebab-case")]
 pub enum RemoteCluster {
     #[default]
     Devnet,
@@ -138,7 +138,7 @@ pub enum RemoteCluster {
 )]
 #[serde(rename_all = "kebab-case")]
 #[strum(serialize_all = "kebab-case")]
-#[clap(rename_all = "kebab-case")]
+#[value(rename_all = "kebab-case")]
 pub enum LifecycleMode {
     Replica,
     #[default]
@@ -205,7 +205,7 @@ impl Default for CommitStrategy {
 )]
 #[serde(rename_all = "kebab-case")]
 #[strum(serialize_all = "kebab-case")]
-#[clap(rename_all = "kebab-case")]
+#[value(rename_all = "kebab-case")]
 pub enum PrepareLookupTables {
     Always,
     #[default]

--- a/magicblock-config/src/accounts_db.rs
+++ b/magicblock-config/src/accounts_db.rs
@@ -1,11 +1,13 @@
 use clap::{Args, ValueEnum};
-use magicblock_config_macro::{clap_from_serde, clap_prefix};
+use magicblock_config_macro::{clap_from_serde, clap_prefix, Mergeable};
 use serde::{Deserialize, Serialize};
 use strum::Display;
 
 #[clap_prefix("db")]
 #[clap_from_serde]
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, Args)]
+#[derive(
+    Debug, Clone, PartialEq, Eq, Deserialize, Serialize, Args, Mergeable,
+)]
 #[serde(rename_all = "kebab-case")]
 pub struct AccountsDbConfig {
     /// size of the main storage, we have to preallocate in advance

--- a/magicblock-config/src/accounts_db.rs
+++ b/magicblock-config/src/accounts_db.rs
@@ -66,7 +66,7 @@ impl Default for AccountsDbConfig {
 )]
 #[serde(rename_all = "kebab-case")]
 #[strum(serialize_all = "kebab-case")]
-#[clap(rename_all = "kebab-case")]
+#[value(rename_all = "kebab-case")]
 #[repr(u32)]
 pub enum BlockSize {
     Block128 = 128,

--- a/magicblock-config/src/cli.rs
+++ b/magicblock-config/src/cli.rs
@@ -8,10 +8,10 @@ use crate::EphemeralConfig;
 
 #[derive(Debug, Clone, Parser)]
 pub struct MagicBlockConfig {
-    #[clap(help = "Path to the config file")]
+    #[arg(help = "Path to the config file")]
     pub config_file: Option<PathBuf>,
 
-    #[clap(
+    #[arg(
         short,
         long,
         help = "The keypair to use for the validator. DO NOT PROVIDE THIS VALUE VIA THE CLI IN PROD! The default keypair has the pubkey mAGicPQYBMvcYveUZA5F5UNNwyHvfYh5xkLS2Fr1mev.",
@@ -20,7 +20,7 @@ pub struct MagicBlockConfig {
     )]
     pub validator_keypair: String,
 
-    #[clap(
+    #[arg(
         long,
         help = "The comma separated list of geyser cache features to disable. Valid values are 'accounts' and 'transactions'.",
         env = "GEYSER_CACHE_DISABLE",
@@ -28,7 +28,7 @@ pub struct MagicBlockConfig {
     )]
     pub geyser_cache_disable: String,
 
-    #[clap(
+    #[arg(
         long,
         help = "The comma separated list of geyser notifications features to disable. Valid values are 'accounts' and 'transactions'.",
         env = "GEYSER_DISABLE",
@@ -36,7 +36,7 @@ pub struct MagicBlockConfig {
     )]
     pub geyser_disable: String,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     pub config: EphemeralConfig,
 }
 

--- a/magicblock-config/src/cli.rs
+++ b/magicblock-config/src/cli.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use clap::{Error, Parser};
+use magicblock_config_helpers::Merge;
 use solana_sdk::signature::Keypair;
 
 use crate::EphemeralConfig;

--- a/magicblock-config/src/ledger.rs
+++ b/magicblock-config/src/ledger.rs
@@ -1,5 +1,5 @@
 use clap::Args;
-use magicblock_config_macro::{clap_from_serde, clap_prefix};
+use magicblock_config_macro::{clap_from_serde, clap_prefix, Mergeable};
 use serde::{Deserialize, Serialize};
 
 use crate::helpers::serde_defaults::bool_true;
@@ -9,7 +9,9 @@ pub const DEFAULT_LEDGER_SIZE_BYTES: u64 = 100 * 1024 * 1024 * 1024;
 
 #[clap_prefix("ledger")]
 #[clap_from_serde]
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, Args)]
+#[derive(
+    Debug, Clone, PartialEq, Eq, Deserialize, Serialize, Args, Mergeable,
+)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub struct LedgerConfig {
     /// If a previous ledger is found it is removed before starting the validator
@@ -34,22 +36,6 @@ pub struct LedgerConfig {
     pub size: u64,
 }
 
-impl LedgerConfig {
-    pub fn merge(&mut self, other: LedgerConfig) {
-        if self.reset == bool_true() && other.reset != bool_true() {
-            self.reset = other.reset;
-        }
-        if self.path == Default::default() && other.path != Default::default() {
-            self.path = other.path;
-        }
-        if self.size == default_ledger_size()
-            && other.size != default_ledger_size()
-        {
-            self.size = other.size;
-        }
-    }
-}
-
 impl Default for LedgerConfig {
     fn default() -> Self {
         Self {
@@ -66,6 +52,8 @@ const fn default_ledger_size() -> u64 {
 
 #[cfg(test)]
 mod tests {
+    use magicblock_config_helpers::Merge;
+
     use super::*;
 
     #[test]

--- a/magicblock-config/src/lib.rs
+++ b/magicblock-config/src/lib.rs
@@ -2,6 +2,7 @@ use std::{fmt, fs, path::PathBuf, str::FromStr};
 
 use clap::Args;
 use errors::{ConfigError, ConfigResult};
+use magicblock_config_macro::Mergeable;
 use serde::{Deserialize, Serialize};
 use solana_sdk::pubkey::Pubkey;
 
@@ -27,7 +28,15 @@ pub use rpc::*;
 pub use validator::*;
 
 #[derive(
-    Debug, Default, Clone, PartialEq, Eq, Deserialize, Serialize, Args,
+    Debug,
+    Default,
+    Clone,
+    PartialEq,
+    Eq,
+    Deserialize,
+    Serialize,
+    Args,
+    Mergeable,
 )]
 #[serde(deny_unknown_fields)]
 pub struct EphemeralConfig {
@@ -101,21 +110,6 @@ impl EphemeralConfig {
         Ok(config)
     }
 
-    pub fn merge(&mut self, other: EphemeralConfig) {
-        // If other differs from the default but not self, use the value from other
-        // Otherwise, use the value from self
-        self.accounts.merge(other.accounts);
-        self.rpc.merge(other.rpc);
-        self.geyser_grpc.merge(other.geyser_grpc.clone());
-        self.validator.merge(other.validator.clone());
-        self.ledger.merge(other.ledger.clone());
-        self.metrics.merge(other.metrics.clone());
-
-        if self.programs.is_empty() && !other.programs.is_empty() {
-            self.programs = other.programs.clone();
-        }
-    }
-
     pub fn post_parse(&mut self) {
         if self.accounts.remote.url.is_some() {
             match &self.accounts.remote.ws_url {
@@ -162,6 +156,7 @@ mod tests {
     use std::net::{IpAddr, Ipv4Addr};
 
     use isocountry::CountryCode;
+    use magicblock_config_helpers::Merge;
     use solana_sdk::pubkey::Pubkey;
     use url::Url;
 

--- a/magicblock-config/src/metrics.rs
+++ b/magicblock-config/src/metrics.rs
@@ -1,5 +1,5 @@
 use clap::Args;
-use magicblock_config_macro::{clap_from_serde, clap_prefix};
+use magicblock_config_macro::{clap_from_serde, clap_prefix, Mergeable};
 use serde::{Deserialize, Serialize};
 
 use crate::helpers;
@@ -13,7 +13,9 @@ helpers::socket_addr_config! {
 
 #[clap_prefix("metrics")]
 #[clap_from_serde]
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, Args)]
+#[derive(
+    Debug, Clone, PartialEq, Eq, Deserialize, Serialize, Args, Mergeable,
+)]
 pub struct MetricsConfig {
     #[derive_env_var]
     #[arg(help = "Whether to enable metrics.")]
@@ -28,25 +30,6 @@ pub struct MetricsConfig {
     #[serde(default)]
     #[serde(flatten)]
     pub service: MetricsServiceConfig,
-}
-
-impl MetricsConfig {
-    pub fn merge(&mut self, other: MetricsConfig) {
-        if self.enabled == helpers::serde_defaults::bool_true()
-            && other.enabled != helpers::serde_defaults::bool_true()
-        {
-            self.enabled = other.enabled;
-        }
-        if self.system_metrics_tick_interval_secs
-            == default_system_metrics_tick_interval_secs()
-            && other.system_metrics_tick_interval_secs
-                != default_system_metrics_tick_interval_secs()
-        {
-            self.system_metrics_tick_interval_secs =
-                other.system_metrics_tick_interval_secs;
-        }
-        self.service.merge(other.service);
-    }
 }
 
 impl Default for MetricsConfig {
@@ -67,6 +50,8 @@ fn default_system_metrics_tick_interval_secs() -> u64 {
 #[cfg(test)]
 mod tests {
     use std::net::{IpAddr, Ipv4Addr};
+
+    use magicblock_config_helpers::Merge;
 
     use super::*;
 

--- a/magicblock-config/src/rpc.rs
+++ b/magicblock-config/src/rpc.rs
@@ -1,12 +1,14 @@
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 use clap::Args;
-use magicblock_config_macro::{clap_from_serde, clap_prefix};
+use magicblock_config_macro::{clap_from_serde, clap_prefix, Mergeable};
 use serde::{Deserialize, Serialize};
 
 #[clap_prefix("rpc")]
 #[clap_from_serde]
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, Args)]
+#[derive(
+    Debug, Clone, PartialEq, Eq, Deserialize, Serialize, Args, Mergeable,
+)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub struct RpcConfig {
     #[derive_env_var]
@@ -24,22 +26,6 @@ pub struct RpcConfig {
     #[arg(help = "The max number of WebSocket connections to accept.")]
     #[serde(default = "default_max_ws_connections")]
     pub max_ws_connections: usize,
-}
-
-impl RpcConfig {
-    pub fn merge(&mut self, other: RpcConfig) {
-        if self.addr == default_addr() && other.addr != default_addr() {
-            self.addr = other.addr;
-        }
-        if self.port == default_port() && other.port != default_port() {
-            self.port = other.port;
-        }
-        if self.max_ws_connections == default_max_ws_connections()
-            && other.max_ws_connections != default_max_ws_connections()
-        {
-            self.max_ws_connections = other.max_ws_connections;
-        }
-    }
 }
 
 impl Default for RpcConfig {
@@ -97,6 +83,8 @@ fn default_max_ws_connections() -> usize {
 
 #[cfg(test)]
 mod tests {
+    use magicblock_config_helpers::Merge;
+
     use super::*;
 
     #[test]

--- a/magicblock-config/src/validator.rs
+++ b/magicblock-config/src/validator.rs
@@ -1,11 +1,13 @@
 use clap::Args;
 use isocountry::CountryCode;
-use magicblock_config_macro::{clap_from_serde, clap_prefix};
+use magicblock_config_macro::{clap_from_serde, clap_prefix, Mergeable};
 use serde::{Deserialize, Serialize};
 
 #[clap_prefix("validator")]
 #[clap_from_serde]
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, Args)]
+#[derive(
+    Debug, Clone, PartialEq, Eq, Deserialize, Serialize, Args, Mergeable,
+)]
 #[serde(deny_unknown_fields)]
 pub struct ValidatorConfig {
     #[derive_env_var]
@@ -44,34 +46,6 @@ pub struct ValidatorConfig {
     )]
     #[serde(default = "default_country_code")]
     pub country_code: CountryCode,
-}
-
-impl ValidatorConfig {
-    pub fn merge(&mut self, other: ValidatorConfig) {
-        if self.millis_per_slot == default_millis_per_slot()
-            && other.millis_per_slot != default_millis_per_slot()
-        {
-            self.millis_per_slot = other.millis_per_slot;
-        }
-        if self.sigverify == default_sigverify()
-            && other.sigverify != default_sigverify()
-        {
-            self.sigverify = other.sigverify;
-        }
-        if self.fqdn == default_fqdn() && other.fqdn != default_fqdn() {
-            self.fqdn = other.fqdn;
-        }
-        if self.base_fees == default_base_fees()
-            && other.base_fees != default_base_fees()
-        {
-            self.base_fees = other.base_fees;
-        }
-        if self.country_code == default_country_code()
-            && other.country_code != default_country_code()
-        {
-            self.country_code = other.country_code;
-        }
-    }
 }
 
 impl Default for ValidatorConfig {
@@ -118,6 +92,8 @@ fn parse_country_code(s: &str) -> Result<CountryCode, String> {
 
 #[cfg(test)]
 mod tests {
+    use magicblock_config_helpers::Merge;
+
     use super::*;
 
     #[test]

--- a/test-integration/Cargo.lock
+++ b/test-integration/Cargo.lock
@@ -3813,6 +3813,7 @@ dependencies = [
  "bs58 0.4.0",
  "clap 4.5.41",
  "isocountry",
+ "magicblock-config-helpers",
  "magicblock-config-macro",
  "serde",
  "solana-sdk",
@@ -3821,6 +3822,10 @@ dependencies = [
  "toml 0.8.23",
  "url 2.5.4",
 ]
+
+[[package]]
+name = "magicblock-config-helpers"
+version = "0.1.7"
 
 [[package]]
 name = "magicblock-config-macro"


### PR DESCRIPTION
Closes #471 

Create a `Mergeable` derive trait that automatically merges the fields with default values with the non-default fields of another instance. It also handles nested Mergeable structs.

Note: in order to handle nested Mergeable structs, it uses the heuristic that nested mergeable struct have a type name containing `Config`. This is not a very robust method, but it works as we only use it for internal config structs.