### PR TITLE
feat: add configurable free airdrop for the feepayer

### DIFF
--- a/magicblock-account-cloner/src/remote_account_cloner_worker.rs
+++ b/magicblock-account-cloner/src/remote_account_cloner_worker.rs
@@ -4,7 +4,7 @@ use std::{
     sync::{Arc, RwLock},
     time::Duration,
 };
-
+use std::cmp::max;
 use conjunto_transwise::{
     AccountChainSnapshot, AccountChainSnapshotShared, AccountChainState,
     DelegationRecord,
@@ -546,6 +546,7 @@ where
                 }
 
                 // Fee payer accounts are non-delegated ones, so we keep track of them as well
+                let lamports = max(self.clone_config.auto_aidrop_lamports, *lamports);
                 self.track_not_delegated_account(*pubkey).await?;
                 match self.validator_charges_fees {
                     ValidatorCollectionMode::NoFees => self
@@ -553,7 +554,7 @@ where
                             pubkey,
                             // TODO(GabrielePicco): change account fetching to return the account
                             &Account {
-                                lamports: *lamports,
+                                lamports,
                                 owner: *owner,
                                 ..Default::default()
                             },

--- a/magicblock-account-cloner/src/remote_account_cloner_worker.rs
+++ b/magicblock-account-cloner/src/remote_account_cloner_worker.rs
@@ -1,10 +1,11 @@
 use std::{
     cell::RefCell,
+    cmp::max,
     collections::{hash_map::Entry, HashMap, HashSet},
     sync::{Arc, RwLock},
     time::Duration,
 };
-use std::cmp::max;
+
 use conjunto_transwise::{
     AccountChainSnapshot, AccountChainSnapshotShared, AccountChainState,
     DelegationRecord,
@@ -546,7 +547,8 @@ where
                 }
 
                 // Fee payer accounts are non-delegated ones, so we keep track of them as well
-                let lamports = max(self.clone_config.auto_aidrop_lamports, *lamports);
+                let lamports =
+                    max(self.clone_config.auto_airdrop_lamports, *lamports);
                 self.track_not_delegated_account(*pubkey).await?;
                 match self.validator_charges_fees {
                     ValidatorCollectionMode::NoFees => self

--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -537,7 +537,7 @@ impl MagicValidator {
             ledger::init(ledger_path, &ledger_config.resume_strategy)?;
         let ledger_shared = Arc::new(ledger);
         init_persister(ledger_shared.clone());
-        Ok((ledger_shared, last_slot + 1))
+        Ok((ledger_shared, last_slot))
     }
 
     fn sync_validator_keypair_with_ledger(

--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -537,7 +537,7 @@ impl MagicValidator {
             ledger::init(ledger_path, &ledger_config.resume_strategy)?;
         let ledger_shared = Arc::new(ledger);
         init_persister(ledger_shared.clone());
-        Ok((ledger_shared, last_slot))
+        Ok((ledger_shared, last_slot + 1))
     }
 
     fn sync_validator_keypair_with_ledger(

--- a/magicblock-config/src/accounts.rs
+++ b/magicblock-config/src/accounts.rs
@@ -438,6 +438,6 @@ auto_aidrop_lamports = 123
             config.clone.prepare_lookup_tables,
             PrepareLookupTables::Always
         );
-        assert_eq!(config.clone.auto_aidrop_lamports, 123);
+        assert_eq!(config.clone.auto_airdrop_lamports, 123);
     }
 }

--- a/magicblock-config/src/accounts.rs
+++ b/magicblock-config/src/accounts.rs
@@ -234,7 +234,7 @@ pub struct AccountsCloneConfig {
     #[derive_env_var]
     #[arg(help = "If > 0, automatically airdrop this many lamports to target accounts when cloning.")]
     #[serde(default)]
-    pub auto_aidrop_lamports: u64,
+    pub auto_airdrop_lamports: u64,
 }
 
 #[derive(

--- a/magicblock-config/src/accounts.rs
+++ b/magicblock-config/src/accounts.rs
@@ -430,7 +430,7 @@ mod tests {
         let toml_str = r#"
 [clone]
 prepare_lookup_tables = "always"
-auto_aidrop_lamports = 123
+auto_airdrop_lamports = 123
 "#;
 
         let config: AccountsConfig = toml::from_str(toml_str).unwrap();

--- a/magicblock-config/src/accounts.rs
+++ b/magicblock-config/src/accounts.rs
@@ -231,6 +231,10 @@ pub enum PrepareLookupTables {
 pub struct AccountsCloneConfig {
     #[serde(default)]
     pub prepare_lookup_tables: PrepareLookupTables,
+    #[derive_env_var]
+    #[arg(help = "If > 0, automatically airdrop this many lamports to target accounts when cloning.")]
+    #[serde(default)]
+    pub auto_aidrop_lamports: u64,
 }
 
 #[derive(
@@ -398,6 +402,7 @@ mod tests {
     fn test_clone_config_default() {
         let config = AccountsCloneConfig::default();
         assert_eq!(config.prepare_lookup_tables, PrepareLookupTables::Never);
+        assert_eq!(config.auto_aidrop_lamports, 0);
     }
 
     #[test]
@@ -406,6 +411,7 @@ mod tests {
         let other = AccountsConfig {
             clone: AccountsCloneConfig {
                 prepare_lookup_tables: PrepareLookupTables::Always,
+                auto_aidrop_lamports: 0,
             },
             ..Default::default()
         };
@@ -422,6 +428,7 @@ mod tests {
         let toml_str = r#"
 [clone]
 prepare_lookup_tables = "always"
+auto_aidrop_lamports = 123
 "#;
 
         let config: AccountsConfig = toml::from_str(toml_str).unwrap();
@@ -429,5 +436,6 @@ prepare_lookup_tables = "always"
             config.clone.prepare_lookup_tables,
             PrepareLookupTables::Always
         );
+        assert_eq!(config.clone.auto_aidrop_lamports, 123);
     }
 }

--- a/magicblock-config/src/accounts.rs
+++ b/magicblock-config/src/accounts.rs
@@ -232,7 +232,9 @@ pub struct AccountsCloneConfig {
     #[serde(default)]
     pub prepare_lookup_tables: PrepareLookupTables,
     #[derive_env_var]
-    #[arg(help = "If > 0, automatically airdrop this many lamports to target accounts when cloning.")]
+    #[arg(
+        help = "If > 0, automatically airdrop this many lamports to target accounts when cloning."
+    )]
     #[serde(default)]
     pub auto_airdrop_lamports: u64,
 }
@@ -402,7 +404,7 @@ mod tests {
     fn test_clone_config_default() {
         let config = AccountsCloneConfig::default();
         assert_eq!(config.prepare_lookup_tables, PrepareLookupTables::Never);
-        assert_eq!(config.auto_aidrop_lamports, 0);
+        assert_eq!(config.auto_airdrop_lamports, 0);
     }
 
     #[test]
@@ -411,7 +413,7 @@ mod tests {
         let other = AccountsConfig {
             clone: AccountsCloneConfig {
                 prepare_lookup_tables: PrepareLookupTables::Always,
-                auto_aidrop_lamports: 0,
+                auto_airdrop_lamports: 0,
             },
             ..Default::default()
         };

--- a/magicblock-config/src/lib.rs
+++ b/magicblock-config/src/lib.rs
@@ -518,6 +518,7 @@ mod tests {
                 db: AccountsDbConfig::default(),
                 clone: AccountsCloneConfig {
                     prepare_lookup_tables: PrepareLookupTables::Always,
+                    auto_airdrop_lamports: 0,
                 },
                 max_monitored_accounts: 2048,
             },

--- a/test-integration/test-config/src/lib.rs
+++ b/test-integration/test-config/src/lib.rs
@@ -52,6 +52,7 @@ pub fn start_validator_with_clone_config(
             lifecycle: LifecycleMode::Ephemeral,
             clone: AccountsCloneConfig {
                 prepare_lookup_tables,
+                auto_airdrop_lamports: 0
             },
             ..Default::default()
         },

--- a/test-integration/test-config/tests/auto_airdrop_feepayer.rs
+++ b/test-integration/test-config/tests/auto_airdrop_feepayer.rs
@@ -1,0 +1,77 @@
+use integration_test_tools::{
+    expect,
+    loaded_accounts::LoadedAccounts,
+    validator::start_magicblock_validator_with_config_struct,
+    IntegrationTestContext,
+};
+use magicblock_config::{
+    AccountsCloneConfig, AccountsConfig, EphemeralConfig, LifecycleMode,
+    RemoteCluster, RemoteConfig,
+};
+use solana_sdk::{
+    signature::Keypair,
+    signer::Signer,
+    system_instruction,
+};
+use test_tools_core::init_logger;
+
+#[test]
+fn test_auto_airdrop_feepayer_balance_after_tx() {
+    init_logger!();
+
+    // Build an Ephemeral validator config that enables auto airdrop for fee payers
+    let config = EphemeralConfig {
+        accounts: AccountsConfig {
+            remote: RemoteConfig {
+                // Connect ephem validator to the local chain RPC used in tests
+                cluster: RemoteCluster::Custom,
+                url: Some(IntegrationTestContext::url_chain().try_into().unwrap()),
+                ws_url: Some(vec![IntegrationTestContext::ws_url_chain()
+                    .try_into()
+                    .unwrap()]),
+            },
+            lifecycle: LifecycleMode::Ephemeral,
+            clone: AccountsCloneConfig {
+                // Set the auto airdrop lamports to 100_000 as requested
+                auto_aidrop_lamports: 100_000,
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    // Start the validator
+    let (_tmpdir, Some(mut validator)) = start_magicblock_validator_with_config_struct(
+        config,
+        &LoadedAccounts::with_delegation_program_test_authority(),
+    ) else {
+        panic!("validator should set up correctly");
+    };
+
+    // Create context and wait for the ephem validator to start producing slots
+    let ctx = expect!(IntegrationTestContext::try_new(), validator);
+    expect!(ctx.wait_for_next_slot_ephem(), validator);
+
+    // Create a brand new fee payer with zero balance on chain
+    let payer = Keypair::new();
+    let recipient = Keypair::new();
+
+    // Send a 0-lamport transfer to trigger account creation/cloning for the new fee payer
+    // This should cause the validator to auto-airdrop 100_000 lamports to the payer
+    let ix = system_instruction::transfer(&payer.pubkey(), &recipient.pubkey(), 0);
+    let _sig = expect!(
+        ctx.send_and_confirm_instructions_with_payer_ephem(&[ix], &payer),
+        validator
+    );
+
+    // Fetch the payer balance from the ephemeral validator and assert it equals 100_000
+    let balance = expect!(
+        ctx.fetch_ephem_account_balance(&payer.pubkey()),
+        validator
+    );
+    assert_eq!(balance, 100_000);
+
+    // Cleanup validator process
+    integration_test_tools::validator::cleanup(&mut validator);
+}

--- a/test-integration/test-config/tests/auto_airdrop_feepayer.rs
+++ b/test-integration/test-config/tests/auto_airdrop_feepayer.rs
@@ -23,7 +23,6 @@ fn test_auto_airdrop_feepayer_balance_after_tx() {
     let config = EphemeralConfig {
         accounts: AccountsConfig {
             remote: RemoteConfig {
-                // Connect ephem validator to the local chain RPC used in tests
                 cluster: RemoteCluster::Custom,
                 url: Some(IntegrationTestContext::url_chain().try_into().unwrap()),
                 ws_url: Some(vec![IntegrationTestContext::ws_url_chain()
@@ -32,8 +31,7 @@ fn test_auto_airdrop_feepayer_balance_after_tx() {
             },
             lifecycle: LifecycleMode::Ephemeral,
             clone: AccountsCloneConfig {
-                // Set the auto airdrop lamports to 100_000 as requested
-                auto_airdrop_lamports: 100_000,
+                auto_airdrop_lamports: 1_000_000_000,
                 ..Default::default()
             },
             ..Default::default()
@@ -58,7 +56,7 @@ fn test_auto_airdrop_feepayer_balance_after_tx() {
     let recipient = Keypair::new();
 
     // Send a 0-lamport transfer to trigger account creation/cloning for the new fee payer
-    // This should cause the validator to auto-airdrop 100_000 lamports to the payer
+    // This should cause the validator to auto-airdrop 1 SOL to the payer
     let ix = system_instruction::transfer(&payer.pubkey(), &recipient.pubkey(), 0);
     let _sig = expect!(
         ctx.send_and_confirm_instructions_with_payer_ephem(&[ix], &payer),
@@ -70,7 +68,7 @@ fn test_auto_airdrop_feepayer_balance_after_tx() {
         ctx.fetch_ephem_account_balance(&payer.pubkey()),
         validator
     );
-    assert_eq!(balance, 100_000);
+    assert_eq!(balance, 1_000_000_000);
 
     // Cleanup validator process
     integration_test_tools::validator::cleanup(&mut validator);

--- a/test-integration/test-config/tests/auto_airdrop_feepayer.rs
+++ b/test-integration/test-config/tests/auto_airdrop_feepayer.rs
@@ -33,7 +33,7 @@ fn test_auto_airdrop_feepayer_balance_after_tx() {
             lifecycle: LifecycleMode::Ephemeral,
             clone: AccountsCloneConfig {
                 // Set the auto airdrop lamports to 100_000 as requested
-                auto_aidrop_lamports: 100_000,
+                auto_airdrop_lamports: 100_000,
                 ..Default::default()
             },
             ..Default::default()


### PR DESCRIPTION
## Summary

This PR introduces a configurable automatic airdrop feature for fee payer accounts in the ephemeral validator system. The changes add a new configuration field `auto_aidrop_lamports` to the `AccountsCloneConfig` struct, allowing users to specify a minimum amount of lamports that should be automatically provided to target accounts during the cloning process.

The implementation works by modifying the account cloning logic to use `max(configured_amount, original_lamports)` when processing fee payer accounts, ensuring they receive at least the configured minimum balance. This is particularly valuable in ephemeral/testing environments where fee payer accounts cloned from mainnet or devnet may have insufficient balance to cover transaction fees.

The feature is fully configurable through multiple channels:
- CLI arguments via the `#[arg]` attribute
- Environment variables via `#[derive_env_var]`
- TOML configuration files via serde serialization
- Defaults to 0 (disabled) when not specified

The changes span the configuration system (`magicblock-config`), the account cloner implementation (`magicblock-account-cloner`), and include comprehensive integration testing to validate the functionality works end-to-end.