### PR TITLE
chore: change default commit/undelegate CU price

### DIFF
--- a/magicblock-config/src/accounts.rs
+++ b/magicblock-config/src/accounts.rs
@@ -178,7 +178,7 @@ fn default_max_monitored_accounts() -> usize {
 fn default_compute_unit_price() -> u64 {
     // This is the lowest we found to pass the transactions through mainnet fairly
     // consistently
-    1_000_000 // 1_000_000 micro-lamports == 1 Lamport
+    100_000 // 100_000 micro-lamports == 0.1 Lamport
 }
 
 impl Default for CommitStrategyConfig {

--- a/magicblock-config/tests/fixtures/02_defaults.toml
+++ b/magicblock-config/tests/fixtures/02_defaults.toml
@@ -7,7 +7,7 @@ remote.cluster = "devnet"
 # lifecycle: replica | programs-replica | ephemeral | offline
 lifecycle = "programs-replica"
 
-commit = { frequency_millis = 500, compute_unit_price = 1_000_000 }
+commit = { frequency_millis = 500, compute_unit_price = 100_000 }
 
 allowed-programs = []
 


### PR DESCRIPTION
## Summary

This PR reduces the default compute unit price for commit and undelegate operations from 1,000,000 micro-lamports (1 Lamport) to 100,000 micro-lamports (0.1 Lamport), representing a 90% cost reduction. The change modifies the `default_compute_unit_price()` function in `magicblock-config/src/accounts.rs`.