### PR TITLE
fix: always run hydration

### DIFF
--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -827,18 +827,12 @@ impl MagicValidator {
                 }
             }
 
-            let remote_account_cloner_worker =
-                remote_account_cloner_worker.clone();
+            let cloner_for_hydrate = Arc::clone(&remote_account_cloner_worker);
+
             tokio::spawn(async move {
-                let _ = remote_account_cloner_worker
-                    .hydrate()
-                    .await
-                    .inspect_err(|err| {
-                        error!(
-                            "Failed to hydrate validator accounts: {:?}",
-                            err
-                        );
-                    });
+                let _ = cloner_for_hydrate.hydrate().await.inspect_err(|err| {
+                    error!("Failed to hydrate validator accounts: {:?}", err);
+                });
                 info!("Validator hydration complete (bank hydrate, replay, account clone)");
             });
 


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

This pull request modifies the validator startup process in `magicblock-api/src/magic_validator.rs` to always run account hydration, regardless of the ledger resume strategy. Previously, the hydration process only executed when `self.config.ledger.resume_strategy().is_replaying()` returned true, meaning it was conditional on the ledger being in a "Replay" state.

The hydration process is a critical initialization step that ensures the validator has access to all necessary account data from the remote chain. It involves:

1. Retrieving all accounts from the internal account provider
2. Filtering out blacklisted accounts and certain executable accounts
3. Cloning the remaining accounts and updating the validator's cache
4. Processing up to 30 accounts concurrently to avoid rate limiting

By removing the conditional check, this change ensures that account hydration occurs during validator startup regardless of whether the resume strategy is "Reset", "ResumeOnly", or "Replay". This makes the validator initialization more consistent and robust, as it guarantees that the validator will always have properly synchronized account state from the remote chain.

The change integrates well with the existing codebase architecture, where the `RemoteAccountClonerWorker` handles the hydration logic through its `hydrate()` method. The modification maintains the same error handling and logging patterns, spawning the hydration as an asynchronous task that logs completion when finished.

## Confidence score: 4/5

- This PR is safe to merge with minimal risk as it only expands when an existing process runs
- Score reflects a straightforward change that makes validator initialization more consistent without introducing new logic
- Pay close attention to startup performance impact and ensure hydration works correctly with all resume strategies

<!-- /greptile_comment -->