### PR TITLE
fix: move hydration to be sync on validator startup

### DIFF
--- a/magicblock-account-cloner/src/remote_account_cloner_worker.rs
+++ b/magicblock-account-cloner/src/remote_account_cloner_worker.rs
@@ -284,7 +284,7 @@ where
             .collect::<HashSet<_>>();
 
         let count = account_keys.len();
-        debug!("Hydrating {count} accounts");
+        info!("Hydrating {count} accounts");
         let stream = stream::iter(account_keys);
         // NOTE: depending on the RPC provider we may get rate limited if we request
         // account states at a too high rate.
@@ -298,7 +298,7 @@ where
         // TODO(GabrielePicco): Make the concurrency configurable
         let result = stream
             .map(Ok::<_, AccountClonerError>)
-            .try_for_each_concurrent(10, |(pubkey, owner)| async move {
+            .try_for_each_concurrent(20, |(pubkey, owner)| async move {
                 trace!("Hydrating '{}'", pubkey);
                 let res = self
                     .do_clone_and_update_cache(

--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -827,14 +827,10 @@ impl MagicValidator {
                 }
             }
 
-            let cloner_for_hydrate = Arc::clone(&remote_account_cloner_worker);
-
-            tokio::spawn(async move {
-                let _ = cloner_for_hydrate.hydrate().await.inspect_err(|err| {
-                    error!("Failed to hydrate validator accounts: {:?}", err);
-                });
-                info!("Validator hydration complete (bank hydrate, replay, account clone)");
+            let _ = remote_account_cloner_worker.hydrate().await.inspect_err(|err| {
+                error!("Failed to hydrate validator accounts: {:?}", err);
             });
+            info!("Validator hydration complete (bank hydrate, replay, account clone)");
 
             let cancellation_token = self.token.clone();
             self.remote_account_cloner_handle =


### PR DESCRIPTION
**Account Hydration Improvements:**

* Increased the concurrency level for account hydration from 10 to 20 in `RemoteAccountClonerWorker`, allowing more accounts to be processed in parallel for improved performance.
* Changed the log level from `debug!` to `info!` when logging the number of accounts being hydrated, making this information more visible in production logs.

**Validator Execution Flow:**

* Changed the hydration call in `MagicValidator` to execute directly (awaited in place) instead of spawning a new async task, simplifying the control flow and error handling for validator account hydration.