### PR TITLE
hot-fix: allow rpc to utilize all cores

### DIFF
--- a/magicblock-rpc/src/json_rpc_service.rs
+++ b/magicblock-rpc/src/json_rpc_service.rs
@@ -16,7 +16,6 @@ use magicblock_bank::bank::Bank;
 use magicblock_ledger::Ledger;
 use solana_perf::thread::renice_this_thread;
 use solana_sdk::{hash::Hash, signature::Keypair};
-use tokio::runtime::Runtime;
 
 use crate::{
     handlers::{
@@ -36,7 +35,6 @@ use crate::{
 pub struct JsonRpcService {
     rpc_addr: SocketAddr,
     rpc_niceness_adj: i8,
-    runtime: Arc<Runtime>,
     request_processor: JsonRpcRequestProcessor,
     startup_verification_complete: Arc<AtomicBool>,
     max_request_body_size: usize,
@@ -61,7 +59,6 @@ impl JsonRpcService {
             .max_request_body_size
             .unwrap_or(MAX_REQUEST_BODY_SIZE);
 
-        let runtime = get_runtime();
         let rpc_niceness_adj = config.rpc_niceness_adj;
 
         let startup_verification_complete =
@@ -82,7 +79,6 @@ impl JsonRpcService {
             rpc_addr,
             rpc_niceness_adj,
             max_request_body_size,
-            runtime,
             request_processor,
             startup_verification_complete,
             rpc_thread_handle: Default::default(),
@@ -100,7 +96,6 @@ impl JsonRpcService {
             self.startup_verification_complete.clone();
         let request_processor = self.request_processor.clone();
         let rpc_addr = self.rpc_addr;
-        let runtime = self.runtime.handle().clone();
         let max_request_body_size = self.max_request_body_size;
 
         let close_handle_rc = self.close_handle.clone();
@@ -126,8 +121,7 @@ impl JsonRpcService {
                         request_processor.clone()
                     },
                 )
-                    .event_loop_executor(runtime)
-                    .threads(1)
+                    .threads(8)
                     .cors(DomainsValidation::AllowOnly(vec![
                         AccessControlAllowOrigin::Any,
                     ]))
@@ -185,21 +179,4 @@ impl JsonRpcService {
     pub fn rpc_addr(&self) -> &SocketAddr {
         &self.rpc_addr
     }
-}
-
-fn get_runtime() -> Arc<tokio::runtime::Runtime> {
-    // Comment from Solana implementation:
-    // sadly, some parts of our current rpc implemention block the jsonrpc's
-    // _socket-listening_ event loop for too long, due to (blocking) long IO or intesive CPU,
-    // causing no further processing of incoming requests and ultimatily innocent clients timing-out.
-    // So create a (shared) multi-threaded event_loop for jsonrpc and set its .threads() to 1,
-    // so that we avoid the single-threaded event loops from being created automatically by
-    // jsonrpc for threads when .threads(N > 1) is given.
-    Arc::new(
-        tokio::runtime::Builder::new_multi_thread()
-            .thread_name("solRpcEl")
-            .enable_all()
-            .build()
-            .expect("Runtime"),
-    )
 }


### PR DESCRIPTION
due to slipshod code, the rpc was running on runtime with a single thread, and thus underutilizing available compute resources, this PR hotfixes the issue, by providing the rpc with a truly multithreaded runtime