### PR TITLE
fix: failed to fetch satisfactory slot

### DIFF
--- a/magicblock-account-cloner/src/remote_account_cloner_worker.rs
+++ b/magicblock-account-cloner/src/remote_account_cloner_worker.rs
@@ -508,10 +508,10 @@ where
 
             // Fetch the account, repeat and retry until we have a satisfactory response
             let mut fetch_count = 0;
+            let min_context_slot =
+                self.account_updates.get_last_known_update_slot(&clock::ID);
             loop {
                 fetch_count += 1;
-                let min_context_slot =
-                    self.account_updates.get_last_known_update_slot(&clock::ID);
                 match self
                     .fetch_account_chain_snapshot(pubkey, min_context_slot)
                     .await


### PR DESCRIPTION
## Description

Moving that target slot call outside the loop to reduce the FailedToFetchSatisfactorySlot probability compared to recomputing it on every retry, because it removes the “moving target” that can keep outrunning a lagging HTTP node.
