### PR TITLE
fix: increase compute budgets due to

### DIFF
--- a/magicblock-committor-service/src/tasks/mod.rs
+++ b/magicblock-committor-service/src/tasks/mod.rs
@@ -186,10 +186,10 @@ impl BaseTask for ArgsTask {
 
     fn compute_units(&self) -> u32 {
         match self {
-            Self::Commit(_) => 65_000,
+            Self::Commit(_) => 75_000,
             Self::BaseAction(task) => task.action.compute_units,
-            Self::Undelegate(_) => 50_000,
-            Self::Finalize(_) => 40_000,
+            Self::Undelegate(_) => 60_000,
+            Self::Finalize(_) => 60_000,
         }
     }
 
@@ -307,7 +307,7 @@ impl BaseTask for BufferTask {
 
     fn compute_units(&self) -> u32 {
         match self {
-            Self::Commit(_) => 65_000,
+            Self::Commit(_) => 75_000,
         }
     }
 


### PR DESCRIPTION
In some cases we run out of compute budget, like [here](https://explorer.solana.com/tx/5hAp9eswfdxCiQvGRg1EzwYhyvffNqmX6mfxV7LTYKtcMRnd4wgEn6H7EJirzZqXVt336xiGhmXjPTjEKSQaC4Pu?cluster=devnet)

<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-11 09:05:28 UTC

This PR addresses compute budget exhaustion issues by increasing the compute unit (CU) limits for three task types in the committor service. The changes modify the `compute_units()` method implementations for both `ArgsTask` and `BufferTask` enums in `magicblock-committor-service/src/tasks/mod.rs`.

Specifically, the compute budgets are increased as follows:
- **Commit tasks**: 65,000 → 75,000 CU (+15%)
- **Undelegate tasks**: 50,000 → 60,000 CU (+20%) 
- **Finalize tasks**: 40,000 → 60,000 CU (+50%)

These changes ensure consistency between `ArgsTask::Commit` and `BufferTask::Commit` variants, both now using 75,000 CU. The modifications are in response to production transaction failures where operations exceeded their allocated compute budgets, as evidenced by the failed transaction referenced in the PR description. This is a defensive programming approach to prevent runtime failures in the blockchain environment where compute unit limits are strictly enforced and exceeded limits cause transaction failures.

## Confidence score: 5/5

- This PR is safe to merge with minimal risk as it only increases compute budget limits without changing core logic
- Score reflects simple, well-understood changes that address a concrete production issue with clear evidence
- No files require special attention as the changes are straightforward numerical increases

<!-- /greptile_comment -->