### PR TITLE
chore: always print core info

### DIFF
--- a/magicblock-validator/src/main.rs
+++ b/magicblock-validator/src/main.rs
@@ -50,6 +50,18 @@ fn init_logger() {
     }
 }
 
+/// Print informational startup messages.
+/// If RUST_LOG is not set, prints to stdout using println! so users always see it.
+/// If RUST_LOG is set, emits an info! log so operators can control visibility
+/// (e.g., by setting RUST_LOG=warn to hide it).
+fn print_info<S: std::fmt::Display>(msg: S) {
+    if std::env::var_os("RUST_LOG").is_some() {
+        info!("{}", msg);
+    } else {
+        println!("{}", msg);
+    }
+}
+
 #[tokio::main]
 async fn main() {
     init_logger();
@@ -96,23 +108,29 @@ async fn main() {
 
     api.start().await.expect("Failed to start validator");
     let version = magicblock_version::Version::default();
-    println!();
-    println!("🧙 Magicblock Validator is running! 🪄✦");
-    println!(
+    print_info("");
+    print_info("🧙 Magicblock Validator is running! 🪄✦");
+    print_info(format!(
         "🏷️ Validator version: {} (Git: {})",
         version, version.git_version
-    );
-    println!("-----------------------------------");
-    println!("📡 RPC endpoint:       http://{}:{}", rpc_host, rpc_port);
-    println!("🔌 WebSocket endpoint: ws://{}:{}", rpc_host, ws_port);
-    println!("🖥️ Validator identity: {}", validator_identity);
-    println!(
+    ));
+    print_info("-----------------------------------");
+    print_info(format!(
+        "📡 RPC endpoint:       http://{}:{}",
+        rpc_host, rpc_port
+    ));
+    print_info(format!(
+        "🔌 WebSocket endpoint: ws://{}:{}",
+        rpc_host, ws_port
+    ));
+    print_info(format!("🖥️ Validator identity: {}", validator_identity));
+    print_info(format!(
         "🗄️ Ledger location:    {}",
         api.ledger().ledger_path().to_str().unwrap_or("")
-    );
-    println!("-----------------------------------");
-    println!("Ready for connections!");
-    println!();
+    ));
+    print_info("-----------------------------------");
+    print_info("Ready for connections!");
+    print_info("");
 
     if let Err(err) = Shutdown::wait().await {
         error!("Failed to gracefully shutdown: {}", err);


### PR DESCRIPTION
## Description

This PR changes how core validator information is displayed during startup by replacing `log::info!` calls with `println!` statements in the main validator startup sequence. The change ensures that essential operational information - including validator version, Git hash, RPC endpoint, WebSocket endpoint, validator identity, and ledger location - is always visible to users regardless of their log level configuration.

This is useful for the distributed binaries of the validator