### PR TITLE
fix: don't block async runtime, when taking snapshot

### DIFF
--- a/magicblock-accounts-db/src/index.rs
+++ b/magicblock-accounts-db/src/index.rs
@@ -24,6 +24,7 @@ const DEALLOCATIONS_INDEX: &str = "deallocations-idx";
 const OWNERS_INDEX: &str = "owners-idx";
 
 /// LMDB Index manager
+#[cfg_attr(test, derive(Debug))]
 pub(crate) struct AccountsDbIndex {
     /// Accounts Index, used for searching accounts by offset in the main storage
     ///

--- a/magicblock-accounts-db/src/index/table.rs
+++ b/magicblock-accounts-db/src/index/table.rs
@@ -5,6 +5,7 @@ use lmdb::{
 
 use super::WEMPTY;
 
+#[cfg_attr(test, derive(Debug))]
 pub(super) struct Table {
     db: Database,
 }

--- a/magicblock-accounts-db/src/storage.rs
+++ b/magicblock-accounts-db/src/storage.rs
@@ -24,6 +24,7 @@ const BLOCKSIZE_OFFSET: usize = SLOT_OFFSET + size_of::<u64>();
 const TOTALBLOCKS_OFFSET: usize = BLOCKSIZE_OFFSET + size_of::<u32>();
 const DEALLOCATED_OFFSET: usize = TOTALBLOCKS_OFFSET + size_of::<u32>();
 
+#[cfg_attr(test, derive(Debug))]
 pub(crate) struct AccountsStorage {
     meta: StorageMeta,
     /// a mutable pointer into memory mapped region
@@ -52,6 +53,7 @@ pub(crate) struct AccountsStorage {
 /// | total blocks  | total number of blocks  | 4            |
 /// | deallocated   | deallocated block count | 4            |
 /// ----------------------------------------------------------
+#[cfg_attr(test, derive(Debug))]
 struct StorageMeta {
     /// offset into memory map, where next allocation will be served
     head: &'static AtomicU64,

--- a/magicblock-bank/src/bank.rs
+++ b/magicblock-bank/src/bank.rs
@@ -152,7 +152,7 @@ impl ForkGraph for SimpleForkGraph {
 //#[derive(Debug)]
 pub struct Bank {
     /// Shared reference to accounts database
-    pub accounts_db: AccountsDb,
+    pub accounts_db: Arc<AccountsDb>,
 
     /// Bank epoch
     epoch: Epoch,
@@ -441,7 +441,7 @@ impl Bank {
         // this is the only place where we have a mutable access to the AccountsDb
         // before it's wrapped in Arc, and thus becomes immutable
         if adb_init_slot_override {
-            accounts_db.set_slot(adb_init_slot);
+            accounts_db.override_slot(adb_init_slot);
         }
         accounts_db.ensure_at_most(adb_init_slot)?;
 
@@ -511,7 +511,7 @@ impl Bank {
         feature_set.activate(&curve25519_restrict_msm_length::ID, 0);
 
         let mut bank = Self {
-            accounts_db: adb,
+            accounts_db: adb.into(),
             epoch: Epoch::default(),
             epoch_schedule: EpochSchedule::default(),
             is_delta: AtomicBool::default(),


### PR DESCRIPTION
this PR introduces a refactoring of snapshot taking flow, where the entire stop the world and snapshot taking is moved to a separate thread, thus allowing the async tasks to continue without blocking the runtime. 

<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-12 11:24:13 UTC

This PR implements a significant performance optimization for the AccountsDb snapshot mechanism to prevent blocking the async runtime. The core issue addressed is that snapshot operations were previously holding "stop the world" locks for extended periods while performing expensive disk I/O, which would freeze all async tasks in the validator.

The refactoring introduces two key architectural changes:

1. **Thread separation**: The entire snapshot process is moved to dedicated background threads using `std::thread::spawn`. This allows the main async runtime to continue processing transactions and other operations while snapshots are taken in parallel.


The implementation changes span multiple components:
- `AccountsDb` now requires `Arc` wrapping to enable thread-safe sharing
- The `set_slot()` method signature changed to `&Arc<Self>` to support background thread spawning
- A new `override_slot()` method was added for initialization scenarios
- Debug traits were conditionally added to core structs to support testing the new architecture
- Test infrastructure was updated to handle the new ownership semantics and async behavior

This optimization is critical for validator performance, as it prevents snapshot operations from creating significant latency spikes that could affect transaction processing and other time-sensitive operations in the validator.

## Confidence score: 4/5

- This PR addresses a critical performance bottleneck but introduces complex threading changes that could affect system stability
- Pay close attention to snapshot.rs and lib.rs where thread spawning occurs without comprehensive error propagation

<!-- /greptile_comment -->