### PR TITLE
fix: use async lock for transaction execution serialization

### DIFF
--- a/magicblock-processor/src/execute_transaction.rs
+++ b/magicblock-processor/src/execute_transaction.rs
@@ -45,7 +45,7 @@ pub fn execute_sanitized_transaction(
     // If we choose this as a long term solution we need to lock simulations/preflight with the
     // same mutex once we enable them again
     // Work tracked here: https://github.com/magicblock-labs/magicblock-validator/issues/181
-    let _execution_guard = TRANSACTION_INDEX_LOCK.write();
+    // let _execution_guard = TRANSACTION_INDEX_LOCK.write();
 
     let batch = bank.prepare_sanitized_batch(txs);
 

--- a/magicblock-rpc/src/json_rpc_request_processor.rs
+++ b/magicblock-rpc/src/json_rpc_request_processor.rs
@@ -42,6 +42,7 @@ use solana_transaction_status::{
     EncodedConfirmedTransactionWithStatusMeta, TransactionConfirmationStatus,
     TransactionStatus, UiInnerInstructions, UiTransactionEncoding,
 };
+use tokio::sync::Mutex;
 
 use crate::{
     account_resolver::{encode_account, get_encoded_account},
@@ -99,6 +100,7 @@ pub struct JsonRpcRequestProcessor {
     pub faucet_keypair: Arc<Keypair>,
 
     pub accounts_manager: Arc<AccountsManager>,
+    pub transaction_lock: Arc<Mutex<()>>,
 }
 impl Metadata for JsonRpcRequestProcessor {}
 
@@ -120,6 +122,7 @@ impl JsonRpcRequestProcessor {
             faucet_keypair: Arc::new(faucet_keypair),
             genesis_hash,
             accounts_manager,
+            transaction_lock: Default::default(),
         }
     }
 

--- a/magicblock-rpc/src/transaction.rs
+++ b/magicblock-rpc/src/transaction.rs
@@ -189,9 +189,11 @@ pub(crate) async fn send_transaction(
     }
 
     if let Some(preflight_bank) = preflight_bank {
+        let _guard = meta.transaction_lock.lock().await;
         meta.transaction_preflight(preflight_bank, &sanitized_transaction)?;
     }
 
+    let _guard = meta.transaction_lock.lock().await;
     metrics::observe_transaction_execution_time(|| {
         execute_sanitized_transaction(
             sanitized_transaction,


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-12 15:58:01 UTC

This PR replaces a problematic synchronous locking mechanism with async-compatible locking for transaction execution serialization. The changes remove a global static synchronous write lock (`TRANSACTION_INDEX_LOCK`) from the processor module that was causing performance issues during snapshotting operations and blocking the entire async runtime.

The new implementation introduces a `transaction_lock: Arc<Mutex<()>>` field to the `JsonRpcRequestProcessor` struct, which uses Tokio's async Mutex instead. This lock is acquired twice during transaction processing: once for preflight checks and once for actual execution, ensuring proper serialization while maintaining async compatibility.

The key architectural change moves the locking responsibility from a global static in the processor layer to the RPC layer, providing better encapsulation and granular control. This approach allows the async runtime to properly yield control while waiting for locks, preventing the deadlocks and performance bottlenecks that were occurring with the synchronous implementation. The change maintains the same safety guarantees for transaction ordering and state consistency that are critical in a blockchain validator context.

## Confidence score: 2/5

- This PR addresses a real performance issue but introduces potential race conditions by removing processor-level locking
- Score reflects concern about incomplete lock coverage - async RPC lock may not protect all transaction execution paths
- Pay close attention to `magicblock-processor/src/execute_transaction.rs` where the sync lock was only commented out rather than properly replaced

<!-- /greptile_comment -->