### PR TITLE
Revert "hotfix: use multi-threaded runtime"

### DIFF
--- a/magicblock-rpc/src/json_rpc_service.rs
+++ b/magicblock-rpc/src/json_rpc_service.rs
@@ -16,7 +16,7 @@ use magicblock_bank::bank::Bank;
 use magicblock_ledger::Ledger;
 use solana_perf::thread::renice_this_thread;
 use solana_sdk::{hash::Hash, signature::Keypair};
-use tokio::runtime;
+use tokio::runtime::Runtime;
 
 use crate::{
     handlers::{
@@ -36,6 +36,7 @@ use crate::{
 pub struct JsonRpcService {
     rpc_addr: SocketAddr,
     rpc_niceness_adj: i8,
+    runtime: Arc<Runtime>,
     request_processor: JsonRpcRequestProcessor,
     startup_verification_complete: Arc<AtomicBool>,
     max_request_body_size: usize,
@@ -60,6 +61,7 @@ impl JsonRpcService {
             .max_request_body_size
             .unwrap_or(MAX_REQUEST_BODY_SIZE);
 
+        let runtime = get_runtime(&config);
         let rpc_niceness_adj = config.rpc_niceness_adj;
 
         let startup_verification_complete =
@@ -80,6 +82,7 @@ impl JsonRpcService {
             rpc_addr,
             rpc_niceness_adj,
             max_request_body_size,
+            runtime,
             request_processor,
             startup_verification_complete,
             rpc_thread_handle: Default::default(),
@@ -97,7 +100,7 @@ impl JsonRpcService {
             self.startup_verification_complete.clone();
         let request_processor = self.request_processor.clone();
         let rpc_addr = self.rpc_addr;
-        let executor = runtime::Handle::current();
+        let runtime = self.runtime.handle().clone();
         let max_request_body_size = self.max_request_body_size;
 
         let close_handle_rc = self.close_handle.clone();
@@ -123,7 +126,7 @@ impl JsonRpcService {
                         request_processor.clone()
                     },
                 )
-                    .event_loop_executor(executor)
+                    .event_loop_executor(runtime)
                     .threads(1)
                     .cors(DomainsValidation::AllowOnly(vec![
                         AccessControlAllowOrigin::Any,
@@ -182,4 +185,28 @@ impl JsonRpcService {
     pub fn rpc_addr(&self) -> &SocketAddr {
         &self.rpc_addr
     }
+}
+
+fn get_runtime(config: &JsonRpcConfig) -> Arc<tokio::runtime::Runtime> {
+    let rpc_threads = 1.max(config.rpc_threads);
+    let rpc_niceness_adj = config.rpc_niceness_adj;
+
+    // Comment from Solana implementation:
+    // sadly, some parts of our current rpc implemention block the jsonrpc's
+    // _socket-listening_ event loop for too long, due to (blocking) long IO or intesive CPU,
+    // causing no further processing of incoming requests and ultimatily innocent clients timing-out.
+    // So create a (shared) multi-threaded event_loop for jsonrpc and set its .threads() to 1,
+    // so that we avoid the single-threaded event loops from being created automatically by
+    // jsonrpc for threads when .threads(N > 1) is given.
+    Arc::new(
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(rpc_threads)
+            .on_thread_start(move || {
+                renice_this_thread(rpc_niceness_adj).unwrap()
+            })
+            .thread_name("solRpcEl")
+            .enable_all()
+            .build()
+            .expect("Runtime"),
+    )
 }


### PR DESCRIPTION
Reverts magicblock-labs/magicblock-validator#539

<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-12 20:53:50 UTC

This PR reverts a previous hotfix (#539) that attempted to use a multi-threaded runtime for the JSON-RPC service. The revert restores the original implementation that creates a dedicated multi-threaded Tokio runtime for handling JSON-RPC requests.

The key changes include:

1. **Added dedicated runtime management**: The `JsonRpcService` struct now contains a `runtime: Arc<Runtime>` field that holds an owned runtime instance instead of relying on the ambient runtime context.

2. **Introduced `get_runtime()` function**: This new function creates a purpose-built multi-threaded runtime with configurable worker threads, custom thread naming ("solRpcEl"), and thread niceness adjustment for optimal performance. It ensures at least one thread is allocated and applies priority adjustments to prevent blocking operations.

3. **Changed runtime usage pattern**: The HTTP server now uses the service's own runtime handle (`.event_loop_executor(runtime)`) instead of relying on `runtime::Handle::current()` from the calling context.

This revert addresses issues where the previous hotfix failed in environments lacking an ambient runtime or where the calling context's runtime wasn't suitable for RPC operations. The dedicated runtime approach provides explicit control over execution context, thread configuration, and performance characteristics, following Solana's implementation pattern to avoid blocking the socket-listening event loop and prevent client timeouts.

## Confidence score: 4/5

- This PR is safe to merge with minimal risk as it reverts to a previously working implementation
- Score reflects the restoration of proven runtime management patterns and explicit control over thread configuration
- Pay close attention to the `get_runtime()` function implementation and runtime handle usage patterns

<!-- /greptile_comment -->