### PR TITLE
fix: update undelegation cu

### DIFF
--- a/magicblock-committor-service/src/compute_budget.rs
+++ b/magicblock-committor-service/src/compute_budget.rs
@@ -114,7 +114,7 @@ impl ComputeBudgetConfig {
             },
             undelegate: Budget {
                 compute_unit_price,
-                base_budget: 60_000,
+                base_budget: 70_000,
                 per_committee: 35_000,
             },
             buffer_init: BufferWithReallocBudget {


### PR DESCRIPTION
Some users are facing errors when undelegating because the [CU budget is exceeded](https://solscan.io/tx/3DrfLpiqWtPTW3XX1zPxs1q8EWC1fArHx78f26fMMZbGbGXMkKREmcutwDFqaZ3HYRkfR5bNu9pmJSRrfQbU6zj6?cluster=devnet).

This PR bumps the CU budget but the value picked is only a guess as the issue is hard reproduce

<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-16 09:10:51 UTC

This PR addresses a user-facing issue where undelegation transactions are failing due to compute unit (CU) budget exceeded errors. The fix increases the base compute budget for undelegation operations from 60,000 to 70,000 compute units (a 16.7% increase) in the `ComputeBudgetConfig::new()` method.

The change is made in the `magicblock-committor-service/src/compute_budget.rs` file, which appears to be part of a compute budget management system that allocates specific CU budgets for different types of operations. The codebase uses a structured approach where operations like `args_process`, `finalize`, `buffer` operations, and `undelegate` each have their own compute unit allocations. The base_budget field being modified likely serves as the foundation for calculating compute units needed for undelegation operations.

The motivation for this change is well-documented with a real transaction failure on devnet that demonstrates the CU limit being exceeded during undelegation. This indicates that the undelegation process involves more complex operations than initially anticipated when the original 60,000 CU budget was set.

## Confidence score: 4/5

- This PR is safe to merge as it addresses a real user issue with a conservative fix that's unlikely to cause problems
- Score reflects the straightforward nature of the change and clear evidence of the problem, though the arbitrary value selection prevents a perfect score
- Pay close attention to monitoring undelegation transaction success rates after deployment to validate the fix

<!-- /greptile_comment -->