### PR TITLE
fix: make transaction execution serialized

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3873,6 +3873,7 @@ dependencies = [
 name = "magicblock-account-dumper"
 version = "0.2.1"
 dependencies = [
+ "async-trait",
  "bincode",
  "magicblock-bank",
  "magicblock-mutator",
@@ -4330,6 +4331,7 @@ dependencies = [
  "solana-timings",
  "spl-token",
  "spl-token-2022 6.0.0",
+ "tokio",
 ]
 
 [[package]]

--- a/magicblock-account-dumper/Cargo.toml
+++ b/magicblock-account-dumper/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 edition.workspace = true
 
 [dependencies]
+async-trait = { workspace = true }
 magicblock-bank = { workspace = true }
 magicblock-mutator = { workspace = true }
 magicblock-processor = { workspace = true }

--- a/magicblock-account-dumper/src/account_dumper.rs
+++ b/magicblock-account-dumper/src/account_dumper.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use magicblock_mutator::errors::MutatorModificationError;
 use solana_sdk::{account::Account, pubkey::Pubkey, signature::Signature};
 use thiserror::Error;
@@ -17,10 +18,11 @@ pub type AccountDumperResult<T> = Result<T, AccountDumperError>;
 //  - a TransactionExecutor trait with a service implementation passed as parameter to the AccountCloner
 //  - using the mutator's functionality directly inside of the AccountCloner
 //  - work tracked here: https://github.com/magicblock-labs/magicblock-validator/issues/159
+#[async_trait]
 pub trait AccountDumper {
     // Overrides the account in the bank to make sure it's usable as a feepayer account (it has no-data)
     // in future transactions that account can be used for signing transactions and transferring lamports
-    fn dump_feepayer_account(
+    async fn dump_feepayer_account(
         &self,
         pubkey: &Pubkey,
         lamports: u64,
@@ -29,7 +31,7 @@ pub trait AccountDumper {
 
     // Overrides the account in the bank to make sure it's a PDA that can be used as readonly
     // Future transactions should be able to read from it (but not write) on the account as-is
-    fn dump_undelegated_account(
+    async fn dump_undelegated_account(
         &self,
         pubkey: &Pubkey,
         account: &Account,
@@ -37,7 +39,7 @@ pub trait AccountDumper {
 
     // Overrides the account in the bank to make sure it's a ready to use delegated account
     // Transactions should be able to write to it, we need to make sure the owner is set correctly
-    fn dump_delegated_account(
+    async fn dump_delegated_account(
         &self,
         pubkey: &Pubkey,
         account: &Account,
@@ -46,7 +48,7 @@ pub trait AccountDumper {
 
     // Overrides the accounts in the bank to make sure the program is usable normally (and upgraded)
     // We make sure all accounts involved in the program are present in the bank with latest state
-    fn dump_program_accounts(
+    async fn dump_program_accounts(
         &self,
         program_id: &Pubkey,
         program_id_account: &Account,
@@ -58,7 +60,7 @@ pub trait AccountDumper {
     /// Edge case handler, when we artificially manufacture 2 accounts for program, which is owned
     /// by older version of BPF loader, and thus only had 1 program account on main chain. This is
     /// necessary for uniformity of program loading pipeline by utilizing single loader (BPF upgradable).
-    fn dump_program_account_with_old_bpf(
+    async fn dump_program_account_with_old_bpf(
         &self,
         program_pubkey: &Pubkey,
         program_account: &Account,

--- a/magicblock-account-dumper/src/account_dumper_bank.rs
+++ b/magicblock-account-dumper/src/account_dumper_bank.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use async_trait::async_trait;
 use magicblock_bank::bank::Bank;
 use magicblock_mutator::{
     program::{
@@ -41,7 +42,7 @@ impl AccountDumperBank {
         }
     }
 
-    fn execute_transaction(
+    async fn execute_transaction(
         &self,
         transaction: Transaction,
     ) -> AccountDumperResult<Signature> {
@@ -55,12 +56,14 @@ impl AccountDumperBank {
             &self.bank,
             self.transaction_status_sender.as_ref(),
         )
+        .await
         .map_err(AccountDumperError::TransactionError)
     }
 }
 
+#[async_trait]
 impl AccountDumper for AccountDumperBank {
-    fn dump_feepayer_account(
+    async fn dump_feepayer_account(
         &self,
         pubkey: &Pubkey,
         lamports: u64,
@@ -77,10 +80,10 @@ impl AccountDumper for AccountDumperBank {
             None,
             self.bank.last_blockhash(),
         );
-        self.execute_transaction(transaction)
+        self.execute_transaction(transaction).await
     }
 
-    fn dump_undelegated_account(
+    async fn dump_undelegated_account(
         &self,
         pubkey: &Pubkey,
         account: &Account,
@@ -91,7 +94,7 @@ impl AccountDumper for AccountDumperBank {
             None,
             self.bank.last_blockhash(),
         );
-        let result = self.execute_transaction(transaction)?;
+        let result = self.execute_transaction(transaction).await?;
         if let Some(mut acc) = self.bank.get_account(pubkey) {
             acc.set_delegated(false);
             self.bank.store_account(*pubkey, acc);
@@ -99,7 +102,7 @@ impl AccountDumper for AccountDumperBank {
         Ok(result)
     }
 
-    fn dump_delegated_account(
+    async fn dump_delegated_account(
         &self,
         pubkey: &Pubkey,
         account: &Account,
@@ -116,7 +119,7 @@ impl AccountDumper for AccountDumperBank {
             overrides,
             self.bank.last_blockhash(),
         );
-        let result = self.execute_transaction(transaction)?;
+        let result = self.execute_transaction(transaction).await?;
         if let Some(mut acc) = self.bank.get_account(pubkey) {
             acc.set_delegated(true);
             self.bank.store_account(*pubkey, acc);
@@ -124,7 +127,7 @@ impl AccountDumper for AccountDumperBank {
         Ok(result)
     }
 
-    fn dump_program_accounts(
+    async fn dump_program_accounts(
         &self,
         program_id_pubkey: &Pubkey,
         program_id_account: &Account,
@@ -157,10 +160,10 @@ impl AccountDumper for AccountDumperBank {
             program_idl_modification,
             self.bank.last_blockhash(),
         );
-        self.execute_transaction(transaction)
+        self.execute_transaction(transaction).await
     }
 
-    fn dump_program_account_with_old_bpf(
+    async fn dump_program_account_with_old_bpf(
         &self,
         program_pubkey: &Pubkey,
         program_account: &Account,
@@ -205,7 +208,7 @@ impl AccountDumper for AccountDumperBank {
             None,
             self.bank.last_blockhash(),
         );
-        self.execute_transaction(transaction)
+        self.execute_transaction(transaction).await
     }
 }
 

--- a/magicblock-account-dumper/src/account_dumper_stub.rs
+++ b/magicblock-account-dumper/src/account_dumper_stub.rs
@@ -3,6 +3,7 @@ use std::{
     sync::{Arc, RwLock},
 };
 
+use async_trait::async_trait;
 use solana_sdk::{
     account::Account, bpf_loader_upgradeable::get_program_data_address,
     pubkey::Pubkey, signature::Signature,
@@ -20,8 +21,9 @@ pub struct AccountDumperStub {
     program_idls: Arc<RwLock<HashSet<Pubkey>>>,
 }
 
+#[async_trait]
 impl AccountDumper for AccountDumperStub {
-    fn dump_feepayer_account(
+    async fn dump_feepayer_account(
         &self,
         pubkey: &Pubkey,
         _lamports: u64,
@@ -34,7 +36,7 @@ impl AccountDumper for AccountDumperStub {
         Ok(Signature::new_unique())
     }
 
-    fn dump_undelegated_account(
+    async fn dump_undelegated_account(
         &self,
         pubkey: &Pubkey,
         _account: &Account,
@@ -46,7 +48,7 @@ impl AccountDumper for AccountDumperStub {
         Ok(Signature::new_unique())
     }
 
-    fn dump_delegated_account(
+    async fn dump_delegated_account(
         &self,
         pubkey: &Pubkey,
         _account: &Account,
@@ -59,7 +61,7 @@ impl AccountDumper for AccountDumperStub {
         Ok(Signature::new_unique())
     }
 
-    fn dump_program_accounts(
+    async fn dump_program_accounts(
         &self,
         program_id_pubkey: &Pubkey,
         _program_id_account: &Account,
@@ -84,7 +86,7 @@ impl AccountDumper for AccountDumperStub {
         Ok(Signature::new_unique())
     }
 
-    fn dump_program_account_with_old_bpf(
+    async fn dump_program_account_with_old_bpf(
         &self,
         program_pubkey: &Pubkey,
         _program_account: &Account,

--- a/magicblock-accounts/src/scheduled_commits_processor.rs
+++ b/magicblock-accounts/src/scheduled_commits_processor.rs
@@ -301,7 +301,9 @@ impl<C: BaseIntentCommittor> ScheduledCommitsProcessorImpl<C> {
             intent_sent_transaction,
             bank,
             Some(transaction_status_sender),
-        ) {
+        )
+        .await
+        {
             Ok(signature) => debug!(
                 "Signaled sent commit with internal signature: {:?}",
                 signature
@@ -327,7 +329,9 @@ impl<C: BaseIntentCommittor> ScheduledCommitsProcessorImpl<C> {
             intent_sent_transaction,
             bank,
             Some(transaction_status_sender),
-        ) {
+        )
+        .await
+        {
             Ok(signature) => debug!(
                 "Signaled sent commit with internal signature: {:?}",
                 signature

--- a/magicblock-api/src/tickers.rs
+++ b/magicblock-api/src/tickers.rs
@@ -81,6 +81,7 @@ async fn handle_scheduled_commits<C: ScheduledCommitsProcessor>(
     let tx = InstructionUtils::accept_scheduled_commits(bank.last_blockhash());
     if let Err(err) =
         execute_legacy_transaction(tx, bank, Some(transaction_status_sender))
+            .await
     {
         error!("Failed to accept scheduled commits: {:?}", err);
         return;

--- a/magicblock-processor/Cargo.toml
+++ b/magicblock-processor/Cargo.toml
@@ -23,6 +23,7 @@ solana-svm = { workspace = true }
 solana-timings = { workspace = true }
 spl-token = { workspace = true }
 spl-token-2022 = { workspace = true }
+tokio = { workspace = true }
 
 [dev-dependencies]
 magicblock-bank = { workspace = true, features = ["dev-context-only-utils"] }

--- a/magicblock-rpc/src/json_rpc_request_processor.rs
+++ b/magicblock-rpc/src/json_rpc_request_processor.rs
@@ -100,6 +100,7 @@ pub struct JsonRpcRequestProcessor {
 
     pub accounts_manager: Arc<AccountsManager>,
 }
+
 impl Metadata for JsonRpcRequestProcessor {}
 
 impl JsonRpcRequestProcessor {

--- a/magicblock-rpc/src/transaction.rs
+++ b/magicblock-rpc/src/transaction.rs
@@ -192,17 +192,16 @@ pub(crate) async fn send_transaction(
         meta.transaction_preflight(preflight_bank, &sanitized_transaction)?;
     }
 
-    metrics::observe_transaction_execution_time(|| {
-        execute_sanitized_transaction(
-            sanitized_transaction,
-            bank,
-            meta.transaction_status_sender(),
-        )
-        .map_err(|err| jsonrpc_core::Error {
-            code: jsonrpc_core::ErrorCode::InternalError,
-            message: err.to_string(),
-            data: None,
-        })
+    execute_sanitized_transaction(
+        sanitized_transaction,
+        bank,
+        meta.transaction_status_sender(),
+    )
+    .await
+    .map_err(|err| jsonrpc_core::Error {
+        code: jsonrpc_core::ErrorCode::InternalError,
+        message: err.to_string(),
+        data: None,
     })?;
 
     // debug!("{:#?}", tx_result);


### PR DESCRIPTION
this is achieved via a single permit semaphore, which is acquired by every transaction, but unlike previous implementation it doesn't involve any OS level synchronous locks, which were causing runtime shortage by blocking all the runtime threads, leading to latency spikes

<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-16 11:13:01 UTC

This PR refactors transaction execution from synchronous OS-level locking to asynchronous semaphore-based serialization to address runtime thread blocking and latency spikes. The key change introduces a single-permit `tokio::Semaphore` (`TXN_SERIALIZER`) in `execute_transaction.rs` that replaces the previous `StWLock` mechanism. This maintains transaction serialization (one transaction at a time) while allowing the async runtime to yield threads instead of blocking them.

The changes cascade throughout the codebase, converting multiple components to async:
- Transaction execution functions (`execute_legacy_transaction`, `execute_sanitized_transaction`) are now async
- The `AccountDumper` trait and its implementations are converted to async with `#[async_trait]`
- Account cloning, dumping, and commit processing operations now use `.await` patterns
- RPC transaction handling removes synchronous metrics wrappers to accommodate async execution
- Several Cargo.toml files add `tokio` and `async-trait` dependencies

The architectural change maintains existing functionality while improving runtime efficiency. The semaphore approach ensures transactions are still processed sequentially but without blocking the entire thread pool, which was causing performance degradation in the previous synchronous implementation.

## Confidence score: 4/5

- This PR is generally safe to merge but requires careful testing due to the async conversion scope
- Score reflects the comprehensive async transformation across multiple critical components that could introduce subtle timing or concurrency issues
- Pay close attention to transaction execution files and account dumping operations for proper async handling

<!-- /greptile_comment -->