### PR TITLE
Hotfix: run periodic hydration

### DIFF
--- a/configs/ephem-localnet.toml
+++ b/configs/ephem-localnet.toml
@@ -1,5 +1,5 @@
 [accounts]
-remote.url = "http://localhost:7799"
+remote.url = "http://localhost:8899"
 lifecycle = "ephemeral"
 commit = { frequency-millis = 50_000 }
 
@@ -24,7 +24,7 @@ snapshot-frequency = 1024
 
 [rpc]
 addr = "0.0.0.0"
-port = 8899
+port = 7799
 
 [validator]
 millis-per-slot = 50


### PR DESCRIPTION
## Description

This hotfix runs a periodic hydration to re-sync all accounts that are in a borked/wrong state due to missed updates.

This is a temporary mitigation and will be remove with the new cloning pipeline (as hydration would be removed)