### PR TITLE
Revert "Hotfix: run periodic hydration"

### DIFF
--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -89,7 +89,6 @@ use solana_sdk::{
     signature::Keypair,
     signer::Signer,
 };
-use tokio::time::{interval, MissedTickBehavior};
 use tokio_util::sync::CancellationToken;
 
 use crate::{
@@ -828,23 +827,6 @@ impl MagicValidator {
         }
     }
 
-    async fn run_hydration_once(
-        worker: &Arc<
-            RemoteAccountClonerWorker<
-                BankAccountProvider,
-                RemoteAccountFetcherClient,
-                RemoteAccountUpdatesClient,
-                AccountDumperBank,
-                CommittorService,
-            >,
-        >,
-    ) {
-        let _ = worker.hydrate().await.inspect_err(|err| {
-            error!("Failed to hydrate validator accounts: {:?}", err);
-        });
-        info!("Validator hydration complete (bank hydrate, replay, account clone)");
-    }
-
     async fn start_remote_account_cloner_worker(&mut self) -> ApiResult<()> {
         if let Some(remote_account_cloner_worker) =
             self.remote_account_cloner_worker.take()
@@ -862,30 +844,12 @@ impl MagicValidator {
                 }
             }
 
-            // Run one hydration and await it.
-            Self::run_hydration_once(&remote_account_cloner_worker).await;
-
-            // Spawn periodic hydration every 15 minutes in the background.
-            {
-                let hydration_worker = remote_account_cloner_worker.clone();
-                let hydration_token = self.token.clone();
-                tokio::spawn(async move {
-                    let mut tick = interval(Duration::from_secs(15 * 60));
-                    tick.set_missed_tick_behavior(MissedTickBehavior::Delay);
-                    tick.tick().await;
-                    loop {
-                        tokio::select! {
-                            _ = hydration_token.cancelled() => {
-                                debug!("Hydration task cancelled");
-                                break;
-                            }
-                            _ = tick.tick() => {
-                                Self::run_hydration_once(&hydration_worker).await;
-                            }
-                        }
-                    }
-                });
-            }
+            let _ = remote_account_cloner_worker.hydrate().await.inspect_err(
+                |err| {
+                    error!("Failed to hydrate validator accounts: {:?}", err);
+                },
+            );
+            info!("Validator hydration complete (bank hydrate, replay, account clone)");
 
             let cancellation_token = self.token.clone();
             self.remote_account_cloner_handle =

--- a/test-integration/Cargo.lock
+++ b/test-integration/Cargo.lock
@@ -3635,7 +3635,6 @@ dependencies = [
 name = "magicblock-account-dumper"
 version = "0.2.1"
 dependencies = [
- "async-trait",
  "bincode",
  "magicblock-bank",
  "magicblock-mutator",
@@ -4076,7 +4075,6 @@ dependencies = [
  "solana-timings",
  "spl-token",
  "spl-token-2022 6.0.0",
- "tokio",
 ]
 
 [[package]]


### PR DESCRIPTION
Reverts magicblock-labs/magicblock-validator#552

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-09-23 16:26:19 UTC

<h3>Summary</h3>

This PR cleanly reverts the periodic hydration hotfix that was introduced in PR #552. The revert removes the background task that ran hydration every 15 minutes and returns to the original behavior of running hydration only once during validator startup.

- Removes periodic hydration background task and related helper function
- Reverts to single hydration run during `start_remote_account_cloner_worker`
- Cleans up unused tokio imports and dependencies in Cargo.lock
- No functional issues identified - clean revert with proper dependency cleanup

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk
- Score reflects a clean revert operation that removes temporary mitigation code. The changes are well-isolated, dependencies are properly cleaned up, and no new functionality is introduced.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | &nbsp;&nbsp;&nbsp;&nbsp; &nbsp;  Score &nbsp;&nbsp;&nbsp;&nbsp; &nbsp; | Overview |
|----------|-------|----------|
| magicblock-api/src/magic_validator.rs | 4/5 | Reverts periodic hydration task, returning to single hydration run during startup - clean revert with no logical issues |
| test-integration/Cargo.lock | 5/5 | Removes unused dependencies (async-trait, tokio) that were no longer needed after revert |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant MV as MagicValidator
    participant RAC as RemoteAccountClonerWorker
    participant Scheduler as Tokio Scheduler
    
    Note over MV,RAC: Before Revert (PR #552)
    MV->>RAC: hydrate() (initial)
    RAC-->>MV: Complete
    MV->>Scheduler: spawn periodic task (15min interval)
    loop Every 15 minutes
        Scheduler->>RAC: hydrate() (periodic)
        RAC-->>Scheduler: Complete/Error
    end
    
    Note over MV,RAC: After Revert (This PR)
    MV->>RAC: hydrate() (single run)
    RAC-->>MV: Complete
    Note over MV: No periodic hydration task
```

<!-- /greptile_comment -->