### PR TITLE
hotfix: always treat dlp owned accounts as dirty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3859,6 +3859,7 @@ dependencies = [
  "magicblock-accounts-api",
  "magicblock-committor-service",
  "magicblock-config",
+ "magicblock-delegation-program 1.0.0 (git+https://github.com/magicblock-labs/delegation-program.git?rev=5fb8d20)",
  "magicblock-metrics",
  "magicblock-mutator",
  "magicblock-program",

--- a/magicblock-account-cloner/Cargo.toml
+++ b/magicblock-account-cloner/Cargo.toml
@@ -12,6 +12,7 @@ conjunto-transwise = { workspace = true }
 flume = { workspace = true }
 futures-util = { workspace = true }
 log = { workspace = true }
+magicblock-delegation-program = { workspace = true }
 magicblock-account-fetcher = { workspace = true }
 magicblock-account-updates = { workspace = true }
 magicblock-account-dumper = { workspace = true }

--- a/magicblock-account-cloner/src/remote_account_cloner_worker.rs
+++ b/magicblock-account-cloner/src/remote_account_cloner_worker.rs
@@ -357,19 +357,23 @@ where
                             account_chain_snapshot: snapshot,
                             ..
                         } => {
-                            if snapshot.at_slot >= last_known_update_slot
-                                || snapshot.chain_state.is_feepayer()
+                            return if (snapshot.at_slot
+                                >= last_known_update_slot
+                                || snapshot.chain_state.is_feepayer())
+                                && !self
+                                    .internal_account_provider
+                                    .get_account(pubkey)
+                                    .is_some_and(|x| x.owner().eq(&dlp::ID))
                             {
-                                return Ok(last_clone_output);
+                                Ok(last_clone_output)
                             } else {
                                 // If the cloned account has been updated since clone, update the cache
-                                return self
-                                    .do_clone_and_update_cache(
-                                        pubkey,
-                                        ValidatorStage::Running,
-                                    )
-                                    .await;
-                            }
+                                self.do_clone_and_update_cache(
+                                    pubkey,
+                                    ValidatorStage::Running,
+                                )
+                                .await
+                            };
                         }
                         AccountClonerOutput::Unclonable {
                             at_slot: until_slot,


### PR DESCRIPTION

<h3>Summary</h3>

This hotfix modifies the account cloning cache logic to always treat DLP (Delegation Program) owned accounts as dirty, forcing them to be re-cloned instead of using cached results.

