### PR TITLE
fix: periodic committer attempts to commit undelegated accounts

### DIFF
--- a/magicblock-accounts/src/external_accounts_manager.rs
+++ b/magicblock-accounts/src/external_accounts_manager.rs
@@ -378,7 +378,7 @@ where
         // Therefore we use the current slot which could result in two commits with the same
         // slot. However since we most likely will phase out frequent commits we accept this
         // inconsistency for now.
-        static MESSAGE_ID: AtomicU64 = AtomicU64::new(u64::MAX - 1);
+        static MESSAGE_ID: AtomicU64 = AtomicU64::new((i64::MAX - 1) as u64);
 
         let slot = self.internal_account_provider.get_slot();
         let blockhash = self.internal_account_provider.get_blockhash();
@@ -394,6 +394,7 @@ where
                         None
                     })
             })
+            .filter(|(_, _, _, acc)| acc.is_delegated())
             .filter(|(_, _, prev_hash, acc)| {
                 prev_hash.map_or(true, |hash| hash_account(acc) != hash)
             })

--- a/magicblock-committor-service/src/intent_execution_manager/intent_execution_engine.rs
+++ b/magicblock-committor-service/src/intent_execution_manager/intent_execution_engine.rs
@@ -246,7 +246,7 @@ where
             .execute(intent.inner.clone(), persister)
             .await
             .inspect_err(|err| {
-                error!("Failed to execute BaseIntent: {:?}", err)
+                error!("Failed to execute BaseIntent. id: {}. {:?}", intent.id, err)
             })
             .map(|output| ExecutionOutputWrapper {
                 id: intent.id,

--- a/magicblock-committor-service/src/intent_execution_manager/intent_execution_engine.rs
+++ b/magicblock-committor-service/src/intent_execution_manager/intent_execution_engine.rs
@@ -246,7 +246,10 @@ where
             .execute(intent.inner.clone(), persister)
             .await
             .inspect_err(|err| {
-                error!("Failed to execute BaseIntent. id: {}. {:?}", intent.id, err)
+                error!(
+                    "Failed to execute BaseIntent. id: {}. {:?}",
+                    intent.id, err
+                )
             })
             .map(|output| ExecutionOutputWrapper {
                 id: intent.id,

--- a/test-integration/Cargo.lock
+++ b/test-integration/Cargo.lock
@@ -3621,6 +3621,7 @@ dependencies = [
  "magicblock-accounts-api",
  "magicblock-committor-service",
  "magicblock-config",
+ "magicblock-delegation-program 1.0.0 (git+https://github.com/magicblock-labs/delegation-program.git?rev=5fb8d20)",
  "magicblock-metrics",
  "magicblock-mutator",
  "magicblock-program",
@@ -3635,6 +3636,7 @@ dependencies = [
 name = "magicblock-account-dumper"
 version = "0.2.1"
 dependencies = [
+ "async-trait",
  "bincode",
  "magicblock-bank",
  "magicblock-mutator",
@@ -4075,6 +4077,7 @@ dependencies = [
  "solana-timings",
  "spl-token",
  "spl-token-2022 6.0.0",
+ "tokio",
 ]
 
 [[package]]


### PR DESCRIPTION
In `ExternalAccountsManager` ignore nondelegated accounts during periodic commits