### PR TITLE
hotfix: reset commit nonce cache on undelegation.

### DIFF
--- a/magicblock-committor-service/src/intent_executor/mod.rs
+++ b/magicblock-committor-service/src/intent_executor/mod.rs
@@ -431,12 +431,13 @@ where
         persister: Option<P>,
     ) -> IntentExecutorResult<ExecutionOutput> {
         let message_id = base_intent.id;
+        let is_undelegate = base_intent.is_undelegate();
         let pubkeys = base_intent.get_committed_pubkeys();
 
         let result = self.execute_inner(base_intent, &persister).await;
         if let Some(pubkeys) = pubkeys {
             // Reset TaskInfoFetcher, as cache could become invalid
-            if result.is_err() {
+            if result.is_err() || is_undelegate {
                 self.task_info_fetcher.reset(ResetType::Specific(&pubkeys));
             }
 


### PR DESCRIPTION
We need to reset cache of commit nonces(ids) when delegation happens. The reason is that delegation_record is deleted on undelegation, hence on redelegation nonce will be 0 again

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-09-29 16:50:56 UTC

<h3>Summary</h3>

This hotfix addresses a cache consistency issue in the intent execution system. The change ensures that commit nonce cache is reset when undelegation operations succeed, not just when they fail.

**Key Changes:**
- Added `is_undelegate()` check to determine if cache reset is needed
- Modified cache reset condition from `result.is_err()` to `result.is_err() || is_undelegate`
- Prevents stale nonce data when delegation records are deleted during undelegation

This change is necessary because delegation records are deleted on undelegation, causing commit nonces to restart from 0 on redelegation. Without this fix, cached nonces would be out of sync with the actual state.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Score reflects a well-targeted hotfix that addresses a specific cache consistency issue. The change is minimal, logically sound, and directly addresses the problem described in the PR. No breaking changes or complex logic introduced.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | &nbsp;&nbsp;&nbsp;&nbsp; &nbsp;  Score &nbsp;&nbsp;&nbsp;&nbsp; &nbsp; | Overview |
|----------|-------|----------|
| magicblock-committor-service/src/intent_executor/mod.rs | 5/5 | Added cache reset on undelegation operations to prevent stale commit nonce data |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client as Client/Scheduler
    participant IE as IntentExecutor
    participant TIF as TaskInfoFetcher
    participant Cache as Commit Nonce Cache

    Client->>IE: execute(base_intent, persister)
    IE->>IE: Check is_undelegate()
    IE->>IE: execute_inner(base_intent, persister)
    
    alt Intent execution fails
        IE->>TIF: reset(ResetType::Specific(pubkeys))
        TIF->>Cache: Clear cached nonces for pubkeys
    else Intent execution succeeds AND is undelegation
        IE->>TIF: reset(ResetType::Specific(pubkeys))
        TIF->>Cache: Clear cached nonces for pubkeys
        Note over Cache: Cache reset prevents stale nonces<br/>when delegation record is deleted
    else Intent execution succeeds AND not undelegation
        Note over IE: No cache reset needed
    end
    
    IE->>Client: Return execution result
```

<!-- /greptile_comment -->