### PR TITLE
release: 0.2.2

### DIFF
--- a/.github/packages/npm-package/package.json
+++ b/.github/packages/npm-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magicblock-labs/ephemeral-validator",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "MagicBlock Ephemeral Validator",
   "homepage": "https://github.com/magicblock-labs/ephemeral-validator#readme",
   "bugs": {
@@ -28,11 +28,11 @@
     "typescript": "^4.9.4"
   },
   "optionalDependencies": {
-    "@magicblock-labs/ephemeral-validator-darwin-arm64": "0.2.1",
-    "@magicblock-labs/ephemeral-validator-darwin-x64": "0.2.1",
-    "@magicblock-labs/ephemeral-validator-linux-arm64": "0.2.1",
-    "@magicblock-labs/ephemeral-validator-linux-x64": "0.2.1",
-    "@magicblock-labs/ephemeral-validator-windows-x64": "0.2.1"
+    "@magicblock-labs/ephemeral-validator-darwin-arm64": "0.2.2",
+    "@magicblock-labs/ephemeral-validator-darwin-x64": "0.2.2",
+    "@magicblock-labs/ephemeral-validator-linux-arm64": "0.2.2",
+    "@magicblock-labs/ephemeral-validator-linux-x64": "0.2.2",
+    "@magicblock-labs/ephemeral-validator-windows-x64": "0.2.2"
   },
   "publishConfig": {
     "access": "public"

--- a/.github/packages/npm-package/package.json.tmpl
+++ b/.github/packages/npm-package/package.json.tmpl
@@ -1,7 +1,7 @@
 {
   "name": "@magicblock-labs/${node_pkg}",
   "description": "Ephemeral Validator (${node_pkg})",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/magicblock-labs/ephemeral-validator.git"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,7 +811,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115e54d64eb62cdebad391c19efc9dce4981c690c85a33a12199d99bb9546fee"
 dependencies = [
  "borsh-derive 0.10.4",
- "hashbrown 0.13.2",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -2073,7 +2073,7 @@ dependencies = [
 
 [[package]]
 name = "expiring-hashmap"
-version = "0.2.1"
+version = "0.2.2"
 
 [[package]]
 name = "fake-simd"
@@ -2477,7 +2477,7 @@ dependencies = [
 
 [[package]]
 name = "geyser-grpc-proto"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3003,7 +3003,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.56.0",
 ]
 
 [[package]]
@@ -3846,7 +3846,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-account-cloner"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "conjunto-transwise",
  "flume",
@@ -3872,7 +3872,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-account-dumper"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "async-trait",
  "bincode",
@@ -3886,7 +3886,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-account-fetcher"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "async-trait",
  "conjunto-transwise",
@@ -3902,7 +3902,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-account-updates"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bincode",
  "conjunto-transwise",
@@ -3923,7 +3923,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-accounts"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "async-trait",
  "conjunto-transwise",
@@ -3958,7 +3958,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-accounts-api"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "magicblock-bank",
  "solana-sdk",
@@ -3966,7 +3966,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-accounts-db"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "const_format",
  "env_logger 0.11.8",
@@ -3985,7 +3985,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-api"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "agave-geyser-plugin-interface",
  "anyhow",
@@ -4036,7 +4036,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-bank"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "agave-geyser-plugin-interface",
  "assert_matches",
@@ -4078,7 +4078,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-committor-program"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "borsh 1.5.7",
  "borsh-derive 1.5.7",
@@ -4095,7 +4095,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-committor-service"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -4129,7 +4129,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-config"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bs58 0.4.0",
  "clap 4.5.40",
@@ -4147,11 +4147,11 @@ dependencies = [
 
 [[package]]
 name = "magicblock-config-helpers"
-version = "0.2.1"
+version = "0.2.2"
 
 [[package]]
 name = "magicblock-config-macro"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "cargo-expand",
  "clap 4.5.40",
@@ -4167,7 +4167,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-core"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "magicblock-magic-program-api",
 ]
@@ -4206,7 +4206,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-geyser-plugin"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "agave-geyser-plugin-interface",
  "anyhow",
@@ -4235,7 +4235,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-ledger"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bincode",
  "byteorder",
@@ -4254,7 +4254,7 @@ dependencies = [
  "solana-measure",
  "solana-metrics",
  "solana-sdk",
- "solana-storage-proto 0.2.1",
+ "solana-storage-proto 0.2.2",
  "solana-svm 2.2.1 (git+https://github.com/magicblock-labs/magicblock-svm.git?rev=e93eb57)",
  "solana-timings",
  "solana-transaction-status",
@@ -4267,7 +4267,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-magic-program-api"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bincode",
  "serde",
@@ -4276,7 +4276,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-metrics"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "http-body-util",
  "hyper 1.6.0",
@@ -4290,7 +4290,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-mutator"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -4307,7 +4307,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-perf-service"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "log",
  "magicblock-bank",
@@ -4316,7 +4316,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-processor"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "lazy_static",
  "log",
@@ -4338,7 +4338,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-program"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -4360,7 +4360,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-pubsub"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bincode",
  "geyser-grpc-proto",
@@ -4382,7 +4382,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-rpc"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "base64 0.21.7",
  "bincode",
@@ -4417,7 +4417,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-rpc-client"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "env_logger 0.11.8",
  "log",
@@ -4431,7 +4431,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-table-mania"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "ed25519-dalek",
  "log",
@@ -4448,7 +4448,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-task-scheduler"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bincode",
  "chrono",
@@ -4475,7 +4475,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-tokens"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "log",
  "magicblock-bank",
@@ -4490,7 +4490,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-transaction-status"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "crossbeam-channel",
  "log",
@@ -4502,7 +4502,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-validator"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "clap 4.5.40",
  "console-subscriber",
@@ -4518,7 +4518,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-validator-admin"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "log",
@@ -4537,7 +4537,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-version"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "git-version",
  "rustc_version",
@@ -9528,7 +9528,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-proto"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bincode",
  "bs58 0.4.0",
@@ -11007,7 +11007,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-tools"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "log",
  "magicblock-accounts-db",
@@ -11027,7 +11027,7 @@ dependencies = [
 
 [[package]]
 name = "test-tools-core"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "env_logger 0.11.8",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ resolver = "2"
 
 [workspace.package]
 # Solana Version (2.2.x)
-version = "0.2.1"
+version = "0.2.2"
 authors = ["MagicBlock Maintainers <maintainers@magicblock.xyz>"]
 repository = "https://github.com/magicblock-labs/ephemeral-validator"
 homepage = "https://www.magicblock.xyz"

--- a/test-integration/Cargo.lock
+++ b/test-integration/Cargo.lock
@@ -748,7 +748,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115e54d64eb62cdebad391c19efc9dce4981c690c85a33a12199d99bb9546fee"
 dependencies = [
  "borsh-derive 0.10.4",
- "hashbrown 0.13.2",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -1853,7 +1853,7 @@ dependencies = [
  "ephemeral-rollups-sdk-attribute-delegate",
  "ephemeral-rollups-sdk-attribute-ephemeral",
  "magicblock-delegation-program 1.1.1",
- "magicblock-magic-program-api 0.2.1 (git+https://github.com/magicblock-labs/magicblock-validator.git?rev=959b63c37eaf07cce31a434c4dcad28ed3d452ef)",
+ "magicblock-magic-program-api 0.2.1",
  "solana-program",
 ]
 
@@ -1931,7 +1931,7 @@ dependencies = [
 
 [[package]]
 name = "expiring-hashmap"
-version = "0.2.1"
+version = "0.2.2"
 
 [[package]]
 name = "fake-simd"
@@ -2303,7 +2303,7 @@ dependencies = [
 
 [[package]]
 name = "geyser-grpc-proto"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3608,7 +3608,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-account-cloner"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "conjunto-transwise",
  "flume",
@@ -3634,7 +3634,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-account-dumper"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "async-trait",
  "bincode",
@@ -3648,7 +3648,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-account-fetcher"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "async-trait",
  "conjunto-transwise",
@@ -3663,7 +3663,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-account-updates"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bincode",
  "conjunto-transwise",
@@ -3682,7 +3682,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-accounts"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "async-trait",
  "conjunto-transwise",
@@ -3698,7 +3698,7 @@ dependencies = [
  "magicblock-committor-service",
  "magicblock-core",
  "magicblock-delegation-program 1.0.0 (git+https://github.com/magicblock-labs/delegation-program.git?rev=5fb8d20)",
- "magicblock-magic-program-api 0.2.1",
+ "magicblock-magic-program-api 0.2.2",
  "magicblock-metrics",
  "magicblock-mutator",
  "magicblock-processor",
@@ -3715,7 +3715,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-accounts-api"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "magicblock-bank",
  "solana-sdk",
@@ -3723,7 +3723,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-accounts-db"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "const_format",
  "lmdb-rkv",
@@ -3741,7 +3741,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-api"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "agave-geyser-plugin-interface",
  "anyhow",
@@ -3767,7 +3767,7 @@ dependencies = [
  "magicblock-delegation-program 1.0.0 (git+https://github.com/magicblock-labs/delegation-program.git?rev=5fb8d20)",
  "magicblock-geyser-plugin",
  "magicblock-ledger",
- "magicblock-magic-program-api 0.2.1",
+ "magicblock-magic-program-api 0.2.2",
  "magicblock-metrics",
  "magicblock-perf-service",
  "magicblock-processor",
@@ -3792,7 +3792,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-bank"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "agave-geyser-plugin-interface",
  "bincode",
@@ -3828,7 +3828,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-committor-program"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "borsh 1.5.7",
  "borsh-derive 1.5.7",
@@ -3842,7 +3842,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-committor-service"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -3874,7 +3874,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-config"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bs58 0.4.0",
  "clap 4.5.41",
@@ -3891,11 +3891,11 @@ dependencies = [
 
 [[package]]
 name = "magicblock-config-helpers"
-version = "0.2.1"
+version = "0.2.2"
 
 [[package]]
 name = "magicblock-config-macro"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "clap 4.5.41",
  "convert_case 0.8.0",
@@ -3907,9 +3907,9 @@ dependencies = [
 
 [[package]]
 name = "magicblock-core"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
- "magicblock-magic-program-api 0.2.1",
+ "magicblock-magic-program-api 0.2.2",
 ]
 
 [[package]]
@@ -3963,7 +3963,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-geyser-plugin"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "agave-geyser-plugin-interface",
  "anyhow",
@@ -3992,7 +3992,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-ledger"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bincode",
  "byteorder",
@@ -4011,22 +4011,13 @@ dependencies = [
  "solana-measure",
  "solana-metrics",
  "solana-sdk",
- "solana-storage-proto 0.2.1",
+ "solana-storage-proto 0.2.2",
  "solana-svm 2.2.1 (git+https://github.com/magicblock-labs/magicblock-svm.git?rev=e93eb57)",
  "solana-timings",
  "solana-transaction-status",
  "thiserror 1.0.69",
  "tokio",
  "tokio-util 0.7.15",
-]
-
-[[package]]
-name = "magicblock-magic-program-api"
-version = "0.2.1"
-dependencies = [
- "bincode",
- "serde",
- "solana-program",
 ]
 
 [[package]]
@@ -4040,8 +4031,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "magicblock-magic-program-api"
+version = "0.2.2"
+dependencies = [
+ "bincode",
+ "serde",
+ "solana-program",
+]
+
+[[package]]
 name = "magicblock-metrics"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "http-body-util",
  "hyper 1.6.0",
@@ -4055,7 +4055,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-mutator"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bincode",
  "log",
@@ -4068,7 +4068,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-perf-service"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "log",
  "magicblock-bank",
@@ -4077,7 +4077,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-processor"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "lazy_static",
  "log",
@@ -4099,12 +4099,12 @@ dependencies = [
 
 [[package]]
 name = "magicblock-program"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bincode",
  "lazy_static",
  "magicblock-core",
- "magicblock-magic-program-api 0.2.1",
+ "magicblock-magic-program-api 0.2.2",
  "magicblock-metrics",
  "num-derive",
  "num-traits",
@@ -4117,7 +4117,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-pubsub"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bincode",
  "geyser-grpc-proto",
@@ -4139,7 +4139,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-rpc"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "base64 0.21.7",
  "bincode",
@@ -4174,7 +4174,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-rpc-client"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "log",
  "solana-rpc-client",
@@ -4187,7 +4187,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-table-mania"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "ed25519-dalek",
  "log",
@@ -4204,7 +4204,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-task-scheduler"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bincode",
  "chrono",
@@ -4231,7 +4231,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-tokens"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "log",
  "magicblock-bank",
@@ -4246,7 +4246,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-transaction-status"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "crossbeam-channel",
  "log",
@@ -4258,7 +4258,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-validator-admin"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "log",
@@ -4277,7 +4277,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-version"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "git-version",
  "rustc_version",
@@ -5188,7 +5188,7 @@ dependencies = [
  "bincode",
  "borsh 1.5.7",
  "ephemeral-rollups-sdk",
- "magicblock-magic-program-api 0.2.1",
+ "magicblock-magic-program-api 0.2.2",
  "serde",
  "solana-program",
 ]
@@ -6069,7 +6069,7 @@ dependencies = [
  "integration-test-tools",
  "log",
  "magicblock-core",
- "magicblock-magic-program-api 0.2.1",
+ "magicblock-magic-program-api 0.2.2",
  "program-schedulecommit",
  "schedulecommit-client",
  "solana-program",
@@ -6085,7 +6085,7 @@ version = "0.0.0"
 dependencies = [
  "integration-test-tools",
  "magicblock-core",
- "magicblock-magic-program-api 0.2.1",
+ "magicblock-magic-program-api 0.2.2",
  "program-schedulecommit",
  "program-schedulecommit-security",
  "schedulecommit-client",
@@ -9113,7 +9113,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-proto"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bincode",
  "bs58 0.4.0",
@@ -10607,7 +10607,7 @@ dependencies = [
 
 [[package]]
 name = "test-tools-core"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "env_logger 0.11.8",
  "log",


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Bumped package version to 0.2.2 across the npm package and Rust workspace.
  - Updated platform-specific validator binary references to 0.2.2 for macOS (Apple Silicon, Intel), Linux (ARM64, x64), and Windows (x64).
  - No functional or behavior changes; maintenance release focused on version alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-12 07:27:32 UTC

<h3>Summary</h3>

Release version bump from 0.2.1 to 0.2.2 across all workspace packages and NPM distributions.

**Key Changes:**
- Updated workspace version in `Cargo.toml`
- Updated NPM package version and all platform-specific dependencies (darwin-arm64, darwin-x64, linux-arm64, linux-x64, windows-x64)
- Regenerated lock files with version updates

**Concerns:**
- Two dependency downgrades detected in `Cargo.lock`: `hashbrown` (0.13.2→0.12.3) and `windows-core` (0.61.2→0.56.0)
- Verify these downgrades are intentional and don't introduce compatibility issues

<h3>Confidence Score: 4/5</h3>

- This release PR is generally safe to merge with minor concerns about dependency downgrades
- The version bump is consistent across all files (Rust workspace and NPM packages). However, two dependency downgrades (hashbrown and windows-core) in Cargo.lock warrant verification before merging to ensure they don't introduce compatibility issues or vulnerabilities
- Verify `Cargo.lock` dependency downgrades are intentional and don't break compatibility

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| Cargo.toml | 5/5 | Workspace version bumped from 0.2.1 to 0.2.2 consistently |
| .github/packages/npm-package/package.json | 5/5 | Package version and all platform-specific dependencies updated to 0.2.2 |
| .github/packages/npm-package/package.json.tmpl | 5/5 | Template version updated to 0.2.2 for NPM package generation |
| Cargo.lock | 3/5 | Version updates with unexpected dependency downgrades (hashbrown 0.13.2→0.12.3, windows-core 0.61.2→0.56.0) |
| test-integration/Cargo.lock | 3/5 | Version updates with hashbrown downgrade and magicblock-magic-program-api source changes |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant CT as Cargo.toml
    participant NPM as NPM Package Files
    participant CL as Cargo.lock Files
    participant CI as CI/CD Pipeline

    Dev->>CT: Update workspace version to 0.2.2
    Dev->>NPM: Update package.json version to 0.2.2
    Dev->>NPM: Update package.json.tmpl version to 0.2.2
    Dev->>NPM: Update all platform dependencies to 0.2.2
    
    Dev->>CL: Run cargo update
    CL-->>CL: Regenerate Cargo.lock
    CL-->>CL: Update all workspace crate versions
    Note over CL: Side effect: hashbrown 0.13.2→0.12.3
    Note over CL: Side effect: windows-core 0.61.2→0.56.0
    
    Dev->>CL: Update test-integration/Cargo.lock
    CL-->>CL: Update integration test dependencies
    
    Dev->>CI: Commit release 0.2.2
    CI->>CI: Build and test all platforms
    CI->>CI: Publish NPM packages
    CI->>CI: Create release artifacts
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->