### PR TITLE
fix: release package with CI

### DIFF
--- a/.github/packages/npm-package/ephemeralValidator.ts
+++ b/.github/packages/npm-package/ephemeralValidator.ts
@@ -52,7 +52,11 @@ function runWithForwardedExit(child: ReturnType<typeof spawn>): void {
 
 function runEphemeralValidator(location: string): void {
   const args = process.argv.slice(2);
-  const ephemeralValidator = spawn(location, args, { stdio: "inherit" });
+  const env = {
+    ...process.env,
+    RUST_LOG: "quiet",
+  };
+  const ephemeralValidator = spawn(location, args, { stdio: "inherit", env});
   runWithForwardedExit(ephemeralValidator);
 }
 

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -191,6 +191,8 @@ jobs:
         run: echo "DRY_RUN=false" >> $GITHUB_ENV
         if: github.event_name == 'release' && github.event.action == 'published'
 
+      - uses: ./magicblock-validator/.github/actions/setup-solana
+
       - name: Publish the NPM package
         shell: bash
         run: |

--- a/magicblock-validator/src/main.rs
+++ b/magicblock-validator/src/main.rs
@@ -51,14 +51,18 @@ fn init_logger() {
 }
 
 /// Print informational startup messages.
-/// If RUST_LOG is not set, prints to stdout using println! so users always see it.
-/// If RUST_LOG is set, emits an info! log so operators can control visibility
-/// (e.g., by setting RUST_LOG=warn to hide it).
+/// - If `RUST_LOG` is not set or is set to "quiet", prints to stdout using `println!()`.
+/// - Otherwise, emits an `info!` log so operators can control visibility
+///   (e.g., by setting `RUST_LOG=warn` to hide it).
 fn print_info<S: std::fmt::Display>(msg: S) {
-    if std::env::var_os("RUST_LOG").is_some() {
-        info!("{}", msg);
-    } else {
+    let rust_log = std::env::var("RUST_LOG").unwrap_or_default();
+    let rust_log_trimmed = rust_log.trim().to_ascii_lowercase();
+    let use_plain_print =
+        rust_log_trimmed.is_empty() || rust_log_trimmed == "quiet";
+    if use_plain_print {
         println!("{}", msg);
+    } else {
+        info!("{}", msg);
     }
 }
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-12 11:40:19 UTC

<h3>Summary</h3>

This PR fixes the NPM package release by suppressing verbose logs when the validator is launched through the TypeScript wrapper. It sets `RUST_LOG=quiet` in the NPM wrapper, and updates the Rust code to handle this special value by printing directly to stdout instead of through the logger.

**Major changes:**
- NPM wrapper now sets `RUST_LOG=quiet` when spawning the validator
- Rust `print_info` function now checks for `RUST_LOG=quiet` to decide between `println!()` and `info!()`
- Added `setup-solana` action to CI workflow for wrapper package publishing

**Issues found:**
- Incorrect path reference in workflow file that will cause CI failure

<h3>Confidence Score: 2/5</h3>

- This PR has a critical CI path error that will prevent the release workflow from running successfully
- The logic changes for log suppression are correct and well-implemented, but the workflow file has an incorrect path reference (`./magicblock-validator/.github/actions/setup-solana` instead of `./.github/actions/setup-solana`) that will cause the CI job to fail
- `.github/workflows/publish-packages.yml` needs the path corrected before merging

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| .github/packages/npm-package/ephemeralValidator.ts | 5/5 | Sets `RUST_LOG=quiet` when spawning ephemeral-validator to suppress logs from the TypeScript wrapper |
| .github/workflows/publish-packages.yml | 4/5 | Adds setup-solana action to publish-wrapper-npm-package job, likely needed for package build or validation |
| magicblock-validator/src/main.rs | 5/5 | Improves `print_info` logic to support `RUST_LOG=quiet` for suppressing startup messages when called from NPM package |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant NPM as NPM Package Wrapper
    participant Validator as ephemeral-validator Binary
    participant Logger as Rust Logger

    User->>NPM: Run ephemeral-validator command
    NPM->>NPM: Set RUST_LOG=quiet in env
    NPM->>Validator: spawn() with RUST_LOG=quiet
    Validator->>Logger: init_logger()
    Validator->>Logger: print_info() for startup messages
    Logger->>Logger: Check RUST_LOG value
    alt RUST_LOG is "quiet" or empty
        Logger->>User: println!() directly to stdout
    else RUST_LOG has other value
        Logger->>User: info!() through logger
    end
    Validator->>User: Start validator services
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Quieter default output: when logging is unset or set to “quiet,” messages print plainly; otherwise, structured logging is used.
- Refactor
  - Standardized log handling based on logging level for more predictable console output.
- Chores
  - Updated package publishing workflow to set up the Solana environment prior to publishing the NPM package, improving reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->