### PR TITLE
feat: use account updates to check context

### DIFF
--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -39,7 +39,8 @@ use magicblock_config::{
 };
 use magicblock_core::{
     link::{
-        blocks::BlockUpdateTx, link, transactions::TransactionSchedulerHandle,
+        accounts::AccountUpdateRx, blocks::BlockUpdateTx, link,
+        transactions::TransactionSchedulerHandle,
     },
     Slot,
 };
@@ -135,6 +136,7 @@ pub struct MagicValidator {
     chainlink: Arc<ChainlinkImpl>,
     rpc_handle: JoinHandle<()>,
     identity: Pubkey,
+    account_update: AccountUpdateRx,
     transaction_scheduler: TransactionSchedulerHandle,
     block_udpate_tx: BlockUpdateTx,
     _metrics: Option<(MetricsService, tokio::task::JoinHandle<()>)>,
@@ -338,6 +340,7 @@ impl MagicValidator {
             claim_fees_task: ClaimFeesTask::new(),
             rpc_handle,
             identity: validator_pubkey,
+            account_update: dispatch.account_update,
             transaction_scheduler: dispatch.transaction_scheduler,
             block_udpate_tx: validator_channels.block_update,
             task_scheduler_handle: None,
@@ -666,6 +669,7 @@ impl MagicValidator {
             &self.config.task_scheduler,
             self.accountsdb.clone(),
             self.transaction_scheduler.clone(),
+            self.account_update.clone(),
             self.ledger.latest_block().clone(),
             self.token.clone(),
         )?;

--- a/magicblock-config/src/lib.rs
+++ b/magicblock-config/src/lib.rs
@@ -268,10 +268,7 @@ mod tests {
                     port: 9090,
                 },
             },
-            task_scheduler: TaskSchedulerConfig {
-                reset: true,
-                millis_per_tick: 1000,
-            },
+            task_scheduler: TaskSchedulerConfig { reset: true },
         };
         let original_config = config.clone();
         let other = EphemeralConfig::default();
@@ -356,10 +353,7 @@ mod tests {
                     port: 9090,
                 },
             },
-            task_scheduler: TaskSchedulerConfig {
-                reset: true,
-                millis_per_tick: 1000,
-            },
+            task_scheduler: TaskSchedulerConfig { reset: true },
         };
 
         config.merge(other.clone());
@@ -441,10 +435,7 @@ mod tests {
                     port: 9090,
                 },
             },
-            task_scheduler: TaskSchedulerConfig {
-                reset: true,
-                millis_per_tick: 2000,
-            },
+            task_scheduler: TaskSchedulerConfig { reset: true },
         };
         let original_config = config.clone();
         let other = EphemeralConfig {
@@ -519,10 +510,7 @@ mod tests {
                     port: 9090,
                 },
             },
-            task_scheduler: TaskSchedulerConfig {
-                reset: true,
-                millis_per_tick: 1000,
-            },
+            task_scheduler: TaskSchedulerConfig { reset: true },
         };
 
         config.merge(other);

--- a/magicblock-config/src/task_scheduler.rs
+++ b/magicblock-config/src/task_scheduler.rs
@@ -5,7 +5,15 @@ use serde::{Deserialize, Serialize};
 #[clap_prefix("task-scheduler")]
 #[clap_from_serde]
 #[derive(
-    Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Args, Mergeable,
+    Debug,
+    Default,
+    Clone,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Eq,
+    Args,
+    Mergeable,
 )]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub struct TaskSchedulerConfig {
@@ -13,21 +21,4 @@ pub struct TaskSchedulerConfig {
     #[derive_env_var]
     #[serde(default)]
     pub reset: bool,
-    /// Determines how frequently the task scheduler will check for executable tasks.
-    #[derive_env_var]
-    #[serde(default = "default_millis_per_tick")]
-    pub millis_per_tick: u64,
-}
-
-impl Default for TaskSchedulerConfig {
-    fn default() -> Self {
-        Self {
-            reset: bool::default(),
-            millis_per_tick: default_millis_per_tick(),
-        }
-    }
-}
-
-fn default_millis_per_tick() -> u64 {
-    200
 }

--- a/magicblock-config/tests/fixtures/11_everything-defined.toml
+++ b/magicblock-config/tests/fixtures/11_everything-defined.toml
@@ -50,4 +50,3 @@ system-metrics-tick-interval-secs = 10
 
 [task-scheduler]
 reset = true
-millis-per-tick = 1000

--- a/magicblock-config/tests/parse_config.rs
+++ b/magicblock-config/tests/parse_config.rs
@@ -282,10 +282,7 @@ fn test_everything_defined() {
                     addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
                 },
             },
-            task_scheduler: TaskSchedulerConfig {
-                reset: true,
-                millis_per_tick: 1000,
-            },
+            task_scheduler: TaskSchedulerConfig { reset: true },
         }
     );
 }

--- a/magicblock-config/tests/read_config.rs
+++ b/magicblock-config/tests/read_config.rs
@@ -142,7 +142,6 @@ fn test_load_local_dev_with_programs_toml_envs_override() {
     env::set_var("METRICS_SYSTEM_METRICS_TICK_INTERVAL_SECS", "10");
     env::set_var("CLONE_AUTO_AIRDROP_LAMPORTS", "123");
     env::set_var("TASK_SCHEDULER_RESET", "true");
-    env::set_var("TASK_SCHEDULER_MILLIS_PER_TICK", "1000");
 
     let config = parse_config_with_file(&config_file_dir);
 
@@ -202,10 +201,7 @@ fn test_load_local_dev_with_programs_toml_envs_override() {
                 },
                 system_metrics_tick_interval_secs: 10,
             },
-            task_scheduler: TaskSchedulerConfig {
-                reset: true,
-                millis_per_tick: 1000,
-            },
+            task_scheduler: TaskSchedulerConfig { reset: true },
         }
     );
 


### PR DESCRIPTION
Fix #523 

Uses the newly introduced account update channel to listen for task context updates and deserialize them instead of blindly polling periodically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified task scheduler configuration by removing the tick interval setting, enabling more efficient event-driven operation.
  * Improved internal account update propagation and handling across system components.

* **Tests**
  * Updated test fixtures and test cases to reflect configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->