### PR TITLE
fix: remove race condition between pings and request response

### DIFF
--- a/magicblock-aperture/src/server/websocket/connection.rs
+++ b/magicblock-aperture/src/server/websocket/connection.rs
@@ -121,7 +121,6 @@ impl ConnectionHandler {
                     let mut request = match parsed {
                         Ok(r) => r,
                         Err(error) => {
-                            // Even on error, we attempted to respond; keep pings scheduled after this activity
                             let _ = self.report_failure(None, error).await;
                             continue;
                         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved WebSocket keep-alive: moved from fixed-interval polling to an activity-driven ping timer (pings every 30s; idle close after 60s).
  * Ping scheduling now resets on inbound activity, outbound writes, and after handling responses or errors, preventing blocked or redundant pings and reducing unnecessary network traffic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->