### PR TITLE
fix: support binary opcode

### DIFF
--- a/magicblock-aperture/src/server/websocket/connection.rs
+++ b/magicblock-aperture/src/server/websocket/connection.rs
@@ -112,7 +112,7 @@ impl ConnectionHandler {
                     // Reschedule the next ping
                     next_ping.as_mut().reset(Instant::now() + PING_PERIOD);
 
-                    if frame.opcode != OpCode::Text {
+                    if frame.opcode != OpCode::Text && frame.opcode != OpCode::Binary {
                         continue;
                     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * WebSocket communication now processes binary payloads in addition to text payloads, expanding the range of supported data types for transmission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->