### PR TITLE
hotfix: unregistered metric COMMITTOR_INTENT_CU_USAGE

### DIFF
--- a/magicblock-metrics/src/metrics/mod.rs
+++ b/magicblock-metrics/src/metrics/mod.rs
@@ -244,6 +244,7 @@ pub(crate) fn register() {
         register!(COMMITTOR_FAILED_INTENTS_COUNT);
         register!(COMMITTOR_EXECUTORS_BUSY_COUNT);
         register!(COMMITTOR_INTENT_EXECUTION_TIME_HISTOGRAM);
+        register!(COMMITTOR_INTENT_CU_USAGE);
         register!(ENSURE_ACCOUNTS_TIME);
         register!(RPC_REQUEST_HANDLING_TIME);
         register!(TRANSACTION_PROCESSING_TIME);


### PR DESCRIPTION
## Summary

* **New Features**
  * Introduced a new compute-unit usage metric for the committor service to enable enhanced resource monitoring and observability. This metric is now registered globally and available for tracking service resource consumption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->