### PR TITLE
fix: enforce accounts to be delegated during commit

### DIFF
--- a/programs/magicblock/src/magic_scheduled_base_intent.rs
+++ b/programs/magicblock/src/magic_scheduled_base_intent.rs
@@ -216,17 +216,17 @@ impl CommitAndUndelegate {
         context: &ConstructionContext<'_, '_>,
     ) -> Result<(), InstructionError> {
         account_indices.iter().copied().try_for_each(|idx| {
-            let is_writable = get_writable_with_idx(&context.transaction_context, idx as u16)?;
+            let is_writable = get_writable_with_idx(context.transaction_context, idx as u16)?;
             if is_writable {
                 Ok(())
             } else {
-                let pubkey = get_instruction_pubkey_with_idx(&context.transaction_context, idx as u16)?;
+                let pubkey = get_instruction_pubkey_with_idx(context.transaction_context, idx as u16)?;
                 ic_msg!(
                     context.invoke_context,
                     "ScheduleCommit ERR: account {} needs to be writable to be undelegated",
                     pubkey
                 );
-                return Err(InstructionError::ReadonlyDataModified);
+                Err(InstructionError::ReadonlyDataModified)
             }
         })
     }


### PR DESCRIPTION
fix: enforce accounts to be delegated during commit
fix: wrong owner set to account in some cases, for example: commit via Proxy program


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for undelegation flows with automatic checks ensuring accounts are writable when required.
  * Streamlined commit processing to preserve original account data and handle delegation transitions reliably.

* **Bug Fixes**
  * Improved detection and reporting for attempts to modify readonly accounts.
  * Tightened delegation-state validation to prevent invalid commit/undelegate operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->