### PR TITLE
feat: Execute CommitDiff as BufferTask

### DIFF
--- a/magicblock-committor-service/src/persist/commit_persister.rs
+++ b/magicblock-committor-service/src/persist/commit_persister.rs
@@ -587,14 +587,14 @@ mod tests {
         persister.set_commit_id(1, &pubkey, 100).unwrap();
 
         persister
-            .set_commit_strategy(100, &pubkey, CommitStrategy::Args)
+            .set_commit_strategy(100, &pubkey, CommitStrategy::StateArgs)
             .unwrap();
 
         let updated = persister
             .get_commit_status_by_message(1, &pubkey)
             .unwrap()
             .unwrap();
-        assert_eq!(updated.commit_strategy, CommitStrategy::Args);
+        assert_eq!(updated.commit_strategy, CommitStrategy::StateArgs);
     }
 
     #[test]

--- a/magicblock-committor-service/src/persist/db.rs
+++ b/magicblock-committor-service/src/persist/db.rs
@@ -772,7 +772,7 @@ mod tests {
             commit_type: CommitType::DataAccount,
             created_at: 1000,
             commit_status: CommitStatus::Pending,
-            commit_strategy: CommitStrategy::Args,
+            commit_strategy: CommitStrategy::StateArgs,
             last_retried_at: 1000,
             retries_count: 0,
         }
@@ -907,7 +907,7 @@ mod tests {
         db.insert_commit_status_rows(std::slice::from_ref(&row))
             .unwrap();
 
-        let new_strategy = CommitStrategy::FromBuffer;
+        let new_strategy = CommitStrategy::StateBuffer;
         db.set_commit_strategy(100, &row.pubkey, new_strategy)
             .unwrap();
 

--- a/magicblock-committor-service/src/persist/types/commit_strategy.rs
+++ b/magicblock-committor-service/src/persist/types/commit_strategy.rs
@@ -4,39 +4,39 @@ use crate::persist::error::CommitPersistError;
 pub enum CommitStrategy {
     /// Args without the use of a lookup table
     #[default]
-    Args,
+    StateArgs,
     /// Args with the use of a lookup table
-    ArgsWithLookupTable,
+    StateArgsWithLookupTable,
     /// Buffer and chunks which has the most overhead
-    FromBuffer,
+    StateBuffer,
     /// Buffer and chunks with the use of a lookup table
-    FromBufferWithLookupTable,
+    StateBufferWithLookupTable,
 }
 
 impl CommitStrategy {
     pub fn args(use_lookup: bool) -> Self {
         if use_lookup {
-            Self::ArgsWithLookupTable
+            Self::StateArgsWithLookupTable
         } else {
-            Self::Args
+            Self::StateArgs
         }
     }
 
     pub fn as_str(&self) -> &str {
         use CommitStrategy::*;
         match self {
-            Args => "Args",
-            ArgsWithLookupTable => "ArgsWithLookupTable",
-            FromBuffer => "FromBuffer",
-            FromBufferWithLookupTable => "FromBufferWithLookupTable",
+            StateArgs => "StateArgs",
+            StateArgsWithLookupTable => "StateArgsWithLookupTable",
+            StateBuffer => "StateBuffer",
+            StateBufferWithLookupTable => "StateBufferWithLookupTable",
         }
     }
 
     pub fn uses_lookup(&self) -> bool {
         matches!(
             self,
-            CommitStrategy::ArgsWithLookupTable
-                | CommitStrategy::FromBufferWithLookupTable
+            CommitStrategy::StateArgsWithLookupTable
+                | CommitStrategy::StateBufferWithLookupTable
         )
     }
 }
@@ -45,10 +45,14 @@ impl TryFrom<&str> for CommitStrategy {
     type Error = CommitPersistError;
     fn try_from(value: &str) -> Result<Self, CommitPersistError> {
         match value {
-            "Args" => Ok(Self::Args),
-            "ArgsWithLookupTable" => Ok(Self::ArgsWithLookupTable),
-            "FromBuffer" => Ok(Self::FromBuffer),
-            "FromBufferWithLookupTable" => Ok(Self::FromBufferWithLookupTable),
+            "Args" | "StateArgs" => Ok(Self::StateArgs),
+            "ArgsWithLookupTable" | "StateArgsWithLookupTable" => {
+                Ok(Self::StateArgsWithLookupTable)
+            }
+            "FromBuffer" | "StateBuffer" => Ok(Self::StateBuffer),
+            "FromBufferWithLookupTable" | "StateBufferWithLookupTable" => {
+                Ok(Self::StateBufferWithLookupTable)
+            }
             _ => Err(CommitPersistError::InvalidCommitStrategy(
                 value.to_string(),
             )),

--- a/magicblock-committor-service/src/persist/types/commit_strategy.rs
+++ b/magicblock-committor-service/src/persist/types/commit_strategy.rs
@@ -11,17 +11,18 @@ pub enum CommitStrategy {
     StateBuffer,
     /// Buffer and chunks with the use of a lookup table
     StateBufferWithLookupTable,
+
+    /// Args without the use of a lookup table
+    DiffArgs,
+    /// Args with the use of a lookup table
+    DiffArgsWithLookupTable,
+    /// Buffer and chunks which has the most overhead
+    DiffBuffer,
+    /// Buffer and chunks with the use of a lookup table
+    DiffBufferWithLookupTable,
 }
 
 impl CommitStrategy {
-    pub fn args(use_lookup: bool) -> Self {
-        if use_lookup {
-            Self::StateArgsWithLookupTable
-        } else {
-            Self::StateArgs
-        }
-    }
-
     pub fn as_str(&self) -> &str {
         use CommitStrategy::*;
         match self {
@@ -29,6 +30,10 @@ impl CommitStrategy {
             StateArgsWithLookupTable => "StateArgsWithLookupTable",
             StateBuffer => "StateBuffer",
             StateBufferWithLookupTable => "StateBufferWithLookupTable",
+            DiffArgs => "DiffArgs",
+            DiffArgsWithLookupTable => "DiffArgsWithLookupTable",
+            DiffBuffer => "DiffBuffer",
+            DiffBufferWithLookupTable => "DiffBufferWithLookupTable",
         }
     }
 
@@ -37,6 +42,8 @@ impl CommitStrategy {
             self,
             CommitStrategy::StateArgsWithLookupTable
                 | CommitStrategy::StateBufferWithLookupTable
+                | CommitStrategy::DiffArgsWithLookupTable
+                | CommitStrategy::DiffBufferWithLookupTable
         )
     }
 }
@@ -53,6 +60,10 @@ impl TryFrom<&str> for CommitStrategy {
             "FromBufferWithLookupTable" | "StateBufferWithLookupTable" => {
                 Ok(Self::StateBufferWithLookupTable)
             }
+            "DiffArgs" => Ok(Self::DiffArgs),
+            "DiffArgsWithLookupTable" => Ok(Self::DiffArgsWithLookupTable),
+            "DiffBuffer" => Ok(Self::DiffBuffer),
+            "DiffBufferWithLookupTable" => Ok(Self::DiffBufferWithLookupTable),
             _ => Err(CommitPersistError::InvalidCommitStrategy(
                 value.to_string(),
             )),

--- a/magicblock-committor-service/src/tasks/args_task.rs
+++ b/magicblock-committor-service/src/tasks/args_task.rs
@@ -127,7 +127,7 @@ impl BaseTask for ArgsTask {
         }
     }
 
-    fn optimize(
+    fn minimize_tx_size(
         self: Box<Self>,
     ) -> Result<Box<dyn BaseTask>, Box<dyn BaseTask>> {
         match self.task_type {

--- a/magicblock-committor-service/src/tasks/args_task.rs
+++ b/magicblock-committor-service/src/tasks/args_task.rs
@@ -137,16 +137,8 @@ impl BaseTask for ArgsTask {
                 )))
             }
             ArgsTaskType::CommitDiff(value) => {
-                // TODO (snawaz): Currently, we do not support executing CommitDiff
-                // as BufferTask, which is why we're forcing CommitDiffTask to become CommitTask
-                // before converting this task into BufferTask. Once CommitDiff is supported
-                // by BufferTask, we do not have to do this, as it's essentially a downgrade.
                 Ok(Box::new(BufferTask::new_preparation_required(
-                    BufferTaskType::Commit(CommitTask {
-                        commit_id: value.commit_id,
-                        allow_undelegation: value.allow_undelegation,
-                        committed_account: value.committed_account,
-                    }),
+                    BufferTaskType::CommitDiff(value),
                 )))
             }
             ArgsTaskType::BaseAction(_)

--- a/magicblock-committor-service/src/tasks/args_task.rs
+++ b/magicblock-committor-service/src/tasks/args_task.rs
@@ -127,7 +127,7 @@ impl BaseTask for ArgsTask {
         }
     }
 
-    fn minimize_tx_size(
+    fn try_optimize_tx_size(
         self: Box<Self>,
     ) -> Result<Box<dyn BaseTask>, Box<dyn BaseTask>> {
         match self.task_type {

--- a/magicblock-committor-service/src/tasks/buffer_task.rs
+++ b/magicblock-committor-service/src/tasks/buffer_task.rs
@@ -1,5 +1,7 @@
 use dlp::{
-    args::CommitStateFromBufferArgs, instruction_builder::commit_size_budget,
+    args::CommitStateFromBufferArgs,
+    compute_diff,
+    instruction_builder::{commit_diff_size_budget, commit_size_budget},
     AccountSizeClass,
 };
 use magicblock_committor_program::Chunks;
@@ -182,6 +184,9 @@ impl BaseTask for BufferTask {
         match self.task_type {
             BufferTaskType::Commit(_) => {
                 commit_size_budget(AccountSizeClass::Huge)
+            }
+            BufferTaskType::CommitDiff(_) => {
+                commit_diff_size_budget(AccountSizeClass::Huge)
             }
         }
     }

--- a/magicblock-committor-service/src/tasks/buffer_task.rs
+++ b/magicblock-committor-service/src/tasks/buffer_task.rs
@@ -149,7 +149,7 @@ impl BaseTask for BufferTask {
     }
 
     /// No further optimizations
-    fn minimize_tx_size(
+    fn try_optimize_tx_size(
         self: Box<Self>,
     ) -> Result<Box<dyn BaseTask>, Box<dyn BaseTask>> {
         Err(self)

--- a/magicblock-committor-service/src/tasks/buffer_task.rs
+++ b/magicblock-committor-service/src/tasks/buffer_task.rs
@@ -149,7 +149,7 @@ impl BaseTask for BufferTask {
     }
 
     /// No further optimizations
-    fn optimize(
+    fn minimize_tx_size(
         self: Box<Self>,
     ) -> Result<Box<dyn BaseTask>, Box<dyn BaseTask>> {
         Err(self)

--- a/magicblock-committor-service/src/tasks/mod.rs
+++ b/magicblock-committor-service/src/tasks/mod.rs
@@ -46,7 +46,6 @@ pub enum PreparationState {
     Cleanup(CleanupTask),
 }
 
-#[cfg(test)]
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum TaskStrategy {
     Args,

--- a/magicblock-committor-service/src/tasks/mod.rs
+++ b/magicblock-committor-service/src/tasks/mod.rs
@@ -66,8 +66,9 @@ pub trait BaseTask: Send + Sync + DynClone + LabelValue {
     /// Gets instruction for task execution
     fn instruction(&self, validator: &Pubkey) -> Instruction;
 
-    /// Optimizes Task strategy if possible, otherwise returns itself
-    fn optimize(
+    /// Optimize for transaction size so that more instructions can be buddled together in a single
+    /// transaction. Return Ok(new_tx_optimized_task), else Err(self) if task cannot be optimized.
+    fn minimize_tx_size(
         self: Box<Self>,
     ) -> Result<Box<dyn BaseTask>, Box<dyn BaseTask>>;
 

--- a/magicblock-committor-service/src/tasks/mod.rs
+++ b/magicblock-committor-service/src/tasks/mod.rs
@@ -68,7 +68,7 @@ pub trait BaseTask: Send + Sync + DynClone + LabelValue {
 
     /// Optimize for transaction size so that more instructions can be buddled together in a single
     /// transaction. Return Ok(new_tx_optimized_task), else Err(self) if task cannot be optimized.
-    fn minimize_tx_size(
+    fn try_optimize_tx_size(
         self: Box<Self>,
     ) -> Result<Box<dyn BaseTask>, Box<dyn BaseTask>>;
 

--- a/magicblock-committor-service/src/tasks/task_strategist.rs
+++ b/magicblock-committor-service/src/tasks/task_strategist.rs
@@ -171,7 +171,8 @@ impl TaskStrategist {
         persistor: &Option<P>,
     ) -> TaskStrategistResult<TransactionStrategy> {
         // Attempt optimizing tasks themselves(using buffers)
-        if Self::optimize_strategy(&mut tasks)? <= MAX_ENCODED_TRANSACTION_SIZE
+        if Self::minimize_tx_size_if_needed(&mut tasks)?
+            <= MAX_ENCODED_TRANSACTION_SIZE
         {
             // Persist tasks strategy
             if let Some(persistor) = persistor {
@@ -278,7 +279,7 @@ impl TaskStrategist {
 
     /// Optimizes set of [`TaskDeliveryStrategy`] to fit [`MAX_ENCODED_TRANSACTION_SIZE`]
     /// Returns size of tx after optimizations
-    fn optimize_strategy(
+    fn minimize_tx_size_if_needed(
         tasks: &mut [Box<dyn BaseTask>],
     ) -> Result<usize, SignerError> {
         // Get initial transaction size
@@ -333,7 +334,7 @@ impl TaskStrategist {
                 let tmp_task = Box::new(tmp_task) as Box<dyn BaseTask>;
                 std::mem::replace(&mut tasks[index], tmp_task)
             };
-            match task.optimize() {
+            match task.minimize_tx_size() {
                 // If we can decrease:
                 // 1. Calculate new tx size & ix size
                 // 2. Insert item's data back in the heap
@@ -716,7 +717,7 @@ mod tests {
             Box::new(create_test_commit_task(3, 1000, 0)) as Box<dyn BaseTask>, // Larger task
         ];
 
-        let _ = TaskStrategist::optimize_strategy(&mut tasks);
+        let _ = TaskStrategist::minimize_tx_size_if_needed(&mut tasks);
         // The larger task should have been optimized first
         assert!(matches!(tasks[0].strategy(), TaskStrategy::Args));
         assert!(matches!(tasks[1].strategy(), TaskStrategy::Buffer));

--- a/magicblock-committor-service/src/tasks/task_visitors/persistor_visitor.rs
+++ b/magicblock-committor-service/src/tasks/task_visitors/persistor_visitor.rs
@@ -27,9 +27,9 @@ where
         match self.context {
             PersistorContext::PersistStrategy { uses_lookup_tables } => {
                 let commit_strategy = if uses_lookup_tables {
-                    CommitStrategy::ArgsWithLookupTable
+                    CommitStrategy::StateArgsWithLookupTable
                 } else {
-                    CommitStrategy::Args
+                    CommitStrategy::StateArgs
                 };
 
                 match &task.task_type {
@@ -69,9 +69,9 @@ where
         match self.context {
             PersistorContext::PersistStrategy { uses_lookup_tables } => {
                 let commit_strategy = if uses_lookup_tables {
-                    CommitStrategy::FromBufferWithLookupTable
+                    CommitStrategy::StateBufferWithLookupTable
                 } else {
-                    CommitStrategy::FromBuffer
+                    CommitStrategy::StateBuffer
                 };
 
                 match &task.task_type {

--- a/magicblock-committor-service/src/tasks/task_visitors/persistor_visitor.rs
+++ b/magicblock-committor-service/src/tasks/task_visitors/persistor_visitor.rs
@@ -26,27 +26,40 @@ where
     fn visit_args_task(&mut self, task: &ArgsTask) {
         match self.context {
             PersistorContext::PersistStrategy { uses_lookup_tables } => {
-                let ArgsTaskType::Commit(ref commit_task) = task.task_type
-                else {
-                    return;
-                };
-
                 let commit_strategy = if uses_lookup_tables {
                     CommitStrategy::ArgsWithLookupTable
                 } else {
                     CommitStrategy::Args
                 };
 
-                if let Err(err) = self.persistor.set_commit_strategy(
-                    commit_task.commit_id,
-                    &commit_task.committed_account.pubkey,
-                    commit_strategy,
-                ) {
-                    error!(
-                        "Failed to persist commit strategy {}: {}",
-                        commit_strategy.as_str(),
-                        err
-                    );
+                match &task.task_type {
+                    ArgsTaskType::Commit(task) => {
+                        if let Err(err) = self.persistor.set_commit_strategy(
+                            task.commit_id,
+                            &task.committed_account.pubkey,
+                            commit_strategy,
+                        ) {
+                            error!(
+                                "Failed to persist commit strategy {}: {}",
+                                commit_strategy.as_str(),
+                                err
+                            );
+                        }
+                    }
+                    ArgsTaskType::CommitDiff(task) => {
+                        if let Err(err) = self.persistor.set_commit_strategy(
+                            task.commit_id,
+                            &task.committed_account.pubkey,
+                            commit_strategy,
+                        ) {
+                            error!(
+                                "Failed to persist commit strategy {}: {}",
+                                commit_strategy.as_str(),
+                                err
+                            );
+                        }
+                    }
+                    _ => {}
                 }
             }
         }
@@ -55,23 +68,39 @@ where
     fn visit_buffer_task(&mut self, task: &BufferTask) {
         match self.context {
             PersistorContext::PersistStrategy { uses_lookup_tables } => {
-                let BufferTaskType::Commit(ref commit_task) = task.task_type;
                 let commit_strategy = if uses_lookup_tables {
                     CommitStrategy::FromBufferWithLookupTable
                 } else {
                     CommitStrategy::FromBuffer
                 };
 
-                if let Err(err) = self.persistor.set_commit_strategy(
-                    commit_task.commit_id,
-                    &commit_task.committed_account.pubkey,
-                    commit_strategy,
-                ) {
-                    error!(
-                        "Failed to persist commit strategy {}: {}",
-                        commit_strategy.as_str(),
-                        err
-                    );
+                match &task.task_type {
+                    BufferTaskType::Commit(task) => {
+                        if let Err(err) = self.persistor.set_commit_strategy(
+                            task.commit_id,
+                            &task.committed_account.pubkey,
+                            commit_strategy,
+                        ) {
+                            error!(
+                                "Failed to persist commit strategy {}: {}",
+                                commit_strategy.as_str(),
+                                err
+                            );
+                        }
+                    }
+                    BufferTaskType::CommitDiff(task) => {
+                        if let Err(err) = self.persistor.set_commit_strategy(
+                            task.commit_id,
+                            &task.committed_account.pubkey,
+                            commit_strategy,
+                        ) {
+                            error!(
+                                "Failed to persist commit strategy {}: {}",
+                                commit_strategy.as_str(),
+                                err
+                            );
+                        }
+                    }
                 }
             }
         }

--- a/magicblock-committor-service/src/tasks/task_visitors/utility_visitor.rs
+++ b/magicblock-committor-service/src/tasks/task_visitors/utility_visitor.rs
@@ -40,25 +40,43 @@ impl Visitor for TaskVisitorUtils {
     fn visit_args_task(&mut self, task: &ArgsTask) {
         let Self::GetCommitMeta(commit_meta) = self;
 
-        if let ArgsTaskType::Commit(ref commit_task) = task.task_type {
-            *commit_meta = Some(CommitMeta {
-                committed_pubkey: commit_task.committed_account.pubkey,
-                commit_id: commit_task.commit_id,
-                remote_slot: commit_task.committed_account.remote_slot,
-            })
-        } else {
-            *commit_meta = None
+        match &task.task_type {
+            ArgsTaskType::Commit(task) => {
+                *commit_meta = Some(CommitMeta {
+                    committed_pubkey: task.committed_account.pubkey,
+                    commit_id: task.commit_id,
+                    remote_slot: task.committed_account.remote_slot,
+                })
+            }
+            ArgsTaskType::CommitDiff(task) => {
+                *commit_meta = Some(CommitMeta {
+                    committed_pubkey: task.committed_account.pubkey,
+                    commit_id: task.commit_id,
+                    remote_slot: task.committed_account.remote_slot,
+                })
+            }
+            _ => *commit_meta = None,
         }
     }
 
     fn visit_buffer_task(&mut self, task: &BufferTask) {
         let Self::GetCommitMeta(commit_meta) = self;
 
-        let BufferTaskType::Commit(ref commit_task) = task.task_type;
-        *commit_meta = Some(CommitMeta {
-            committed_pubkey: commit_task.committed_account.pubkey,
-            commit_id: commit_task.commit_id,
-            remote_slot: commit_task.committed_account.remote_slot,
-        })
+        match &task.task_type {
+            BufferTaskType::Commit(task) => {
+                *commit_meta = Some(CommitMeta {
+                    committed_pubkey: task.committed_account.pubkey,
+                    commit_id: task.commit_id,
+                    remote_slot: task.committed_account.remote_slot,
+                })
+            }
+            BufferTaskType::CommitDiff(task) => {
+                *commit_meta = Some(CommitMeta {
+                    committed_pubkey: task.committed_account.pubkey,
+                    commit_id: task.commit_id,
+                    remote_slot: task.committed_account.remote_slot,
+                })
+            }
+        }
     }
 }

--- a/test-integration/schedulecommit/test-scenarios/tests/02_commit_and_undelegate.rs
+++ b/test-integration/schedulecommit/test-scenarios/tests/02_commit_and_undelegate.rs
@@ -309,13 +309,13 @@ fn test_committing_and_undelegating_huge_order_book_account() {
             println!("Important: use {rng_seed} as seed to regenerate the random inputs in case of test failure");
             let mut random = StdRng::seed_from_u64(rng_seed);
             let mut update = BookUpdate::default();
-            update.bids.extend((0..random.gen_range(5..10)).map(|_| {
+            update.bids.extend((0..random.gen_range(5..100)).map(|_| {
                 OrderLevel {
                     price: random.gen_range(75000..90000),
                     size: random.gen_range(1..10),
                 }
             }));
-            update.asks.extend((0..random.gen_range(5..10)).map(|_| {
+            update.asks.extend((0..random.gen_range(5..100)).map(|_| {
                 OrderLevel {
                     price: random.gen_range(125000..150000),
                     size: random.gen_range(1..10),

--- a/test-integration/test-committor-service/tests/test_ix_commit_local.rs
+++ b/test-integration/test-committor-service/tests/test_ix_commit_local.rs
@@ -342,11 +342,7 @@ async fn test_commit_5_accounts_1kb_bundle_size_3() {
 async fn test_commit_5_accounts_1kb_bundle_size_3_undelegate_all() {
     commit_5_accounts_1kb(
         3,
-        expect_strategies(&[
-            // Intent fits in 1 TX only with ALT, see IntentExecutorImpl::try_unite_tasks
-            (CommitStrategy::FromBufferWithLookupTable, 3),
-            (CommitStrategy::Args, 2),
-        ]),
+        expect_strategies(&[(CommitStrategy::Args, 5)]),
         true,
     )
     .await;


### PR DESCRIPTION
## Problem

The previous PR #575 in this stack implements support for `CommitDiff` that executes as `ArgsTask`. When the transaction size grows beyond the limit, `CommitDiff` first degrades to `CommitState` and then gets executed as `BufferTask` to reduce the transaction size. 

Degration of `CommitDiff` to `CommitState` is not a desirable thing. 

## Solution

So this PR implements support for `CommitDiff` as `BufferTask`. Means degradation of `CommitDiff` to `CommitState` is not required anymore.

## Related 

Another PR https://github.com/magicblock-labs/delegation-program/pull/118 that implements `CommitDiffFromBuffer` instruction, is created in the delegation-program.

## Screenshot 

<img width="2216" height="1658" alt="image" src="https://github.com/user-attachments/assets/120f85a7-a4b8-49d1-9042-5b070502f0ea" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CommitDiff buffer commit mode for differential commits.

* **Improvements**
  * Introduced a try‑optimize transaction‑size flow with clearer success/failure semantics.
  * Renamed and expanded commit‑strategy identifiers, adding explicit Diff and State variants.
  * Unified Commit and CommitDiff handling across task flows, visitors, and persistence.

* **Tests**
  * Updated and expanded tests, increasing randomized ranges and adding size-specific scenarios and expectations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->