### PR TITLE
refactor: Rename optimize() -> try_optimize_tx_size()

### DIFF
--- a/magicblock-committor-service/src/tasks/args_task.rs
+++ b/magicblock-committor-service/src/tasks/args_task.rs
@@ -122,7 +122,7 @@ impl BaseTask for ArgsTask {
         }
     }
 
-    fn minimize_tx_size(
+    fn try_optimize_tx_size(
         self: Box<Self>,
     ) -> Result<Box<dyn BaseTask>, Box<dyn BaseTask>> {
         match self.task_type {

--- a/magicblock-committor-service/src/tasks/buffer_task.rs
+++ b/magicblock-committor-service/src/tasks/buffer_task.rs
@@ -146,7 +146,7 @@ impl BaseTask for BufferTask {
     }
 
     /// No further optimizations
-    fn minimize_tx_size(
+    fn try_optimize_tx_size(
         self: Box<Self>,
     ) -> Result<Box<dyn BaseTask>, Box<dyn BaseTask>> {
         Err(self)

--- a/magicblock-committor-service/src/tasks/mod.rs
+++ b/magicblock-committor-service/src/tasks/mod.rs
@@ -68,7 +68,7 @@ pub trait BaseTask: Send + Sync + DynClone + LabelValue {
 
     /// Optimize for transaction size so that more instructions can be buddled together in a single
     /// transaction. Return Ok(new_tx_optimized_task), else Err(self) if task cannot be optimized.
-    fn minimize_tx_size(
+    fn try_optimize_tx_size(
         self: Box<Self>,
     ) -> Result<Box<dyn BaseTask>, Box<dyn BaseTask>>;
 

--- a/magicblock-committor-service/src/tasks/task_strategist.rs
+++ b/magicblock-committor-service/src/tasks/task_strategist.rs
@@ -171,7 +171,7 @@ impl TaskStrategist {
         persistor: &Option<P>,
     ) -> TaskStrategistResult<TransactionStrategy> {
         // Attempt optimizing tasks themselves(using buffers)
-        if Self::minimize_tx_size_if_needed(&mut tasks)?
+        if Self::try_optimize_tx_size_if_needed(&mut tasks)?
             <= MAX_ENCODED_TRANSACTION_SIZE
         {
             // Persist tasks strategy
@@ -269,9 +269,11 @@ impl TaskStrategist {
         )
     }
 
-    /// Optimizes set of [`TaskDeliveryStrategy`] to fit [`MAX_ENCODED_TRANSACTION_SIZE`]
-    /// Returns size of tx after optimizations
-    fn minimize_tx_size_if_needed(
+    /// Optimizes tasks so as to bring the transaction size within the limit [`MAX_ENCODED_TRANSACTION_SIZE`]
+    /// Returns Ok(size of tx after optimizations) else Err(SignerError).
+    /// Note that the returned size, though possibly optimized one, may still not be under
+    /// the limit MAX_ENCODED_TRANSACTION_SIZE. The caller needs to check and make decision accordingly.
+    fn try_optimize_tx_size_if_needed(
         tasks: &mut [Box<dyn BaseTask>],
     ) -> Result<usize, SignerError> {
         // Get initial transaction size
@@ -326,7 +328,7 @@ impl TaskStrategist {
                 let tmp_task = Box::new(tmp_task) as Box<dyn BaseTask>;
                 std::mem::replace(&mut tasks[index], tmp_task)
             };
-            match task.minimize_tx_size() {
+            match task.try_optimize_tx_size() {
                 // If we can decrease:
                 // 1. Calculate new tx size & ix size
                 // 2. Insert item's data back in the heap
@@ -705,7 +707,7 @@ mod tests {
             Box::new(create_test_commit_task(3, 1000, 0)) as Box<dyn BaseTask>, // Larger task
         ];
 
-        let _ = TaskStrategist::minimize_tx_size_if_needed(&mut tasks);
+        let _ = TaskStrategist::try_optimize_tx_size_if_needed(&mut tasks);
         // The larger task should have been optimized first
         assert!(matches!(tasks[0].strategy(), TaskStrategy::Args));
         assert!(matches!(tasks[1].strategy(), TaskStrategy::Buffer));


### PR DESCRIPTION
The current name `optimize()` is too generic and doesn’t convey what exactly to optimize for: **space or performance?**.

Initially, I assumed it was meant for _performance_ optimization, but after reading through the relevant code, especially `optimize_strategy()`, I realized the optimization is actually about reducing **transaction size**.

Changes:

- Renamed `optimize()` → `try_optimize_tx_size()`
- Renamed `optimize_strategy()` → `try_optimize_tx_size_if_needed()`

I think this makes the purpose explicit and avoids ambiguity. The function focuses on minimizing **transaction** size (not _any_ size in general), not improving speed or compute efficiency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal task optimization APIs renamed to explicit "try_optimize_tx_size" naming and related call sites/docs updated; external behavior unchanged.
* **Bug Fixes / Behavior**
  * Optimization flow now returns explicit success/failure and reports resulting size so callers can handle potential size-limit exceedance.
* **Tests**
  * Unit tests updated to use the renamed APIs and adjusted return semantics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->