### PR TITLE
fix: capping solana program version due to transit dependency issue

### DIFF
--- a/magicblock-magic-program-api/Cargo.toml
+++ b/magicblock-magic-program-api/Cargo.toml
@@ -9,6 +9,6 @@ homepage.workspace = true
 edition.workspace = true
 
 [dependencies]
-solana-program = ">0"
+solana-program = ">=1.16, <3.0.0"
 bincode = ">0"
 serde = { version = ">0", features = ["derive"] }


### PR DESCRIPTION
## Problem

Programs using ephemeral-rollups-sdk may unintentionally build with latest solana-program which triggers type errors for `Pubkey` by `solana-program 3.0.0` and above.


## Solution

Capping solana-program version will fix dependency issues and type errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency constraints for solana-program to specify a supported version range, ensuring better compatibility and stability with the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->