### PR TITLE
chore: add access-control-max-age header to cors

### DIFF
--- a/magicblock-aperture/src/server/http/dispatch.rs
+++ b/magicblock-aperture/src/server/http/dispatch.rs
@@ -176,7 +176,7 @@ impl HttpDispatcher {
     fn handle_cors_preflight() -> Result<Response<JsonBody>, Infallible> {
         use hyper::header::{
             ACCESS_CONTROL_ALLOW_HEADERS, ACCESS_CONTROL_ALLOW_METHODS,
-            ACCESS_CONTROL_ALLOW_ORIGIN, ACCESS_CONTROL_MAX_AGE
+            ACCESS_CONTROL_ALLOW_ORIGIN, ACCESS_CONTROL_MAX_AGE,
         };
 
         let response = Response::builder()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced CORS preflight handling to support GET in addition to POST and OPTIONS.
  * Added an Access-Control-Max-Age header (86400) so preflight responses can be cached.
  * Updated allowed CORS headers to include Access-Control-Max-Age.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->