### PR TITLE
fix: enable CodeRabbit reviews for non-base PRs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -38,7 +38,7 @@ reviews:
     ignore_title_keywords: []
     labels: []
     drafts: false
-    base_branches: []
+    base_branches: [".*"]
     ignore_usernames: []
   finishing_touches:
     docstrings:


### PR DESCRIPTION
## Summary

Enable CodeRabbit to review pull requests against any branch by configuring the `base_branches` pattern to match all branches.

## Details

CodeRabbit's review configuration was restricting reviews to an empty list of base branches, which effectively disabled reviews on PRs targeting non-master branches. This change updates the `base_branches` configuration to use a wildcard regex pattern `[".*"]`, allowing CodeRabbit to review pull requests regardless of which branch they target.

This ensures consistent code quality reviews across all development branches, not just those explicitly configured.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated auto-review configuration to enable automatic code reviews across all repository branches. Auto-review checks now apply universally throughout the codebase, extending coverage from a previously limited scope to ensure consistent code quality standards.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->