### PR TITLE
chore: preserve undelegating and delegated accounts on startup

### DIFF
--- a/magicblock-chainlink/src/chainlink/mod.rs
+++ b/magicblock-chainlink/src/chainlink/mod.rs
@@ -200,8 +200,8 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
 Kept: {} delegated, {} blacklisted",
             non_empty,
             remaining_empty.into_inner(),
-            undelegating,
             delegated_only,
+            undelegating,
             delegated_only + undelegating,
             blacklisted.into_inner()
         );


### PR DESCRIPTION
## Summary

Refine account filtering on startup to preserve undelegating and delegated accounts by distinguishing between delegated-only and undelegating states.

## Details

### magicblock-chainlink Account Filtering

The startup account filtering logic was updated to provide better tracking and preservation of account states:

- **Removed DLP-owned account filtering**: Previously, DLP-owned non-delegated accounts were explicitly filtered out during startup. This behavior has been removed, allowing these accounts to be preserved.

- **Refined delegated account tracking**: The delegated account tracking now distinguishes between two states:
  - `delegated_only`: Accounts that are delegated but not undelegating
  - `undelegating`: Accounts that are both delegated and in an undelegating state

- **Updated filtering logic**: Accounts are now kept on startup if they are delegated (whether delegated-only or undelegating), ensuring that accounts in transition states are preserved for proper state management.

- **Improved logging**: The startup logs now provide a clearer breakdown of account states, making it easier to track what's being filtered and what's being kept.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal delegation-account tracking to separate currently undelegating from delegated-only accounts for clearer logic.
* **Bug Fixes**
  * Fixed delegation counting so reported counts and percentages are accurate after the new partitioning.
* **Logs**
  * Updated log output to show a clearer breakdown (delegated-only vs undelegating) and combined totals for easier reporting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->