### PR TITLE
fix: don't check for empty account with data

### DIFF
--- a/magicblock-processor/src/executor/processing.rs
+++ b/magicblock-processor/src/executor/processing.rs
@@ -376,37 +376,6 @@ impl super::TransactionExecutor {
                 return;
             }
         }
-        // SVM ignores rent exemption enforcement for accounts, which have
-        // 0 lamports, so it's possible to call realloc on account with zero
-        // balance bypassing the runtime checks. In order to prevent this
-        // edge case we perform explicit post execution check here.
-        for (i, (pubkey, acc)) in txn.accounts.iter().enumerate() {
-            if !acc.is_dirty() {
-                continue;
-            }
-            let Some(rent) = self.environment.rent_collector else {
-                continue;
-            };
-            if acc.lamports() == 0 && acc.data().is_empty() {
-                continue;
-            }
-            let rent_exemption_balance =
-                rent.get_rent().minimum_balance(acc.data().len());
-            if acc.lamports() >= rent_exemption_balance {
-                continue;
-            }
-            let error = Err(TransactionError::InsufficientFundsForRent {
-                account_index: i as u8,
-            });
-            executed.execution_details.status = error;
-            let logs = executed
-                .execution_details
-                .log_messages
-                .get_or_insert_default();
-            let msg = format!("Account {pubkey} has violated rent exemption");
-            logs.push(msg);
-            return;
-        }
     }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed post-execution rent-exemption verification. Accounts are no longer validated for rent-exemption requirements after transaction execution completes, changing how account state validation is handled in the transaction processing pipeline.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->