### PR TITLE
chore: change ActionArgs::default to ::new

### DIFF
--- a/magicblock-magic-program-api/src/args.rs
+++ b/magicblock-magic-program-api/src/args.rs
@@ -13,7 +13,7 @@ pub struct ActionArgs {
 }
 
 impl ActionArgs {
-    pub fn default(data: Vec<u8>) -> Self {
+    pub fn new(data: Vec<u8>) -> Self {
         Self {
             escrow_index: 255,
             data,


### PR DESCRIPTION
avoid using ::default, instead use ::new

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated constructor method naming convention for the ActionArgs API to follow standard practices.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->