### PR TITLE
hotfix: remove vrf ephem queue

### DIFF
--- a/magicblock-chainlink/src/chainlink/mod.rs
+++ b/magicblock-chainlink/src/chainlink/mod.rs
@@ -161,7 +161,9 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
                 blacklisted.fetch_add(1, Ordering::Relaxed);
                 return false;
             }
-            if pubkey.eq(&pubkey!("5hBR571xnXppuCPveTrctfTU7tJLSN94nq7kv7FRK5Tc")){
+            if pubkey
+                .eq(&pubkey!("5hBR571xnXppuCPveTrctfTU7tJLSN94nq7kv7FRK5Tc"))
+            {
                 return true;
             }
             // Undelegating accounts are normally also delegated, but if that ever changes


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated account-handling logic to add a special-case removal rule that unconditionally removes a specific account from the bank, bypassing normal checks (delegation, balance, owner status). This alters how that particular account is treated during reset operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->