### PR TITLE
fix: reset program cache upon error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9087,7 +9087,7 @@ dependencies = [
 [[package]]
 name = "solana-svm"
 version = "2.2.1"
-source = "git+https://github.com/magicblock-labs/magicblock-svm.git?rev=e480fa2#e480fa202f0680476b51b2d41210667ffc241bf4"
+source = "git+https://github.com/magicblock-labs/magicblock-svm.git?rev=86c2cb0f#86c2cb0f2d92c6e92757e951a8f27757fef3aaea"
 dependencies = [
  "ahash 0.8.12",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -221,7 +221,7 @@ vergen = "8.3.1"
 
 [workspace.dependencies.solana-svm]
 git = "https://github.com/magicblock-labs/magicblock-svm.git"
-rev = "e480fa2"
+rev = "86c2cb0f"
 features = ["dev-context-only-utils"]
 
 [patch.crates-io]
@@ -230,4 +230,4 @@ features = ["dev-context-only-utils"]
 # and we use protobuf-src v2.1.1. Otherwise compilation fails
 solana-account = { git = "https://github.com/magicblock-labs/solana-account.git", rev = "5afcedc" }
 solana-storage-proto = { path = "./storage-proto" }
-solana-svm = { git = "https://github.com/magicblock-labs/magicblock-svm.git", rev = "e480fa2" }
+solana-svm = { git = "https://github.com/magicblock-labs/magicblock-svm.git", rev = "86c2cb0f" }

--- a/magicblock-processor/src/executor/mod.rs
+++ b/magicblock-processor/src/executor/mod.rs
@@ -91,6 +91,7 @@ impl TransactionExecutor {
             ExecutionRecordingConfig::new_single_setting(true);
         let config = Box::new(TransactionProcessingConfig {
             recording_config,
+            limit_to_load_programs: true,
             ..Default::default()
         });
         let this = Self {


### PR DESCRIPTION
This fix introduces a retry logic into SVM program cache replenishing logic, where upon first error,
the cache is reset and replenish is re-attempted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Solana SVM dependency to the latest version.
  * Modified transaction processing configuration settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->