### PR TITLE
fix: don't unbork for same delegation slot as remote slot

### DIFF
--- a/magicblock-chainlink/src/chainlink/account_still_undelegating_on_chain.rs
+++ b/magicblock-chainlink/src/chainlink/account_still_undelegating_on_chain.rs
@@ -55,7 +55,7 @@ pub(crate) fn account_still_undelegating_on_chain(
             .as_ref()
             .map(|d| d.delegation_slot)
             .unwrap_or_default();
-        if delegation_slot < remote_slot_in_bank {
+        if delegation_slot <= remote_slot_in_bank {
             // The last update of the account was after the last delegation
             // Therefore the account was not redelegated which indicates
             // that the undelegation is still not completed. Case (D))
@@ -132,14 +132,17 @@ mod tests {
         // Case B: The account was undelegated and was re-delegated to us.
         // Conditions:
         // - is_delegated: true (account is delegated to us on chain)
-        // - delegation_slot >= remote_slot (delegation happend after we last updated the account)
+        // - delegation_slot > remote_slot (delegation happend after we last updated the account)
         // Expected: true (should override/update)
 
         let pubkey = Pubkey::default();
         let is_delegated = true;
         let remote_slot = 100;
 
+        // NOTE: this case led to incorrect unborking if delegation + undelegation + redelegation
+        // happend all in the same slot
         // Subcase B1: delegation_slot == remote_slot
+        /*
         let delegation_slot = 100;
         let deleg_record = Some(create_delegation_record(delegation_slot));
         assert!(!account_still_undelegating_on_chain(
@@ -149,6 +152,7 @@ mod tests {
             deleg_record,
             &Pubkey::default(),
         ));
+        */
 
         // Subcase B2: delegation_slot > remote_slot
         let delegation_slot = 101;


### PR DESCRIPTION
## Summary

Fix incorrect unborking logic when delegation and undelegation occur in the same slot.

## Details

We had an account that was delegated in slot X. The only update that we received from that account was also from slot X.
Thus, the logic that was trying to determine if this is a new delegation, assumed that it was since the delegation slot was not smaller than the last remote slot that we had.
This was changed to assume that it could be the old delegation if those slots are equal.

The only downside is that if someone manages to delegate undelegate and re-delegate all in the same slot, we will think that it is still the old delegation and that the account is still undelegating.
However, without access to some delegation index, this case is not avoidable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account undelegation state detection by adjusting the boundary condition for determining when accounts remain in an undelegating state, addressing edge cases that occur during rapid delegation transitions.

* **Tests**
  * Updated test coverage to validate the adjusted boundary logic and documented edge cases where delegation, undelegation, and redelegation operations may occur within the same time window.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->