### PR TITLE
fix: set default base fee to 0

### DIFF
--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -452,7 +452,7 @@ impl MagicValidator {
         // In case if we have a perfect match between accountsdb and ledger slot
         // (note: that accountsdb is always 1 slot ahead of ledger), then there's
         // no need to run any kind of ledger replay
-        if accountsdb_slot - 1 == ledger_slot {
+        if accountsdb_slot.saturating_sub(1) == ledger_slot {
             return Ok(());
         }
         // SOLANA only allows blockhash to be valid for 150 slot back in time,

--- a/magicblock-config/src/config/validator.rs
+++ b/magicblock-config/src/config/validator.rs
@@ -9,7 +9,6 @@ use crate::{consts, types::SerdeKeypair};
 #[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
 pub struct ValidatorConfig {
     /// The minimum fee (in lamports) required to process a transaction.
-    /// Defaults to 100 lamports.
     pub basefee: u64,
 
     /// The validator's identity keypair, encoded in Base58.

--- a/magicblock-config/src/consts.rs
+++ b/magicblock-config/src/consts.rs
@@ -9,7 +9,7 @@ pub const DEFAULT_STORAGE_DIRECTORY: &str = "magicblock-test-storage/";
 // MUST provide their own keypair via config file, env var or CLI argument
 pub const DEFAULT_VALIDATOR_KEYPAIR: &str =
     "9Vo7TbA5YfC5a33JhAi9Fb41usA6JwecHNRw3f9MzzHAM8hFnXTzL5DcEHwsAFjuUZ8vNQcJ4XziRFpMc3gTgBQ";
-pub const DEFAULT_BASE_FEE: u64 = 100;
+pub const DEFAULT_BASE_FEE: u64 = 0;
 pub const DEFAULT_COMPUTE_UNIT_PRICE: u64 = 1_000_000;
 
 // Remote URL Aliases


### PR DESCRIPTION
and use saturating sub for accountsdb slot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Safer slot comparison to prevent rare underflow issues during slot validation.
  * Default base fee updated to 0, changing the system's initial fee setting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->