### PR TITLE
fix: prune program cache on each slot transition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6481,7 +6481,7 @@ dependencies = [
 [[package]]
 name = "solana-svm"
 version = "2.2.1"
-source = "git+https://github.com/magicblock-labs/magicblock-svm.git?rev=48787597#48787597fcbbdf301a068c2fec9c032419a2d3ce"
+source = "git+https://github.com/magicblock-labs/magicblock-svm.git?rev=3e9456ec4#3e9456ec4d5798ad8281537501c1e777d6888ba3"
 dependencies = [
  "ahash",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,7 +189,7 @@ url = "2.5.0"
 
 [workspace.dependencies.solana-svm]
 git = "https://github.com/magicblock-labs/magicblock-svm.git"
-rev = "48787597"
+rev = "3e9456ec4"
 features = ["dev-context-only-utils"]
 
 [patch.crates-io]
@@ -198,4 +198,4 @@ features = ["dev-context-only-utils"]
 # and we use protobuf-src v2.1.1. Otherwise compilation fails
 solana-account = { git = "https://github.com/magicblock-labs/solana-account.git", rev = "1beed4c" }
 solana-storage-proto = { path = "./storage-proto" }
-solana-svm = { git = "https://github.com/magicblock-labs/magicblock-svm.git", rev = "48787597" }
+solana-svm = { git = "https://github.com/magicblock-labs/magicblock-svm.git", rev = "3e9456ec4" }

--- a/magicblock-processor/src/executor/mod.rs
+++ b/magicblock-processor/src/executor/mod.rs
@@ -239,8 +239,17 @@ impl TransactionExecutor {
 pub(super) struct SimpleForkGraph;
 
 impl ForkGraph for SimpleForkGraph {
-    fn relationship(&self, _: u64, _: u64) -> BlockRelation {
-        BlockRelation::Unrelated
+    fn relationship(&self, a: u64, b: u64) -> BlockRelation {
+        if a < b {
+            // In a forkless chain, earlier slots are always ancestors
+            BlockRelation::Ancestor
+        } else if a > b {
+            // Later slots are always descendants
+            BlockRelation::Descendant
+        } else {
+            // Same slot
+            BlockRelation::Equal
+        }
     }
 }
 

--- a/magicblock-processor/src/scheduler.rs
+++ b/magicblock-processor/src/scheduler.rs
@@ -141,9 +141,14 @@ impl TransactionScheduler {
 
     /// Updates the scheduler's state when a new slot begins.
     fn transition_to_new_slot(&self) {
+        let root = self.latest_block.load().slot;
+        let mut cache = self.program_cache.write().unwrap();
+        // Remove duplicate entries from programs cache
+        // NOTE: this is an important cleanup, as otherwise it might
+        // lead cache corruption issues over time as it fills up
+        cache.prune(root, 0);
         // Re-root the shared program cache to the new slot.
-        self.program_cache.write().unwrap().latest_root_slot =
-            self.latest_block.load().slot;
+        cache.latest_root_slot = root;
     }
 }
 


### PR DESCRIPTION
This PR introduces proper solution to the cache corruption issue, by pruning the program cache on each slot transition. This keeps the cache duplicate free on each slot, while avoiding full cache reset and ensuing program recompilation. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed slot relationship comparison logic to correctly identify ancestor, descendant, and equal relationships.

* **Performance**
  * Optimized program cache handling with pruning to remove stale entries.

* **Chores**
  * Updated dependencies to latest versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->