### PR TITLE
fix: remove graceful http connection shutdown

### DIFF
--- a/magicblock-aperture/src/server/websocket/mod.rs
+++ b/magicblock-aperture/src/server/websocket/mod.rs
@@ -10,7 +10,7 @@ use hyper::{
     Request, Response,
 };
 use hyper_util::rt::TokioIo;
-use log::warn;
+use log::{info, warn};
 use tokio::{
     net::{TcpListener, TcpStream},
     sync::oneshot::Receiver,
@@ -94,13 +94,17 @@ impl WebsocketServer {
                     self.handle(stream);
                 },
                 // The server shutdown signal has been received.
-                _ = self.state.cancel.cancelled() => break,
+                _ = self.state.cancel.cancelled() => {
+                    info!("Websocket server shutdown signal has been received");
+                    break
+                }
             }
         }
         // Drop the main `ConnectionState` which holds the original `Shutdown` handle.
         drop(self.state);
         // Wait for all spawned connection tasks to finish.
         let _ = self.shutdown.await;
+        info!("Websocket server has shutdown");
     }
 
     /// Spawns a task to handle a new TCP stream as a potential WebSocket connection.


### PR DESCRIPTION
## Summary
Removes graceful HTTP connection shutdown mechanism to simplify service shutdown process.

## Compatibility
- [x] No breaking changes

## Testing
- [x] Existing unit tests pass

## Checklist
- [x] linked issue: #772

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced server shutdown procedures with improved diagnostic logging across HTTP and WebSocket services for better observability during shutdown events.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->