### PR TITLE
feat: speedup ChainPubsubClientImpl creation by connecting them asynchronously

### DIFF
--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -15,6 +15,7 @@ use config::RemoteAccountProviderConfig;
 pub(crate) use errors::{
     RemoteAccountProviderError, RemoteAccountProviderResult,
 };
+use futures_util::future::try_join_all;
 use log::*;
 pub use lru_cache::AccountsLruCache;
 pub(crate) use remote_account::RemoteAccount;
@@ -358,9 +359,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
         };
 
         // Build pubsub clients and wrap them into a SubMuxClient
-        let mut pubsubs: Vec<(Arc<ChainPubsubClientImpl>, mpsc::Receiver<()>)> =
-            Vec::with_capacity(endpoints.len());
-        for ep in endpoints {
+        let pubsub_futs = endpoints.iter().map(|ep| async {
             let (abort_tx, abort_rx) = mpsc::channel(1);
             let client = ChainPubsubClientImpl::try_new_from_url(
                 ep.pubsub_url.as_str(),
@@ -368,9 +367,9 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                 commitment,
             )
             .await?;
-            pubsubs.push((Arc::new(client), abort_rx));
-        }
-
+            Ok::<_, RemoteAccountProviderError>((Arc::new(client), abort_rx))
+        });
+        let pubsubs = try_join_all(pubsub_futs).await?;
         let subscribed_accounts = Arc::new(AccountsLruCache::new({
             // SAFETY: NonZeroUsize::new only returns None if the value is 0.
             // RemoteAccountProviderConfig can only be constructed with
@@ -389,9 +388,11 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                     &config.program_subs().iter().cloned().collect::<Vec<_>>()
                 )
             );
-            for program_id in config.program_subs() {
-                submux.subscribe_program(*program_id).await?;
-            }
+            let subscribe_program_futs = config
+                .program_subs()
+                .iter()
+                .map(|program_id| submux.subscribe_program(*program_id));
+            try_join_all(subscribe_program_futs).await?;
         }
 
         RemoteAccountProvider::<


### PR DESCRIPTION
<!--
PR title must match:
  type(scope): summary
Types: feat|fix|docs|chore|refactor|test|perf|ci|build
Examples:
  fix: avoid panic on empty slot
  feat(rpc): add getFoo endpoint
-->

## Summary
At the moment we create `ChainPubsubClientImpl` sequentually, awaiting for creation & connection 1 by 1. Examining logs this takes around from 1,5 to 2 seconds, which  leads to startup downtime. 

This PR creates them in asynchronous manner and awaiting for resulting array of `ChainPubsubClientImpl`s

<img width="1547" height="51" alt="image" src="https://github.com/user-attachments/assets/7a204d9d-f382-4914-b1a4-af0fd3dcf600" />


## Compatibility
- [x] No breaking changes

## Testing
- [ ] tests (or explain)

## Checklist
- [ ] docs updated (if needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved initialization of blockchain connections through parallel processing of client construction and program subscriptions, enhancing connection setup efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->