### PR TITLE
feat: add account subscription updates metric

### DIFF
--- a/magicblock-chainlink/src/remote_account_provider/chain_pubsub_actor.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_pubsub_actor.rs
@@ -10,8 +10,8 @@ use std::{
 use futures_util::stream::FuturesUnordered;
 use log::*;
 use magicblock_metrics::metrics::{
-    inc_account_subscription_account_updates,
-    inc_program_subscription_account_updates,
+    inc_account_subscription_account_updates_count,
+    inc_program_subscription_account_updates_count,
 };
 use solana_account_decoder_client_types::{UiAccount, UiAccountEncoding};
 use solana_commitment_config::CommitmentConfig;
@@ -486,7 +486,7 @@ impl ChainPubsubActor {
                                rpc_response.context.slot % CLOCK_LOG_SLOT_FREQ == 0) {
                                 trace!("[client_id={client_id}] Received update for {pubkey}: {rpc_response:?}");
                             }
-                            inc_account_subscription_account_updates(
+                            inc_account_subscription_account_updates_count(
                                 &client_id.to_string(),
                             );
                             let _ = subscription_updates_sender.send(SubscriptionUpdate {
@@ -623,7 +623,7 @@ impl ChainPubsubActor {
                                          },
                                      };
                                      trace!("[client_id={client_id}] Sending program {program_pubkey} account update: {sub_update:?}");
-                                     inc_program_subscription_account_updates(
+                                     inc_program_subscription_account_updates_count(
                                          &client_id.to_string(),
                                      );
                                      let _ = subscription_updates_sender.send(sub_update)

--- a/magicblock-metrics/src/metrics/mod.rs
+++ b/magicblock-metrics/src/metrics/mod.rs
@@ -162,20 +162,20 @@ lazy_static::lazy_static! {
         "evicted_accounts_count", "Total cumulative number of accounts forcefully removed from monitored list and database (monotonically increasing)",
     ).unwrap();
 
-    static ref PROGRAM_SUBSCRIPTION_ACCOUNT_UPDATES: IntCounterVec =
+    static ref PROGRAM_SUBSCRIPTION_ACCOUNT_UPDATES_COUNT: IntCounterVec =
         IntCounterVec::new(
             Opts::new(
-                "program_subscription_account_updates",
+                "program_subscription_account_updates_count",
                 "Number of account updates received via program subscription",
             ),
             &["client_id"],
         )
         .unwrap();
 
-    static ref ACCOUNT_SUBSCRIPTION_ACCOUNT_UPDATES: IntCounterVec =
+    static ref ACCOUNT_SUBSCRIPTION_ACCOUNT_UPDATES_COUNT: IntCounterVec =
         IntCounterVec::new(
             Opts::new(
-                "account_subscription_account_updates",
+                "account_subscription_account_updates_count",
                 "Number of account updates received via account subscription",
             ),
             &["client_id"],
@@ -430,8 +430,8 @@ pub(crate) fn register() {
         register!(PENDING_ACCOUNT_CLONES_GAUGE);
         register!(MONITORED_ACCOUNTS_GAUGE);
         register!(EVICTED_ACCOUNTS_COUNT);
-        register!(PROGRAM_SUBSCRIPTION_ACCOUNT_UPDATES);
-        register!(ACCOUNT_SUBSCRIPTION_ACCOUNT_UPDATES);
+        register!(PROGRAM_SUBSCRIPTION_ACCOUNT_UPDATES_COUNT);
+        register!(ACCOUNT_SUBSCRIPTION_ACCOUNT_UPDATES_COUNT);
         register!(COMMITTOR_INTENTS_COUNT);
         register!(COMMITTOR_INTENTS_BACKLOG_COUNT);
         register!(COMMITTOR_FAILED_INTENTS_COUNT);
@@ -649,14 +649,18 @@ pub fn inc_account_fetches_not_found(
         .inc_by(count);
 }
 
-pub fn inc_program_subscription_account_updates(client_id: &impl LabelValue) {
-    PROGRAM_SUBSCRIPTION_ACCOUNT_UPDATES
+pub fn inc_program_subscription_account_updates_count(
+    client_id: &impl LabelValue,
+) {
+    PROGRAM_SUBSCRIPTION_ACCOUNT_UPDATES_COUNT
         .with_label_values(&[client_id.value()])
         .inc();
 }
 
-pub fn inc_account_subscription_account_updates(client_id: &impl LabelValue) {
-    ACCOUNT_SUBSCRIPTION_ACCOUNT_UPDATES
+pub fn inc_account_subscription_account_updates_count(
+    client_id: &impl LabelValue,
+) {
+    ACCOUNT_SUBSCRIPTION_ACCOUNT_UPDATES_COUNT
         .with_label_values(&[client_id.value()])
         .inc();
 }


### PR DESCRIPTION
## Summary

Add a new metric to track account updates received via account subscriptions, providing
visibility into the frequency of account subscription updates alongside the existing program
subscription metric.

## Details

A new counter metric `account_subscription_account_updates_count` has been introduced to monitor the number of account updates received through account subscriptions. This metric is incremented each time an account update arrives in the chain pubsub actor, labeled by client ID for better observability.

### magicblock-metrics

- Added `ACCOUNT_SUBSCRIPTION_ACCOUNT_UPDATES_COUNT` counter metric with `client_id` label
- Implemented `inc_account_subscription_account_updates_count()` function to increment the metric

### magicblock-chainlink

- Integrated the new metric into `ChainPubsubActor` to track account updates as they arrive from subscriptions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added distinct per-client metrics to separately track program subscription vs account subscription update counts, and updated metric names/registration to reflect the split. Improved observability for subscription update activity and monitoring accuracy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->