### PR TITLE
fix: make truncator test more deterministic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ magicblock-committor-program = { path = "./magicblock-committor-program", featur
 magicblock-committor-service = { path = "./magicblock-committor-service" }
 magicblock-config = { path = "./magicblock-config" }
 magicblock-core = { path = "./magicblock-core" }
-magicblock-delegation-program = { git = "https://github.com/magicblock-labs/delegation-program.git", rev = "3edb41022" , features = [
+magicblock-delegation-program = { git = "https://github.com/magicblock-labs/delegation-program.git", rev = "3edb41022", features = [
   "no-entrypoint",
 ] }
 magicblock-ledger = { path = "./magicblock-ledger" }
@@ -186,7 +186,7 @@ solana-system-transaction = { version = "2.2" }
 solana-sysvar = { version = "2.2" }
 solana-timings = "2.2"
 solana-transaction = { version = "2.2" }
-solana-transaction-context = { version = "2.2" }
+solana-transaction-context = { version = "2.2", features = ["serde"] }
 solana-transaction-error = { version = "2.2" }
 solana-transaction-status = { version = "2.2" }
 solana-transaction-status-client-types = "2.2"

--- a/magicblock-ledger/Cargo.toml
+++ b/magicblock-ledger/Cargo.toml
@@ -29,7 +29,7 @@ solana-transaction-status = { workspace = true }
 solana-clock = { workspace = true }
 solana-hash = { workspace = true }
 solana-pubkey = { workspace = true }
-solana-signature = { workspace = true }
+solana-signature = { workspace = true, features = ["rand"] }
 solana-signer = { workspace = true }
 solana-keypair = { workspace = true }
 solana-instruction = { workspace = true }

--- a/magicblock-ledger/tests/common.rs
+++ b/magicblock-ledger/tests/common.rs
@@ -1,5 +1,3 @@
-use std::fs;
-
 use magicblock_ledger::Ledger;
 use solana_clock::Slot;
 use solana_hash::Hash;
@@ -10,12 +8,11 @@ use solana_transaction::sanitized::SanitizedTransaction;
 use solana_transaction_status::{
     TransactionStatusMeta, VersionedConfirmedBlock,
 };
-use tempfile::NamedTempFile;
+use tempfile::tempdir;
 
 pub fn setup() -> Ledger {
-    let file = NamedTempFile::new().unwrap();
-    let path = file.into_temp_path();
-    fs::remove_file(&path).unwrap();
+    let directory = tempdir().unwrap();
+    let path = directory.keep();
     Ledger::open(&path).unwrap()
 }
 

--- a/magicblock-ledger/tests/test_ledger_truncator.rs
+++ b/magicblock-ledger/tests/test_ledger_truncator.rs
@@ -89,11 +89,12 @@ async fn test_truncator_non_empty_ledger() {
         .collect::<Vec<_>>();
 
     ledger.flush().unwrap();
+    ledger.set_lowest_cleanup_slot(FINAL_SLOT);
     let mut ledger_truncator =
         LedgerTruncator::new(ledger.clone(), TEST_TRUNCATION_TIME_INTERVAL, 0);
 
     ledger_truncator.start();
-    tokio::time::sleep(TEST_TRUNCATION_TIME_INTERVAL).await;
+    tokio::time::sleep(TEST_TRUNCATION_TIME_INTERVAL * 2).await;
 
     ledger_truncator.stop();
     assert!(ledger_truncator.join().is_ok());


### PR DESCRIPTION
<!--
PR title must match:
  type(scope): summary
Types: feat|fix|docs|chore|refactor|test|perf|ci|build
Examples:
  fix: avoid panic on empty slot
  feat(rpc): add getFoo endpoint
-->

## Summary
Make lowest cleanup slot explicit in ledger truncator test, this should prevent flaky behavior in CI. 

## Compatibility
- [x] No breaking changes

## Testing
- [x] tests (or explain)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enabled serialization and random number generation features in core dependencies for enhanced functionality.

* **Tests**
  * Improved test infrastructure with better temporary directory handling and optimized ledger truncation test timing parameters.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->