### PR TITLE
chore: add path_instructions to reviews with one simple rule about expect/unwrap

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -94,6 +94,14 @@ reviews:
       enabled: true
     osvScanner:
       enabled: true
+  path_instructions:
+    - path: "{magicblock-*,programs,storage-proto}/**"
+      instructions: |
+        Treat any usage of `.unwrap()` or `.expect()` in production Rust code as a MAJOR issue.
+        These should not be categorized as trivial or nit-level concerns.
+        Request proper error handling or explicit justification with invariants.
+    - path: "{test-*,tools}/**"
+      instructions: Usage of `.unwrap()` or `.expect()` in test code is acceptable and may be treated as trivial.
 chat:
   # We leave emoji/ASCII art, but no auto-replies
   art: true

--- a/test-integration/Cargo.lock
+++ b/test-integration/Cargo.lock
@@ -3650,6 +3650,7 @@ dependencies = [
  "solana-transaction-error",
  "solana-transaction-status",
  "tokio",
+ "tokio-util 0.7.15",
 ]
 
 [[package]]


### PR DESCRIPTION



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code analysis configuration to enforce stricter error handling standards in production code.
  * Adjusted rules to allow more flexibility for error handling patterns in test code.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->