### PR TITLE
fix(aperture): support data_slice in account subscriptions

### DIFF
--- a/magicblock-aperture/src/encoder.rs
+++ b/magicblock-aperture/src/encoder.rs
@@ -10,7 +10,9 @@ use magicblock_core::{
     Slot,
 };
 use solana_account::ReadableAccount;
-use solana_account_decoder::{encode_ui_account, UiAccountEncoding};
+use solana_account_decoder::{
+    encode_ui_account, UiAccountEncoding, UiDataSliceConfig,
+};
 use solana_pubkey::Pubkey;
 use solana_transaction_error::TransactionError;
 
@@ -33,35 +35,27 @@ pub(crate) trait Encoder: Ord + Eq + Clone + Debug {
 }
 
 /// A `accountSubscribe` payload encoder
-#[derive(Debug, PartialEq, PartialOrd, Eq, Ord, Clone)]
-pub(crate) enum AccountEncoder {
-    Base58,
-    Base64,
-    Base64Zstd,
-    JsonParsed,
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub(crate) struct AccountEncoder {
+    pub(crate) encoding: UiAccountEncoding,
+    pub(crate) data_slice: Option<UiDataSliceConfig>,
 }
 
-impl From<&AccountEncoder> for UiAccountEncoding {
-    fn from(value: &AccountEncoder) -> Self {
-        match value {
-            AccountEncoder::Base58 => Self::Base58,
-            AccountEncoder::Base64 => Self::Base64,
-            AccountEncoder::Base64Zstd => Self::Base64Zstd,
-            AccountEncoder::JsonParsed => Self::JsonParsed,
-        }
+impl PartialOrd for AccountEncoder {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
     }
 }
 
-impl From<UiAccountEncoding> for AccountEncoder {
-    fn from(value: UiAccountEncoding) -> Self {
-        match value {
-            UiAccountEncoding::Base58 | UiAccountEncoding::Binary => {
-                Self::Base58
-            }
-            UiAccountEncoding::Base64 => Self::Base64,
-            UiAccountEncoding::Base64Zstd => Self::Base64Zstd,
-            UiAccountEncoding::JsonParsed => Self::JsonParsed,
-        }
+impl Ord for AccountEncoder {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        let key = |e: &Self| {
+            (
+                e.encoding as u32,
+                e.data_slice.map(|ds| (ds.offset, ds.length)),
+            )
+        };
+        key(self).cmp(&key(other))
     }
 }
 
@@ -82,7 +76,7 @@ impl Encoder for AccountEncoder {
         id: SubscriptionID,
     ) -> Option<Bytes> {
         let encoded = data.read_locked(|pk, acc| {
-            encode_ui_account(pk, acc, self.into(), None, None)
+            encode_ui_account(pk, acc, self.encoding, None, self.data_slice)
         });
         let method = "accountNotification";
         NotificationPayload::encode(encoded, slot, method, id)
@@ -101,7 +95,11 @@ impl Encoder for ProgramAccountEncoder {
         data.read_locked(|_, acc| {
             self.filters.matches(acc.data()).then_some(())
         })?;
-        let value = AccountWithPubkey::new(data, (&self.encoder).into(), None);
+        let value = AccountWithPubkey::new(
+            data,
+            self.encoder.encoding,
+            self.encoder.data_slice,
+        );
         let method = "programNotification";
         NotificationPayload::encode(value, slot, method, id)
     }

--- a/magicblock-aperture/src/requests/websocket/account_subscribe.rs
+++ b/magicblock-aperture/src/requests/websocket/account_subscribe.rs
@@ -2,7 +2,7 @@ use solana_account_decoder::UiAccountEncoding;
 use solana_rpc_client_api::config::RpcAccountInfoConfig;
 
 use super::prelude::*;
-use crate::some_or_err;
+use crate::{encoder::AccountEncoder, some_or_err};
 
 impl WsDispatcher {
     /// Handles the `accountSubscribe` WebSocket RPC request.
@@ -23,8 +23,11 @@ impl WsDispatcher {
 
         let pubkey = some_or_err!(pubkey);
         let config = config.unwrap_or_default();
-        let encoder =
-            config.encoding.unwrap_or(UiAccountEncoding::Base58).into();
+        let encoding = config.encoding.unwrap_or(UiAccountEncoding::Base58);
+        let encoder = AccountEncoder {
+            encoding,
+            data_slice: config.data_slice,
+        };
 
         // Register the subscription with the global database.
         let handle = self

--- a/magicblock-aperture/src/requests/websocket/program_subscribe.rs
+++ b/magicblock-aperture/src/requests/websocket/program_subscribe.rs
@@ -28,12 +28,16 @@ impl WsDispatcher {
         let pubkey = some_or_err!(pubkey);
         let config = config.unwrap_or_default();
 
-        let encoder: AccountEncoder = config
+        let encoding = config
             .account_config
             .encoding
-            .unwrap_or(UiAccountEncoding::Base58)
-            .into();
+            .unwrap_or(UiAccountEncoding::Base58);
+
         let filters = ProgramFilters::from(config.filters);
+        let encoder = AccountEncoder {
+            encoding,
+            data_slice: config.account_config.data_slice,
+        };
 
         // Bundle the encoding and filtering options for the subscription.
         let encoder = ProgramAccountEncoder { encoder, filters };

--- a/magicblock-aperture/src/tests.rs
+++ b/magicblock-aperture/src/tests.rs
@@ -9,6 +9,7 @@ use std::{
 use hyper::body::Bytes;
 use magicblock_accounts_db::AccountsDb;
 use magicblock_config::config::ChainLinkConfig;
+use solana_account_decoder::UiAccountEncoding;
 use solana_pubkey::Pubkey;
 use test_kit::{
     guinea::{self, GuineaInstruction},
@@ -114,14 +115,24 @@ mod event_processor {
         // Subscribe to both the specific account and the program that owns it.
         let _acc_sub = state
             .subscriptions
-            .subscribe_to_account(acc, AccountEncoder::Base58, tx.clone())
+            .subscribe_to_account(
+                acc,
+                AccountEncoder {
+                    encoding: UiAccountEncoding::Base58,
+                    data_slice: None,
+                },
+                tx.clone(),
+            )
             .await;
         let _prog_sub = state
             .subscriptions
             .subscribe_to_program(
                 guinea::ID,
                 ProgramAccountEncoder {
-                    encoder: AccountEncoder::Base58,
+                    encoder: AccountEncoder {
+                        encoding: UiAccountEncoding::Base58,
+                        data_slice: None,
+                    },
                     filters: ProgramFilters::default(),
                 },
                 tx,
@@ -219,11 +230,25 @@ mod event_processor {
 
         let _acc_sub1 = state
             .subscriptions
-            .subscribe_to_account(acc1, AccountEncoder::Base58, acc_tx1)
+            .subscribe_to_account(
+                acc1,
+                AccountEncoder {
+                    encoding: UiAccountEncoding::Base58,
+                    data_slice: None,
+                },
+                acc_tx1,
+            )
             .await;
         let _acc_sub2 = state
             .subscriptions
-            .subscribe_to_account(acc1, AccountEncoder::Base58, acc_tx2)
+            .subscribe_to_account(
+                acc1,
+                AccountEncoder {
+                    encoding: UiAccountEncoding::Base58,
+                    data_slice: None,
+                },
+                acc_tx2,
+            )
             .await;
 
         let ix1 = Instruction::new_with_bincode(
@@ -245,7 +270,10 @@ mod event_processor {
         let (prog_tx1, mut prog_rx1) = ws_channel();
         let (prog_tx2, mut prog_rx2) = ws_channel();
         let prog_encoder = ProgramAccountEncoder {
-            encoder: AccountEncoder::Base58,
+            encoder: AccountEncoder {
+                encoding: UiAccountEncoding::Base58,
+                data_slice: None,
+            },
             filters: ProgramFilters::default(),
         };
 
@@ -361,7 +389,10 @@ mod subscriptions_db {
         let account_handle = db
             .subscribe_to_account(
                 Pubkey::new_unique(),
-                AccountEncoder::Base58,
+                AccountEncoder {
+                    encoding: UiAccountEncoding::Base58,
+                    data_slice: None,
+                },
                 tx.clone(),
             )
             .await;
@@ -383,7 +414,10 @@ mod subscriptions_db {
             .subscribe_to_program(
                 guinea::ID,
                 ProgramAccountEncoder {
-                    encoder: AccountEncoder::Base58,
+                    encoder: AccountEncoder {
+                        encoding: UiAccountEncoding::Base58,
+                        data_slice: None,
+                    },
                     filters: ProgramFilters::default(),
                 },
                 tx.clone(),


### PR DESCRIPTION
## Summary
Support `data_slice` configuration in account subscriptions by refactoring `AccountEncoder` from an enum to a struct that can hold both encoding and optional data slice configuration.

## Compatibility
- [x] No breaking changes
- [ ] Config change
- [ ] Migration needed

## Testing
- [x] tests (all 6 unit tests + 36 integration tests passing)

## Checklist
- [x] closes #579

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal account encoding configuration to improve code organization and maintainability.
  * Updated encoding construction paths to use a consistent struct-based approach across account and program subscriptions.

* **Tests**
  * Updated test cases to reflect the refactored encoding configuration structure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->