### PR TITLE
docs(config): fix example remotes list 

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -55,8 +55,10 @@ lifecycle = "ephemeral"
 # If no remotes are specified, defaults to ["devnet"] with an auto-added WebSocket endpoint.
 # Default: ["https://api.devnet.solana.com/"]
 # Env: Not supported (must be configured via TOML or CLI)
-# Note: gRPC remote requires a Helius API key/token (see Helius gRPC docs).
-remotes = ["https://api.devnet.solana.com", "wss://api.devnet.solana.com", "grpcs://<your-helius-grpc-endpoint>"]
+# Note: gRPC remote requires a Helius API key/token.
+# Example format: grpcs://<network>.helius-rpc.com?api-key=<YOUR_API_KEY>
+# See Helius gRPC docs for available network endpoints.
+remotes = ["https://api.devnet.solana.com", "wss://api.devnet.solana.com", "grpcs://laserstream-devnet-ewr.helius-rpc.com?api-key=YOUR_API_KEY"]
 
 # Root directory for application storage (ledger, accountsdb, snapshots).
 # Default: "magicblock-test-storage" (created in current working directory)


### PR DESCRIPTION
## Summary
- Fix `config.example.toml` remotes examples to include 3 remotes (devnet HTTP, devnet WebSocket, and Helius gRPC) to match `magicblock-config` coverage expectations.

## Compatibility
- [x] No breaking changes
- [x] Config change (describe): example config/comment only (no runtime behavior change)
- [ ] Migration needed 

## Testing
- [x] cargo test -p magicblock-config test_example_config_full_coverage

## Checklist
- [x] docs updated
- [ ] closes N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated default devnet endpoints to HTTPS/WSS/gRPC-style addresses for improved connectivity.
  * Added a clear note that gRPC remotes require a Helius API key/token and should be configured using your Helius gRPC endpoint.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->