### PR TITLE
hotfix: map eata to ata also on update

### DIFF
--- a/magicblock-chainlink/src/chainlink/fetch_cloner.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner.rs
@@ -15,8 +15,7 @@ use log::*;
 use magicblock_config::config::AllowedProgram;
 use magicblock_core::{
     token_programs::{
-        is_ata, try_derive_eata_address_and_bump, MaybeIntoAta,
-        EATA_PROGRAM_ID,
+        is_ata, try_derive_eata_address_and_bump, MaybeIntoAta, EATA_PROGRAM_ID,
     },
     traits::AccountsBank,
 };


### PR DESCRIPTION
## Summary

Fix so that ata when eata is delegate to us are also mapped on account update.

## Compatibility
- [x] No breaking changes
- [ ] Config change (describe):
- [ ] Migration needed (describe):

## Testing
- [ ] tests (or explain)

## Checklist
- [ ] docs updated (if needed)
- [ ] closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Detect and respect custom account mappings to avoid incorrect delegation resolution.
  * Improved handling of associated token accounts (ATAs) and companion records so delegated balances and projected views are correctly applied and remote slot information is preserved.
  * Prevent unsubscribing while requests are pending and add safer subscription cancellation.
  * Expanded error logging around companion-account subscribe/fetch operations to surface and recover from failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->