### PR TITLE
feat: allow setting listen only with a port

### DIFF
--- a/magicblock-config/src/config/cli.rs
+++ b/magicblock-config/src/config/cli.rs
@@ -24,9 +24,9 @@ pub struct CliParams {
     /// ALIASES: mainnet, devnet, testnet, localhost
     ///
     /// EXAMPLES:
-    /// - `--remote devnet`
-    /// - `--remote wss://devnet.solana.com`
-    /// - `--remote grpcs://grpc.example.com`
+    /// - `--remotes devnet`
+    /// - `--remotes wss://devnet.solana.com`
+    /// - `--remotes grpcs://grpc.example.com`
     ///
     /// DEFAULT: devnet (HTTP endpoint with auto-added WS endpoint)
     #[arg(long)]

--- a/magicblock-config/src/tests.rs
+++ b/magicblock-config/src/tests.rs
@@ -8,7 +8,7 @@ use tempfile::TempDir;
 use crate::{
     config::{BlockSize, LifecycleMode},
     consts::{self, DEFAULT_VALIDATOR_KEYPAIR},
-    types::network::Remote,
+    types::network::{BindAddress, Remote},
     ValidatorParams,
 };
 
@@ -592,4 +592,70 @@ fn test_to_websocket_from_http() {
     let ws_remote = remote.to_websocket().unwrap();
     assert!(matches!(ws_remote, Remote::Websocket(_)));
     assert_eq!(ws_remote.url_str(), "ws://localhost:8900/");
+}
+
+// ============================================================================
+// 10. BindAddress Type Parsing
+// ============================================================================
+
+#[test]
+#[parallel]
+fn test_bind_address_from_str_accepts_port_only() {
+    let addr: BindAddress = "7799".parse().expect("should parse port-only");
+    assert_eq!(addr.0.to_string(), "127.0.0.1:7799");
+}
+
+#[test]
+#[parallel]
+fn test_bind_address_from_str_accepts_socket_addr() {
+    let addr: BindAddress =
+        "0.0.0.0:8899".parse().expect("should parse socket addr");
+    assert_eq!(addr.0.to_string(), "0.0.0.0:8899");
+}
+
+#[test]
+#[parallel]
+fn test_bind_address_toml_deserialize_from_integer() {
+    #[derive(serde::Deserialize)]
+    struct Cfg {
+        listen: BindAddress,
+    }
+
+    let cfg: Cfg =
+        toml::from_str("listen = 7799\n").expect("toml int to parse");
+    assert_eq!(cfg.listen.0.to_string(), "127.0.0.1:7799");
+}
+
+#[test]
+#[parallel]
+fn test_bind_address_toml_deserialize_from_string() {
+    #[derive(serde::Deserialize)]
+    struct Cfg {
+        listen: BindAddress,
+    }
+
+    let cfg: Cfg = toml::from_str("listen = \"0.0.0.0:8899\"\n")
+        .expect("toml str to parse");
+    assert_eq!(cfg.listen.0.to_string(), "0.0.0.0:8899");
+}
+
+#[test]
+#[parallel]
+fn test_bind_address_toml_deserialize_port_out_of_range_errors() {
+    #[derive(serde::Deserialize)]
+    struct Cfg {
+        #[allow(dead_code)]
+        listen: BindAddress,
+    }
+
+    let msg = toml::from_str::<Cfg>("listen = 70000\n")
+        .err()
+        .unwrap()
+        .to_string();
+    // Error message can vary, but it should mention invalid value or out of range
+    assert!(
+        msg.contains("out of range") || msg.contains("invalid"),
+        "unexpected error: {}",
+        msg
+    );
 }

--- a/test-integration/Cargo.lock
+++ b/test-integration/Cargo.lock
@@ -2231,10 +2231,10 @@ dependencies = [
 
 [[package]]
 name = "guinea"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "bincode",
- "magicblock-magic-program-api 0.5.2",
+ "magicblock-magic-program-api 0.5.3",
  "serde",
  "solana-program",
 ]
@@ -3260,7 +3260,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-account-cloner"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "async-trait",
  "bincode",
@@ -3271,7 +3271,7 @@ dependencies = [
  "magicblock-config",
  "magicblock-core",
  "magicblock-ledger",
- "magicblock-magic-program-api 0.5.2",
+ "magicblock-magic-program-api 0.5.3",
  "magicblock-program",
  "magicblock-rpc-client",
  "rand 0.9.2",
@@ -3292,7 +3292,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-accounts"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "async-trait",
  "log",
@@ -3314,7 +3314,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-accounts-db"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "lmdb-rkv",
  "log",
@@ -3330,7 +3330,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-aperture"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "arc-swap",
  "base64 0.21.7",
@@ -3375,7 +3375,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-api"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "borsh 1.6.0",
@@ -3391,7 +3391,7 @@ dependencies = [
  "magicblock-config",
  "magicblock-core",
  "magicblock-ledger",
- "magicblock-magic-program-api 0.5.2",
+ "magicblock-magic-program-api 0.5.3",
  "magicblock-metrics",
  "magicblock-processor",
  "magicblock-program",
@@ -3430,7 +3430,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-chainlink"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -3443,7 +3443,7 @@ dependencies = [
  "magicblock-config",
  "magicblock-core",
  "magicblock-delegation-program 1.1.3 (git+https://github.com/magicblock-labs/delegation-program.git?rev=1874b4f5f5f55cb9ab54b64de2cc0d41107d1435)",
- "magicblock-magic-program-api 0.5.2",
+ "magicblock-magic-program-api 0.5.3",
  "magicblock-metrics",
  "parking_lot",
  "scc",
@@ -3483,7 +3483,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-committor-program"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "borsh 1.6.0",
  "paste",
@@ -3495,7 +3495,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-committor-service"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -3538,7 +3538,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-config"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "clap",
  "derive_more",
@@ -3556,10 +3556,10 @@ dependencies = [
 
 [[package]]
 name = "magicblock-core"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "flume",
- "magicblock-magic-program-api 0.5.2",
+ "magicblock-magic-program-api 0.5.3",
  "solana-account",
  "solana-account-decoder",
  "solana-hash",
@@ -3606,12 +3606,12 @@ dependencies = [
  "solana-security-txt",
  "static_assertions",
  "strum 0.27.2",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "magicblock-ledger"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -3661,7 +3661,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-magic-program-api"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "bincode",
  "serde",
@@ -3670,7 +3670,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-metrics"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "http-body-util",
  "hyper 1.8.1",
@@ -3684,7 +3684,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-processor"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "bincode",
  "log",
@@ -3719,12 +3719,12 @@ dependencies = [
 
 [[package]]
 name = "magicblock-program"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "bincode",
  "lazy_static",
  "magicblock-core",
- "magicblock-magic-program-api 0.5.2",
+ "magicblock-magic-program-api 0.5.3",
  "num-derive",
  "num-traits",
  "parking_lot",
@@ -3751,7 +3751,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-rpc-client"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "log",
  "solana-account",
@@ -3772,7 +3772,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-table-mania"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "ed25519-dalek",
  "log",
@@ -3798,7 +3798,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-task-scheduler"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "bincode",
  "chrono",
@@ -3825,7 +3825,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-validator-admin"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "log",
  "magicblock-delegation-program 1.1.3 (git+https://github.com/magicblock-labs/delegation-program.git?rev=1874b4f5f5f55cb9ab54b64de2cc0d41107d1435)",
@@ -3842,7 +3842,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-version"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "git-version",
  "rustc_version",
@@ -4751,7 +4751,7 @@ dependencies = [
  "bincode",
  "borsh 1.6.0",
  "ephemeral-rollups-sdk",
- "magicblock-magic-program-api 0.5.2",
+ "magicblock-magic-program-api 0.5.3",
  "serde",
  "solana-program",
 ]
@@ -4775,7 +4775,7 @@ dependencies = [
  "borsh 1.6.0",
  "ephemeral-rollups-sdk",
  "magicblock-delegation-program 1.1.3 (git+https://github.com/magicblock-labs/delegation-program.git?rev=1874b4f5f5f55cb9ab54b64de2cc0d41107d1435)",
- "magicblock-magic-program-api 0.5.2",
+ "magicblock-magic-program-api 0.5.3",
  "rkyv 0.7.45",
  "solana-program",
  "static_assertions",
@@ -5810,7 +5810,7 @@ dependencies = [
  "integration-test-tools",
  "log",
  "magicblock-core",
- "magicblock-magic-program-api 0.5.2",
+ "magicblock-magic-program-api 0.5.3",
  "program-schedulecommit",
  "rand 0.8.5",
  "schedulecommit-client",
@@ -5827,7 +5827,7 @@ version = "0.0.0"
 dependencies = [
  "integration-test-tools",
  "magicblock-core",
- "magicblock-magic-program-api 0.5.2",
+ "magicblock-magic-program-api 0.5.3",
  "program-schedulecommit",
  "program-schedulecommit-security",
  "schedulecommit-client",
@@ -8546,7 +8546,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-proto"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "bincode",
  "bs58",
@@ -10047,7 +10047,7 @@ dependencies = [
 
 [[package]]
 name = "test-kit"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "env_logger 0.11.8",
  "guinea",


### PR DESCRIPTION
## Summary

Allow setting listen only with a port

## Compatibility
- [x] No breaking changes
- [ ] Config change (describe):
- [ ] Migration needed (describe):

## Testing
- [ ] tests (or explain)

## Checklist
- [ ] docs updated (if needed)
- [ ] closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected CLI parameter documentation examples to reflect current naming conventions.

* **New Features**
  * Enhanced bind address configuration flexibility:
    * Supports simplified port-only format that defaults to localhost binding
    * Accepts full socket address specifications in configuration files
    * TOML files can now use integer port values for bind address configuration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->