### PR TITLE
fix: persist sysvar hash to accountsdb on update

### DIFF
--- a/magicblock-accounts-db/src/lib.rs
+++ b/magicblock-accounts-db/src/lib.rs
@@ -273,7 +273,10 @@ impl AccountsDb {
     /// An optimized accountsdb accessor, which can be used for multiple reads,
     /// without incurring the overhead of repeated creation of index transaction
     pub fn reader(&self) -> AccountsDbResult<AccountsReader<'_>> {
-        let offset = self.index.offset_finder()?;
+        let offset = self
+            .index
+            .offset_finder()
+            .log_err(|| "Failed to create offset iterator")?;
         Ok(AccountsReader {
             offset,
             storage: &self.storage,


### PR DESCRIPTION
<!--
PR title must match:
  type(scope): summary
Types: feat|fix|docs|chore|refactor|test|perf|ci|build
Examples:
  fix: avoid panic on empty slot
  feat(rpc): add getFoo endpoint
-->

## Summary
Persist sysvar hash to the accountsdb on each slot update. Fixes the issue when clients pass sysvar account explicitly and read stale data.

## Compatibility
- [x] No breaking changes
