### PR TITLE
perf: eliminate unnecessary get_slot calls from table mania manager

### DIFF
--- a/magicblock-table-mania/src/manager.rs
+++ b/magicblock-table-mania/src/manager.rs
@@ -723,16 +723,14 @@ impl TableMania {
         released_tables: &Mutex<Vec<LookupTableRc>>,
         compute_budget: &TableManiaComputeBudget,
     ) {
-        // Avoid doing any work if there aren't any  deactivated tables to close.
+        // Avoid doing any work if there aren't any deactivated tables to close.
         // Mainly we avoid the `get_slot` call in that case
-        if released_tables
+        let has_deactivated_tables = released_tables
             .lock()
             .await
             .iter()
-            .filter(|x| x.deactivate_triggered())
-            .count()
-            == 0
-        {
+            .any(|x| x.deactivate_triggered());
+        if !has_deactivated_tables {
             return;
         }
 


### PR DESCRIPTION
## Summary

Performance optimizations to reduce unnecessary RPC calls:

- Table-mania now skips the `get_slot()` call when there are no deactivated tables to close, avoiding unnecessary RPC traffic

CLOSES: #818

## Details

### magicblock-table-mania

Added an early return in the table closing logic to check if there are any deactivated tables before making an RPC call. This avoids the expensive `get_slot()` call when there's no actual work to do.

### Reproduction steps

#### Modified Configs to Use

1. I told the solana-test-validator (devnet) to listen on 17799.
2. I told the ephemeral validator's pubsub to bypass the proxy and directly connect to 17800.

```diff
diff --git a/test-integration/configs/chainlink-conf.devnet.toml b/test-integration/configs/chainlink-conf.devnet.toml
index 16da71f8..8cc9d908 100644
--- a/test-integration/configs/chainlink-conf.devnet.toml
+++ b/test-integration/configs/chainlink-conf.devnet.toml
@@ -2,7 +2,7 @@ lifecycle = "offline"
 remotes = ["devnet"]

 [aperture]
-listen = "0.0.0.0:7799"
+listen = "0.0.0.0:17799"

 [commit]
 compute-unit-price = 1_000_000
diff --git a/test-integration/configs/cloning-conf.ephem.toml b/test-integration/configs/cloning-conf.ephem.toml
index 8eb6b38b..40055079 100644
--- a/test-integration/configs/cloning-conf.ephem.toml
+++ b/test-integration/configs/cloning-conf.ephem.toml
@@ -1,5 +1,5 @@
 lifecycle = "ephemeral"
-remotes = ["http://0.0.0.0:7799", "ws://0.0.0.0:7800"]
+remotes = ["http://0.0.0.0:7799", "ws://0.0.0.0:17800"]

 [aperture]
 listen = "0.0.0.0:8899"
```

#### Termial 1 Proxy

```sh
mitmproxy --mode reverse:http://127.0.0.1:17799/ --listen-host 127.0.0.1 --listen-port 7799
```

#### Terminal 2 Solana Test Validator

From `test-integration` directory:

```sh
make setup-chainlink-devnet
```

- launches a solana-test-validator configured from `chainlink-conf.devnet.toml`

#### Terminal 3 Ephemeral Validator

From `test-integration` directory:

```sh
make setup-cloning-ephem
```

- launches an ephemeral validator configured from `cloning-conf.ephem.toml`

#### Observations

- then I waited 10 seconds and confirmed that I received to `get_slot()` calls in the mitmproxy
  terminal.
- after my change I repeated the same and confirmed that no `get_slot()` calls were made



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reduced unnecessary background API calls when no tables need closing, improving performance and resource usage.
  * Improved reliability by handling slot-fetch errors early to avoid extra work when closure can't proceed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->