### PR TITLE
chore: apply structured logging to magicblock-ledger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3170,6 +3170,7 @@ dependencies = [
  "solana-transaction-error",
  "solana-transaction-status",
  "tempfile",
+ "test-kit",
  "thiserror 1.0.69",
  "tokio",
  "tokio-util",

--- a/magicblock-ledger/Cargo.toml
+++ b/magicblock-ledger/Cargo.toml
@@ -46,6 +46,7 @@ rocksdb = { workspace = true }
 [dev-dependencies]
 tempfile = { workspace = true }
 solana-system-transaction = { workspace = true }
+test-kit = { workspace = true }
 
 [build-dependencies]
 

--- a/magicblock-ledger/src/conversions/transaction.rs
+++ b/magicblock-ledger/src/conversions/transaction.rs
@@ -151,7 +151,7 @@ fn try_address_table_lookup_from_generated(
     let account_key = match Pubkey::try_from(lookup.account_key) {
         Ok(pubkey) => pubkey,
         Err(err) => {
-            warn!("Invalid pubkey: {:?}", err);
+            warn!(error = ?err, "Invalid pubkey");
             return None;
         }
     };
@@ -170,7 +170,7 @@ fn signatures_from_slices(signatures: Vec<Vec<u8>>) -> Vec<Signature> {
         .flat_map(|slice| {
             Signature::try_from(slice.as_slice())
                 .inspect_err(|e| {
-                    warn!("Invalid signature: {:?}", e);
+                    warn!(error = ?e, "Invalid signature");
                 })
                 .ok()
         })
@@ -219,7 +219,7 @@ fn status_from_generated(
         Some(err) => {
             let e: Option<TransactionError> = bincode::deserialize(&err.err)
                 .map_err(|e| {
-                    warn!("Invalid transaction error: {:?}", e);
+                    warn!(error = ?e, "Invalid transaction error");
                     e
                 })
                 .ok();
@@ -264,7 +264,7 @@ fn pubkeys_from_slices(pubkeys: Vec<Vec<u8>>) -> Vec<Pubkey> {
         .flat_map(|slice| {
             Pubkey::try_from(slice)
                 .map_err(|e| {
-                    warn!("Invalid pubkey: {:?}", e);
+                    warn!(error = ?e, "Invalid pubkey");
                     e
                 })
                 .ok()
@@ -341,7 +341,7 @@ fn return_data_from_generated(
         None => None,
         Some(data) => match Pubkey::try_from(data.program_id) {
             Err(e) => {
-                warn!("Invalid pubkey: {:?}", e);
+                warn!(error = ?e, "Invalid pubkey");
                 None
             }
             Ok(program_id) => Some(TransactionReturnData {

--- a/magicblock-ledger/src/database/cf_descriptors.rs
+++ b/magicblock-ledger/src/database/cf_descriptors.rs
@@ -60,7 +60,7 @@ pub fn cf_descriptors(
     let detected_cfs = match DB::list_cf(&Options::default(), path) {
         Ok(detected_cfs) => detected_cfs,
         Err(err) => {
-            debug!("Unable to detect Rocks columns: {err:?}. This is expected for a new ledger.");
+            debug!(error = ?err, "Unable to detect Rocks columns; this is expected for a new ledger");
             vec![]
         }
     };
@@ -75,7 +75,7 @@ pub fn cf_descriptors(
         .collect();
     detected_cfs.iter().for_each(|cf_name| {
             if !known_cfs.contains(cf_name.as_str()) {
-                info!("Detected unknown column {cf_name}, opening column with basic options");
+                info!(column_name = %cf_name, "Detected unknown column; opening with basic options");
                 // This version of the software was unaware of the column, so
                 // it is fair to assume that we will not attempt to read or
                 // write the column. So, set some bare bones settings to avoid

--- a/magicblock-ledger/src/database/ledger_column.rs
+++ b/magicblock-ledger/src/database/ledger_column.rs
@@ -651,7 +651,7 @@ pub fn try_decrease_entry_counter(entry_counter: &AtomicI64, by: u64) {
                 return;
             }
         } else {
-            warn!("Negative entry counter!");
+            warn!(counter = prev, "Negative entry counter");
             // In case value fixed to valid one in between
             if entry_counter
                 .compare_exchange(

--- a/magicblock-ledger/src/database/rocks_db.rs
+++ b/magicblock-ledger/src/database/rocks_db.rs
@@ -276,12 +276,14 @@ mod tests {
 
     use rocksdb::Options;
     use tempfile::tempdir;
+    use test_kit::init_logger;
 
     use super::*;
     use crate::database::columns::columns;
 
     #[test]
     fn test_cf_names_and_descriptors_equal_length() {
+        init_logger!();
         let path = PathBuf::default();
         let options = LedgerOptions::default();
         // The names and descriptors don't need to be in the same order for our use cases;
@@ -295,6 +297,7 @@ mod tests {
 
     #[test]
     fn test_open_unknown_columns() {
+        init_logger!();
         let temp_dir = tempdir().unwrap();
         let db_path = temp_dir.path();
 

--- a/magicblock-ledger/src/ledger_truncator.rs
+++ b/magicblock-ledger/src/ledger_truncator.rs
@@ -12,7 +12,7 @@ use magicblock_metrics::metrics::{
 use solana_measure::measure::Measure;
 use tokio::{runtime::Builder, time::interval};
 use tokio_util::sync::CancellationToken;
-use tracing::{error, info, warn};
+use tracing::{error, info, instrument, warn};
 
 use crate::{
     database::{
@@ -54,6 +54,7 @@ impl LedgerTrunctationWorker {
         }
     }
 
+    #[instrument(skip(self))]
     pub async fn run(self) {
         let mut interval = interval(self.truncation_time_interval);
         loop {
@@ -67,20 +68,20 @@ impl LedgerTrunctationWorker {
                     let current_size = match self.ledger.storage_size() {
                         Ok(value) => value,
                         Err(err) => {
-                            error!("Failed to check truncation condition: {err}");
+                            error!(error = ?err, "Truncation check failed");
                             continue;
                         }
                     };
 
                     // Check if we should truncate
                     if current_size < (self.ledger_size / 100) * FILLED_PERCENTAGE_LIMIT as u64 {
-                        info!("Skipping truncation, ledger size: {}", current_size);
+                        info!(current_size, "Skipping truncation");
                         continue;
                     }
 
-                    info!("Ledger size: {current_size}");
+                    info!(current_size, "Checking ledger size");
                     if let Err(err) = self.truncate(current_size) {
-                        error!("Failed to truncate ledger!: {:?}", err);
+                        error!(error = ?err, "Truncation failed");
                     }
                 }
             }
@@ -111,7 +112,7 @@ impl LedgerTrunctationWorker {
         &self,
         current_ledger_size: u64,
     ) -> LedgerResult<()> {
-        info!("Fat truncation");
+        info!("Starting fat truncation");
 
         // Calculate excessive size
         let desired_size =
@@ -120,12 +121,9 @@ impl LedgerTrunctationWorker {
 
         let (highest_slot, _) = self.ledger.get_max_blockhash()?;
         let lowest_slot = self.ledger.get_lowest_slot()?.unwrap_or(0);
-        info!(
-            "Fat truncation. lowest slot: {}, hightest slot: {}",
-            lowest_slot, highest_slot
-        );
+        info!(lowest_slot, highest_slot, "Fat truncation bounds");
         if lowest_slot == highest_slot {
-            warn!("Nani3?");
+            warn!("Invalid slot range");
             return Ok(());
         }
 
@@ -137,17 +135,14 @@ impl LedgerTrunctationWorker {
         // Calculating up to which slot we're truncating
         let truncate_to_slot = lowest_slot + num_slots_to_truncate - 1;
 
-        info!(
-            "Fat truncation: truncating up to(inclusive): {}",
-            truncate_to_slot
-        );
+        info!(truncate_to_slot, "Fat truncation complete");
 
         self.ledger.set_lowest_cleanup_slot(truncate_to_slot);
         Self::delete_slots(&self.ledger, 0, truncate_to_slot)?;
 
         if let Err(err) = self.ledger.flush() {
             // We will still compact
-            error!("Failed to flush: {}", err);
+            error!(error = ?err, "Flush failed");
         }
         Self::compact_slot_range(
             &self.ledger,
@@ -279,20 +274,18 @@ impl LedgerTrunctationWorker {
         cancellation_token: CancellationToken,
     ) -> LedgerResult<()> {
         if to_slot < from_slot {
-            warn!("LedgerTruncator: Nani?");
+            warn!("Invalid slot range");
             return Ok(());
         }
 
-        info!(
-            "LedgerTruncator: truncating slot range [{from_slot}; {to_slot}]"
-        );
+        info!(from_slot, to_slot, "Truncating slot range");
 
         ledger.set_lowest_cleanup_slot(to_slot);
         Self::delete_slots(ledger, from_slot, to_slot)?;
 
         // Flush memtables with tombstones prior to compaction
         if let Err(err) = ledger.flush() {
-            error!("Failed to flush ledger: {err}");
+            error!(error = ?err, "Flush failed");
         }
         Self::compact_slot_range(
             ledger,
@@ -314,7 +307,7 @@ impl LedgerTrunctationWorker {
         use crate::compact_cf_or_return;
 
         if to_slot < from_slot {
-            warn!("LedgerTruncator: Nani2?");
+            warn!("Invalid slot range");
             return;
         }
         if cancellation_token.is_cancelled() {
@@ -322,9 +315,7 @@ impl LedgerTrunctationWorker {
             return;
         }
 
-        info!(
-            "LedgerTruncator: compacting slot range [{from_slot}; {to_slot}]"
-        );
+        info!(from_slot, to_slot, "Compacting slot range");
 
         struct CompactionMeasure {
             measure: Measure,
@@ -493,8 +484,8 @@ macro_rules! compact_cf_or_return {
         $ledger.compact_slot_range_cf::<$cf>(Some($from), Some($to));
         if $token.is_cancelled() {
             info!(
-                "Validator shutting down - stopping compaction after {}",
-                <$cf as $crate::database::columns::ColumnName>::NAME
+                column_name = %<$cf as $crate::database::columns::ColumnName>::NAME,
+                "Shutdown during compaction"
             );
             return;
         }
@@ -503,8 +494,8 @@ macro_rules! compact_cf_or_return {
         $ledger.compact_slot_range_cf::<$cf>($from, $to);
         if $token.is_cancelled() {
             info!(
-                "Validator shutting down - stopping compaction after {}",
-                <$cf as $crate::database::columns::ColumnName>::NAME
+                column_name = %<$cf as $crate::database::columns::ColumnName>::NAME,
+                "Shutdown during compaction"
             );
             return;
         }

--- a/magicblock-ledger/src/store/api.rs
+++ b/magicblock-ledger/src/store/api.rs
@@ -131,7 +131,7 @@ impl Ledger {
 
         // Open the database
         let mut measure = Measure::start("ledger open");
-        info!("Opening ledger at {:?}", ledger_path);
+        info!(path = ?ledger_path, "Opening ledger");
         let db = Database::open(&ledger_path, options)?;
 
         let transaction_status_cf = db.column();
@@ -271,7 +271,10 @@ impl Ledger {
             _ => 0,
         };
 
-        info!("initializing lowest cleanup slot: {}", lowest_cleanup_slot);
+        info!(
+            slot = lowest_cleanup_slot,
+            "Initializing lowest cleanup slot"
+        );
         self.set_lowest_cleanup_slot(lowest_cleanup_slot);
 
         Ok(())
@@ -1366,6 +1369,7 @@ mod tests {
         VersionedTransactionWithStatusMeta,
     };
     use tempfile::{Builder, TempDir};
+    use test_kit::init_logger;
 
     use super::*;
 
@@ -1500,7 +1504,7 @@ mod tests {
             transaction
                 .try_into()
                 .map_err(|e| {
-                    error!("VersionedTransaction::try_into failed: {:?}", e)
+                    error!(error = ?e, "VersionedTransaction::try_into failed")
                 })
                 .unwrap(),
             Default::default(),
@@ -1508,7 +1512,7 @@ mod tests {
             SimpleAddressLoader::Enabled(meta.loaded_addresses.clone()),
             &Default::default(),
         )
-        .map_err(|e| error!("SanitizedTransaction::try_new failed: {:?}", e))
+        .map_err(|e| error!(error = ?e, "SanitizedTransaction::try_new failed"))
         .unwrap();
 
         (
@@ -1529,6 +1533,7 @@ mod tests {
 
     #[test]
     fn test_persist_transaction_status() {
+        init_logger!();
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let store = Ledger::open(ledger_path.path()).unwrap();
 
@@ -1590,6 +1595,7 @@ mod tests {
 
     #[test]
     fn test_get_transaction_status_by_signature() {
+        init_logger!();
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let store = Ledger::open(ledger_path.path()).unwrap();
 
@@ -1667,6 +1673,7 @@ mod tests {
 
     #[test]
     fn test_get_complete_transaction_by_signature() {
+        init_logger!();
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let store = Ledger::open(ledger_path.path()).unwrap();
 
@@ -1748,6 +1755,7 @@ mod tests {
 
     #[test]
     fn test_find_address_signatures_no_intra_slot_limits() {
+        init_logger!();
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let store = Ledger::open(ledger_path.path()).unwrap();
 
@@ -2108,6 +2116,7 @@ mod tests {
 
     #[test]
     fn test_find_address_signatures_intra_slot_limits() {
+        init_logger!();
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let store = Ledger::open(ledger_path.path()).unwrap();
 
@@ -2349,6 +2358,7 @@ mod tests {
 
     #[test]
     fn test_get_confirmed_signatures_with_memos() {
+        init_logger!();
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let store = Ledger::open(ledger_path.path()).unwrap();
 

--- a/magicblock-ledger/src/store/data_mod_persister.rs
+++ b/magicblock-ledger/src/store/data_mod_persister.rs
@@ -7,7 +7,7 @@ use crate::Ledger;
 
 impl PersistsAccountModData for Ledger {
     fn persist(&self, id: u64, data: Vec<u8>) -> Result<(), Box<dyn Error>> {
-        trace!("Persisting data with id: {}, data-len: {}", id, data.len());
+        trace!(id, data_len = data.len(), "Persisting data");
         self.write_account_mod_data(id, &data.into())?;
         Ok(())
     }
@@ -16,13 +16,9 @@ impl PersistsAccountModData for Ledger {
         let data = self.read_account_mod_data(id)?.map(|x| x.data);
         if enabled!(Level::TRACE) {
             if let Some(data) = &data {
-                trace!(
-                    "Loading data with id: {}, data-len: {}",
-                    id,
-                    data.len()
-                );
+                trace!(id, data_len = data.len(), "Loading data");
             } else {
-                trace!("Loading data with id: {} (not found)", id);
+                trace!(id, found = false, "Loading data");
             }
         }
         Ok(data)

--- a/magicblock-ledger/src/store/utils.rs
+++ b/magicblock-ledger/src/store/utils.rs
@@ -57,7 +57,7 @@ pub fn adjust_ulimit_nofile(
 
         nofile = get_nofile();
     }
-    info!("Maximum open file descriptors: {}", nofile.rlim_cur);
+    info!(limit = nofile.rlim_cur, "Maximum open file descriptors");
     Ok(())
 }
 

--- a/magicblock-ledger/tests/get_block.rs
+++ b/magicblock-ledger/tests/get_block.rs
@@ -1,6 +1,7 @@
 mod common;
 
 use solana_hash::Hash;
+use test_kit::init_logger;
 
 use crate::common::{
     get_block, get_block_transaction_hash, setup, write_dummy_transaction,
@@ -8,6 +9,7 @@ use crate::common::{
 
 #[test]
 fn test_get_block_meta() {
+    init_logger!();
     let ledger = setup();
 
     let slot_0_time = 5;
@@ -37,6 +39,7 @@ fn test_get_block_meta() {
 
 #[test]
 fn test_get_block_transactions() {
+    init_logger!();
     let ledger = setup();
 
     let (slot_41_tx1, _) = write_dummy_transaction(&ledger, 41);

--- a/magicblock-ledger/tests/test_ledger_truncator.rs
+++ b/magicblock-ledger/tests/test_ledger_truncator.rs
@@ -4,6 +4,7 @@ use std::{sync::Arc, time::Duration};
 use magicblock_ledger::{ledger_truncator::LedgerTruncator, Ledger};
 use solana_hash::Hash;
 use solana_signature::Signature;
+use test_kit::init_logger;
 
 use crate::common::{setup, write_dummy_transaction};
 
@@ -41,6 +42,7 @@ fn verify_transactions_state(
 // Tests that ledger is not truncated while there is still enough space
 #[tokio::test]
 async fn test_truncator_not_purged_size() {
+    init_logger!();
     const NUM_TRANSACTIONS: u64 = 100;
 
     let ledger = Arc::new(setup());
@@ -77,6 +79,7 @@ async fn test_truncator_not_purged_size() {
 // Tests that ledger got truncated but not after finality slot
 #[tokio::test]
 async fn test_truncator_non_empty_ledger() {
+    init_logger!();
     const FINAL_SLOT: u64 = 80;
 
     let ledger = Arc::new(setup());
@@ -139,6 +142,7 @@ async fn transaction_spammer(
 // Tests if ledger truncated correctly during tx spamming
 #[tokio::test]
 async fn test_truncator_with_tx_spammer() {
+    init_logger!();
     let ledger = Arc::new(setup());
 
     let mut ledger_truncator =
@@ -169,6 +173,7 @@ async fn test_truncator_with_tx_spammer() {
 #[ignore = "Long running test"]
 #[tokio::test]
 async fn test_with_1gb_db() {
+    init_logger!();
     const DB_SIZE: u64 = 1 << 30;
     const CHECK_RATE: u64 = 100;
 


### PR DESCRIPTION
## Summary

Adapting crate magicblock-ledger to use structured logging.

## Description

This PR implements structured logging for the crate magicblock-ledger as per the plan included below which was derived from a _master_ plan with detailed structured logging practices in order to be consistent with other crates in the project.

<details>
<summary>
Plan file: 07_plan-magicblock-ledger.md
</summary>

# Magicblock-Ledger Structured Logging Implementation Plan

Based on the deterministic pattern from `02_plan-general.md`, this document provides a concrete, step-by-step implementation guide specific to the `magicblock-ledger` crate.

---

## Overview

The `magicblock-ledger` crate is primarily a **synchronous, storage-focused library** with minimal async operations. It contains three async functions with logging statements:

1. **`blockstore_processor/mod.rs`**: Ledger block replay and processing
2. **`ledger_truncator.rs`**: Ledger size management and compaction

Total files to update: **3 files** with meaningful async logging (some files have sync logging only, which we defer to later passes).

### Crate Structure

- **Core Logic**: Synchronous database operations (get, put, delete)
- **Block Processing**: Async replay of blocks from ledger to transaction scheduler
- **Maintenance**: Async ledger truncation and compaction
- **Utilities**: File descriptor limits, conversions (mostly sync)

---

## Critical Files (Process First)

### File 1: `src/blockstore_processor/mod.rs`

**Priority**: 1 (Foundational, replay logic)

**Async functions with logging**:
1. `replay_blocks()` - Main async block replay loop (lines 32-142)
2. `process_ledger()` - Public entry point (lines 146-170)

**Current log statements**:

```rust
// Line 59-63: Progress reporting
info!(
    "Processing block: {}/{}",
    slot.to_formatted_string(&Locale::en),
    max_slot
);

// Line 131: Trace transaction result (conditional)
debug!("Result: {signature} - {result:?}");

// Line 156-158: Debug parameter logging
debug!(
    "Loaded accounts into bank from storage replaying blockhashes from {} and transactions from {}",
    blockhashes_only_starting_slot, full_process_starting_slot
);
```

**Implementation**:

1. Add `#[instrument(skip(params, transaction_scheduler))]` to `replay_blocks()` with fields:
   - `full_process_starting_slot = params.full_process_starting_slot`
   - `blockhashes_only_starting_slot = params.blockhashes_only_starting_slot`

2. Add `#[instrument(skip(ledger, transaction_scheduler))]` to `process_ledger()` with fields:
   - `full_process_starting_slot`
   - `max_age`

3. Rewrite log statements:
   - Line 59-63: `info!(slot = slot, "Processing block");`
   - Line 131: `debug!(signature = %signature, result = ?result, "Transaction replay result");`
   - Line 156: `debug!("Replay configuration");` (constants can go in span field)

### File 2: `src/ledger_truncator.rs`

**Priority**: 2 (Async background service)

**Key async function**:
- `run()` (lines 57-87) - Main async event loop for truncation worker

**Current log statements** (in `run()` and related functions):

```rust
// Line 70: Error checking truncation
error!("Failed to check truncation condition: {err}");

// Line 77: Skip truncation
info!("Skipping truncation, ledger size: {}", current_size);

// Line 81: Ledger size report
info!("Ledger size: {current_size}");

// Line 83: Truncation failure
error!("Failed to truncate ledger!: {:?}", err);

// Line 101: Warning on missing range
warn!("Could not estimate truncation range");

// Line 114: Fat truncation start
info!("Fat truncation");

// Line 123-126: Fat truncation progress
info!(
    "Fat truncation. lowest slot: {}, hightest slot: {}",
    lowest_slot, highest_slot
);

// Line 128: Edge case warning
warn!("Nani3?");

// Line 140-143: Fat truncation complete
info!(
    "Fat truncation: truncating up to(inclusive): {}",
    truncate_to_slot
);

// Line 150: Flush error
error!("Failed to flush: {}", err);

// Line 287: Slot range truncation
info!(
    "LedgerTruncator: truncating slot range [{from_slot}; {to_slot}]"
);

// Line 325-327: Compaction start
info!(
    "LedgerTruncator: compacting slot range [{from_slot}; {to_slot}]"
);

// Lines 495-499, 506-510 (macro): Shutdown during compaction
info!(
    "Validator shutting down - stopping compaction after {}",
    <$cf as $crate::database::columns::ColumnName>::NAME
);
```

**Implementation**:

1. Add `#[instrument(skip(self))]` to `run()`

2. Rewrite all log statements following constant message pattern:
   - Line 70: `error!(error = ?err, "Truncation check failed");`
   - Line 77: `info!(current_size, "Skipping truncation");`
   - Line 81: `info!(current_size, "Checking ledger size");`
   - Line 83: `error!(error = ?err, "Truncation failed");`
   - Line 101: `warn!("No truncation range available");`
   - Line 114: `info!("Starting fat truncation");`
   - Line 123: `info!(lowest_slot, highest_slot, "Fat truncation bounds");`
   - Line 128: `warn!("Invalid slot range");`
   - Line 140: `info!(truncate_to_slot, "Fat truncation complete");`
   - Line 150: `error!(error = ?err, "Flush failed");`
   - Line 287: `info!(from_slot, to_slot, "Truncating slot range");`
   - Line 325: `info!(from_slot, to_slot, "Compacting slot range");`
   - Macro: `info!(column_name = %<$cf as ColumnName>::NAME, "Shutdown during compaction");`

---

## Standard Field Naming for Magicblock-Ledger

| Field | Type | Format | Use Case |
|-------|------|--------|----------|
| `slot` | u64 | bare | Block slot number |
| `full_process_starting_slot` | u64 | bare | Replay start for transactions |
| `blockhashes_only_starting_slot` | u64 | bare | Replay start for hashes only |
| `max_age` | u64 | bare | Maximum block age |
| `from_slot` | u64 | bare | Range start (truncation) |
| `to_slot` | u64 | bare | Range end (truncation) |
| `lowest_slot` | u64 | bare | Lowest slot in ledger |
| `highest_slot` | u64 | bare | Highest slot in ledger |
| `current_size` | u64 | bare | Current storage size in bytes |
| `truncate_to_slot` | u64 | bare | Target slot for truncation |
| `signature` | Signature | `%` | Transaction signature |
| `result` | Result/Error | `?` | Transaction execution result |
| `error` | Error | `?` | Error details |
| `column_name` | String | `%` | RocksDB column family name |

---

## Deferred: Sync Code and Minor Logging

The following files contain logging but are **not async** and thus do **not get spans**. Defer these to a second pass:

### Non-Async Files (No Spans Needed)

**File**: `src/store/utils.rs`
- `adjust_ulimit_nofile()` - Sync function
- Lines 32, 42-51, 60 - Logging for file descriptor setup
- These are sync so they do NOT get `#[instrument]`
- Just rewrite messages to constant format without adding attributes

**File**: `src/conversions/transaction.rs`
- Multiple sync helper functions
- Lines 154, 173, 222, 267, 344 - Validation warnings
- No `#[instrument]` needed (sync code)
- Rewrite: `warn!(error = ?err, "Invalid pubkey");` etc.

**File**: `src/database/cf_descriptors.rs`
- Sync column descriptor detection
- Lines 63, 78 - Column family setup logging
- No spans needed

**File**: `src/database/ledger_column.rs`
- Line 654: Sync utility function
- `warn!("Negative entry counter!");`
- No spans needed

---

## Implementation Order

Process files in this exact order:

1. **`src/blockstore_processor/mod.rs`** - Two async functions, foundational
2. **`src/ledger_truncator.rs`** - One main async function, background service

Then for follow-up pass (sync code):
3. `src/store/utils.rs` - File descriptor setup (sync)
4. `src/conversions/transaction.rs` - Validation helpers (sync)
5. `src/database/cf_descriptors.rs` - Column setup (sync)
6. `src/database/ledger_column.rs` - Utilities (sync)

---

## Validation Steps

### 1. Syntax Check
```bash
cd magicblock-ledger
cargo check
```

### 2. Lint
```bash
make lint
```

### 3. Tests
```bash
cargo nextest run -p magicblock-ledger
```

### 4. Log Inspection
```bash
RUST_LOG=debug cargo test --package magicblock-ledger --lib 2>&1 | head -100
```

**Verify**:
- [ ] Each async function creates one top-level span
- [ ] Log messages are constant (no variables in message)
- [ ] Fields appear with correct values in span context
- [ ] No duplicate information (in both message and field)
- [ ] Slot/block info is in span fields, not message

---

## Summary

This plan provides **2 critical async files to update** with concrete before/after examples. The magicblock-ledger crate is storage-focused with minimal async operations:

1. **blockstore_processor/mod.rs**: Two async functions for block replay with progress logging
2. **ledger_truncator.rs**: One main async function for background ledger maintenance

**Key characteristics**:
- Minimal logging in async paths
- Most logging is in synchronous utility functions (deferred to pass 2)
- Focus on slot/block numbers and error conditions
- Background service pattern with progress reporting

**Next steps**:
1. Apply `#[instrument]` to the two async functions
2. Rewrite all log messages in these files to constant format
3. Extract parameters to structured fields
4. Run validation checks (cargo check, lint, test)
5. Proceed to sync code pass if needed

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal logging architecture by implementing structured tracing throughout the ledger processing, database, and storage systems for enhanced diagnostics and troubleshooting.
  * Enhanced test infrastructure with automatic logging initialization to improve test observability.
  * Updated development dependencies to support improved testing utilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->