### PR TITLE
fix: persist sysvar clock account

### DIFF
--- a/magicblock-processor/src/executor/mod.rs
+++ b/magicblock-processor/src/executor/mod.rs
@@ -202,7 +202,7 @@ impl TransactionExecutor {
             return;
         };
         if let Err(e) = account.serialize_data(data) {
-            warn!(?e, "Failed to serialize sysvar: {}");
+            warn!(%e, "Failed to serialize sysvar");
             return;
         }
         let _ = self.accountsdb.insert_account(&slot_hashes::ID, &account);


### PR DESCRIPTION
<!--
PR title must match:
  type(scope): summary
Types: feat|fix|docs|chore|refactor|test|perf|ci|build
Examples:
  fix: avoid panic on empty slot
  feat(rpc): add getFoo endpoint
-->

## Summary
- Sysvar Clock account is now persisted 

## Compatibility
- [x] No breaking changes

## Testing
- [x] tests pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved persistence of system variable data (e.g., slot hashes and clock) during block/slot transitions by adding serialization, storage, and error handling to ensure these values are reliably retained and failures are logged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->