### PR TITLE
chore: revert #865 (649ed7ca) to reenable original owner program subs

### DIFF
--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -383,8 +383,26 @@ where
                                 );
 
                                 // For accounts delegated to us, always unsubscribe from the delegated account
+                                // and subscribe to the original owner program for undelegation update resilience
                                 if account.delegated() {
                                     subs_to_remove.insert(pubkey);
+
+                                    // Subscribe to the original owner program for undelegation update resilience
+                                    // Fire-and-forget to avoid blocking subscription updates
+                                    let provider =
+                                        self.remote_account_provider.clone();
+                                    let owner = delegation_record.owner;
+                                    tokio::spawn(async move {
+                                        if let Err(err) = provider
+                                            .subscribe_program(owner)
+                                            .await
+                                        {
+                                            warn!(
+                                                "Failed to subscribe to owner program {} for account {}: {}",
+                                                owner, pubkey, err
+                                            );
+                                        }
+                                    });
                                 }
 
                                 (

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/pipeline.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/pipeline.rs
@@ -278,6 +278,9 @@ where
         let mut record_subs = Vec::with_capacity(accounts_fully_resolved.len());
         let mut accounts_to_clone = plain;
 
+        // Collect unique owner programs to subscribe to concurrently
+        let mut owner_programs_to_subscribe: HashSet<Pubkey> = HashSet::new();
+
         // Now process the accounts (this can fail without affecting unsubscription)
         for AccountWithCompanion {
             pubkey,
@@ -331,6 +334,12 @@ where
                     &mut account,
                     &delegation_record,
                 );
+
+                // Collect unique owner programs to subscribe concurrently after the loop
+                if account.delegated() {
+                    owner_programs_to_subscribe.insert(delegation_record.owner);
+                }
+
                 (commit_freq, delegated_to_other)
             } else {
                 missing_delegation_record.push((pubkey, account.remote_slot()));
@@ -341,6 +350,29 @@ where
                 account: account.into_account_shared_data(),
                 commit_frequency_ms,
                 delegated_to_other,
+            });
+        }
+
+        // Subscribe to owner programs concurrently in background (best-effort)
+        if !owner_programs_to_subscribe.is_empty() {
+            let remote_account_provider = this.remote_account_provider.clone();
+            tokio::spawn(async move {
+                let subscribe_futures =
+                    owner_programs_to_subscribe.into_iter().map(|owner| {
+                        let provider = remote_account_provider.clone();
+                        async move {
+                            let result =
+                                provider.subscribe_program(owner).await;
+                            (owner, result)
+                        }
+                    });
+                let results =
+                    futures_util::future::join_all(subscribe_futures).await;
+                for (owner, result) in results {
+                    if let Err(err) = result {
+                        warn!(program_id = %owner, error = %err, "Failed to subscribe to owner program");
+                    }
+                }
             });
         }
 

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -1659,3 +1659,327 @@ async fn test_allowed_programs_empty_allows_all() {
         "Program 2 should be in the bank (empty allowed_programs allows all)"
     );
 }
+
+// -----------------
+// Program Subscription Tests for Delegated Accounts
+// -----------------
+
+#[tokio::test]
+async fn test_subscribe_to_original_owner_program_on_delegated_account_fetch() {
+    init_logger();
+    let validator_pubkey = random_pubkey();
+    let account_owner = random_pubkey();
+    const CURRENT_SLOT: u64 = 100;
+
+    let account_pubkey = random_pubkey();
+    let account = Account {
+        lamports: 1_000_000,
+        data: vec![1, 2, 3, 4],
+        owner: dlp::id(),
+        executable: false,
+        rent_epoch: 0,
+    };
+
+    let FetcherTestCtx {
+        remote_account_provider,
+        accounts_bank,
+        rpc_client,
+        fetch_cloner,
+        ..
+    } = setup(
+        [(account_pubkey, account.clone())],
+        CURRENT_SLOT,
+        validator_pubkey,
+    )
+    .await;
+
+    // Add delegation record with original owner
+    add_delegation_record_for(
+        &rpc_client,
+        account_pubkey,
+        validator_pubkey,
+        account_owner,
+    );
+
+    // Fetch and clone the delegated account
+    let result = fetch_cloner
+        .fetch_and_clone_accounts(
+            &[account_pubkey],
+            None,
+            None,
+            AccountFetchOrigin::GetAccount,
+            None,
+        )
+        .await;
+
+    assert!(result.is_ok());
+
+    // Verify account was cloned and marked as delegated
+    assert_cloned_delegated_account!(
+        accounts_bank,
+        account_pubkey,
+        account,
+        CURRENT_SLOT,
+        account_owner
+    );
+
+    // Verify that we subscribed to the original owner program
+    let pubsub_client = remote_account_provider.pubsub_client();
+    let subscribed_programs = pubsub_client.subscribed_program_ids();
+    assert!(
+        subscribed_programs.contains(&account_owner),
+        "Should subscribe to original owner program {}, got: {:?}",
+        account_owner,
+        subscribed_programs
+    );
+}
+
+#[tokio::test]
+async fn test_no_program_subscription_for_undelegated_account() {
+    init_logger();
+    let validator_pubkey = random_pubkey();
+    let account_owner = random_pubkey();
+    const CURRENT_SLOT: u64 = 100;
+
+    let account_pubkey = random_pubkey();
+    let undelegated_account = Account {
+        lamports: 1_000_000,
+        data: vec![1, 2, 3, 4],
+        owner: account_owner,
+        executable: false,
+        rent_epoch: 0,
+    };
+
+    let FetcherTestCtx {
+        remote_account_provider,
+        accounts_bank,
+        fetch_cloner,
+        ..
+    } = setup(
+        [(account_pubkey, undelegated_account.clone())],
+        CURRENT_SLOT,
+        validator_pubkey,
+    )
+    .await;
+
+    // Verify that initially we don't subscribe to any program
+    let pubsub_client = remote_account_provider.pubsub_client();
+    let initial_programs = pubsub_client.subscribed_program_ids();
+    assert!(
+        initial_programs.is_empty(),
+        "Should have no program subscriptions initially"
+    );
+
+    // Fetch and clone the undelegated account
+    let result = fetch_cloner
+        .fetch_and_clone_accounts(
+            &[account_pubkey],
+            None,
+            None,
+            AccountFetchOrigin::GetAccount,
+            None,
+        )
+        .await;
+
+    assert!(result.is_ok());
+
+    // Verify account was cloned but not delegated
+    assert_cloned_undelegated_account!(
+        accounts_bank,
+        account_pubkey,
+        undelegated_account,
+        CURRENT_SLOT,
+        account_owner
+    );
+
+    // Still no program subscriptions since it wasn't delegated
+    let programs_after_fetch = pubsub_client.subscribed_program_ids();
+    assert!(
+        programs_after_fetch.is_empty(),
+        "Should have no program subscriptions after fetching undelegated account"
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn send_subscription_update_and_get_subscribed_programs(
+    remote_account_provider: &Arc<
+        RemoteAccountProvider<ChainRpcClientMock, ChainPubsubClientMock>,
+    >,
+    accounts_bank: &Arc<AccountsBankStub>,
+    subscription_tx: &mpsc::Sender<ForwardedSubscriptionUpdate>,
+    account_pubkey: Pubkey,
+    bank_account: Account,
+    update_account: Account,
+    slot: u64,
+    expected_program_id: Option<Pubkey>,
+) -> std::collections::HashSet<Pubkey> {
+    use crate::remote_account_provider::{
+        RemoteAccount, RemoteAccountUpdateSource,
+    };
+
+    accounts_bank.insert(account_pubkey, AccountSharedData::from(bank_account));
+
+    let pubsub_client = remote_account_provider.pubsub_client();
+    let initial_programs = pubsub_client.subscribed_program_ids();
+    assert!(
+        initial_programs.is_empty(),
+        "Should have no program subscriptions initially"
+    );
+
+    let remote_account = RemoteAccount::from_fresh_account(
+        update_account,
+        slot,
+        RemoteAccountUpdateSource::Subscription,
+    );
+    let update = ForwardedSubscriptionUpdate {
+        pubkey: account_pubkey,
+        account: remote_account,
+    };
+    subscription_tx.send(update).await.unwrap();
+
+    const POLL_INTERVAL: std::time::Duration = Duration::from_millis(10);
+    const TIMEOUT: std::time::Duration = Duration::from_millis(200);
+
+    let result = tokio::time::timeout(TIMEOUT, async {
+        loop {
+            let subscribed = pubsub_client.subscribed_program_ids();
+            match expected_program_id {
+                Some(expected) if subscribed.contains(&expected) => {
+                    return subscribed;
+                }
+                None if !subscribed.is_empty() => {
+                    return subscribed;
+                }
+                _ => {}
+            }
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+    })
+    .await;
+
+    match result {
+        Ok(subscribed) => subscribed,
+        Err(_) if expected_program_id.is_some() => {
+            panic!(
+                "Timeout waiting for program subscription {:?}",
+                expected_program_id
+            )
+        }
+        Err(_) => pubsub_client.subscribed_program_ids(),
+    }
+}
+
+#[tokio::test]
+async fn test_subscribe_to_original_owner_program_on_delegated_account_subscription_update(
+) {
+    init_logger();
+    let validator_pubkey = random_pubkey();
+    let account_owner = random_pubkey();
+    const CURRENT_SLOT: u64 = 100;
+
+    let account_pubkey = random_pubkey();
+    let delegated_account = Account {
+        lamports: 1_000_000,
+        data: vec![1, 2, 3, 4],
+        owner: dlp::id(),
+        executable: false,
+        rent_epoch: 0,
+    };
+
+    let FetcherTestCtx {
+        remote_account_provider,
+        accounts_bank,
+        rpc_client,
+        subscription_tx,
+        ..
+    } = setup(
+        [(account_pubkey, delegated_account.clone())],
+        CURRENT_SLOT,
+        validator_pubkey,
+    )
+    .await;
+
+    add_delegation_record_for(
+        &rpc_client,
+        account_pubkey,
+        validator_pubkey,
+        account_owner,
+    );
+
+    let bank_account = Account {
+        lamports: 500_000,
+        data: vec![0, 0, 0, 0],
+        owner: account_owner,
+        executable: false,
+        rent_epoch: 0,
+    };
+
+    let subscribed_programs =
+        send_subscription_update_and_get_subscribed_programs(
+            &remote_account_provider,
+            &accounts_bank,
+            &subscription_tx,
+            account_pubkey,
+            bank_account,
+            delegated_account,
+            CURRENT_SLOT,
+            Some(account_owner),
+        )
+        .await;
+
+    assert!(
+        subscribed_programs.contains(&account_owner),
+        "Should subscribe to original owner program {} via subscription update, got: {:?}",
+        account_owner,
+        subscribed_programs
+    );
+}
+
+#[tokio::test]
+async fn test_no_program_subscription_for_undelegated_account_subscription_update(
+) {
+    init_logger();
+    let validator_pubkey = random_pubkey();
+    let account_owner = random_pubkey();
+    const CURRENT_SLOT: u64 = 100;
+
+    let account_pubkey = random_pubkey();
+    let undelegated_account = Account {
+        lamports: 1_000_000,
+        data: vec![1, 2, 3, 4],
+        owner: account_owner,
+        executable: false,
+        rent_epoch: 0,
+    };
+
+    let FetcherTestCtx {
+        remote_account_provider,
+        accounts_bank,
+        subscription_tx,
+        ..
+    } = setup(
+        [(account_pubkey, undelegated_account.clone())],
+        CURRENT_SLOT,
+        validator_pubkey,
+    )
+    .await;
+
+    let subscribed_programs =
+        send_subscription_update_and_get_subscribed_programs(
+            &remote_account_provider,
+            &accounts_bank,
+            &subscription_tx,
+            account_pubkey,
+            undelegated_account.clone(),
+            undelegated_account,
+            CURRENT_SLOT,
+            None,
+        )
+        .await;
+
+    assert!(
+        subscribed_programs.is_empty(),
+        "Should have no program subscriptions for undelegated account subscription update, got: {:?}",
+        subscribed_programs
+    );
+}

--- a/magicblock-chainlink/src/remote_account_provider/chain_laser_actor.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_laser_actor.rs
@@ -512,6 +512,7 @@ impl ChainLaserActor {
             .as_ref()
             .map(|x| x.0.iter().cloned().collect::<HashSet<Pubkey>>())
             .unwrap_or_default();
+
         subscribed_programs.insert(program_id);
 
         let mut accounts = HashMap::new();

--- a/magicblock-chainlink/src/remote_account_provider/chain_pubsub_client.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_pubsub_client.rs
@@ -385,6 +385,7 @@ pub mod mock {
         updates_sndr: mpsc::Sender<SubscriptionUpdate>,
         updates_rcvr: Arc<Mutex<Option<mpsc::Receiver<SubscriptionUpdate>>>>,
         subscribed_pubkeys: Arc<Mutex<HashSet<Pubkey>>>,
+        subscribed_programs: Arc<Mutex<HashSet<Pubkey>>>,
         subscription_count_at_disconnect: Arc<Mutex<usize>>,
         connected: Arc<Mutex<bool>>,
         pending_resubscribe_failures: Arc<Mutex<usize>>,
@@ -400,6 +401,7 @@ pub mod mock {
                 updates_sndr,
                 updates_rcvr: Arc::new(Mutex::new(Some(updates_rcvr))),
                 subscribed_pubkeys: Arc::new(Mutex::new(HashSet::new())),
+                subscribed_programs: Arc::new(Mutex::new(HashSet::new())),
                 subscription_count_at_disconnect: Arc::new(Mutex::new(0)),
                 connected: Arc::new(Mutex::new(true)),
                 pending_resubscribe_failures: Arc::new(Mutex::new(0)),
@@ -468,6 +470,10 @@ pub mod mock {
                     == *self.subscription_count_at_disconnect.lock()
         }
 
+        pub fn subscribed_program_ids(&self) -> HashSet<Pubkey> {
+            self.subscribed_programs.lock().clone()
+        }
+
         /// Directly insert a subscription without going through subscribe().
         /// Useful for testing reconciliation scenarios.
         pub fn insert_subscription(&self, pubkey: Pubkey) {
@@ -504,7 +510,7 @@ pub mod mock {
 
         async fn subscribe_program(
             &self,
-            _program_id: Pubkey,
+            program_id: Pubkey,
         ) -> RemoteAccountProviderResult<()> {
             if !*self.connected.lock() {
                 return Err(
@@ -514,7 +520,8 @@ pub mod mock {
                     ),
                 );
             }
-            // Program subscriptions don't track individual accounts in the mock
+            let mut subscribed_programs = self.subscribed_programs.lock();
+            subscribed_programs.insert(program_id);
             Ok(())
         }
 


### PR DESCRIPTION
## Summary

Reenables the following feature by reverting commit: 649ed7ca PR #865

CLOSES: #883 

Reenabled feature details below:

> ## Summary
>
> Subscribe to original owner programs for delegated accounts to improve undelegation update resilience. This reintroduces program subscriptions with two key improvements:
> - Subscriptions are handled asynchronously in background tasks to avoid blocking account processing
> - Multiple owner programs are collected and subscribed to concurrently for efficiency
> - Comprehensive test coverage for both fetch and subscription update paths
>
> ## Details
>
> ### magicblock-chainlink
>
> #### fetch_cloner/mod.rs
>
> When processing delegated accounts that are being unsubscribed from, we now spawn a background task to subscribe to their original owner program. This allows us to detect undelegation events via program subscription updates, providing resilience against missing account subscription updates.
>
> The subscription is fire-and-forget with warning logging on failure to avoid blocking the main account processing pipeline.
>
> #### fetch_cloner/pipeline.rs
>
> Optimized the program subscription approach for the account processing pipeline:
> - Collects all unique owner programs from delegated accounts being processed
> - Spawns a single background task that concurrently subscribes to all programs using `join_all`
> - This is more efficient than individual background tasks per account and reduces subscription churn
>
> Failed subscriptions are logged but don't impact the processing flow.
>
> #### fetch_cloner/tests.rs
>
> Added comprehensive test coverage for program subscription behavior:
> - `test_subscribe_to_original_owner_program_on_delegated_account_fetch`: Verifies that fetching a delegated account triggers a subscription to its original owner program
> - `test_no_program_subscription_for_undelegated_account`: Confirms no subscriptions occur for regular (non-delegated) accounts
> - `test_subscribe_to_original_owner_program_on_delegated_account_subscription_update`: Tests subscription via the account subscription update path
> - `test_no_program_subscription_for_undelegated_account_subscription_update`: Verifies subscription update path doesn't subscribe for undelegated accounts
>
> Helper function `send_subscription_update_and_get_subscribed_programs` enables testing subscription behavior after account updates.
>
> #### chain_pubsub_client.rs (mock)
>
> Enhanced the mock pubsub client to track program subscriptions:
> - Added `subscribed_programs` field to store subscribed program IDs
> - Implemented `subscribed_program_ids()` method to retrieve the set of subscribed programs
> - Updated `subscribe_program()` to actually track subscriptions (was a no-op before)
>
> This enables tests to verify program subscription behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automatic subscription to owner programs when accounts are delegated to validators, with asynchronous background processing that doesn't block operations.
  * Enhanced tracking and management of delegated accounts.

* **Tests**
  * Comprehensive test coverage for delegated account subscription behavior.
  * Tests for concurrent requests, deduplication, and various edge cases in delegation scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->