### PR TITLE
feat: enable ed25519, secp256k1 and secp256r1 precompiles

### DIFF
--- a/magicblock-processor/src/lib.rs
+++ b/magicblock-processor/src/lib.rs
@@ -14,6 +14,7 @@ use solana_sdk_ids::{
     ed25519_program, native_loader, secp256k1_program, secp256r1_program,
 };
 use solana_svm::transaction_processor::TransactionProcessingEnvironment;
+use tracing::error;
 
 /// Initialize an SVM environment for transaction processing.
 pub fn build_svm_env(
@@ -90,7 +91,7 @@ fn ensure_precompile_account(accountsdb: &AccountsDb, id: &Pubkey) {
     let mut account = AccountSharedData::new(1, 0, &native_loader::ID);
     account.set_executable(true);
     if let Err(e) = accountsdb.insert_account(id, &account) {
-        log::error!("Failed to insert precompile account {}: {:?}", id, e);
+        error!("Failed to insert precompile account {}: {:?}", id, e);
     }
 }
 


### PR DESCRIPTION
## Summary

Enable ed25519, secp256k1 and secp256r1 precompiles

## Compatibility
- [x] No breaking changes
- [ ] Config change (describe):
- [ ] Migration needed (describe):

## Testing
- [ ] tests (or explain)

## Checklist
- [ ] docs updated (if needed)
- [ ] closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded cryptographic support by enabling ed25519, secp256k1, and secp256r1 verification at environment startup.
  * Improved initialization to proactively provision and mark required cryptographic precompile accounts so signature verification features are available immediately when the environment is created.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->