### PR TITLE
fix: broken links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ cargo build --release
 
 ## ⚙️ Configuration
 
-The validator is highly configurable via TOML files or environment variables. A comprehensive reference configuration is available in [`config.example.toml`](https://www.google.com/search?q=./config.example.toml).
+The validator is highly configurable via TOML files or environment variables. A comprehensive reference configuration is available in [`config.example.toml`](./config.example.toml).
 
 ### Core Operational Modes (`lifecycle`)
 
@@ -127,7 +127,7 @@ make test
 
 
 * **Run integration tests specifically:**
-See [test-integration/README.md](https://www.google.com/search?q=./test-integration/README.md) for detailed instructions on running specific scenarios.
+See [test-integration/README.md](./test-integration/README.md) for detailed instructions on running specific scenarios.
 ```bash
 make -C test-integration test
 
@@ -155,7 +155,7 @@ Open Source is at the heart of what we do at MagicBlock. We believe building sof
 
 ## 📄 License
 
-This project is licensed under the **Business Source License 1.1**. See [LICENSE.md](https://www.google.com/search?q=./LICENSE.md) for details.
+This project is licensed under the **Business Source License 1.1**. See [LICENSE.md](./LICENSE.md) for details.
 
 ---
 


### PR DESCRIPTION
## Summary
Removed incorrect `https://www.google.com/search?q=` prefixes from relative links (./config.example.toml, ./test-integration/README.md, ./LICENSE.md). Links now work as intended.

## Compatibility
- No breaking changes

## Testing
- Manually verified links work correctly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed broken links in the README by replacing external search redirects with proper relative paths, improving access to configuration files, test documentation, and license information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->