### PR TITLE
corrected unify cargo run syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ You can override any configuration value using environment variables with the `M
 # Example: Run as an ephemeral validator syncing from Mainnet
 MBV_LIFECYCLE=ephemeral \
 MBV_LISTEN=0.0.0.0:8899 \
-cargo run --release config.example.toml
+cargo run --release -- config.example.toml
 
 ```
 


### PR DESCRIPTION
In magicblock-config/README.md, the app launch commands used different syntax:

cargo run --release -- config.example.toml
cargo run --release config.example.toml


Without --, Cargo interpret the configuration file as an argument to Cargo itself, causing errors during startup.

I corrected the commands and made them identical.

Now the commands run correctly and predictably.

## Summary
-

## Compatibility
- [ ] No breaking changes
- [ ] Config change (describe):
- [ ] Migration needed (describe):

## Testing
- [ ] tests (or explain)

## Checklist
- [ ] docs updated (if needed)
- [ ] closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated usage example in README to correctly forward arguments to the executable via cargo run, ensuring the configuration file path is properly passed to the binary rather than interpreted as a cargo flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->