### PR TITLE
Fixed a typo in the reference

### DIFF
--- a/magicblock-metrics/README.md
+++ b/magicblock-metrics/README.md
@@ -49,7 +49,7 @@ A dashboard with ID `1860` can be imported to Grafana to visualize these metrics
 
 ### Optionally Install Telegraf
 
-- [get it here](ihttps://www.influxdata.com/time-series-platform/telegraf/)
+- [get it here](https://www.influxdata.com/time-series-platform/telegraf/)
 
 ```sh
 brew install telegraf


### PR DESCRIPTION
Removed the `i` and the link works now.

## Compatibility
- [ ] No breaking changes
- [ ] Config change (describe):
- [ ] Migration needed (describe):

## Testing
- [ ] tests (or explain)

## Checklist
- [ ] docs updated (if needed)
- [ ] closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a malformed URL in the installation guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->