### PR TITLE
fix: stop setting loaded accounts data size limit

### DIFF
--- a/magicblock-committor-service/src/tasks/utils.rs
+++ b/magicblock-committor-service/src/tasks/utils.rs
@@ -160,15 +160,12 @@ impl TransactionUtils {
     pub fn budget_instructions(
         compute_units: u32,
         compute_unit_price: u64,
-        accounts_size_budget: u32,
-    ) -> [Instruction; 3] {
+        _accounts_size_budget: u32,
+    ) -> [Instruction; 2] {
         [
             ComputeBudgetInstruction::set_compute_unit_limit(compute_units),
             ComputeBudgetInstruction::set_compute_unit_price(
                 compute_unit_price,
-            ),
-            ComputeBudgetInstruction::set_loaded_accounts_data_size_limit(
-                accounts_size_budget,
             ),
         ]
     }


### PR DESCRIPTION
## Summary

fix: stop setting loaded accounts data size limit

## Compatibility
- [x] No breaking changes
- [ ] Config change (describe):
- [ ] Migration needed (describe):

## Testing
- [ ] tests (or explain)

## Checklist
- [ ] docs updated (if needed)
- [ ] closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Optimized transaction budget instruction handling to improve system efficiency and streamline transaction processing performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->