### PR TITLE
feat: Add ScheduleCommitFinalize to program-api only

### DIFF
--- a/magicblock-magic-program-api/src/args.rs
+++ b/magicblock-magic-program-api/src/args.rs
@@ -85,12 +85,16 @@ pub enum MagicBaseIntentArgs {
     BaseActions(Vec<BaseActionArgs>),
     Commit(CommitTypeArgs),
     CommitAndUndelegate(CommitAndUndelegateArgs),
+    CommitFinalize(CommitTypeArgs),
+    CommitFinalizeAndUndelegate(CommitAndUndelegateArgs),
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct MagicIntentBundleArgs {
     pub commit: Option<CommitTypeArgs>,
     pub commit_and_undelegate: Option<CommitAndUndelegateArgs>,
+    pub commit_finalize: Option<CommitTypeArgs>,
+    pub commit_finalize_and_undelegate: Option<CommitAndUndelegateArgs>,
     pub standalone_actions: Vec<BaseActionArgs>,
 }
 
@@ -104,6 +108,12 @@ impl From<MagicBaseIntentArgs> for MagicIntentBundleArgs {
             MagicBaseIntentArgs::Commit(value) => this.commit = Some(value),
             MagicBaseIntentArgs::CommitAndUndelegate(value) => {
                 this.commit_and_undelegate = Some(value)
+            }
+            MagicBaseIntentArgs::CommitFinalize(value) => {
+                this.commit_finalize = Some(value)
+            }
+            MagicBaseIntentArgs::CommitFinalizeAndUndelegate(value) => {
+                this.commit_finalize_and_undelegate = Some(value)
             }
         }
 

--- a/magicblock-magic-program-api/src/instruction.rs
+++ b/magicblock-magic-program-api/src/instruction.rs
@@ -178,6 +178,22 @@ pub enum MagicBlockInstruction {
     /// - **1.** `[WRITE]` Ephemeral account to close
     /// - **2.** `[WRITE]` Vault account (source of rent refund)
     CloseEphemeralAccount,
+
+    /// Schedules the accounts provided at end of accounts Vec to be committed and finalized in a
+    /// single DLP instruction.
+    /// It should be invoked from the program whose PDA accounts are to be
+    /// committed.
+    ///
+    /// This is the first part of scheduling a commit.
+    /// A second transaction [MagicBlockInstruction::AcceptScheduleCommits] has to run in order
+    /// to finish scheduling the commit.
+    ///
+    /// # Account references
+    /// - **0.**   `[WRITE, SIGNER]` Payer requesting the commit to be scheduled
+    /// - **1.**   `[WRITE]`         Magic Context Account containing to which we store
+    ///   the scheduled commits
+    /// - **2..n** `[]`              Accounts to be committed
+    ScheduleCommitFinalize { request_undelegation: bool },
 }
 
 impl MagicBlockInstruction {

--- a/programs/magicblock/src/magic_scheduled_base_intent.rs
+++ b/programs/magicblock/src/magic_scheduled_base_intent.rs
@@ -407,6 +407,8 @@ impl MagicBaseIntent {
                     CommitAndUndelegate::try_from_args(type_, context)?;
                 Ok(MagicBaseIntent::CommitAndUndelegate(commit_and_undelegate))
             }
+            MagicBaseIntentArgs::CommitFinalize(_) => todo!(),
+            MagicBaseIntentArgs::CommitFinalizeAndUndelegate(_) => todo!(),
         }
     }
 

--- a/programs/magicblock/src/magicblock_processor.rs
+++ b/programs/magicblock/src/magicblock_processor.rs
@@ -63,6 +63,9 @@ declare_process_instruction!(
                     request_undelegation: true,
                 },
             ),
+            ScheduleCommitFinalize {
+                request_undelegation: _,
+            } => todo!(),
             AcceptScheduleCommits => {
                 process_accept_scheduled_commits(signers, invoke_context)
             }

--- a/test-integration/Cargo.lock
+++ b/test-integration/Cargo.lock
@@ -1700,7 +1700,7 @@ dependencies = [
 [[package]]
 name = "ephemeral-rollups-sdk"
 version = "0.8.5"
-source = "git+https://github.com/magicblock-labs/ephemeral-rollups-sdk.git?rev=dec833e0#dec833e000302f01f4a845c8a38b879453af8eef"
+source = "git+https://github.com/magicblock-labs/ephemeral-rollups-sdk.git?rev=d6a81e25a80d78fea9adf3fb1342df9bc9b87ba6#d6a81e25a80d78fea9adf3fb1342df9bc9b87ba6"
 dependencies = [
  "base64ct",
  "borsh 0.10.4",
@@ -1710,7 +1710,7 @@ dependencies = [
  "ephemeral-rollups-sdk-attribute-ephemeral",
  "getrandom 0.2.16",
  "magicblock-delegation-program 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "magicblock-magic-program-api 0.6.2",
+ "magicblock-magic-program-api 0.8.0 (git+https://github.com/magicblock-labs/magicblock-validator.git?branch=snawaz%2Fschedule-commit-finalize)",
  "solana-account",
  "solana-account-info",
  "solana-cpi",
@@ -1725,7 +1725,7 @@ dependencies = [
 [[package]]
 name = "ephemeral-rollups-sdk-attribute-action"
 version = "0.8.5"
-source = "git+https://github.com/magicblock-labs/ephemeral-rollups-sdk.git?rev=dec833e0#dec833e000302f01f4a845c8a38b879453af8eef"
+source = "git+https://github.com/magicblock-labs/ephemeral-rollups-sdk.git?rev=d6a81e25a80d78fea9adf3fb1342df9bc9b87ba6#d6a81e25a80d78fea9adf3fb1342df9bc9b87ba6"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -1734,7 +1734,7 @@ dependencies = [
 [[package]]
 name = "ephemeral-rollups-sdk-attribute-commit"
 version = "0.8.5"
-source = "git+https://github.com/magicblock-labs/ephemeral-rollups-sdk.git?rev=dec833e0#dec833e000302f01f4a845c8a38b879453af8eef"
+source = "git+https://github.com/magicblock-labs/ephemeral-rollups-sdk.git?rev=d6a81e25a80d78fea9adf3fb1342df9bc9b87ba6#d6a81e25a80d78fea9adf3fb1342df9bc9b87ba6"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -1743,7 +1743,7 @@ dependencies = [
 [[package]]
 name = "ephemeral-rollups-sdk-attribute-delegate"
 version = "0.8.5"
-source = "git+https://github.com/magicblock-labs/ephemeral-rollups-sdk.git?rev=dec833e0#dec833e000302f01f4a845c8a38b879453af8eef"
+source = "git+https://github.com/magicblock-labs/ephemeral-rollups-sdk.git?rev=d6a81e25a80d78fea9adf3fb1342df9bc9b87ba6#d6a81e25a80d78fea9adf3fb1342df9bc9b87ba6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1753,7 +1753,7 @@ dependencies = [
 [[package]]
 name = "ephemeral-rollups-sdk-attribute-ephemeral"
 version = "0.8.5"
-source = "git+https://github.com/magicblock-labs/ephemeral-rollups-sdk.git?rev=dec833e0#dec833e000302f01f4a845c8a38b879453af8eef"
+source = "git+https://github.com/magicblock-labs/ephemeral-rollups-sdk.git?rev=d6a81e25a80d78fea9adf3fb1342df9bc9b87ba6#d6a81e25a80d78fea9adf3fb1342df9bc9b87ba6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2251,10 +2251,10 @@ dependencies = [
 
 [[package]]
 name = "guinea"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bincode",
- "magicblock-magic-program-api 0.7.0",
+ "magicblock-magic-program-api 0.8.0",
  "serde",
  "solana-program",
 ]
@@ -3273,7 +3273,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-account-cloner"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "bincode",
@@ -3283,7 +3283,7 @@ dependencies = [
  "magicblock-config",
  "magicblock-core",
  "magicblock-ledger",
- "magicblock-magic-program-api 0.7.0",
+ "magicblock-magic-program-api 0.8.0",
  "magicblock-program",
  "magicblock-rpc-client",
  "rand 0.9.2",
@@ -3305,7 +3305,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-accounts"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "magicblock-account-cloner",
@@ -3327,7 +3327,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-accounts-db"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "lmdb-rkv",
  "magicblock-config",
@@ -3342,7 +3342,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-aperture"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "agave-geyser-plugin-interface",
  "arc-swap",
@@ -3390,7 +3390,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-api"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "borsh 1.6.0",
@@ -3405,7 +3405,7 @@ dependencies = [
  "magicblock-config",
  "magicblock-core",
  "magicblock-ledger",
- "magicblock-magic-program-api 0.7.0",
+ "magicblock-magic-program-api 0.8.0",
  "magicblock-metrics",
  "magicblock-processor",
  "magicblock-program",
@@ -3445,7 +3445,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-chainlink"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -3457,7 +3457,7 @@ dependencies = [
  "magicblock-config",
  "magicblock-core",
  "magicblock-delegation-program 1.1.3 (git+https://github.com/magicblock-labs/delegation-program.git?rev=2cb491032f372)",
- "magicblock-magic-program-api 0.7.0",
+ "magicblock-magic-program-api 0.8.0",
  "magicblock-metrics",
  "parking_lot",
  "scc",
@@ -3499,7 +3499,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-committor-program"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "borsh 1.6.0",
  "paste",
@@ -3511,7 +3511,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-committor-service"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -3555,7 +3555,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-config"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "clap",
  "derive_more",
@@ -3573,10 +3573,10 @@ dependencies = [
 
 [[package]]
 name = "magicblock-core"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "flume",
- "magicblock-magic-program-api 0.7.0",
+ "magicblock-magic-program-api 0.8.0",
  "solana-account",
  "solana-account-decoder",
  "solana-hash",
@@ -3628,12 +3628,12 @@ dependencies = [
  "solana-security-txt",
  "static_assertions",
  "strum 0.27.2",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "magicblock-ledger"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -3673,9 +3673,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-magic-program-api"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e90106f6b76f802c3e7c6d9875fd21cf200e6b53020ba5099b402a90c6d78d10"
+version = "0.8.0"
 dependencies = [
  "bincode",
  "serde",
@@ -3684,7 +3682,8 @@ dependencies = [
 
 [[package]]
 name = "magicblock-magic-program-api"
-version = "0.7.0"
+version = "0.8.0"
+source = "git+https://github.com/magicblock-labs/magicblock-validator.git?branch=snawaz%2Fschedule-commit-finalize#33f3097e3ceb40538b2983ff89623c788469620e"
 dependencies = [
  "bincode",
  "serde",
@@ -3693,7 +3692,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-metrics"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "http-body-util",
  "hyper 1.8.1",
@@ -3707,7 +3706,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-processor"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bincode",
  "magicblock-accounts-db",
@@ -3743,12 +3742,12 @@ dependencies = [
 
 [[package]]
 name = "magicblock-program"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bincode",
  "lazy_static",
  "magicblock-core",
- "magicblock-magic-program-api 0.7.0",
+ "magicblock-magic-program-api 0.8.0",
  "num-derive",
  "num-traits",
  "parking_lot",
@@ -3775,7 +3774,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-rpc-client"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "solana-account",
  "solana-account-decoder-client-types",
@@ -3797,7 +3796,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-table-mania"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "ed25519-dalek",
  "magicblock-metrics",
@@ -3823,7 +3822,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-task-scheduler"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bincode",
  "chrono",
@@ -3849,7 +3848,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-validator-admin"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "magicblock-delegation-program 1.1.3 (git+https://github.com/magicblock-labs/delegation-program.git?rev=2cb491032f372)",
  "magicblock-program",
@@ -3866,7 +3865,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-version"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "git-version",
  "rustc_version",
@@ -4766,7 +4765,7 @@ dependencies = [
  "bincode",
  "borsh 1.6.0",
  "ephemeral-rollups-sdk",
- "magicblock-magic-program-api 0.7.0",
+ "magicblock-magic-program-api 0.8.0",
  "serde",
  "solana-program",
 ]
@@ -4790,7 +4789,7 @@ dependencies = [
  "borsh 1.6.0",
  "ephemeral-rollups-sdk",
  "magicblock-delegation-program 1.1.3 (git+https://github.com/magicblock-labs/delegation-program.git?rev=2cb491032f372)",
- "magicblock-magic-program-api 0.7.0",
+ "magicblock-magic-program-api 0.8.0",
  "rkyv 0.7.45",
  "solana-program",
  "static_assertions",
@@ -5824,7 +5823,7 @@ dependencies = [
  "ephemeral-rollups-sdk",
  "integration-test-tools",
  "magicblock-core",
- "magicblock-magic-program-api 0.7.0",
+ "magicblock-magic-program-api 0.8.0",
  "program-schedulecommit",
  "rand 0.8.5",
  "schedulecommit-client",
@@ -5842,7 +5841,7 @@ version = "0.0.0"
 dependencies = [
  "integration-test-tools",
  "magicblock-core",
- "magicblock-magic-program-api 0.7.0",
+ "magicblock-magic-program-api 0.8.0",
  "program-schedulecommit",
  "program-schedulecommit-security",
  "schedulecommit-client",
@@ -8561,7 +8560,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-proto"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bincode",
  "bs58",
@@ -10062,7 +10061,7 @@ dependencies = [
 
 [[package]]
 name = "test-kit"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "guinea",
  "magicblock-accounts-db",

--- a/test-integration/Cargo.toml
+++ b/test-integration/Cargo.toml
@@ -36,7 +36,7 @@ chrono = "0.4"
 cleanass = "0.0.1"
 color-backtrace = { version = "0.7" }
 ctrlc = "3.4.7"
-ephemeral-rollups-sdk = { git = "https://github.com/magicblock-labs/ephemeral-rollups-sdk.git", rev = "dec833e0", default-features = false, features = [
+ephemeral-rollups-sdk = { git = "https://github.com/magicblock-labs/ephemeral-rollups-sdk.git", rev = "d6a81e25a80d78fea9adf3fb1342df9bc9b87ba6", default-features = false, features = [
   "modular-sdk",
 ] }
 futures = "0.3.31"


### PR DESCRIPTION
I splitted #847 and this PR contains the program-API only so that related PRs (in this repo as well as in DLP and SDK repo) can be merged in the correct order starting with https://github.com/magicblock-labs/ephemeral-rollups-sdk/pull/108.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added commit finalization operations with optional undelegation, expanding commit lifecycle controls.
  * Introduced a scheduling instruction to initiate commit finalization with configurable undelegation requests.

* **Chores**
  * Updated an internal test dependency reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->