### PR TITLE
Update `test-manual/README.md`

### DIFF
--- a/test-manual/README.md
+++ b/test-manual/README.md
@@ -10,7 +10,7 @@ Tests the validator's laser gRPC client integration with Helius devnet. This tes
 
 **Requirements**: Helius API key, Solana devnet keypair with SOL
 
-**Run with**: `make manual-test-laser`
+**Run with**: `make test-laser`
 
 See the [helius-laser README](helius-laser/README.md) for detailed setup and usage instructions.
 


### PR DESCRIPTION
## Summary
The `test-manual/README.md` file specified the `manual-test-laser` target, which is not present in the [Makefile](https://github.com/magicblock-labs/magicblock-validator/blob/master/test-manual/Makefile).

The Makefile only has the `test-laser` target, so the `make manual-test-laser` command does not work.

The `READM`E has now been updated with the correct target: `make test-laser`



## Compatibility
- [ ] No breaking changes
- [ ] Config change (describe):
- [ ] Migration needed (describe):

## Testing
- [ ] tests (or explain)

## Checklist
- [ ] docs updated (if needed)
- [ ] closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated manual test instructions for improved accuracy and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->