### PR TITLE
Fix incorrect short flag for --success in ledger-stats log

### DIFF
--- a/tools/ledger-stats/README.md
+++ b/tools/ledger-stats/README.md
@@ -22,7 +22,7 @@ USAGE:
 
 FLAGS:
     -h, --help       Prints help information
-    -s, --success    Show successful transactions, default: false
+    -u, --success    Show successful transactions, default: false
     -V, --version    Prints version information
 
 OPTIONS:


### PR DESCRIPTION
## Summary
In the documentation for the log `subcommand` in `ledger-stats`, the short flag for `--success` was specified as `-s`, which was misleading.

Reason for the fix:

In the code (`src/main.rs`), the short flag `-u` (short = `“u”`) is used for `--success`.

At the same time, `-s` is reserved for `--start`, so using `-s` for `--success` created a conflict and was misinterpreted by `StructOpt`.

Fix:

The short flag for `--success` has been changed to `-u` in the README.

The usage examples have been updated to match the code and avoid confusion.

## Compatibility
- [ ] No breaking changes
- [ ] Config change (describe):
- [ ] Migration needed (describe):

## Testing
- [ ] tests (or explain)

## Checklist
- [ ] docs updated (if needed)
- [ ] closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated command-line flag documentation for the ledger-stats tool to reflect the correct syntax for displaying successful transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->