### PR TITLE
chore: demote non-critical logs to warnings in chainlink

### DIFF
--- a/magicblock-chainlink/src/chainlink/fetch_cloner/delegation.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/delegation.rs
@@ -146,7 +146,7 @@ where
             .unsubscribe(&delegation_record_pubkey)
             .await
         {
-            error!(pubkey = %delegation_record_pubkey, error = %err, "Failed to unsubscribe from delegation record");
+            warn!(pubkey = %delegation_record_pubkey, error = %err, "Failed to unsubscribe from delegation record");
         }
     }
 

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -281,7 +281,7 @@ where
                             })
                             .await
                         {
-                            error!(
+                            warn!(
                                 pubkey = %pubkey,
                                 error = %err,
                                 "Failed to clone account into bank"
@@ -294,7 +294,7 @@ where
                                 .clone_account(projected_ata_clone_request)
                                 .await
                             {
-                                error!(
+                                warn!(
                                     pubkey = %pubkey,
                                     error = %err,
                                     "Failed to clone projected ATA from delegated eATA update"
@@ -383,7 +383,7 @@ where
                                 ) {
                                     Ok(x) => Some(x),
                                     Err(err) => {
-                                        error!(
+                                        warn!(
                                             pubkey = %pubkey,
                                             error = %err,
                                             "Failed to parse delegation record"
@@ -462,7 +462,7 @@ where
                     }
                     // In case of errors fetching the delegation record we cannot clone the account
                     Ok(Err(err)) => {
-                        error!(
+                        warn!(
                             pubkey = %pubkey,
                             error = ?err,
                             "Failed to fetch delegation record"
@@ -470,7 +470,7 @@ where
                         (None, None)
                     }
                     Err(err) => {
-                        error!(
+                        warn!(
                             pubkey = %pubkey,
                             error = ?err,
                             "Failed to fetch delegation record"
@@ -1128,7 +1128,7 @@ where
                     })
                 {
                     // The sender was dropped, likely due to an error in the other request
-                    error!(
+                    warn!(
                         "Failed to receive account from pending request: {err}"
                     );
                 }

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/program_loader.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/program_loader.rs
@@ -76,11 +76,11 @@ pub(crate) async fn handle_executable_sub_update<T, U, V, C>(
     ) {
         Ok(x) => x.into_loaded_program(),
         Err(err) => {
-            error!(pubkey = %pubkey, error = %err, "Failed to resolve program account into bank");
+            warn!(pubkey = %pubkey, error = %err, "Failed to resolve program account into bank");
             return;
         }
     };
     if let Err(err) = this.cloner.clone_program(loaded_program).await {
-        error!(pubkey = %pubkey, error = %err, "Failed to clone program into bank");
+        warn!(pubkey = %pubkey, error = %err, "Failed to clone program into bank");
     }
 }

--- a/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/actor.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/actor.rs
@@ -401,7 +401,7 @@ impl<H: StreamHandle, S: StreamFactory<H>> ChainLaserActor<H, S> {
         let response = match result {
             Ok(()) => Ok(()),
             Err(e) => {
-                error!(
+                warn!(
                     pubkey = %pubkey,
                     error = ?e,
                     "Failed to subscribe to account"
@@ -496,7 +496,7 @@ impl<H: StreamHandle, S: StreamFactory<H>> ChainLaserActor<H, S> {
             self.spawn_fallen_behind_diagnostics(source);
         }
 
-        error!(
+        warn!(
             error = ?err,
             slots = ?self.slots,
             "Error in {} stream",
@@ -602,7 +602,7 @@ impl<H: StreamHandle, S: StreamFactory<H>> ChainLaserActor<H, S> {
         // coalesce signals
         let _ = abort_sender.try_send(()).inspect_err(|err| {
             if !matches!(err, mpsc::error::TrySendError::Full(_)) {
-                error!(
+                warn!(
                     error = ?err,
                     "Failed to signal connection issue"
                 );
@@ -722,7 +722,7 @@ impl<H: StreamHandle, S: StreamFactory<H>> ChainLaserActor<H, S> {
             .send(subscription_update)
             .await
             .unwrap_or_else(|_| {
-                error!(pubkey = %pubkey, "Failed to send subscription update");
+                warn!(pubkey = %pubkey, "Failed to send subscription update");
             });
     }
 }

--- a/magicblock-chainlink/src/remote_account_provider/chain_pubsub_actor.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_pubsub_actor.rs
@@ -756,7 +756,7 @@ impl ChainPubsubActor {
             match pubsub_connection.account_subscribe(&pubkey, config).await {
                 Ok(res) => res,
                 Err(err) => {
-                    error!(
+                    warn!(
                         error = ?err,
                         "Failed to verify connection via subscribe"
                     );

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -485,7 +485,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                             RemoteAccountUpdateSource::Subscription,
                         ),
                         None => {
-                            error!(
+                            warn!(
                                 pubkey = %update.pubkey,
                                 "Account update could not be decoded"
                             );
@@ -531,7 +531,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                         if let Err(err) =
                             subscription_forwarder.send(forward_update).await
                         {
-                            error!(
+                            warn!(
                                 pubkey = %update.pubkey,
                                 error = ?err,
                                 "Failed to forward subscription update"
@@ -757,12 +757,12 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                         resolved_accounts.push(remote_account)
                     }
                     Err(err) => {
-                        error!(pubkey = %pubkey, error = %err, "Failed to fetch account");
+                        warn!(pubkey = %pubkey, error = %err, "Failed to fetch account");
                         errors.push((idx, err));
                     }
                 },
                 Err(err) => {
-                    error!(pubkey = %pubkey, stream_index = idx, error = ?err, total_pubkeys = pubkeys.len(), "Failed to resolve account (unexpected RecvError)");
+                    warn!(pubkey = %pubkey, stream_index = idx, error = ?err, total_pubkeys = pubkeys.len(), "Failed to resolve account (unexpected RecvError)");
                     errors.push((
                         idx,
                         RemoteAccountProviderError::RecvrError(err),
@@ -955,7 +955,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
             // Helper to notify all pending requests of fetch failure
             let notify_error = |error_msg: &str| {
                 let mut fetching = fetching_accounts.lock().unwrap();
-                error!("{error_msg}");
+                warn!("{error_msg}");
                 inc_account_fetches_failed(pubkeys.len() as u64);
                 if let Some(program_ids) = &program_ids {
                     for program_id in program_ids {


### PR DESCRIPTION
## Summary

Demote non-critical error logs to warning level in the magicblock-chainlink crate. These logs document recoverable issues that don't justify error-level severity, improving signal-to-noise ratio in production logs.

These changes reduce error log noise while maintaining visibility through warning-level logging.
This allows us to turn on alerts for errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted logging severity levels across multiple modules; error conditions that do not affect system functionality now emit warnings instead of errors in logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->