### PR TITLE
fix: serialize nan for explorer compatibility

### DIFF
--- a/magicblock-aperture/src/requests/http/get_transaction.rs
+++ b/magicblock-aperture/src/requests/http/get_transaction.rs
@@ -34,15 +34,19 @@ impl HttpDispatcher {
             transaction.and_then(|tx| tx.encode(encoding, max_version).ok());
 
         if encoding == UiTransactionEncoding::JsonParsed {
-            if let Some(mut encoded_value) =
-                value_from_serializable(&encoded_transaction)
-            {
-                sanitize_nan_strings(&mut encoded_value);
-                return Ok(ResponsePayload::encode_no_context(
-                    &request.id,
-                    encoded_value,
-                ));
-            }
+            let mut encoded_value = value_from_serializable(
+                &encoded_transaction,
+            )
+            .ok_or_else(|| {
+                RpcError::internal(
+                    "failed to serialize JsonParsed getTransaction response",
+                )
+            })?;
+            sanitize_nan_strings(&mut encoded_value);
+            return Ok(ResponsePayload::encode_no_context(
+                &request.id,
+                encoded_value,
+            ));
         }
 
         Ok(ResponsePayload::encode_no_context(
@@ -55,31 +59,100 @@ impl HttpDispatcher {
 fn value_from_serializable<T: json::Serialize>(
     value: &T,
 ) -> Option<json::Value> {
-    let serialized = json::to_vec(value).ok()?;
-    json::from_slice(&serialized).ok()
+    json::to_value(value).ok()
 }
 
 fn sanitize_nan_strings(value: &mut json::Value) {
+    sanitize_nan_strings_for_key(value, None);
+}
+
+fn sanitize_nan_strings_for_key(
+    value: &mut json::Value,
+    parent_key: Option<&str>,
+) {
     if let Some(values) = value.as_array_mut() {
         for value in values {
-            sanitize_nan_strings(value);
+            sanitize_nan_strings_for_key(value, parent_key);
         }
         return;
     }
 
     if let Some(values) = value.as_object_mut() {
-        for (_key, value) in values.iter_mut() {
-            sanitize_nan_strings(value);
+        for (key, value) in values.iter_mut() {
+            sanitize_nan_strings_for_key(value, Some(key));
         }
         return;
     }
 
     if let Some(s) = value.as_str() {
-        if s.eq_ignore_ascii_case("nan")
-            || s.eq_ignore_ascii_case("+nan")
-            || s.eq_ignore_ascii_case("-nan")
-        {
+        if parent_key.is_some_and(is_numeric_amount_field) && is_nan_string(s) {
             *value = "0".into();
         }
+    }
+}
+
+fn is_numeric_amount_field(key: &str) -> bool {
+    matches!(key, "amount" | "uiAmount" | "uiAmountString")
+}
+
+fn is_nan_string(value: &str) -> bool {
+    value.eq_ignore_ascii_case("nan")
+        || value.eq_ignore_ascii_case("+nan")
+        || value.eq_ignore_ascii_case("-nan")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_nan_strings_only_changes_numeric_amount_fields() {
+        let mut value = json::json!({
+            "meta": {
+                "logMessages": ["nan", "+nan", "-nan"],
+                "memo": "nan"
+            },
+            "transaction": {
+                "message": {
+                    "instructions": [{
+                        "parsed": {
+                            "info": {
+                                "amount": "nan",
+                                "uiAmount": "+nan",
+                                "uiAmountString": "-nan",
+                                "note": "nan"
+                            }
+                        }
+                    }]
+                }
+            }
+        });
+
+        sanitize_nan_strings(&mut value);
+
+        assert_eq!(value["meta"]["logMessages"][0], "nan");
+        assert_eq!(value["meta"]["logMessages"][1], "+nan");
+        assert_eq!(value["meta"]["logMessages"][2], "-nan");
+        assert_eq!(value["meta"]["memo"], "nan");
+        assert_eq!(
+            value["transaction"]["message"]["instructions"][0]["parsed"]
+                ["info"]["amount"],
+            "0"
+        );
+        assert_eq!(
+            value["transaction"]["message"]["instructions"][0]["parsed"]
+                ["info"]["uiAmount"],
+            "0"
+        );
+        assert_eq!(
+            value["transaction"]["message"]["instructions"][0]["parsed"]
+                ["info"]["uiAmountString"],
+            "0"
+        );
+        assert_eq!(
+            value["transaction"]["message"]["instructions"][0]["parsed"]
+                ["info"]["note"],
+            "nan"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- fix: serialize nan for explorer compatibility

This change allow the explorer to render correctly failed transactions

## Compatibility
- [x] No breaking changes
- [ ] Config change (describe):
- [ ] Migration needed (describe):

## Testing
- [ ] tests (or explain)

## Checklist
- [ ] docs updated (if needed)
- [ ] closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Normalize invalid NaN string values in JSON-parsed transactions, replacing NaN in amount-related fields with 0 to prevent malformed numeric fields.
  * Preserve existing behavior for non-JSON-parsed transaction encodings.

* **Tests**
  * Added unit tests ensuring NaN strings are sanitized only for numeric amount fields and other values remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->