### PR TITLE
fix: delegation status of not eata accounts owned by the token program

### DIFF
--- a/magicblock-chainlink/src/chainlink/fetch_cloner/delegation.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/delegation.rs
@@ -2,7 +2,7 @@ use dlp::{
     pda::delegation_record_pda_from_delegated_account, state::DelegationRecord,
 };
 use magicblock_accounts_db::traits::AccountsBank;
-use magicblock_core::token_programs::EATA_PROGRAM_ID;
+use magicblock_core::token_programs::{derive_eata, EATA_PROGRAM_ID};
 use magicblock_metrics::metrics;
 use solana_account::ReadableAccount;
 use solana_pubkey::Pubkey;
@@ -34,6 +34,7 @@ pub(crate) fn parse_delegation_record(
 
 pub(crate) fn apply_delegation_record_to_account<T, U, V, C>(
     this: &FetchCloner<T, U, V, C>,
+    account_pubkey: Pubkey,
     account: &mut ResolvedAccountSharedData,
     delegation_record: &DelegationRecord,
 ) -> Option<u64>
@@ -46,22 +47,43 @@ where
     let is_confined = delegation_record.authority.eq(&Pubkey::default());
     let is_delegated_to_us =
         delegation_record.authority.eq(&this.validator_pubkey) || is_confined;
+    let is_raw_eata = parse_raw_eata_pda(
+        &account_pubkey,
+        account.data(),
+        delegation_record.owner,
+    )
+    .is_some();
 
     // Always update owner and confined flags
     account
         .set_owner(delegation_record.owner)
         .set_confined(is_confined);
 
-    if is_delegated_to_us && delegation_record.owner != EATA_PROGRAM_ID {
+    if is_delegated_to_us && !is_raw_eata {
         account.set_delegated(true);
-    } else if !is_delegated_to_us {
+    } else {
         account.set_delegated(false);
     }
-    if is_delegated_to_us {
+    if is_delegated_to_us && !is_raw_eata {
         Some(delegation_record.commit_frequency_ms)
     } else {
         None
     }
+}
+
+pub(crate) fn parse_raw_eata_pda(
+    account_pubkey: &Pubkey,
+    data: &[u8],
+    owner_program: Pubkey,
+) -> Option<(Pubkey, Pubkey)> {
+    if owner_program != EATA_PROGRAM_ID || data.len() < 72 {
+        return None;
+    }
+
+    let wallet_owner = Pubkey::new_from_array(data[0..32].try_into().ok()?);
+    let mint = Pubkey::new_from_array(data[32..64].try_into().ok()?);
+    (derive_eata(&wallet_owner, &mint) == *account_pubkey)
+        .then_some((wallet_owner, mint))
 }
 
 pub(crate) fn get_delegated_to_other<T, U, V, C>(

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -14,7 +14,7 @@ use magicblock_accounts_db::traits::AccountsBank;
 use magicblock_config::config::AllowedProgram;
 use magicblock_core::token_programs::{
     is_ata, try_derive_ata_address_and_bump, try_derive_eata_address_and_bump,
-    MaybeIntoAta, EATA_PROGRAM_ID,
+    MaybeIntoAta,
 };
 use magicblock_metrics::metrics::{self, AccountFetchOrigin};
 use scc::{hash_map::Entry, HashMap};
@@ -408,6 +408,7 @@ where
                                 }
 
                                 self.apply_delegation_record_to_account(
+                                    pubkey,
                                     &mut account,
                                     &delegation_record,
                                 );
@@ -494,7 +495,7 @@ where
 
     fn maybe_build_projected_ata_clone_request_from_eata_sub_update(
         &self,
-        _eata_pubkey: Pubkey,
+        eata_pubkey: Pubkey,
         eata_account: &AccountSharedData,
         deleg_record: Option<&DelegationRecord>,
     ) -> Option<AccountCloneRequest> {
@@ -503,26 +504,11 @@ where
         if deleg_record.authority != self.validator_pubkey {
             return None;
         }
-        if deleg_record.owner != EATA_PROGRAM_ID {
-            return None;
-        }
-
-        let data = eata_account.data();
-        if data.len() < 64 {
-            return None;
-        }
-        let wallet_owner = match data[0..32].try_into() {
-            Ok(bytes) => Pubkey::new_from_array(bytes),
-            Err(_) => {
-                return None;
-            }
-        };
-        let mint = match data[32..64].try_into() {
-            Ok(bytes) => Pubkey::new_from_array(bytes),
-            Err(_) => {
-                return None;
-            }
-        };
+        let (wallet_owner, mint) = delegation::parse_raw_eata_pda(
+            &eata_pubkey,
+            eata_account.data(),
+            deleg_record.owner,
+        )?;
         let (ata_pubkey, _) =
             try_derive_ata_address_and_bump(&wallet_owner, &mint)?;
 
@@ -665,11 +651,13 @@ where
     /// Returns commit frequency if account is delegated to us
     fn apply_delegation_record_to_account(
         &self,
+        account_pubkey: Pubkey,
         account: &mut ResolvedAccountSharedData,
         delegation_record: &DelegationRecord,
     ) -> Option<u64> {
         delegation::apply_delegation_record_to_account(
             self,
+            account_pubkey,
             account,
             delegation_record,
         )

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/pipeline.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/pipeline.rs
@@ -331,6 +331,7 @@ where
                     this.get_delegated_to_other(&delegation_record);
 
                 let commit_freq = this.apply_delegation_record_to_account(
+                    pubkey,
                     &mut account,
                     &delegation_record,
                 );

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -168,6 +168,36 @@ where
     }
 }
 
+fn create_non_raw_eata_owned_account(
+    pubkey: Pubkey,
+    data_len: usize,
+) -> (Account, Pubkey, Pubkey) {
+    let (wallet_owner, mint) = loop {
+        let wallet_owner = random_pubkey();
+        let mint = random_pubkey();
+        if derive_eata(&wallet_owner, &mint) != pubkey {
+            break (wallet_owner, mint);
+        }
+    };
+
+    let mut data = vec![0u8; data_len.max(72)];
+    data[0..32].copy_from_slice(wallet_owner.as_ref());
+    data[32..64].copy_from_slice(mint.as_ref());
+    data[64..72].copy_from_slice(&777u64.to_le_bytes());
+
+    (
+        Account {
+            lamports: 1_000_000,
+            data,
+            owner: dlp::id(),
+            executable: false,
+            rent_epoch: 0,
+        },
+        wallet_owner,
+        mint,
+    )
+}
+
 /// Helper function to initialize FetchCloner for tests with subscription updates
 /// Returns (FetchCloner, subscription_sender) for simulating subscription updates in tests
 fn init_fetch_cloner(
@@ -2167,6 +2197,133 @@ async fn test_no_program_subscription_for_undelegated_account_subscription_updat
         subscribed_programs.is_empty(),
         "Should have no program subscriptions for undelegated account subscription update, got: {:?}",
         subscribed_programs
+    );
+}
+
+#[tokio::test]
+async fn test_fetch_and_clone_non_raw_eata_owned_account_as_delegated() {
+    init_logger();
+    let validator_pubkey = random_pubkey();
+    let account_pubkey = random_pubkey();
+    const CURRENT_SLOT: u64 = 100;
+    const DATA_LEN: usize = 9728;
+
+    let (account, wallet_owner, mint) =
+        create_non_raw_eata_owned_account(account_pubkey, DATA_LEN);
+    let ata_pubkey = derive_ata(&wallet_owner, &mint);
+
+    let FetcherTestCtx {
+        accounts_bank,
+        fetch_cloner,
+        rpc_client,
+        ..
+    } = setup(
+        [(account_pubkey, account.clone())],
+        CURRENT_SLOT,
+        validator_pubkey,
+    )
+    .await;
+
+    add_delegation_record_for(
+        &rpc_client,
+        account_pubkey,
+        validator_pubkey,
+        EATA_PROGRAM_ID,
+    );
+
+    fetch_cloner
+        .fetch_and_clone_accounts(
+            &[account_pubkey],
+            None,
+            None,
+            AccountFetchOrigin::GetAccount,
+            None,
+        )
+        .await
+        .expect("Failed to fetch and clone delegated EATA-owned account");
+
+    let cloned_account = accounts_bank
+        .get_account(&account_pubkey)
+        .expect("account should be cloned");
+    assert_eq!(*cloned_account.owner(), EATA_PROGRAM_ID);
+    assert!(cloned_account.delegated());
+    assert!(!cloned_account.confined());
+    assert_eq!(cloned_account.remote_slot(), CURRENT_SLOT);
+    assert_eq!(cloned_account.data().len(), DATA_LEN);
+    assert!(
+        accounts_bank.get_account(&ata_pubkey).is_none(),
+        "non-raw EATA-owned account must not project an ATA clone"
+    );
+}
+
+#[tokio::test]
+async fn test_non_raw_eata_owned_account_subscription_update_stays_delegated() {
+    init_logger();
+    let validator_pubkey = random_pubkey();
+    let account_pubkey = random_pubkey();
+    const CURRENT_SLOT: u64 = 100;
+    const DATA_LEN: usize = 9728;
+
+    let (account, wallet_owner, mint) =
+        create_non_raw_eata_owned_account(account_pubkey, DATA_LEN);
+    let ata_pubkey = derive_ata(&wallet_owner, &mint);
+
+    let FetcherTestCtx {
+        accounts_bank,
+        rpc_client,
+        subscription_tx,
+        ..
+    } = setup(
+        [(account_pubkey, account.clone())],
+        CURRENT_SLOT,
+        validator_pubkey,
+    )
+    .await;
+
+    add_delegation_record_for(
+        &rpc_client,
+        account_pubkey,
+        validator_pubkey,
+        EATA_PROGRAM_ID,
+    );
+
+    use crate::remote_account_provider::{
+        RemoteAccount, RemoteAccountUpdateSource,
+    };
+
+    subscription_tx
+        .send(ForwardedSubscriptionUpdate {
+            pubkey: account_pubkey,
+            account: RemoteAccount::from_fresh_account(
+                account,
+                CURRENT_SLOT,
+                RemoteAccountUpdateSource::Subscription,
+            ),
+        })
+        .await
+        .unwrap();
+
+    const POLL_INTERVAL: std::time::Duration = Duration::from_millis(10);
+    const TIMEOUT: std::time::Duration = Duration::from_millis(500);
+    tokio::time::timeout(TIMEOUT, async {
+        while accounts_bank.get_account(&account_pubkey).is_none() {
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+    })
+    .await
+    .expect("timed out waiting for delegated EATA-owned subscription update");
+
+    let cloned_account = accounts_bank
+        .get_account(&account_pubkey)
+        .expect("account should be cloned from subscription update");
+    assert_eq!(*cloned_account.owner(), EATA_PROGRAM_ID);
+    assert!(cloned_account.delegated());
+    assert!(!cloned_account.confined());
+    assert_eq!(cloned_account.remote_slot(), CURRENT_SLOT);
+    assert_eq!(cloned_account.data().len(), DATA_LEN);
+    assert!(
+        accounts_bank.get_account(&ata_pubkey).is_none(),
+        "non-raw EATA-owned account subscription update must not project an ATA clone"
     );
 }
 


### PR DESCRIPTION
## Summary

- fix: delegation status of not eata accounts owned by the token program

## Compatibility
- [ ] No breaking changes
- [ ] Config change (describe):
- [ ] Migration needed (describe):

## Testing
- [ ] tests (or explain)

## Checklist
- [ ] docs updated (if needed)
- [ ] closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved delegation record handling for EATA accounts with enhanced account validation
  * Refined delegation flag logic for more accurate account processing

* **Tests**
  * Added tests for proper delegation handling of EATA-owned accounts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->