### PR TITLE
Fix: replace `EphemeralConfig` with `ValidatorParams`

### DIFF
--- a/magicblock-api/README.md
+++ b/magicblock-api/README.md
@@ -4,9 +4,9 @@ Provides a highlevel API which allows to initialize and startup all pieces of th
 
 ## Usage
 
-Provide a `EphemeralConfig` which includes the following:
+Provide `ValidatorParams` which includes the following:
 
-- `validator_config: EphemeralConfig` which indicates how the validator should be configured,
+- configuration parameters which indicate how the validator should be configured,
 see [this default config toml](../magicblock-config/tests/fixtures/02_defaults.toml) for more
 info
 - `ledger: Option<Ledger>` if you want to control the ledger location, otherwise it is placed


### PR DESCRIPTION
## Fix README config type mismatch

The README referenced `EphemeralConfig` and `validator_config: EphemeralConfig`, but the current implementation uses `ValidatorParams`.

For example, `MagicValidator` stores the configuration as:

```rust
pub struct MagicValidator {
    config: ValidatorParams,
}
```
and the validator is created using:
```rust
MagicValidator::try_from_config(config, identity_keypair)
```

Following the README as written would therefore lead to compilation errors.

Updated the documentation to reflect the current API by replacing
`EphemeralConfig` with `ValidatorParams` and removing the outdated
`validator_config` field reference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated usage guide with clearer terminology for configuration parameters
  * Added details about service configuration and ledger storage location in temporary directory
  * Improved documentation clarity and semantic descriptions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->