### PR TITLE
feat: ingress subscription events properly to trigger actions execution

### DIFF
--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -1,14 +1,17 @@
 use std::{
-    collections::HashSet,
+    collections::{HashMap as StdHashMap, HashSet},
     sync::{
         atomic::{AtomicU64, Ordering},
-        Arc,
+        Arc, Mutex,
     },
     time::Duration,
 };
 
 use dlp_api::dlp::{
-    pda::delegation_record_pda_from_delegated_account, state::DelegationRecord,
+    pda::delegation_record_pda_from_delegated_account,
+    state::{
+        CommitRecord, DelegationMetadata, DelegationRecord, ProgramConfig,
+    },
 };
 use magicblock_accounts_db::traits::AccountsBank;
 use magicblock_config::config::AllowedProgram;
@@ -84,6 +87,9 @@ where
     validator_pubkey: Pubkey,
     validator_keypair: Arc<Keypair>,
 
+    /// delegation_record_pubkey -> delegated_account_pubkey
+    pending_delegation_records: Arc<Mutex<StdHashMap<Pubkey, Pubkey>>>,
+
     /// These are accounts that we should never clone into our validator.
     /// native programs, sysvars, native tokens, validator identity and faucet
     blacklisted_accounts: HashSet<Pubkey>,
@@ -112,6 +118,9 @@ where
             cloner: self.cloner.clone(),
             validator_pubkey: self.validator_pubkey,
             validator_keypair: Arc::clone(&self.validator_keypair),
+            pending_delegation_records: Arc::clone(
+                &self.pending_delegation_records,
+            ),
             blacklisted_accounts: self.blacklisted_accounts.clone(),
             allowed_programs: self.allowed_programs.clone(),
         }
@@ -147,6 +156,7 @@ where
             cloner: cloner.clone(),
             validator_pubkey,
             validator_keypair: Arc::new(validator_keypair),
+            pending_delegation_records: Arc::new(Mutex::new(StdHashMap::new())),
             pending_requests: Arc::new(HashMap::new()),
             fetch_count: Arc::new(AtomicU64::new(0)),
             blacklisted_accounts,
@@ -266,6 +276,45 @@ where
         pubkey: Pubkey,
         update: ForwardedSubscriptionUpdate,
     ) {
+        if update.account.is_owned_by_delegation_program() {
+            let maybe_delegated_pubkey = self
+                .pending_delegation_records
+                .lock()
+                .expect("pending_delegation_records lock poisoned")
+                .get(&pubkey)
+                .copied();
+            if let Some(delegated_pubkey) = maybe_delegated_pubkey {
+                trace!(
+                    delegation_record = %pubkey,
+                    delegated_account = %delegated_pubkey,
+                    "Delegation record update received; re-fetching delegated account"
+                );
+                if let Err(err) = self
+                    .fetch_and_clone_accounts(
+                        &[delegated_pubkey],
+                        None,
+                        None,
+                        AccountFetchOrigin::GetAccount,
+                        None,
+                    )
+                    .await
+                {
+                    warn!(
+                        delegation_record = %pubkey,
+                        delegated_account = %delegated_pubkey,
+                        error = %err,
+                        "Failed to re-fetch delegated account after delegation record update"
+                    );
+                } else {
+                    self.pending_delegation_records
+                        .lock()
+                        .expect("pending_delegation_records lock poisoned")
+                        .remove(&pubkey);
+                }
+                return;
+            }
+        }
+
         let (resolved_account, deleg_record, delegation_actions) = self
             .resolve_account_to_clone_from_forwarded_sub_with_unsubscribe(
                 update,
@@ -459,15 +508,17 @@ where
                         // We need to remove subs for the delegation record and the account
                         // if it is delegated to us
                         let mut subs_to_remove = HashSet::new();
-
-                        // Always unsubscribe from delegation record if it was a new subscription
-                        if !was_delegation_record_subscribed {
-                            subs_to_remove.insert(delegation_record_pubkey);
-                        }
+                        let mut keep_delegation_record_sub = false;
 
                         let account = if let Some(delegation_record) =
                             delegation_record
                         {
+                            self.pending_delegation_records
+                                .lock()
+                                .expect(
+                                    "pending_delegation_records lock poisoned",
+                                )
+                                .remove(&delegation_record_pubkey);
                             let delegation_record_with_actions = match self
                                 .parse_delegation_record(
                                     delegation_record.data(),
@@ -544,14 +595,33 @@ where
                                 (None, None, DelegationActions::default())
                             }
                         } else {
-                            // If no delegation record exists we must assume the account itself is
-                            // a delegation record or metadata
+                            // If this update is for a delegated account before its record exists,
+                            // remember the expected record PDA so a subsequent record update can
+                            // re-trigger delegated-account cloning through the normal path.
+                            if !is_dlp_internal_account(account.data()) {
+                                self.pending_delegation_records
+                                    .lock()
+                                    .expect("pending_delegation_records lock poisoned")
+                                    .insert(delegation_record_pubkey, pubkey);
+                                keep_delegation_record_sub = true;
+                            }
+                            // If no delegation record exists we assume this account is either a
+                            // still-unresolved delegated account or a delegation internal account.
                             (
                                 Some(account.into_account_shared_data()),
                                 None,
                                 DelegationActions::default(),
                             )
                         };
+
+                        // Always unsubscribe from delegation record if it was a new subscription,
+                        // except when we intentionally keep it to await the record update and
+                        // re-trigger delegated-account fetch.
+                        if !was_delegation_record_subscribed
+                            && !keep_delegation_record_sub
+                        {
+                            subs_to_remove.insert(delegation_record_pubkey);
+                        }
 
                         if !subs_to_remove.is_empty() {
                             cancel_subs(
@@ -1652,6 +1722,13 @@ where
             .await?;
         Ok(())
     }
+}
+
+fn is_dlp_internal_account(data: &[u8]) -> bool {
+    DelegationRecord::try_from_bytes_with_discriminator(data).is_ok()
+        || DelegationMetadata::try_from_bytes_with_discriminator(data).is_ok()
+        || CommitRecord::try_from_bytes_with_discriminator(data).is_ok()
+        || ProgramConfig::try_from_bytes_with_discriminator(data).is_ok()
 }
 
 // -----------------

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -314,6 +314,18 @@ where
                 return;
             }
         }
+        if update.account.is_owned_by_delegation_program()
+            && update
+                .account
+                .fresh_account()
+                .is_some_and(|account| is_dlp_internal_account(account.data()))
+        {
+            trace!(
+                pubkey = %pubkey,
+                "Ignoring DLP internal account update"
+            );
+            return;
+        }
 
         let (resolved_account, deleg_record, delegation_actions) = self
             .resolve_account_to_clone_from_forwarded_sub_with_unsubscribe(
@@ -402,6 +414,47 @@ where
                 &account,
                 deleg_record.as_ref(),
             );
+        if self.accounts_bank.get_account(&pubkey).is_none()
+            && delegated_to_other.is_some()
+        {
+            trace!(
+                pubkey = %pubkey,
+                delegated_to_other = ?delegated_to_other,
+                "Ignoring auto-discovery update for account delegated to another validator"
+            );
+            return;
+        }
+        if !delegation_actions.is_empty()
+            && projected_ata_clone_request.is_none()
+        {
+            trace!(
+                pubkey = %pubkey,
+                slot = account.remote_slot(),
+                "Re-fetching delegated account through full pipeline to materialize action dependencies"
+            );
+            if let Err(err) = self
+                .fetch_and_clone_accounts(
+                    &[pubkey],
+                    None,
+                    Some(account.remote_slot()),
+                    AccountFetchOrigin::GetAccount,
+                    None,
+                )
+                .await
+            {
+                warn!(
+                    pubkey = %pubkey,
+                    error = %err,
+                    "Failed to re-fetch delegated account with action dependencies"
+                );
+            }
+            return;
+        }
+        let delegation_actions = if projected_ata_clone_request.is_some() {
+            DelegationActions::default()
+        } else {
+            delegation_actions
+        };
 
         // Once we clone an account that is delegated to us we no
         // longer need to receive updates for it from chain.
@@ -432,13 +485,20 @@ where
         } else if let Some(projected_ata_clone_request) =
             projected_ata_clone_request
         {
-            if let Err(err) =
-                self.cloner.clone_account(projected_ata_clone_request).await
+            if let Err(err) = self
+                .fetch_and_clone_accounts_with_dedup(
+                    &[projected_ata_clone_request.pubkey],
+                    None,
+                    Some(projected_ata_clone_request.account.remote_slot()),
+                    AccountFetchOrigin::ProjectAta,
+                    None,
+                )
+                .await
             {
                 error!(
                     pubkey = %pubkey,
                     error = %err,
-                    "Failed to clone projected ATA from delegated eATA update"
+                    "Failed to auto-trigger ATA clone from delegated eATA update"
                 );
             }
         }
@@ -1077,11 +1137,6 @@ where
                         .any(|program| program.program_id.eq(dependency))
             })
             .collect::<Vec<_>>();
-
-        error!(
-            "action_dependencies_to_fetch: {:#?}",
-            action_dependencies_to_fetch
-        );
 
         if !action_dependencies_to_fetch.is_empty() {
             if tracing::enabled!(tracing::Level::TRACE) {

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -2376,6 +2376,7 @@ async fn test_delegated_eata_subscription_update_clones_raw_eata_and_projects_at
 
     let eata_pubkey = derive_eata(&wallet_owner, &mint);
     let ata_pubkey = derive_ata(&wallet_owner, &mint);
+    let ata_account = create_ata_account(&wallet_owner, &mint);
     let eata_account = create_eata_account(&wallet_owner, &mint, AMOUNT, true);
 
     let FetcherTestCtx {
@@ -2384,7 +2385,10 @@ async fn test_delegated_eata_subscription_update_clones_raw_eata_and_projects_at
         subscription_tx,
         ..
     } = setup(
-        [(eata_pubkey, eata_account.clone())],
+        [
+            (ata_pubkey, ata_account),
+            (eata_pubkey, eata_account.clone()),
+        ],
         CURRENT_SLOT,
         validator_keypair.insecure_clone(),
     )

--- a/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/actor.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/actor.rs
@@ -734,7 +734,10 @@ impl<H: StreamHandle, S: StreamFactory<H>> ChainLaserActor<H, S> {
             );
         }
 
-        if !self.stream_manager.is_subscribed(&pubkey) {
+        let should_forward = self.stream_manager.is_subscribed(&pubkey)
+            || matches!(source, AccountUpdateSource::Program)
+                && owner.eq(&dlp_api::dlp::id());
+        if !should_forward {
             return;
         }
 
@@ -775,9 +778,6 @@ impl<H: StreamHandle, S: StreamFactory<H>> ChainLaserActor<H, S> {
     }
 }
 
-// -----------------
-// Helpers
-// -----------------
 fn grpc_commitment_from_solana(
     commitment: SolanaCommitmentLevel,
 ) -> CommitmentLevel {
@@ -802,5 +802,165 @@ fn is_fallen_behind_error(err: &LaserstreamError) -> bool {
                     .contains("fallen behind")
         }
         _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::AtomicU64;
+
+    use dlp_api::dlp::state::DelegationRecord;
+    use helius_laserstream::grpc::{
+        subscribe_update::UpdateOneof, SubscribeUpdate, SubscribeUpdateAccount,
+        SubscribeUpdateAccountInfo,
+    };
+    use solana_commitment_config::CommitmentConfig;
+    use tokio::time::{timeout, Duration};
+
+    use super::*;
+    use crate::remote_account_provider::{
+        chain_laser_actor::mock::MockStreamFactory,
+        chain_rpc_client::ChainRpcClientImpl,
+    };
+
+    fn test_slots() -> Slots {
+        Slots {
+            chain_slot: ChainSlot::new(Arc::new(AtomicU64::new(0))),
+            supports_backfill: false,
+        }
+    }
+
+    fn test_rpc_client() -> ChainRpcClientImpl {
+        ChainRpcClientImpl::new_from_url(
+            "http://127.0.0.1:8899",
+            CommitmentConfig::processed(),
+        )
+    }
+
+    fn account_update(
+        pubkey: Pubkey,
+        owner: Pubkey,
+        data: Vec<u8>,
+    ) -> SubscribeUpdate {
+        SubscribeUpdate {
+            filters: vec![],
+            update_oneof: Some(UpdateOneof::Account(SubscribeUpdateAccount {
+                account: Some(SubscribeUpdateAccountInfo {
+                    pubkey: pubkey.to_bytes().to_vec(),
+                    lamports: 1,
+                    owner: owner.to_bytes().to_vec(),
+                    executable: false,
+                    rent_epoch: 0,
+                    data,
+                    write_version: 0,
+                    txn_signature: None,
+                }),
+                slot: 42,
+                is_startup: false,
+            })),
+            created_at: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn forwards_non_internal_dlp_program_updates_without_direct_sub() {
+        let factory = MockStreamFactory::new();
+        let (abort_tx, _abort_rx) = mpsc::channel(1);
+        let (actor, msg_tx, mut updates_rx, _) =
+            ChainLaserActor::with_stream_factory(
+                "test",
+                factory.clone(),
+                SolanaCommitmentLevel::Processed,
+                abort_tx,
+                test_slots(),
+                test_rpc_client(),
+                &GrpcConfig::default(),
+            );
+        let actor_task = tokio::spawn(actor.run());
+
+        let (response_tx, response_rx) = oneshot::channel();
+        msg_tx
+            .send(ChainPubsubActorMessage::ProgramSubscribe {
+                pubkey: dlp_api::dlp::id(),
+                response: response_tx,
+            })
+            .await
+            .unwrap();
+        response_rx.await.unwrap().unwrap();
+
+        let delegated_account = Pubkey::new_unique();
+        factory.push_update_to_stream(
+            0,
+            Ok(account_update(
+                delegated_account,
+                dlp_api::dlp::id(),
+                vec![1, 2, 3, 4],
+            )),
+        );
+
+        let update = timeout(Duration::from_millis(200), updates_rx.recv())
+            .await
+            .expect("timed out waiting for forwarded update")
+            .expect("subscription update channel closed");
+        assert_eq!(update.pubkey, delegated_account);
+
+        actor_task.abort();
+    }
+
+    #[tokio::test]
+    async fn forwards_internal_dlp_program_updates_without_direct_sub() {
+        let factory = MockStreamFactory::new();
+        let (abort_tx, _abort_rx) = mpsc::channel(1);
+        let (actor, msg_tx, mut updates_rx, _) =
+            ChainLaserActor::with_stream_factory(
+                "test",
+                factory.clone(),
+                SolanaCommitmentLevel::Processed,
+                abort_tx,
+                test_slots(),
+                test_rpc_client(),
+                &GrpcConfig::default(),
+            );
+        let actor_task = tokio::spawn(actor.run());
+
+        let (response_tx, response_rx) = oneshot::channel();
+        msg_tx
+            .send(ChainPubsubActorMessage::ProgramSubscribe {
+                pubkey: dlp_api::dlp::id(),
+                response: response_tx,
+            })
+            .await
+            .unwrap();
+        response_rx.await.unwrap().unwrap();
+
+        let mut record_data =
+            vec![0u8; DelegationRecord::size_with_discriminator()];
+        let record_pubkey = Pubkey::new_unique();
+        DelegationRecord {
+            authority: Pubkey::new_unique(),
+            owner: Pubkey::new_unique(),
+            delegation_slot: 1,
+            lamports: 1,
+            commit_frequency_ms: 1000,
+        }
+        .to_bytes_with_discriminator(&mut record_data)
+        .unwrap();
+
+        factory.push_update_to_stream(
+            0,
+            Ok(account_update(
+                record_pubkey,
+                dlp_api::dlp::id(),
+                record_data,
+            )),
+        );
+
+        let update = timeout(Duration::from_millis(200), updates_rx.recv())
+            .await
+            .expect("timed out waiting for forwarded update")
+            .expect("subscription update channel closed");
+        assert_eq!(update.pubkey, record_pubkey);
+
+        actor_task.abort();
     }
 }

--- a/magicblock-chainlink/src/remote_account_provider/chain_pubsub_actor.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_pubsub_actor.rs
@@ -698,13 +698,24 @@ impl ChainPubsubActor {
                                     &program_pubkey.to_string(),
                                 );
 
-                                if subs.lock().expect("subscriptions lock poisoned").contains_key(&acc_pubkey) {
-                                    let ui_account = rpc_response.value.account;
-                                    let rpc_response = RpcResponse {
-                                        context: rpc_response.context,
-                                        value: ui_account,
-                                    };
-                                    let sub_update = SubscriptionUpdate::from((acc_pubkey, rpc_response));
+                                let is_directly_subscribed = subs
+                                    .lock()
+                                    .expect("subscriptions lock poisoned")
+                                    .contains_key(&acc_pubkey);
+                                let ui_account = rpc_response.value.account;
+                                let rpc_response = RpcResponse {
+                                    context: rpc_response.context,
+                                    value: ui_account,
+                                };
+                                let sub_update = SubscriptionUpdate::from((
+                                    acc_pubkey,
+                                    rpc_response,
+                                ));
+                                let should_forward =
+                                    is_directly_subscribed
+                                        || program_pubkey.eq(&dlp_api::dlp::id());
+
+                                if should_forward {
                                     if acc_pubkey != clock::ID {
                                         inc_program_subscription_account_updates_count(
                                             &client_id,

--- a/test-integration/Cargo.lock
+++ b/test-integration/Cargo.lock
@@ -2465,7 +2465,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 [[package]]
 name = "helius-laserstream"
 version = "0.1.2"
-source = "git+https://github.com/magicblock-labs/laserstream-sdk?branch=v0.2.2-magicblock#c3e42c5424d317093ce3ce3652d0c9c998f52eba"
+source = "git+https://github.com/magicblock-labs/laserstream-sdk?branch=v0.2.2-magicblock%2Bconn-fix#fe205cb2b85864d1821027d663813d66160285dc"
 dependencies = [
  "async-stream",
  "bs58",


### PR DESCRIPTION
 resolves https://github.com/magicblock-labs/magicblock-validator/issues/1056

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust handling of delegation-record vs delegated-account updates to avoid missed clones and premature unsubscriptions.
  * Suppressed noisy error logging and ensured program-originated delegation updates are forwarded consistently; metrics and forwarding now respect new gating.

* **Refactor**
  * Added tracking for pending delegation records and classification of internal delegation-related accounts to prevent misclassification.

* **Tests**
  * Added tests validating forwarded subscription updates for delegation-related accounts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->