### PR TITLE
feat: Pass actions tx sig to MagicProgram::CloneAccount and log it

### DIFF
--- a/magicblock-account-cloner/src/lib.rs
+++ b/magicblock-account-cloner/src/lib.rs
@@ -139,8 +139,14 @@ impl ChainlinkCloner {
         pubkey: Pubkey,
         data: Vec<u8>,
         fields: AccountCloneFields,
+        actions_tx_sig: Option<Signature>,
     ) -> Instruction {
-        InstructionUtils::clone_account_instruction(pubkey, data, fields)
+        InstructionUtils::clone_account_instruction(
+            pubkey,
+            data,
+            fields,
+            actions_tx_sig,
+        )
     }
 
     fn clone_init_ix(
@@ -148,12 +154,14 @@ impl ChainlinkCloner {
         total_len: u32,
         initial_data: Vec<u8>,
         fields: AccountCloneFields,
+        actions_tx_sig: Option<Signature>,
     ) -> Instruction {
         InstructionUtils::clone_account_init_instruction(
             pubkey,
             total_len,
             initial_data,
             fields,
+            actions_tx_sig,
         )
     }
 
@@ -210,12 +218,14 @@ impl ChainlinkCloner {
         &self,
         request: &AccountCloneRequest,
         blockhash: Hash,
+        actions_tx_sig: Option<Signature>,
     ) -> Transaction {
         let fields = Self::clone_fields(request);
         let clone_ix = Self::clone_ix(
             request.pubkey,
             request.account.data().to_vec(),
             fields,
+            actions_tx_sig,
         );
 
         // TODO(#625): Re-enable frequency commits when proper limits are in place:
@@ -263,6 +273,7 @@ impl ChainlinkCloner {
         &self,
         request: &AccountCloneRequest,
         blockhash: Hash,
+        actions_tx_sig: Option<Signature>,
     ) -> Vec<Transaction> {
         let data = request.account.data();
         let fields = Self::clone_fields(request);
@@ -278,6 +289,7 @@ impl ChainlinkCloner {
             data.len() as u32,
             first_chunk,
             fields,
+            actions_tx_sig,
         );
         txs.push(self.create_signed_tx(&[init_ix], blockhash));
 
@@ -352,6 +364,7 @@ impl ChainlinkCloner {
                 buffer_pubkey,
                 program_data,
                 buffer_fields,
+                None,
             )];
             ixs.extend(finalize_ixs);
             vec![self.create_signed_tx(&ixs, blockhash)]
@@ -497,6 +510,7 @@ impl ChainlinkCloner {
             total_len,
             first_chunk.to_vec(),
             fields,
+            None,
         );
         let mut txs = vec![self.create_signed_tx(&[init_ix], blockhash)];
 
@@ -553,27 +567,41 @@ impl ChainlinkCloner {
 
     async fn send_actions_tx(
         &self,
-        actions: &DelegationActions,
-        recent_blockhash: Hash,
+        actions_tx: Option<SanitizedTransaction>,
     ) -> ClonerResult<Option<()>> {
-        if actions.is_empty() {
+        let Some(sanitized_tx) = actions_tx else {
             return Ok(None);
-        }
-        let mut tx = Transaction::new_with_payer(
-            &actions.clone().into_iter().collect::<Vec<_>>(),
-            Some(&validator_authority_id()),
-        );
-        tx.partial_sign(&[&validator_authority()], recent_blockhash);
-
-        let sanitized_tx = tx.sanitize(false)?;
+        };
+        let action_tx_sig = *sanitized_tx.signature();
 
         Ok(Some(
             self.send_sanitized_tx(sanitized_tx)
                 .await
                 .inspect_err(|err| {
-                    error!("send_sanitized_tx failed to execute actions, with error: {:?}", err);
+                    error!(
+                        tx_sig = %action_tx_sig,
+                        error = ?err,
+                        "Failed to execute post-delegation actions transaction"
+                    );
                 })?,
         ))
+    }
+
+    fn create_actions_tx(
+        &self,
+        actions: &DelegationActions,
+        recent_blockhash: Hash,
+    ) -> ClonerResult<Option<SanitizedTransaction>> {
+        if actions.is_empty() {
+            return Ok(None);
+        }
+
+        let mut tx = Transaction::new_with_payer(
+            actions,
+            Some(&validator_authority_id()),
+        );
+        tx.partial_sign(&[&validator_authority()], recent_blockhash);
+        Ok(Some(tx.sanitize(false)?))
     }
 }
 
@@ -586,6 +614,9 @@ impl Cloner for ChainlinkCloner {
     ) -> ClonerResult<Signature> {
         let blockhash = self.block.load().blockhash;
         let data_len = request.account.data().len();
+        let actions_tx =
+            self.create_actions_tx(&request.delegation_actions, blockhash)?;
+        let actions_tx_sig = actions_tx.as_ref().map(|tx| *tx.signature());
 
         if request.account.delegated() {
             self.maybe_prepare_lookup_tables(
@@ -596,7 +627,11 @@ impl Cloner for ChainlinkCloner {
 
         // Small account: single tx
         if data_len <= MAX_INLINE_DATA_SIZE {
-            let tx = self.build_small_account_tx(&request, blockhash);
+            let tx = self.build_small_account_tx(
+                &request,
+                blockhash,
+                actions_tx_sig,
+            );
 
             let signature = self.send_tx(tx).await.map_err(|err| {
                 ClonerError::FailedToCloneRegularAccount(
@@ -605,14 +640,14 @@ impl Cloner for ChainlinkCloner {
                 )
             })?;
 
-            self.send_actions_tx(&request.delegation_actions, blockhash)
-                .await?;
+            self.send_actions_tx(actions_tx).await?;
 
             return Ok(signature);
         }
 
         // Large account: multi-tx with cleanup on failure
-        let txs = self.build_large_account_txs(&request, blockhash);
+        let txs =
+            self.build_large_account_txs(&request, blockhash, actions_tx_sig);
 
         let mut last_sig = None;
         for tx in txs {
@@ -630,8 +665,7 @@ impl Cloner for ChainlinkCloner {
             }
         }
 
-        self.send_actions_tx(&request.delegation_actions, blockhash)
-            .await?;
+        self.send_actions_tx(actions_tx).await?;
 
         Ok(last_sig.unwrap_or_default())
     }

--- a/magicblock-magic-program-api/src/instruction.rs
+++ b/magicblock-magic-program-api/src/instruction.rs
@@ -203,6 +203,7 @@ pub enum MagicBlockInstruction {
         pubkey: Pubkey,
         data: Vec<u8>,
         fields: AccountCloneFields,
+        actions_tx_sig: Option<String>,
     },
 
     /// Initialize a multi-transaction clone for a large account.
@@ -217,6 +218,7 @@ pub enum MagicBlockInstruction {
         total_data_len: u32,
         initial_data: Vec<u8>,
         fields: AccountCloneFields,
+        actions_tx_sig: Option<String>,
     },
 
     /// Continue a multi-transaction clone with the next data chunk.

--- a/programs/magicblock/src/clone_account/process_clone.rs
+++ b/programs/magicblock/src/clone_account/process_clone.rs
@@ -26,6 +26,7 @@ pub(crate) fn process_clone_account(
     pubkey: Pubkey,
     data: Vec<u8>,
     fields: AccountCloneFields,
+    actions_tx_sig: Option<String>,
 ) -> Result<(), InstructionError> {
     validate_authority(signers, invoke_context)?;
 
@@ -59,6 +60,13 @@ pub(crate) fn process_clone_account(
         pubkey,
         data.len()
     );
+    if let Some(actions_tx_sig) = actions_tx_sig {
+        ic_msg!(
+            invoke_context,
+            "CloneAccount: actions_tx_sig={}",
+            actions_tx_sig
+        );
+    }
 
     let current_lamports = account.borrow().lamports();
     let lamports_delta = fields.lamports as i64 - current_lamports as i64;

--- a/programs/magicblock/src/clone_account/process_clone_init.rs
+++ b/programs/magicblock/src/clone_account/process_clone_init.rs
@@ -27,6 +27,7 @@ use crate::errors::MagicBlockProgramError;
 /// 4. Registers pubkey in `PENDING_CLONES`
 ///
 /// Must be followed by `CloneAccountContinue` instructions until `is_last=true`.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn process_clone_account_init(
     signers: &HashSet<Pubkey>,
     invoke_context: &InvokeContext,
@@ -35,6 +36,7 @@ pub(crate) fn process_clone_account_init(
     total_data_len: u32,
     initial_data: Vec<u8>,
     fields: AccountCloneFields,
+    actions_tx_sig: Option<String>,
 ) -> Result<(), InstructionError> {
     validate_authority(signers, invoke_context)?;
 
@@ -88,6 +90,13 @@ pub(crate) fn process_clone_account_init(
         total_data_len,
         initial_data.len()
     );
+    if let Some(actions_tx_sig) = actions_tx_sig {
+        ic_msg!(
+            invoke_context,
+            "CloneAccountInit: actions_tx_sig={}",
+            actions_tx_sig
+        );
+    }
 
     let current_lamports = account.borrow().lamports();
     let lamports_delta = fields.lamports as i64 - current_lamports as i64;

--- a/programs/magicblock/src/clone_account/tests.rs
+++ b/programs/magicblock/src/clone_account/tests.rs
@@ -75,6 +75,7 @@ fn test_rejects_wrong_signer_pubkey() {
             pubkey,
             data: vec![],
             fields: clone_fields(200, 0),
+            actions_tx_sig: None,
         },
         vec![
             AccountMeta::new(wrong_signer, true), // wrong signer!
@@ -108,6 +109,7 @@ fn test_clone_account_basic() {
         pubkey,
         vec![1, 2, 3],
         fields,
+        None,
     );
 
     let mut result = process_instruction(
@@ -138,6 +140,7 @@ fn test_clone_account_rejects_stale_slot() {
         pubkey,
         vec![],
         clone_fields(200, 50), // slot 50 < current 100
+        None,
     );
 
     process_instruction(
@@ -162,6 +165,7 @@ fn test_clone_account_rejects_delegated_account() {
         pubkey,
         vec![],
         clone_fields(200, 0),
+        None,
     );
 
     process_instruction(
@@ -186,6 +190,7 @@ fn test_clone_account_rejects_ephemeral_account() {
         pubkey,
         vec![],
         clone_fields(200, 0),
+        None,
     );
 
     process_instruction(
@@ -206,6 +211,7 @@ fn test_clone_account_adjusts_authority_lamports() {
         pubkey,
         vec![],
         clone_fields(300, 0),
+        None,
     );
     let mut result = process_instruction(
         &ix.data,
@@ -233,6 +239,7 @@ fn test_clone_init_allocates_buffer() {
         10,
         vec![1, 2, 3, 4],
         clone_fields(1000, 50),
+        None,
     );
     let mut result = process_instruction(
         &ix.data,
@@ -324,6 +331,7 @@ fn test_clone_init_rejects_double_init() {
         10,
         vec![],
         clone_fields(100, 0),
+        None,
     );
     process_instruction(
         &ix.data,
@@ -344,6 +352,7 @@ fn test_clone_init_rejects_oversized_initial_data() {
         5,
         vec![1, 2, 3, 4, 5, 6],
         clone_fields(100, 0),
+        None,
     );
     process_instruction(
         &ix.data,

--- a/programs/magicblock/src/magicblock_processor.rs
+++ b/programs/magicblock/src/magicblock_processor.rs
@@ -128,6 +128,7 @@ declare_process_instruction!(
                 pubkey,
                 data,
                 fields,
+                actions_tx_sig,
             } => process_clone_account(
                 &signers,
                 invoke_context,
@@ -135,12 +136,14 @@ declare_process_instruction!(
                 pubkey,
                 data,
                 fields,
+                actions_tx_sig,
             ),
             CloneAccountInit {
                 pubkey,
                 total_data_len,
                 initial_data,
                 fields,
+                actions_tx_sig,
             } => process_clone_account_init(
                 &signers,
                 invoke_context,
@@ -149,6 +152,7 @@ declare_process_instruction!(
                 total_data_len,
                 initial_data,
                 fields,
+                actions_tx_sig,
             ),
             CloneAccountContinue {
                 pubkey,

--- a/programs/magicblock/src/utils/instruction_utils.rs
+++ b/programs/magicblock/src/utils/instruction_utils.rs
@@ -15,6 +15,7 @@ use solana_hash::Hash;
 use solana_instruction::{AccountMeta, Instruction};
 use solana_keypair::Keypair;
 use solana_pubkey::Pubkey;
+use solana_signature::Signature;
 use solana_signer::Signer;
 use solana_transaction::Transaction;
 
@@ -296,6 +297,7 @@ impl InstructionUtils {
         pubkey: Pubkey,
         data: Vec<u8>,
         fields: magicblock_magic_program_api::instruction::AccountCloneFields,
+        actions_tx_sig: Option<Signature>,
     ) -> Instruction {
         Instruction::new_with_bincode(
             crate::id(),
@@ -303,6 +305,7 @@ impl InstructionUtils {
                 pubkey,
                 data,
                 fields,
+                actions_tx_sig: actions_tx_sig.map(|sig| sig.to_string()),
             },
             vec![
                 AccountMeta::new(validator_authority_id(), true),
@@ -316,6 +319,7 @@ impl InstructionUtils {
         total_data_len: u32,
         initial_data: Vec<u8>,
         fields: magicblock_magic_program_api::instruction::AccountCloneFields,
+        actions_tx_sig: Option<Signature>,
     ) -> Instruction {
         Instruction::new_with_bincode(
             crate::id(),
@@ -324,6 +328,7 @@ impl InstructionUtils {
                 total_data_len,
                 initial_data,
                 fields,
+                actions_tx_sig: actions_tx_sig.map(|sig| sig.to_string()),
             },
             vec![
                 AccountMeta::new(validator_authority_id(), true),


### PR DESCRIPTION
Log `actions_tx_sig` from `CloneAccount*` instructions in MagicProgram.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for optional delegation action transaction signatures in the account cloning process
  * Enhanced transaction handling to track action signatures throughout cloning workflows

* **Chores**
  * Improved logging to include action transaction signature details when applicable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->