### PR TITLE
Fix(README): incorrect Task Scheduler configuration example

### DIFF
--- a/magicblock-task-scheduler/README.md
+++ b/magicblock-task-scheduler/README.md
@@ -23,9 +23,9 @@
 The task scheduler can be configured via the validator configuration:
 
 ```toml
-[task_scheduler]
+[task-scheduler]
 reset = false
-millis_per_tick = 100
+min-interval = "10ms"
 ```
 
 ## Security Considerations


### PR DESCRIPTION
## Summary
The Task Scheduler configuration example in `magicblock-task-scheduler/README.md` is outdated and does not match the current configuration format.

**Changes:**

Updated section name:

`[task_scheduler]` - `[task-scheduler]`

Updated parameter:

`millis_per_tick` - `min-interval`

Updated value format:

`100` - `"10ms"` (humantime format)

## Compatibility
- [ ] No breaking changes
- [ ] Config change (describe):
- [ ] Migration needed (describe):

## Testing
- [ ] tests (or explain)

## Checklist
- [ ] docs updated (if needed)
- [ ] closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration section naming for task scheduler settings.
  * Modified configuration option format from millisecond-based to time interval format (e.g., "10ms").

<!-- end of auto-generated comment: release notes by coderabbit.ai -->