### PR TITLE
fix(readme): use correct `aperture.listen` field

### DIFF
--- a/magicblock-config/README.md
+++ b/magicblock-config/README.md
@@ -28,7 +28,7 @@ fn main() -> Result<(), figment::Error> {
     let config = ValidatorParams::try_new(args)?;
 
     println!("Validator Mode: {:?}", config.lifecycle);
-    println!("Listening on: {}", config.listen);
+    println!("Listening on: {}", config.aperture.listen);
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
The README example uses `config.listen`, which does not exist in the current configuration structure.

The `listen` field is part of the `aperture` section, so accessing it via `config.listen` results in a compilation error.

Updated the example to use the correct field:
- `config.aperture.listen`

## Compatibility
- [ ] No breaking changes
- [ ] Config change (describe):
- [ ] Migration needed (describe):

## Testing
- [ ] tests (or explain)

## Checklist
- [ ] docs updated (if needed)
- [ ] closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration example to reflect the correct field path for accessing listening address information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->