### PR TITLE
fix(readme): replace invalid `[accounts-db]` section with `[accountsdb]`

### DIFF
--- a/magicblock-config/README.md
+++ b/magicblock-config/README.md
@@ -77,7 +77,7 @@ storage = "/data/ledger"
 basefee = 500
 keypair = "9Vo7Tb..."
 
-[accounts-db]
+[accountsdb]
 database-size = 104857600 # 100MB
 block-size = "block256"
 ```


### PR DESCRIPTION
## Summary
The README contains an invalid TOML section `[accounts-db]` in the example configuration.

However, the actual configuration structure expects the section to be named `accountsdb`. Since deserialization uses strict field validation (`deny_unknown_fields`), the provided example config is rejected at runtime.

Updated the section name:
- `[accounts-db]` --> `[accountsdb]`

## Compatibility
- [ ] No breaking changes
- [ ] Config change (describe):
- [ ] Migration needed (describe):

## Testing
- [ ] tests (or explain)

## Checklist
- [ ] docs updated (if needed)
- [ ] closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration file examples in the README to use standardized naming conventions for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->