### PR TITLE
Remove stop-time accountsdb flush

### DIFF
--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -950,12 +950,6 @@ impl MagicValidator {
             }
             log_timing("shutdown", "unregister_validator_on_chain", step_start);
         }
-        // we have two memory mapped databases,
-        // flush them to disk before exitting
-        let step_start = Instant::now();
-        self.accountsdb.flush();
-        log_timing("shutdown", "accountsdb_flush", step_start);
-
         let step_start = Instant::now();
         if let Err(err) = self.ledger.shutdown(true) {
             error!(error = ?err, "Failed to shutdown ledger");


### PR DESCRIPTION
## Summary
- keep the existing pre-shutdown ledger flush in `prepare_ledger_for_shutdown`
- remove the synchronous AccountsDb flush from `MagicValidator::stop`
- minimize stop-time shutdown latency by avoiding flush work after shutdown begins

## Testing
- `cargo test -p magicblock-api --lib --no-run`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the shutdown sequence by removing a flush operation from the graceful shutdown process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->