### PR TITLE
fix: update README with correct workspace run commands and environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ You can override any configuration value using environment variables with the `M
 # Example: Run as an ephemeral validator syncing from Mainnet
 MBV_LIFECYCLE=ephemeral \
 MBV_APERTURE__LISTEN=0.0.0.0:8899 \
-cargo run -p magicblock-validator --release config.example.toml
+cargo run -p magicblock-validator --release -- config.example.toml
 
 ```
 


### PR DESCRIPTION
## Summary
This PR fixes issues in the README regarding validator startup:

- Corrected `cargo run` commands to specify the package (`-p magicblock-validator`) since the repo is a workspace.
- Updated environment variable for the listener from `MBV_LISTEN` to `MBV_APERTURE__LISTEN` to match the actual config schema.
- Docker example updated to use the correct env variable.

These changes align the documentation with the current codebase and prevent immediate startup failures.

## Compatibility
- [ ] No breaking changes
- [ ] Config change (describe):
- [ ] Migration needed (describe):

## Testing
- [ ] tests (or explain)

## Checklist
- [ ] docs updated (if needed)
- [ ] closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified startup instructions for the validator application to ensure the correct component is launched.
  * Updated example environment variable name and corresponding run instructions to match the new configuration format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->