### PR TITLE
fix: Dedup actions execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3089,6 +3089,7 @@ version = "0.8.4"
 dependencies = [
  "async-trait",
  "bincode",
+ "lru 0.16.2",
  "magicblock-accounts-db",
  "magicblock-chainlink",
  "magicblock-committor-service",

--- a/magicblock-account-cloner/Cargo.toml
+++ b/magicblock-account-cloner/Cargo.toml
@@ -10,6 +10,7 @@ edition.workspace = true
 [dependencies]
 async-trait = { workspace = true }
 bincode = { workspace = true }
+lru = { workspace = true }
 tracing = { workspace = true }
 magicblock-accounts-db = { workspace = true }
 magicblock-chainlink = { workspace = true }

--- a/magicblock-account-cloner/src/lib.rs
+++ b/magicblock-account-cloner/src/lib.rs
@@ -26,9 +26,13 @@
 //! The buffer is a temporary account that holds the raw ELF data during cloning.
 //! It's derived as a PDA: `["buffer", program_id]` owned by validator authority.
 
-use std::sync::Arc;
+use std::{
+    num::NonZeroUsize,
+    sync::{Arc, Mutex, MutexGuard},
+};
 
 use async_trait::async_trait;
+use lru::LruCache;
 use magicblock_chainlink::{
     cloner::{
         errors::{ClonerError, ClonerResult},
@@ -76,11 +80,18 @@ mod util;
 pub use account_cloner::*;
 pub use util::derive_buffer_pubkey;
 
+/// Keep only a bounded history of sent action tx signatures to avoid
+/// unbounded memory growth while still preventing near-term duplicate sends.
+const SENT_ACTION_TXS_MAX_ENTRIES: usize = 16_384;
+
+type ActionTxDedupCache = LruCache<Signature, ()>;
+
 pub struct ChainlinkCloner {
     changeset_committor: Option<Arc<CommittorService>>,
     config: ChainLinkConfig,
     tx_scheduler: TransactionSchedulerHandle,
     block: LatestBlock,
+    sent_action_txs: Arc<Mutex<ActionTxDedupCache>>,
 }
 
 impl ChainlinkCloner {
@@ -95,7 +106,18 @@ impl ChainlinkCloner {
             config,
             tx_scheduler,
             block,
+            sent_action_txs: Arc::new(Mutex::new(ActionTxDedupCache::new(
+                NonZeroUsize::new(SENT_ACTION_TXS_MAX_ENTRIES)
+                    .expect("SENT_ACTION_TXS_MAX_ENTRIES must be non-zero"),
+            ))),
         }
+    }
+
+    fn lock_sent_action_txs(&self) -> MutexGuard<'_, ActionTxDedupCache> {
+        self.sent_action_txs.lock().unwrap_or_else(|poisoned| {
+            warn!("sent_action_txs mutex poisoned; recovering inner state");
+            poisoned.into_inner()
+        })
     }
 
     // -----------------
@@ -573,18 +595,29 @@ impl ChainlinkCloner {
             return Ok(None);
         };
         let action_tx_sig = *sanitized_tx.signature();
+        {
+            let mut sent = self.lock_sent_action_txs();
+            if sent.contains(&action_tx_sig) {
+                warn!(
+                    tx_sig = %action_tx_sig,
+                    "Skipping duplicate post-delegation actions transaction"
+                );
+                return Ok(Some(()));
+            }
+            sent.put(action_tx_sig, ());
+        }
 
-        Ok(Some(
-            self.send_sanitized_tx(sanitized_tx)
-                .await
-                .inspect_err(|err| {
-                    error!(
-                        tx_sig = %action_tx_sig,
-                        error = ?err,
-                        "Failed to execute post-delegation actions transaction"
-                    );
-                })?,
-        ))
+        if let Err(err) = self.send_sanitized_tx(sanitized_tx).await {
+            self.lock_sent_action_txs().pop(&action_tx_sig);
+            error!(
+                tx_sig = %action_tx_sig,
+                error = ?err,
+                "Failed to execute post-delegation actions transaction"
+            );
+            return Err(err);
+        }
+
+        Ok(Some(()))
     }
 
     fn create_actions_tx(

--- a/test-integration/Cargo.lock
+++ b/test-integration/Cargo.lock
@@ -3430,6 +3430,7 @@ version = "0.8.4"
 dependencies = [
  "async-trait",
  "bincode",
+ "lru",
  "magicblock-accounts-db",
  "magicblock-chainlink",
  "magicblock-committor-service",


### PR DESCRIPTION
We noticed that sometimes tx (that executes `ExecuteReadyQueuedTransfer` ix) is executed twice for same `PostDelegationActions`.

I believe it is because `CloneAccount` does not prevent duplicate cloning if they're in the same slot (i.e `incoming == current` scenario in the following snippet, which is invoked by `CloneAccount`). Our `send_actins_tx` incorrectly assumed that `CloneAccount` will fail for duplicate clones.

This PR ensures that actions are executed once by using a cache.

https://github.com/magicblock-labs/magicblock-validator/blob/55f969d74c85705bc9f198b6078cd023a793351f/programs/magicblock/src/clone_account/common.rs#L117-L138

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate post-delegation action transactions from being submitted, reducing redundant network requests and improving reliability.
  * Added client-side de-duplication to skip already-sent actions, avoiding unnecessary replays.
  * Improved error handling and cleanup when transaction submission fails to keep operation state consistent and reduce spurious retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->