### PR TITLE
Fix replay cache reservation before transaction validation causing incorrect AlreadyProcessed errors

### DIFF
--- a/magicblock-aperture/src/requests/http/send_transaction.rs
+++ b/magicblock-aperture/src/requests/http/send_transaction.rs
@@ -34,10 +34,8 @@ impl HttpDispatcher {
             )?;
         let signature = *transaction.txn.signature();
 
-        // Perform a replay check and reserve the signature in the cache
-        if self.transactions.contains(&signature)
-            || !self.transactions.push(signature, None)
-        {
+        // Fast replay check before doing account resolution / scheduling work.
+        if self.transactions.contains(&signature) {
             return Err(TransactionError::AlreadyProcessed.into());
         }
 
@@ -50,6 +48,12 @@ impl HttpDispatcher {
             self.transactions_scheduler.schedule(transaction).await?;
         } else {
             self.transactions_scheduler.execute(transaction).await?;
+        }
+
+        // Reserve signature only after we successfully handed the transaction
+        // to the execution pipeline so failed pre-checks don't poison retries.
+        if !self.transactions.push(signature, None) {
+            return Err(TransactionError::AlreadyProcessed.into());
         }
 
         let signature = SerdeSignature(signature);


### PR DESCRIPTION
## Summary
### Description

This PR fixes an issue where a transaction signature is inserted into the replay/cache before full validation and scheduling are completed.

Currently, the flow calls push(signature, None) prior to:
- `ensure_transaction_accounts()`
- transaction scheduling/execution pipeline

If any of these steps fail, the transaction is not actually processed, but its signature remains reserved in the replay cache. As a result, retrying the same signed transaction may incorrectly return AlreadyProcessed, effectively breaking the retry mechanism.

### Solution

Move replay cache insertion to occur only after the transaction is successfully handed off to the execution pipeline (schedule / execute).

This ensures that:

- failed validation or pre-checks do not reserve the signature
- retries of the same transaction remain valid
- replay protection only applies to transactions that actually entered processing

## Compatibility
- [ ] No breaking changes
- [ ] Config change (describe):
- [ ] Migration needed (describe):

## Testing
- [ ] tests (or explain)

## Checklist
- [ ] docs updated (if needed)
- [ ] closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized transaction processing and signature cache management timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->