### PR TITLE
fix: actions dropping on eata cold cloning

### DIFF
--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -22,6 +22,7 @@ use solana_account::{AccountSharedData, ReadableAccount};
 use solana_keypair::Keypair;
 use solana_pubkey::Pubkey;
 use solana_sdk_ids::system_program;
+use solana_signature::Signature;
 use solana_signer::Signer;
 use tokio::{
     sync::{mpsc, oneshot},
@@ -306,8 +307,9 @@ where
                     projected_ata_clone_request
                 {
                     if let Err(err) = self
-                        .cloner
-                        .clone_account(projected_ata_clone_request)
+                        .clone_projected_ata_request(
+                            projected_ata_clone_request,
+                        )
                         .await
                     {
                         warn!(
@@ -505,6 +507,20 @@ where
         ))
     }
 
+    async fn clone_projected_ata_request(
+        &self,
+        request: AccountCloneRequest,
+    ) -> ChainlinkResult<Signature> {
+        self.ensure_delegation_action_dependencies(
+            request.pubkey,
+            request.account.remote_slot(),
+            &request.delegation_actions,
+        )
+        .await?;
+
+        Ok(self.cloner.clone_account(request).await?)
+    }
+
     async fn maybe_greedily_clone_discovered_delegated_account(
         &self,
         pubkey: Pubkey,
@@ -608,8 +624,9 @@ where
                     let projected_ata_pubkey =
                         projected_ata_clone_request.pubkey;
                     if let Err(err) = self
-                        .cloner
-                        .clone_account(projected_ata_clone_request)
+                        .clone_projected_ata_request(
+                            projected_ata_clone_request,
+                        )
                         .await
                     {
                         warn!(

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -2601,6 +2601,96 @@ async fn test_out_of_order_delegated_eata_subscription_update_still_projects_ata
 }
 
 #[tokio::test]
+async fn test_out_of_order_delegated_eata_update_clones_action_dependencies() {
+    init_logger();
+    let validator_keypair = Keypair::new();
+    let validator_pubkey = validator_keypair.pubkey();
+    let wallet_owner = random_pubkey();
+    let mint = random_pubkey();
+    let action_program_pubkey = random_pubkey();
+    const CURRENT_SLOT: u64 = 100;
+    const AMOUNT: u64 = 777;
+
+    let eata_pubkey = derive_eata(&wallet_owner, &mint);
+    let ata_pubkey = derive_ata(&wallet_owner, &mint);
+    let eata_account = create_eata_account(&wallet_owner, &mint, AMOUNT, true);
+    let action_program_account = Account {
+        lamports: 1_000_000,
+        data: vec![1, 2, 3, 4],
+        owner: solana_sdk_ids::bpf_loader::id(),
+        executable: true,
+        rent_epoch: 0,
+    };
+
+    let FetcherTestCtx {
+        accounts_bank,
+        rpc_client,
+        subscription_tx,
+        ..
+    } = setup(
+        [
+            (eata_pubkey, eata_account.clone()),
+            (action_program_pubkey, action_program_account),
+        ],
+        CURRENT_SLOT,
+        validator_keypair.insecure_clone(),
+    )
+    .await;
+
+    add_delegation_record_with_actions_for(
+        &rpc_client,
+        eata_pubkey,
+        validator_pubkey,
+        EATA_PROGRAM_ID,
+        action_program_pubkey,
+    );
+
+    let mut in_bank_eata = AccountSharedData::from(eata_account.clone());
+    in_bank_eata.set_owner(EATA_PROGRAM_ID);
+    in_bank_eata.set_remote_slot(CURRENT_SLOT);
+    accounts_bank.insert(eata_pubkey, in_bank_eata);
+
+    use crate::remote_account_provider::{
+        RemoteAccount, RemoteAccountUpdateSource,
+    };
+
+    subscription_tx
+        .send(ForwardedSubscriptionUpdate {
+            pubkey: eata_pubkey,
+            account: RemoteAccount::from_fresh_account(
+                eata_account,
+                CURRENT_SLOT,
+                RemoteAccountUpdateSource::Subscription,
+            ),
+        })
+        .await
+        .unwrap();
+
+    const POLL_INTERVAL: std::time::Duration = Duration::from_millis(10);
+    const TIMEOUT: std::time::Duration = Duration::from_millis(500);
+    tokio::time::timeout(TIMEOUT, async {
+        loop {
+            let has_ata = accounts_bank.get_account(&ata_pubkey).is_some();
+            let has_action_program =
+                accounts_bank.get_account(&action_program_pubkey).is_some();
+            if has_ata && has_action_program {
+                break;
+            }
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+    })
+    .await
+    .expect(
+        "timed out waiting for projected ATA action dependencies on out-of-order delegated eATA update",
+    );
+
+    assert!(
+        accounts_bank.get_account(&action_program_pubkey).is_some(),
+        "out-of-order projected ATA clone should ensure action dependencies before running post-delegation actions",
+    );
+}
+
+#[tokio::test]
 async fn test_subscription_update_with_delegation_actions_clones_dependencies()
 {
     init_logger();
@@ -2791,6 +2881,92 @@ async fn test_delegated_eata_subscription_update_clones_raw_eata_and_projects_at
     assert_eq!(projected_mint, mint);
     assert_eq!(projected_owner, wallet_owner);
     assert_eq!(projected_amount, AMOUNT);
+}
+
+#[tokio::test]
+async fn test_delegated_eata_subscription_update_clones_action_dependencies() {
+    init_logger();
+    let validator_keypair = Keypair::new();
+    let validator_pubkey = validator_keypair.pubkey();
+    let wallet_owner = random_pubkey();
+    let mint = random_pubkey();
+    let action_program_pubkey = random_pubkey();
+    const CURRENT_SLOT: u64 = 100;
+    const AMOUNT: u64 = 777;
+
+    let eata_pubkey = derive_eata(&wallet_owner, &mint);
+    let ata_pubkey = derive_ata(&wallet_owner, &mint);
+    let eata_account = create_eata_account(&wallet_owner, &mint, AMOUNT, true);
+    let action_program_account = Account {
+        lamports: 1_000_000,
+        data: vec![1, 2, 3, 4],
+        owner: solana_sdk_ids::bpf_loader::id(),
+        executable: true,
+        rent_epoch: 0,
+    };
+
+    let FetcherTestCtx {
+        accounts_bank,
+        rpc_client,
+        subscription_tx,
+        ..
+    } = setup(
+        [
+            (eata_pubkey, eata_account.clone()),
+            (action_program_pubkey, action_program_account),
+        ],
+        CURRENT_SLOT,
+        validator_keypair.insecure_clone(),
+    )
+    .await;
+
+    add_delegation_record_with_actions_for(
+        &rpc_client,
+        eata_pubkey,
+        validator_pubkey,
+        EATA_PROGRAM_ID,
+        action_program_pubkey,
+    );
+
+    use crate::remote_account_provider::{
+        RemoteAccount, RemoteAccountUpdateSource,
+    };
+
+    subscription_tx
+        .send(ForwardedSubscriptionUpdate {
+            pubkey: eata_pubkey,
+            account: RemoteAccount::from_fresh_account(
+                eata_account,
+                CURRENT_SLOT,
+                RemoteAccountUpdateSource::Subscription,
+            ),
+        })
+        .await
+        .unwrap();
+
+    const POLL_INTERVAL: std::time::Duration = Duration::from_millis(10);
+    const TIMEOUT: std::time::Duration = Duration::from_millis(500);
+    tokio::time::timeout(TIMEOUT, async {
+        loop {
+            let has_eata = accounts_bank.get_account(&eata_pubkey).is_some();
+            let has_ata = accounts_bank.get_account(&ata_pubkey).is_some();
+            let has_action_program =
+                accounts_bank.get_account(&action_program_pubkey).is_some();
+            if has_eata && has_ata && has_action_program {
+                break;
+            }
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+    })
+    .await
+    .expect(
+        "timed out waiting for projected ATA action dependencies on delegated eATA update",
+    );
+
+    assert!(
+        accounts_bank.get_account(&action_program_pubkey).is_some(),
+        "projected ATA clone should ensure action dependencies before running post-delegation actions",
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

TL;DR: actions dropping on eata cold cloning

When chainlink receives the first eATA subscription update after startup, it builds the projected ATA clone request through `magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs:880`. That helper was hardcoding delegation_actions: DelegationActions::default() at `magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs:917`, so the projected ATA clone was sent without actions. That is why the clone tx has no `actions_tx_sig`, and no post-delegation actions tx is ever built.

## Compatibility
- [x] No breaking changes
- [ ] Config change (describe):
- [ ] Migration needed (describe):

## Testing
- [ ] tests (or explain)

## Checklist
- [ ] docs updated (if needed)
- [ ] closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced delegation action handling in token account cloning to ensure action dependencies are correctly maintained and resolved throughout delegated subscription update flows.

* **Tests**
  * Added comprehensive test coverage validating action-dependency handling for various delegated account update scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->