### PR TITLE
feat (services): Auto-commit callback-modified accounts to L1

### DIFF
--- a/magicblock-services/src/actions_callback_service.rs
+++ b/magicblock-services/src/actions_callback_service.rs
@@ -137,31 +137,36 @@ impl<L: LatestBlockProvider> ActionsCallbackScheduler
         signature: Option<Signature>,
         result: ActionResult,
     ) -> Vec<Result<Signature, CallbackScheduleError>> {
-        // Collect writable accounts from callbacks before consuming them.
-        // These are the accounts that the callback will modify on ER and
-        // that need to be auto-committed to L1 afterward.
-        let writable_accounts: Vec<Pubkey> = callbacks
+        let authority_pubkey = self.authority.pubkey();
+
+        // Extract normalized writable accounts per callback BEFORE consuming them.
+        // Applies the same authority exclusion as build_instruction (line 114):
+        // validator authority is never writable in the callback instruction,
+        // so it must not appear in the auto-commit target list either.
+        let per_callback_accounts: Vec<Vec<Pubkey>> = callbacks
             .iter()
-            .flat_map(|cb| {
+            .map(|cb| {
                 cb.account_metas_per_program
                     .iter()
-                    .filter(|m| m.is_writable)
+                    .filter(|m| m.is_writable && m.pubkey != authority_pubkey)
                     .map(|m| m.pubkey)
+                    .collect()
             })
-            .collect::<HashSet<_>>()
-            .into_iter()
             .collect();
 
         let transactions_result =
             self.build_transactions(callbacks, signature, result);
 
         let mut valid_transactions = vec![];
+        let mut valid_accounts = vec![];
         let signatures = transactions_result
             .into_iter()
-            .map(|el| match el {
+            .enumerate()
+            .map(|(i, el)| match el {
                 Ok(tx) => {
                     let signature = *tx.get_signature();
                     valid_transactions.push(tx);
+                    valid_accounts.push(per_callback_accounts[i].clone());
                     Ok(signature)
                 }
                 Err(err) => Err(err),
@@ -182,28 +187,35 @@ impl<L: LatestBlockProvider> ActionsCallbackScheduler
                 )
                 .await;
 
-                let any_confirmed = send_results
-                    .iter()
-                    .any(|r| r.is_ok());
-
-                for result in &send_results {
-                    if let Err(err) = result {
-                        error!(
-                            error = ?err,
-                            "Failed to send action callback transaction"
-                        );
+                // 2. Collect writable accounts only from confirmed callbacks
+                let mut confirmed_accounts = HashSet::new();
+                for (i, result) in send_results.iter().enumerate() {
+                    match result {
+                        Ok(_) => {
+                            if let Some(accounts) = valid_accounts.get(i) {
+                                confirmed_accounts.extend(accounts);
+                            }
+                        }
+                        Err(err) => {
+                            error!(
+                                error = ?err,
+                                "Failed to send action callback transaction"
+                            );
+                        }
                     }
                 }
 
-                // 2. Auto-commit callback-modified accounts to L1.
+                // 3. Auto-commit only accounts modified by confirmed callbacks.
                 //    ScheduleCommit accepts validator authority as signer,
                 //    bypassing the CPI ownership check.
-                if any_confirmed && !writable_accounts.is_empty() {
+                if !confirmed_accounts.is_empty() {
+                    let accounts: Vec<Pubkey> =
+                        confirmed_accounts.into_iter().collect();
                     if let Err(err) = Self::schedule_auto_commit(
                         &rpc_client,
                         &authority,
                         &latest_block,
-                        &writable_accounts,
+                        &accounts,
                     )
                     .await
                     {


### PR DESCRIPTION
## Summary
- After Action Callbacks confirm on ER, automatically schedule a `ScheduleCommit` for the writable accounts they modified
- Callback state changes now reach L1 within ~1s instead of waiting for the next application-scheduled `MagicIntentBundle`
- Uses existing `validate_commit_schedule_permissions` validator authority path — no Magic Program changes needed
- Only `actions_callback_service.rs` modified (106 insertions, 8 deletions)


## Compatibility
- [x] No breaking changes
- [ ] Config change (describe):
- [ ] Migration needed (describe):

## Testing
Tested locally with a subscription billing dApp (2-min tick interval):
- Before: `payments_made` update visible via WebSocket ~120s later (next tick commit)
- After: `payments_made` update visible via WebSocket ~1s later (auto-commit)
- Grace period transitions (ACTIVE → PAYMENT_FAILED → CANCELLED) all committed to L1 immediately after callback

## Checklist
- [ ] docs updated (if needed)
- [ ] closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Callback transactions are processed concurrently and awaited together.
  * Automatic commit transaction is submitted after successful callback confirmations when confirmed writable accounts exist.

* **Improvements**
  * Improved logging with both debug and error messages across the callback flow.
  * Expanded error handling that logs failures for the auto-commit operation and ties commit behavior to confirmation results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->