### PR TITLE
feat: allow non-existing accounts in PostDelegationActions

### DIFF
--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashSet,
+    collections::{HashMap as StdHashMap, HashSet},
     sync::{
         atomic::{AtomicU64, Ordering},
         Arc,
@@ -64,6 +64,12 @@ use crate::{
 };
 
 type RemoteAccountRequests = Vec<oneshot::Sender<()>>;
+
+#[derive(Default)]
+struct DelegationActionDependencies {
+    required_existing: Vec<Pubkey>,
+    may_be_created_in_actions: HashSet<Pubkey>,
+}
 
 pub struct FetchCloner<T, U, V, C>
 where
@@ -163,6 +169,50 @@ where
     /// Get the current fetch count
     pub fn fetch_count(&self) -> u64 {
         self.fetch_count.load(Ordering::Relaxed)
+    }
+
+    fn classify_delegation_action_dependencies(
+        &self,
+        root_pubkey: Pubkey,
+        delegation_actions: &DelegationActions,
+    ) -> DelegationActionDependencies {
+        #[derive(Default, Clone, Copy)]
+        struct Usage {
+            writable: bool,
+            signer: bool,
+        }
+
+        let mut required_existing = HashSet::new();
+        let mut account_usage: StdHashMap<Pubkey, Usage> = StdHashMap::new();
+
+        for instruction in delegation_actions.iter() {
+            required_existing.insert(instruction.program_id);
+            for account_meta in &instruction.accounts {
+                if account_meta.pubkey == root_pubkey {
+                    continue;
+                }
+
+                let usage = account_usage.entry(account_meta.pubkey).or_default();
+                usage.writable |= account_meta.is_writable;
+                usage.signer |= account_meta.is_signer;
+            }
+        }
+
+        let mut may_be_created_in_actions = HashSet::new();
+        for (pubkey, usage) in account_usage {
+            if usage.signer {
+                required_existing.insert(pubkey);
+            } else if usage.writable {
+                may_be_created_in_actions.insert(pubkey);
+            } else {
+                required_existing.insert(pubkey);
+            }
+        }
+
+        DelegationActionDependencies {
+            required_existing: required_existing.into_iter().collect(),
+            may_be_created_in_actions,
+        }
     }
 
     /// Check if a program is allowed to be cloned.
@@ -465,24 +515,19 @@ where
             return Ok(());
         }
 
-        let dependencies = delegation_actions
-            .iter()
-            .flat_map(|instruction| {
-                std::iter::once(instruction.program_id)
-                    .chain(instruction.accounts.iter().map(|meta| meta.pubkey))
-            })
-            .filter(|dependency| dependency != &pubkey)
-            .collect::<HashSet<_>>()
-            .into_iter()
-            .collect::<Vec<_>>();
+        let dependencies = self.classify_delegation_action_dependencies(
+            pubkey,
+            delegation_actions,
+        );
+        let required_existing = dependencies.required_existing;
 
-        if dependencies.is_empty() {
+        if required_existing.is_empty() {
             return Ok(());
         }
 
         let result = self
             .fetch_and_clone_accounts_with_dedup(
-                &dependencies,
+                &required_existing,
                 None,
                 Some(remote_slot),
                 AccountFetchOrigin::GetAccount,
@@ -1300,6 +1345,16 @@ where
                         .any(|program| program.program_id.eq(dependency))
             })
             .collect::<Vec<_>>();
+        let mut may_be_created_in_actions = HashSet::new();
+        for request in &accounts_to_clone {
+            may_be_created_in_actions.extend(
+                self.classify_delegation_action_dependencies(
+                    request.pubkey,
+                    &request.delegation_actions,
+                )
+                .may_be_created_in_actions,
+            );
+        }
 
         if !action_dependencies_to_fetch.is_empty() {
             if tracing::enabled!(tracing::Level::TRACE) {
@@ -1343,12 +1398,6 @@ where
                 &action_dependencies_to_fetch,
             );
 
-            if !not_found.is_empty() {
-                return Err(ChainlinkError::MissingDelegationActionAccounts(
-                    not_found.iter().map(|(pubkey, _)| *pubkey).collect(),
-                ));
-            }
-
             let ResolvedDelegatedAccounts {
                 accounts_to_clone: action_dep_accounts_to_clone,
                 record_subs: action_dep_record_subs,
@@ -1363,6 +1412,23 @@ where
                 existing_subs.clone(),
             )
             .await?;
+
+            let unexpected_missing_accounts = not_found
+                .into_iter()
+                .filter_map(|(pubkey, _)| {
+                    (!may_be_created_in_actions.contains(&pubkey))
+                        .then_some(pubkey)
+                })
+                .collect::<Vec<_>>();
+            let mut unexpected_missing_accounts =
+                unexpected_missing_accounts;
+            unexpected_missing_accounts.sort_unstable();
+
+            if !unexpected_missing_accounts.is_empty() {
+                return Err(ChainlinkError::MissingDelegationActionAccounts(
+                    unexpected_missing_accounts,
+                ));
+            }
 
             if !action_dep_missing_delegation_record.is_empty() {
                 return Err(ChainlinkError::MissingDelegationActionAccounts(

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashMap as StdHashMap, HashSet},
+    collections::HashSet,
     sync::{
         atomic::{AtomicU64, Ordering},
         Arc,
@@ -64,12 +64,6 @@ use crate::{
 };
 
 type RemoteAccountRequests = Vec<oneshot::Sender<()>>;
-
-#[derive(Default)]
-struct DelegationActionDependencies {
-    required_existing: Vec<Pubkey>,
-    may_be_created_in_actions: HashSet<Pubkey>,
-}
 
 pub struct FetchCloner<T, U, V, C>
 where
@@ -169,50 +163,6 @@ where
     /// Get the current fetch count
     pub fn fetch_count(&self) -> u64 {
         self.fetch_count.load(Ordering::Relaxed)
-    }
-
-    fn classify_delegation_action_dependencies(
-        &self,
-        root_pubkey: Pubkey,
-        delegation_actions: &DelegationActions,
-    ) -> DelegationActionDependencies {
-        #[derive(Default, Clone, Copy)]
-        struct Usage {
-            writable: bool,
-            signer: bool,
-        }
-
-        let mut required_existing = HashSet::new();
-        let mut account_usage: StdHashMap<Pubkey, Usage> = StdHashMap::new();
-
-        for instruction in delegation_actions.iter() {
-            required_existing.insert(instruction.program_id);
-            for account_meta in &instruction.accounts {
-                if account_meta.pubkey == root_pubkey {
-                    continue;
-                }
-
-                let usage = account_usage.entry(account_meta.pubkey).or_default();
-                usage.writable |= account_meta.is_writable;
-                usage.signer |= account_meta.is_signer;
-            }
-        }
-
-        let mut may_be_created_in_actions = HashSet::new();
-        for (pubkey, usage) in account_usage {
-            if usage.signer {
-                required_existing.insert(pubkey);
-            } else if usage.writable {
-                may_be_created_in_actions.insert(pubkey);
-            } else {
-                required_existing.insert(pubkey);
-            }
-        }
-
-        DelegationActionDependencies {
-            required_existing: required_existing.into_iter().collect(),
-            may_be_created_in_actions,
-        }
     }
 
     /// Check if a program is allowed to be cloned.
@@ -515,41 +465,31 @@ where
             return Ok(());
         }
 
-        let dependencies = self.classify_delegation_action_dependencies(
-            pubkey,
-            delegation_actions,
-        );
-        let required_existing = dependencies.required_existing;
+        let dependencies = delegation_actions
+            .iter()
+            .flat_map(|instruction| {
+                std::iter::once(instruction.program_id)
+                    .chain(instruction.accounts.iter().map(|meta| meta.pubkey))
+            })
+            .filter(|dependency| dependency != &pubkey)
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
 
-        if required_existing.is_empty() {
+        if dependencies.is_empty() {
             return Ok(());
         }
 
-        let result = self
+        self
             .fetch_and_clone_accounts_with_dedup(
-                &required_existing,
+                &dependencies,
                 None,
                 Some(remote_slot),
                 AccountFetchOrigin::GetAccount,
                 None,
             )
             .await?;
-        if result.is_ok() {
-            return Ok(());
-        }
-
-        let missing_accounts = result
-            .pubkeys_not_found_on_chain()
-            .into_iter()
-            .chain(result.pubkeys_missing_delegation_record())
-            .collect::<HashSet<_>>()
-            .into_iter()
-            .collect::<Vec<_>>();
-        let mut missing_accounts = missing_accounts;
-        missing_accounts.sort_unstable();
-        Err(ChainlinkError::MissingDelegationActionAccounts(
-            missing_accounts,
-        ))
+        Ok(())
     }
 
     async fn clone_projected_ata_request(
@@ -1345,16 +1285,6 @@ where
                         .any(|program| program.program_id.eq(dependency))
             })
             .collect::<Vec<_>>();
-        let mut may_be_created_in_actions = HashSet::new();
-        for request in &accounts_to_clone {
-            may_be_created_in_actions.extend(
-                self.classify_delegation_action_dependencies(
-                    request.pubkey,
-                    &request.delegation_actions,
-                )
-                .may_be_created_in_actions,
-            );
-        }
 
         if !action_dependencies_to_fetch.is_empty() {
             if tracing::enabled!(tracing::Level::TRACE) {
@@ -1412,32 +1342,6 @@ where
                 existing_subs.clone(),
             )
             .await?;
-
-            let unexpected_missing_accounts = not_found
-                .into_iter()
-                .filter_map(|(pubkey, _)| {
-                    (!may_be_created_in_actions.contains(&pubkey))
-                        .then_some(pubkey)
-                })
-                .collect::<Vec<_>>();
-            let mut unexpected_missing_accounts =
-                unexpected_missing_accounts;
-            unexpected_missing_accounts.sort_unstable();
-
-            if !unexpected_missing_accounts.is_empty() {
-                return Err(ChainlinkError::MissingDelegationActionAccounts(
-                    unexpected_missing_accounts,
-                ));
-            }
-
-            if !action_dep_missing_delegation_record.is_empty() {
-                return Err(ChainlinkError::MissingDelegationActionAccounts(
-                    action_dep_missing_delegation_record
-                        .iter()
-                        .map(|(pubkey, _)| *pubkey)
-                        .collect(),
-                ));
-            }
 
             new_subs.extend(action_dep_record_subs.iter().copied());
             record_subs.extend(action_dep_record_subs);

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use dlp_api::state::DelegationRecord;
 use solana_account::{Account, AccountSharedData, WritableAccount};
+use solana_instruction::{AccountMeta, Instruction};
 use solana_keypair::Keypair;
 use solana_sdk_ids::system_program;
 use solana_signer::Signer;
@@ -253,6 +254,114 @@ fn init_fetch_cloner(
         None,
     );
     (fetch_cloner, subscription_tx)
+}
+
+#[tokio::test]
+async fn test_classify_delegation_action_dependencies_allows_missing_writable_nonsigner(
+) {
+    let validator_keypair = Keypair::new();
+    let FetcherTestCtx {
+        fetch_cloner,
+        ..
+    } = setup(
+        std::iter::empty::<(Pubkey, Account)>(),
+        100,
+        validator_keypair.insecure_clone(),
+    )
+    .await;
+
+    let root_pubkey = random_pubkey();
+    let action_program = random_pubkey();
+    let creatable_account = random_pubkey();
+    let readonly_dependency = random_pubkey();
+    let signer_dependency = random_pubkey();
+
+    let actions = DelegationActions::from(vec![Instruction {
+        program_id: action_program,
+        accounts: vec![
+            AccountMeta::new(creatable_account, false),
+            AccountMeta::new_readonly(readonly_dependency, false),
+            AccountMeta::new_readonly(signer_dependency, true),
+            AccountMeta::new(root_pubkey, false),
+        ],
+        data: vec![],
+    }]);
+
+    let deps = fetch_cloner
+        .classify_delegation_action_dependencies(root_pubkey, &actions);
+
+    assert!(
+        deps.required_existing.contains(&action_program),
+        "program ids must already exist",
+    );
+    assert!(
+        deps.required_existing.contains(&readonly_dependency),
+        "readonly accounts must already exist",
+    );
+    assert!(
+        deps.required_existing.contains(&signer_dependency),
+        "signer accounts must already exist",
+    );
+    assert!(
+        deps.may_be_created_in_actions.contains(&creatable_account),
+        "writable non-signer accounts may be created by earlier action instructions",
+    );
+    assert!(
+        !deps.required_existing.contains(&creatable_account),
+        "creatable writable non-signer accounts should not be required to pre-exist",
+    );
+    assert!(
+        !deps.required_existing.contains(&root_pubkey),
+        "root cloned account should be excluded from dependency classification",
+    );
+}
+
+#[tokio::test]
+async fn test_classify_delegation_action_dependencies_writable_readonly_mix_allows_creation(
+) {
+    let validator_keypair = Keypair::new();
+    let FetcherTestCtx {
+        fetch_cloner,
+        ..
+    } = setup(
+        std::iter::empty::<(Pubkey, Account)>(),
+        100,
+        validator_keypair.insecure_clone(),
+    )
+    .await;
+
+    let root_pubkey = random_pubkey();
+    let action_program = random_pubkey();
+    let account_created_then_read = random_pubkey();
+
+    let actions = DelegationActions::from(vec![
+        Instruction {
+            program_id: action_program,
+            accounts: vec![AccountMeta::new(account_created_then_read, false)],
+            data: vec![1],
+        },
+        Instruction {
+            program_id: action_program,
+            accounts: vec![AccountMeta::new_readonly(
+                account_created_then_read,
+                false,
+            )],
+            data: vec![2],
+        },
+    ]);
+
+    let deps = fetch_cloner
+        .classify_delegation_action_dependencies(root_pubkey, &actions);
+
+    assert!(
+        deps.may_be_created_in_actions
+            .contains(&account_created_then_read),
+        "an account that is writable in one instruction and readonly in a later one should still be treated as creatable in-actions",
+    );
+    assert!(
+        !deps.required_existing.contains(&account_created_then_read),
+        "later readonly usage should not force pre-existence when an earlier action can create it",
+    );
 }
 
 // -----------------

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -2,7 +2,6 @@ use std::{collections::HashMap, sync::Arc};
 
 use dlp_api::state::DelegationRecord;
 use solana_account::{Account, AccountSharedData, WritableAccount};
-use solana_instruction::{AccountMeta, Instruction};
 use solana_keypair::Keypair;
 use solana_sdk_ids::system_program;
 use solana_signer::Signer;
@@ -254,114 +253,6 @@ fn init_fetch_cloner(
         None,
     );
     (fetch_cloner, subscription_tx)
-}
-
-#[tokio::test]
-async fn test_classify_delegation_action_dependencies_allows_missing_writable_nonsigner(
-) {
-    let validator_keypair = Keypair::new();
-    let FetcherTestCtx {
-        fetch_cloner,
-        ..
-    } = setup(
-        std::iter::empty::<(Pubkey, Account)>(),
-        100,
-        validator_keypair.insecure_clone(),
-    )
-    .await;
-
-    let root_pubkey = random_pubkey();
-    let action_program = random_pubkey();
-    let creatable_account = random_pubkey();
-    let readonly_dependency = random_pubkey();
-    let signer_dependency = random_pubkey();
-
-    let actions = DelegationActions::from(vec![Instruction {
-        program_id: action_program,
-        accounts: vec![
-            AccountMeta::new(creatable_account, false),
-            AccountMeta::new_readonly(readonly_dependency, false),
-            AccountMeta::new_readonly(signer_dependency, true),
-            AccountMeta::new(root_pubkey, false),
-        ],
-        data: vec![],
-    }]);
-
-    let deps = fetch_cloner
-        .classify_delegation_action_dependencies(root_pubkey, &actions);
-
-    assert!(
-        deps.required_existing.contains(&action_program),
-        "program ids must already exist",
-    );
-    assert!(
-        deps.required_existing.contains(&readonly_dependency),
-        "readonly accounts must already exist",
-    );
-    assert!(
-        deps.required_existing.contains(&signer_dependency),
-        "signer accounts must already exist",
-    );
-    assert!(
-        deps.may_be_created_in_actions.contains(&creatable_account),
-        "writable non-signer accounts may be created by earlier action instructions",
-    );
-    assert!(
-        !deps.required_existing.contains(&creatable_account),
-        "creatable writable non-signer accounts should not be required to pre-exist",
-    );
-    assert!(
-        !deps.required_existing.contains(&root_pubkey),
-        "root cloned account should be excluded from dependency classification",
-    );
-}
-
-#[tokio::test]
-async fn test_classify_delegation_action_dependencies_writable_readonly_mix_allows_creation(
-) {
-    let validator_keypair = Keypair::new();
-    let FetcherTestCtx {
-        fetch_cloner,
-        ..
-    } = setup(
-        std::iter::empty::<(Pubkey, Account)>(),
-        100,
-        validator_keypair.insecure_clone(),
-    )
-    .await;
-
-    let root_pubkey = random_pubkey();
-    let action_program = random_pubkey();
-    let account_created_then_read = random_pubkey();
-
-    let actions = DelegationActions::from(vec![
-        Instruction {
-            program_id: action_program,
-            accounts: vec![AccountMeta::new(account_created_then_read, false)],
-            data: vec![1],
-        },
-        Instruction {
-            program_id: action_program,
-            accounts: vec![AccountMeta::new_readonly(
-                account_created_then_read,
-                false,
-            )],
-            data: vec![2],
-        },
-    ]);
-
-    let deps = fetch_cloner
-        .classify_delegation_action_dependencies(root_pubkey, &actions);
-
-    assert!(
-        deps.may_be_created_in_actions
-            .contains(&account_created_then_read),
-        "an account that is writable in one instruction and readonly in a later one should still be treated as creatable in-actions",
-    );
-    assert!(
-        !deps.required_existing.contains(&account_created_then_read),
-        "later readonly usage should not force pre-existence when an earlier action can create it",
-    );
 }
 
 // -----------------


### PR DESCRIPTION
<!--
PR title must match:
  type(scope): summary
Types: feat|fix|docs|chore|refactor|test|perf|ci|build
Examples:
  fix: avoid panic on empty slot
  feat(rpc): add getFoo endpoint
-->

## Summary
-

## Compatibility
- [ ] No breaking changes
- [ ] Config change (describe):
- [ ] Migration needed (describe):

## Testing
- [ ] tests (or explain)

## Checklist
- [ ] docs updated (if needed)
- [ ] closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved account dependency resolution handling to allow continued processing when certain accounts cannot be retrieved, enabling more flexible downstream processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->