### PR TITLE
chore: upgrade magicblock-delegation-program-api to v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3438,9 +3438,9 @@ dependencies = [
 
 [[package]]
 name = "magicblock-delegation-program-api"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5611f6531116831ac425882640ec21848c67446c2cab58364cab1e82a7ccdee"
+checksum = "b8447309107c033ed0b5416c485b64f281a2e49c28adee03d14899fe58301187"
 dependencies = [
  "bincode",
  "borsh 1.6.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,7 @@ magicblock-committor-program = { path = "./magicblock-committor-program", featur
 magicblock-committor-service = { path = "./magicblock-committor-service" }
 magicblock-config = { path = "./magicblock-config" }
 magicblock-core = { path = "./magicblock-core" }
-magicblock-delegation-program-api = { version = "0.2.0" }
+magicblock-delegation-program-api = { version = "0.3.0" }
 magicblock-ledger = { path = "./magicblock-ledger" }
 magicblock-magic-program-api = { path = "./magicblock-magic-program-api" }
 magicblock-metrics = { path = "./magicblock-metrics" }

--- a/test-integration/Cargo.lock
+++ b/test-integration/Cargo.lock
@@ -2983,7 +2983,7 @@ dependencies = [
  "color-backtrace",
  "magicblock-config",
  "magicblock-core",
- "magicblock-delegation-program-api 0.2.0",
+ "magicblock-delegation-program-api 0.3.0",
  "rand 0.8.5",
  "rayon",
  "serde",
@@ -3560,7 +3560,7 @@ dependencies = [
  "magicblock-committor-service",
  "magicblock-config",
  "magicblock-core",
- "magicblock-delegation-program-api 0.2.0",
+ "magicblock-delegation-program-api 0.3.0",
  "magicblock-ledger",
  "magicblock-magic-program-api 0.8.5",
  "magicblock-metrics",
@@ -3615,7 +3615,7 @@ dependencies = [
  "magicblock-accounts-db",
  "magicblock-config",
  "magicblock-core",
- "magicblock-delegation-program-api 0.2.0",
+ "magicblock-delegation-program-api 0.3.0",
  "magicblock-magic-program-api 0.8.5",
  "magicblock-metrics",
  "parking_lot",
@@ -3681,7 +3681,7 @@ dependencies = [
  "lru",
  "magicblock-committor-program",
  "magicblock-core",
- "magicblock-delegation-program-api 0.2.0",
+ "magicblock-delegation-program-api 0.3.0",
  "magicblock-metrics",
  "magicblock-program",
  "magicblock-rpc-client",
@@ -3799,9 +3799,9 @@ dependencies = [
 
 [[package]]
 name = "magicblock-delegation-program-api"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5611f6531116831ac425882640ec21848c67446c2cab58364cab1e82a7ccdee"
+checksum = "b8447309107c033ed0b5416c485b64f281a2e49c28adee03d14899fe58301187"
 dependencies = [
  "bincode",
  "borsh 1.6.0",
@@ -4069,7 +4069,7 @@ dependencies = [
 name = "magicblock-validator-admin"
 version = "0.8.5"
 dependencies = [
- "magicblock-delegation-program-api 0.2.0",
+ "magicblock-delegation-program-api 0.3.0",
  "magicblock-program",
  "magicblock-rpc-client",
  "solana-commitment-config",
@@ -5020,7 +5020,7 @@ version = "0.0.0"
 dependencies = [
  "borsh 1.6.0",
  "ephemeral-rollups-sdk",
- "magicblock-delegation-program-api 0.2.0",
+ "magicblock-delegation-program-api 0.3.0",
  "magicblock-magic-program-api 0.8.5",
  "rkyv 0.7.45",
  "solana-program",
@@ -6007,7 +6007,7 @@ dependencies = [
  "borsh 1.6.0",
  "integration-test-tools",
  "magicblock-core",
- "magicblock-delegation-program-api 0.2.0",
+ "magicblock-delegation-program-api 0.3.0",
  "program-schedulecommit",
  "solana-program",
  "solana-rpc-client",
@@ -6026,7 +6026,7 @@ dependencies = [
  "magicblock-committor-program",
  "magicblock-committor-service",
  "magicblock-core",
- "magicblock-delegation-program-api 0.2.0",
+ "magicblock-delegation-program-api 0.3.0",
  "magicblock-program",
  "magicblock-rpc-client",
  "magicblock-table-mania",
@@ -6051,7 +6051,7 @@ dependencies = [
  "ephemeral-rollups-sdk",
  "integration-test-tools",
  "magicblock-core",
- "magicblock-delegation-program-api 0.2.0",
+ "magicblock-delegation-program-api 0.3.0",
  "magicblock-magic-program-api 0.8.5",
  "magicblock-program",
  "program-schedulecommit",
@@ -6072,7 +6072,7 @@ version = "0.0.0"
 dependencies = [
  "integration-test-tools",
  "magicblock-core",
- "magicblock-delegation-program-api 0.2.0",
+ "magicblock-delegation-program-api 0.3.0",
  "magicblock-magic-program-api 0.8.5",
  "program-schedulecommit",
  "program-schedulecommit-security",
@@ -10356,7 +10356,7 @@ dependencies = [
  "integration-test-tools",
  "magicblock-chainlink",
  "magicblock-config",
- "magicblock-delegation-program-api 0.2.0",
+ "magicblock-delegation-program-api 0.3.0",
  "program-flexi-counter",
  "program-mini",
  "solana-account",
@@ -10379,7 +10379,7 @@ name = "test-cloning"
 version = "0.0.0"
 dependencies = [
  "integration-test-tools",
- "magicblock-delegation-program-api 0.2.0",
+ "magicblock-delegation-program-api 0.3.0",
  "program-flexi-counter",
  "program-mini",
  "solana-loader-v4-interface",
@@ -10443,7 +10443,7 @@ dependencies = [
  "integration-test-tools",
  "magicblock-accounts-db",
  "magicblock-config",
- "magicblock-delegation-program-api 0.2.0",
+ "magicblock-delegation-program-api 0.3.0",
  "program-flexi-counter",
  "solana-rpc-client",
  "solana-sdk",
@@ -10464,7 +10464,7 @@ dependencies = [
  "magic-domain-program",
  "magicblock-api",
  "magicblock-config",
- "magicblock-delegation-program-api 0.2.0",
+ "magicblock-delegation-program-api 0.3.0",
  "magicblock-program",
  "magicblock-validator-admin",
  "solana-rpc-client",
@@ -10506,7 +10506,7 @@ dependencies = [
  "ephemeral-rollups-sdk",
  "integration-test-tools",
  "log",
- "magicblock-delegation-program-api 0.2.0",
+ "magicblock-delegation-program-api 0.3.0",
  "magicblock-magic-program-api 0.8.5",
  "program-flexi-counter",
  "solana-rpc-client-api",

--- a/test-integration/Cargo.toml
+++ b/test-integration/Cargo.toml
@@ -60,7 +60,7 @@ magic-domain-program = { git = "https://github.com/magicblock-labs/magic-domain-
   "modular-sdk",
 ] }
 magicblock_magic_program_api = { package = "magicblock-magic-program-api", path = "../magicblock-magic-program-api" }
-magicblock-delegation-program-api = { version = "0.2.0", default-features = false }
+magicblock-delegation-program-api = { version = "0.3.0", default-features = false }
 magicblock-program = { path = "../programs/magicblock" }
 magicblock-rpc-client = { path = "../magicblock-rpc-client" }
 magicblock-table-mania = { path = "../magicblock-table-mania" }


### PR DESCRIPTION
This upgrade uses the fix: 

- https://github.com/magicblock-labs/delegation-program/pull/166

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `magicblock-delegation-program-api` dependency to version 0.3.0 across the workspace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->