### PR TITLE
feat: added a way to verify validator identity within ER

### DIFF
--- a/magicblock-magic-program-api/src/instruction.rs
+++ b/magicblock-magic-program-api/src/instruction.rs
@@ -303,6 +303,11 @@ pub enum MagicBlockInstruction {
     /// - **0.** `[SIGNER]`  Validator Authority
     /// - **1.** `[WRITE]`   Account to evict
     EvictAccount { pubkey: Pubkey },
+
+    /// Verifies if account's pubkey corresponds to current validator identity
+    /// # Account references
+    /// - **0.** `[]`  Validator Authority
+    VerifyValidatorIdentity,
 }
 
 impl MagicBlockInstruction {

--- a/programs/magicblock/src/lib.rs
+++ b/programs/magicblock/src/lib.rs
@@ -13,6 +13,7 @@ pub mod magicblock_processor;
 pub mod test_utils;
 mod utils;
 pub mod validator;
+pub mod verify_validator_identity;
 
 pub use magic_sys::init_magic_sys;
 pub use magicblock_magic_program_api::*;

--- a/programs/magicblock/src/magicblock_processor.rs
+++ b/programs/magicblock/src/magicblock_processor.rs
@@ -21,6 +21,7 @@ use crate::{
         process_schedule_intent_bundle, ProcessScheduleCommitOptions,
     },
     toggle_executable_check::process_toggle_executable_check,
+    verify_validator_identity::process_verify_validator_identity,
 };
 
 pub const DEFAULT_COMPUTE_UNITS: u64 = 150;
@@ -214,6 +215,9 @@ declare_process_instruction!(
                 remote_slot,
                 authority,
             ),
+            VerifyValidatorIdentity => {
+                process_verify_validator_identity(signers, invoke_context)
+            }
         }
     }
 );

--- a/programs/magicblock/src/verify_validator_identity.rs
+++ b/programs/magicblock/src/verify_validator_identity.rs
@@ -1,0 +1,187 @@
+use std::collections::HashSet;
+
+use solana_instruction::error::InstructionError;
+use solana_log_collector::ic_msg;
+use solana_program_runtime::invoke_context::InvokeContext;
+use solana_pubkey::Pubkey;
+
+use crate::{
+    schedule_transactions, utils::accounts::get_instruction_pubkey_with_idx,
+    validator::validator_authority_id,
+};
+
+pub(crate) fn process_verify_validator_identity(
+    _signers: HashSet<Pubkey>,
+    invoke_context: &mut InvokeContext,
+) -> Result<(), InstructionError> {
+    const MAGIC_CONTEXT_IDX: u16 = 0;
+    const VALIDATOR_ACCOUNT_IDX: u16 = MAGIC_CONTEXT_IDX + 1;
+
+    schedule_transactions::check_magic_context_id(
+        invoke_context,
+        MAGIC_CONTEXT_IDX,
+    )?;
+
+    let transaction_context = &invoke_context.transaction_context;
+    let ix_ctx = transaction_context.get_current_instruction_context()?;
+
+    // Assert MagicBlock program
+    ix_ctx
+        .find_index_of_program_account(transaction_context, &crate::id())
+        .ok_or_else(|| {
+            ic_msg!(
+                invoke_context,
+                "ScheduleCommit ERR: Magic program account not found"
+            );
+            InstructionError::UnsupportedProgramId
+        })?;
+
+    let validator_identity = get_instruction_pubkey_with_idx(
+        transaction_context,
+        VALIDATOR_ACCOUNT_IDX,
+    )?;
+    let expected_validator_identity = validator_authority_id();
+    if validator_identity == &expected_validator_identity {
+        Ok(())
+    } else {
+        Err(InstructionError::IncorrectAuthority)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use magicblock_magic_program_api::{
+        instruction::MagicBlockInstruction, MAGIC_CONTEXT_PUBKEY,
+    };
+    use serial_test::serial;
+    use solana_account::AccountSharedData;
+    use solana_instruction::{
+        error::InstructionError, AccountMeta, Instruction,
+    };
+    use solana_pubkey::Pubkey;
+    use solana_sdk_ids::system_program;
+
+    use crate::{
+        magic_context::MagicContext,
+        test_utils::{
+            ensure_started_validator, process_instruction, AUTHORITY_BALANCE,
+        },
+        validator::validator_authority_id,
+    };
+
+    fn verify_validator_identity_instruction(validator: Pubkey) -> Instruction {
+        let account_metas = vec![
+            AccountMeta::new_readonly(MAGIC_CONTEXT_PUBKEY, false),
+            AccountMeta::new_readonly(validator, false),
+        ];
+        Instruction::new_with_bincode(
+            crate::id(),
+            &MagicBlockInstruction::VerifyValidatorIdentity,
+            account_metas,
+        )
+    }
+
+    fn setup_transaction_accounts() -> Vec<(Pubkey, AccountSharedData)> {
+        let mut account_data = HashMap::new();
+        account_data.insert(
+            MAGIC_CONTEXT_PUBKEY,
+            AccountSharedData::new(u64::MAX, MagicContext::SIZE, &crate::id()),
+        );
+        ensure_started_validator(&mut account_data, None);
+        let validator = validator_authority_id();
+        vec![
+            (
+                MAGIC_CONTEXT_PUBKEY,
+                account_data.remove(&MAGIC_CONTEXT_PUBKEY).unwrap(),
+            ),
+            (validator, account_data.remove(&validator).unwrap()),
+        ]
+    }
+
+    #[test]
+    #[serial]
+    fn test_verify_validator_identity_success() {
+        let validator = validator_authority_id();
+        let ix = verify_validator_identity_instruction(validator);
+        let transaction_accounts = setup_transaction_accounts();
+        process_instruction(
+            &ix.data,
+            transaction_accounts,
+            ix.accounts,
+            Ok(()),
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_verify_validator_identity_wrong_validator() {
+        let wrong_validator = Pubkey::new_unique();
+        let ix = verify_validator_identity_instruction(wrong_validator);
+
+        let mut account_data = HashMap::new();
+        account_data.insert(
+            MAGIC_CONTEXT_PUBKEY,
+            AccountSharedData::new(u64::MAX, MagicContext::SIZE, &crate::id()),
+        );
+        ensure_started_validator(&mut account_data, None);
+
+        let transaction_accounts = vec![
+            (
+                MAGIC_CONTEXT_PUBKEY,
+                account_data.remove(&MAGIC_CONTEXT_PUBKEY).unwrap(),
+            ),
+            (
+                wrong_validator,
+                AccountSharedData::new(
+                    AUTHORITY_BALANCE,
+                    0,
+                    &system_program::id(),
+                ),
+            ),
+        ];
+
+        process_instruction(
+            &ix.data,
+            transaction_accounts,
+            ix.accounts,
+            Err(InstructionError::IncorrectAuthority),
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_verify_validator_identity_wrong_magic_context() {
+        let validator = validator_authority_id();
+        let wrong_context = Pubkey::new_unique();
+
+        let account_metas = vec![
+            AccountMeta::new_readonly(wrong_context, false),
+            AccountMeta::new_readonly(validator, false),
+        ];
+        let ix = Instruction::new_with_bincode(
+            crate::id(),
+            &MagicBlockInstruction::VerifyValidatorIdentity,
+            account_metas,
+        );
+
+        let mut account_data = HashMap::new();
+        ensure_started_validator(&mut account_data, None);
+
+        let transaction_accounts = vec![
+            (
+                wrong_context,
+                AccountSharedData::new(0, 0, &system_program::id()),
+            ),
+            (validator, account_data.remove(&validator).unwrap()),
+        ];
+
+        process_instruction(
+            &ix.data,
+            transaction_accounts,
+            ix.accounts,
+            Err(InstructionError::MissingAccount),
+        );
+    }
+}

--- a/test-integration/Cargo.lock
+++ b/test-integration/Cargo.lock
@@ -2340,10 +2340,10 @@ dependencies = [
 
 [[package]]
 name = "guinea"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "bincode",
- "magicblock-magic-program-api 0.8.5",
+ "magicblock-magic-program-api 0.8.6",
  "serde",
  "solana-program",
 ]
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-account-cloner"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "async-trait",
  "bincode",
@@ -3437,7 +3437,7 @@ dependencies = [
  "magicblock-config",
  "magicblock-core",
  "magicblock-ledger",
- "magicblock-magic-program-api 0.8.5",
+ "magicblock-magic-program-api 0.8.6",
  "magicblock-program",
  "magicblock-rpc-client",
  "rand 0.9.2",
@@ -3459,7 +3459,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-accounts"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "async-trait",
  "magicblock-account-cloner",
@@ -3482,7 +3482,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-accounts-db"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "lmdb-rkv",
  "magicblock-config",
@@ -3498,7 +3498,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-aperture"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "agave-geyser-plugin-interface",
  "arc-swap",
@@ -3546,7 +3546,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-api"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "anyhow",
  "borsh 1.6.0",
@@ -3562,7 +3562,7 @@ dependencies = [
  "magicblock-core",
  "magicblock-delegation-program-api 0.3.0",
  "magicblock-ledger",
- "magicblock-magic-program-api 0.8.5",
+ "magicblock-magic-program-api 0.8.6",
  "magicblock-metrics",
  "magicblock-processor",
  "magicblock-program",
@@ -3603,7 +3603,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-chainlink"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -3616,7 +3616,7 @@ dependencies = [
  "magicblock-config",
  "magicblock-core",
  "magicblock-delegation-program-api 0.3.0",
- "magicblock-magic-program-api 0.8.5",
+ "magicblock-magic-program-api 0.8.6",
  "magicblock-metrics",
  "parking_lot",
  "scc",
@@ -3658,7 +3658,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-committor-program"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "borsh 1.6.0",
  "paste",
@@ -3670,7 +3670,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-committor-service"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -3715,7 +3715,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-config"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "clap",
  "derive_more",
@@ -3733,11 +3733,11 @@ dependencies = [
 
 [[package]]
 name = "magicblock-core"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "bincode",
  "flume",
- "magicblock-magic-program-api 0.8.5",
+ "magicblock-magic-program-api 0.8.6",
  "serde",
  "solana-account",
  "solana-account-decoder",
@@ -3827,7 +3827,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-ledger"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -3877,7 +3877,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-magic-program-api"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "bincode",
  "serde",
@@ -3887,7 +3887,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-metrics"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "http-body-util",
  "hyper 1.8.1",
@@ -3902,7 +3902,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-processor"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "bincode",
  "magicblock-accounts-db",
@@ -3938,12 +3938,12 @@ dependencies = [
 
 [[package]]
 name = "magicblock-program"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "bincode",
  "lazy_static",
  "magicblock-core",
- "magicblock-magic-program-api 0.8.5",
+ "magicblock-magic-program-api 0.8.6",
  "num-derive",
  "num-traits",
  "parking_lot",
@@ -3972,7 +3972,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-rpc-client"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "solana-account",
  "solana-account-decoder-client-types",
@@ -3994,12 +3994,12 @@ dependencies = [
 
 [[package]]
 name = "magicblock-services"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "bincode",
  "futures-util",
  "magicblock-core",
- "magicblock-magic-program-api 0.8.5",
+ "magicblock-magic-program-api 0.8.6",
  "solana-instruction 2.2.1",
  "solana-keypair",
  "solana-message",
@@ -4015,7 +4015,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-table-mania"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "ed25519-dalek",
  "magicblock-metrics",
@@ -4041,7 +4041,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-task-scheduler"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "bincode",
  "chrono",
@@ -4067,7 +4067,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-validator-admin"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "magicblock-delegation-program-api 0.3.0",
  "magicblock-program",
@@ -4084,7 +4084,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-version"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "git-version",
  "rustc_version",
@@ -4997,7 +4997,7 @@ dependencies = [
  "bincode",
  "borsh 1.6.0",
  "ephemeral-rollups-sdk",
- "magicblock-magic-program-api 0.8.5",
+ "magicblock-magic-program-api 0.8.6",
  "serde",
  "solana-program",
 ]
@@ -5021,7 +5021,7 @@ dependencies = [
  "borsh 1.6.0",
  "ephemeral-rollups-sdk",
  "magicblock-delegation-program-api 0.3.0",
- "magicblock-magic-program-api 0.8.5",
+ "magicblock-magic-program-api 0.8.6",
  "rkyv 0.7.45",
  "solana-program",
  "static_assertions",
@@ -6052,7 +6052,7 @@ dependencies = [
  "integration-test-tools",
  "magicblock-core",
  "magicblock-delegation-program-api 0.3.0",
- "magicblock-magic-program-api 0.8.5",
+ "magicblock-magic-program-api 0.8.6",
  "magicblock-program",
  "program-schedulecommit",
  "rand 0.8.5",
@@ -6073,7 +6073,7 @@ dependencies = [
  "integration-test-tools",
  "magicblock-core",
  "magicblock-delegation-program-api 0.3.0",
- "magicblock-magic-program-api 0.8.5",
+ "magicblock-magic-program-api 0.8.6",
  "program-schedulecommit",
  "program-schedulecommit-security",
  "schedulecommit-client",
@@ -8908,7 +8908,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-proto"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "bincode",
  "bs58",
@@ -10411,7 +10411,7 @@ dependencies = [
 
 [[package]]
 name = "test-kit"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "guinea",
  "magicblock-accounts-db",
@@ -10507,7 +10507,7 @@ dependencies = [
  "integration-test-tools",
  "log",
  "magicblock-delegation-program-api 0.3.0",
- "magicblock-magic-program-api 0.8.5",
+ "magicblock-magic-program-api 0.8.6",
  "program-flexi-counter",
  "solana-rpc-client-api",
  "solana-sdk",


### PR DESCRIPTION
<!--
PR title must match:
  type(scope): summary
Types: feat|fix|docs|chore|refactor|test|perf|ci|build
Examples:
  fix: avoid panic on empty slot
  feat(rpc): add getFoo endpoint
-->

## Summary
With callbacks it is importmant for developers to verify if callback was triggered by validator and not someone else. For that purpose they can now call VerifyValidatorIdentity in magicblock-program with "validator" account, magic-program will compare pubkeys and error if they do not match.

## Compatibility
- [x] No breaking changes
- [ ] Config change (describe):
- [ ] Migration needed (describe):

## Testing
- [x] tests (or explain)

## Checklist
- [ ] docs updated (if needed)
- [ ] closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new validator identity verification instruction to the MagicBlock program, enabling validation of validator authority accounts against expected identities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->