### PR TITLE
ci: scope integration tests and block third-party deploys

### DIFF
--- a/.github/workflows/ci-test-integration.yml
+++ b/.github/workflows/ci-test-integration.yml
@@ -11,7 +11,181 @@ on:
     types: [opened, reopened, synchronize, ready_for_review]
 
 jobs:
+  determine_scope:
+    runs-on: ubuntu-latest
+    outputs:
+      run_all: ${{ steps.scope.outputs.run_all }}
+      run_any: ${{ steps.scope.outputs.run_any }}
+      selected_batches_csv: ${{ steps.scope.outputs.selected_batches_csv }}
+      reason: ${{ steps.scope.outputs.reason }}
+    steps:
+      - name: Determine integration test scope
+        id: scope
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const allBatches = [
+              'schedulecommit',
+              'chainlink',
+              'cloning',
+              'restore_ledger',
+              'magicblock_api',
+              'config',
+              'table_mania',
+              'committor',
+              'pubsub',
+              'schedule_intents',
+              'task-scheduler',
+            ];
+
+            if (context.eventName !== 'pull_request') {
+              core.setOutput('run_all', 'true');
+              core.setOutput('run_any', 'true');
+              core.setOutput(
+                'selected_batches_csv',
+                `,${allBatches.join(',')},`
+              );
+              core.setOutput('reason', 'push to protected branch');
+              return;
+            }
+
+            const batchPrefixes = {
+              schedulecommit: [
+                'test-integration/schedulecommit/',
+                'test-integration/programs/schedulecommit/',
+                'test-integration/programs/schedulecommit-security/',
+              ],
+              chainlink: ['test-integration/test-chainlink/'],
+              cloning: ['test-integration/test-cloning/'],
+              restore_ledger: ['test-integration/test-ledger-restore/'],
+              magicblock_api: ['test-integration/test-magicblock-api/'],
+              config: ['test-integration/test-config/'],
+              table_mania: ['test-integration/test-table-mania/'],
+              committor: ['test-integration/test-committor-service/'],
+              pubsub: ['test-integration/test-pubsub/'],
+              schedule_intents: ['test-integration/test-schedule-intent/'],
+              'task-scheduler': ['test-integration/test-task-scheduler/'],
+            };
+
+            const runAllPrefixes = [
+              '.github/actions/',
+              '.github/workflows/ci-test-integration.yml',
+              'Cargo.toml',
+              'Cargo.lock',
+              'Makefile',
+              'magicblock-',
+              'programs/',
+              'storage-proto/',
+              'test-integration/Makefile',
+              'test-integration/configs/',
+              'test-integration/test-runner/',
+              'test-integration/test-tools/',
+              'test-kit/',
+            ];
+
+            const ignoredPrefixes = [
+              '.claude/',
+              '.github/ISSUE_TEMPLATE/',
+              '.github/packages/',
+              '.github/workflows/',
+              'docs/',
+              'magicblock-validator-admin/',
+              'sh/',
+              'test-manual/',
+              'tools/',
+            ];
+
+            const ignoredExact = new Set([
+              '.gitignore',
+            ]);
+
+            const ignoredSuffixes = ['.md'];
+
+            const matchesAnyPrefix = (file, prefixes) =>
+              prefixes.some(prefix => file === prefix || file.startsWith(prefix));
+
+            const isIgnored = file =>
+              ignoredExact.has(file) ||
+              ignoredSuffixes.some(suffix => file.endsWith(suffix)) ||
+              ignoredPrefixes.some(prefix => {
+                if (
+                  prefix === '.github/workflows/' &&
+                  file === '.github/workflows/ci-test-integration.yml'
+                ) {
+                  return false;
+                }
+                return file.startsWith(prefix);
+              });
+
+            const files = await github.paginate(
+              github.rest.pulls.listFiles,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.pull_request.number,
+                per_page: 100,
+              }
+            );
+
+            const selectedBatches = new Set();
+            const changedFiles = files.map(file => file.filename);
+            let runAll = false;
+            let reason = '';
+
+            for (const file of changedFiles) {
+              if (isIgnored(file)) {
+                continue;
+              }
+
+              let matchedBatch = false;
+              for (const [batch, prefixes] of Object.entries(batchPrefixes)) {
+                if (matchesAnyPrefix(file, prefixes)) {
+                  selectedBatches.add(batch);
+                  matchedBatch = true;
+                }
+              }
+
+              if (matchedBatch) {
+                continue;
+              }
+
+              if (matchesAnyPrefix(file, runAllPrefixes)) {
+                runAll = true;
+                reason = `full integration run required by ${file}`;
+                break;
+              }
+
+              runAll = true;
+              reason = `full integration run required by unclassified change ${file}`;
+              break;
+            }
+
+            const finalBatches = runAll
+              ? allBatches
+              : Array.from(selectedBatches).sort();
+            const runAny = finalBatches.length > 0;
+
+            if (!reason) {
+              reason = runAny
+                ? `targeted integration batches: ${finalBatches.join(', ')}`
+                : 'integration tests skipped for docs/tooling-only changes';
+            }
+
+            core.info(`Changed files: ${changedFiles.join(', ') || '(none)'}`);
+            core.info(`Integration scope: ${reason}`);
+
+            core.setOutput('run_all', runAll ? 'true' : 'false');
+            core.setOutput('run_any', runAny ? 'true' : 'false');
+            core.setOutput(
+              'selected_batches_csv',
+              finalBatches.length ? `,${finalBatches.join(',')},` : ''
+            );
+            core.setOutput('reason', reason);
+
   build:
+    needs: determine_scope
+    if: needs.determine_scope.outputs.run_any == 'true'
     runs-on: ubuntu-latest-m
     name: Build Project
     steps:
@@ -37,7 +211,13 @@ jobs:
         working-directory: magicblock-validator
 
   run_integration_tests:
-    needs: build
+    needs: [determine_scope, build]
+    if: |
+      needs.determine_scope.outputs.run_all == 'true' ||
+      contains(
+        needs.determine_scope.outputs.selected_batches_csv,
+        format(',{0},', matrix.batch_tests)
+      )
     runs-on: ubuntu-latest-m
     strategy:
       matrix:

--- a/.github/workflows/deploy-testnet-by-pr-comment.yml
+++ b/.github/workflows/deploy-testnet-by-pr-comment.yml
@@ -91,17 +91,12 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const body = context.payload.comment.body.trim();
-            if (body !== '/deploy') {
-              core.setOutput('should_deploy', 'false');
-              core.info(`Skipping non-exact deploy command: '${body}'`);
-              return;
-            }
+            core.setOutput('should_deploy', 'false');
+            core.setOutput('branch', '');
+            core.setOutput('failure_reason', '');
 
-            const authorizedUsers = (process.env.AUTHORIZED_USERS || '')
-              .split(/\s+/)
-              .filter(Boolean);
-            if (!authorizedUsers.includes(context.actor)) {
-              core.setFailed(`Unauthorized user: ${context.actor}`);
+            if (body !== '/deploy') {
+              core.info(`Skipping non-exact deploy command: '${body}'`);
               return;
             }
 
@@ -111,6 +106,19 @@ jobs:
               repo: context.repo.repo,
               pull_number: prNumber,
             });
+            core.setOutput('branch', pr.data.head.ref);
+
+            const authorizedUsers = (process.env.AUTHORIZED_USERS || '')
+              .split(/\s+/)
+              .filter(Boolean);
+            if (!authorizedUsers.includes(context.actor)) {
+              core.setOutput(
+                'failure_reason',
+                `@${context.actor} is not authorized to trigger testnet deploys.`
+              );
+              core.setFailed(`Unauthorized user: ${context.actor}`);
+              return;
+            }
 
             const internalAssociations = new Set([
               'OWNER',
@@ -123,6 +131,10 @@ jobs:
               internalAssociations.has(pr.data.author_association);
 
             if (!isInternalPr) {
+              core.setOutput(
+                'failure_reason',
+                'Deploy-by-comment is disabled for third-party contributor PRs.'
+              );
               core.setFailed(
                 'Deploy-by-comment is disabled for third-party contributor PRs.'
               );
@@ -130,9 +142,9 @@ jobs:
             }
 
             core.setOutput('should_deploy', 'true');
-            core.setOutput('branch', pr.data.head.ref);
 
       - name: Trigger main deploy workflow (workflow_dispatch)
+        id: dispatch
         if: steps.validate.outputs.should_deploy == 'true'
         uses: actions/github-script@v7
         with:
@@ -152,7 +164,7 @@ jobs:
             });
 
       - name: Add success comment
-        if: success()
+        if: success() && steps.validate.outputs.should_deploy == 'true'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -165,14 +177,23 @@ jobs:
             });
 
       - name: Add failure comment
-        if: failure()
+        if: always() && (steps.validate.outcome == 'failure' || steps.dispatch.outcome == 'failure')
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            const branch = '${{ steps.validate.outputs.branch }}';
+            const reason = '${{ steps.validate.outputs.failure_reason }}';
+            const branchText = branch
+              ? ` for branch \`${branch}\``
+              : '';
+            const detail = reason
+              ? ` ${reason}`
+              : ' Make sure you have permission and that the PR comes from an internal branch rather than a third-party contributor.';
+
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.issue.number,
-              body: `❌ Failed to trigger deploy. Make sure you have permission and that the PR comes from an internal branch rather than a third-party contributor.`
+              body: `❌ Failed to trigger deploy${branchText}.${detail}`
             });

--- a/.github/workflows/deploy-testnet-by-pr-comment.yml
+++ b/.github/workflows/deploy-testnet-by-pr-comment.yml
@@ -19,7 +19,14 @@ permissions:
 jobs:
   add-deploy-comment:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'master'
+    if: |
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.base.ref == 'master' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(
+        fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
+        github.event.pull_request.author_association
+      )
     steps:
       - name: Add or update deploy link comment
         uses: actions/github-script@v7
@@ -75,54 +82,63 @@ jobs:
       github.event.issue.pull_request &&
       contains(github.event.comment.body, '/deploy')
     steps:
-      - name: Validate comment is deploy command & check authorization
+      - name: Validate deploy request
         id: validate
-        run: |
-          # Trim the comment body
-          BODY="${{ github.event.comment.body }}"
-          BODY_TRIM="$(echo "$BODY" | xargs)"
-          if [ "$BODY_TRIM" != "/deploy" ]; then
-            echo "Not a deploy command (trimmed body: '$BODY_TRIM'), skipping."
-            exit 0
-          fi
-
-          # Load authorized users (space-separated)
-          AUTH="${{ secrets.TEST_NODE_MANUAL_DEPLOY_AUTHORIZED_USERS }}"
-          IFS=' ' read -ra AUTH_ARR <<< "$AUTH"
-          USER="${{ github.actor }}"
-          authorized=false
-          for u in "${AUTH_ARR[@]}"; do
-            if [ "$u" = "$USER" ]; then
-              authorized=true
-              break
-            fi
-          done
-
-          if [ "$authorized" != "true" ]; then
-            echo "Unauthorized user: $USER"
-            exit 1
-          fi
-
-      - name: Get PR branch
-        id: get_branch
         uses: actions/github-script@v7
+        env:
+          AUTHORIZED_USERS: ${{ secrets.TEST_NODE_MANUAL_DEPLOY_AUTHORIZED_USERS }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            const body = context.payload.comment.body.trim();
+            if (body !== '/deploy') {
+              core.setOutput('should_deploy', 'false');
+              core.info(`Skipping non-exact deploy command: '${body}'`);
+              return;
+            }
+
+            const authorizedUsers = (process.env.AUTHORIZED_USERS || '')
+              .split(/\s+/)
+              .filter(Boolean);
+            if (!authorizedUsers.includes(context.actor)) {
+              core.setFailed(`Unauthorized user: ${context.actor}`);
+              return;
+            }
+
             const prNumber = context.payload.issue.number;
             const pr = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: prNumber
+              pull_number: prNumber,
             });
+
+            const internalAssociations = new Set([
+              'OWNER',
+              'MEMBER',
+              'COLLABORATOR',
+            ]);
+            const isInternalPr =
+              pr.data.head.repo.full_name ===
+                `${context.repo.owner}/${context.repo.repo}` &&
+              internalAssociations.has(pr.data.author_association);
+
+            if (!isInternalPr) {
+              core.setFailed(
+                'Deploy-by-comment is disabled for third-party contributor PRs.'
+              );
+              return;
+            }
+
+            core.setOutput('should_deploy', 'true');
             core.setOutput('branch', pr.data.head.ref);
 
       - name: Trigger main deploy workflow (workflow_dispatch)
+        if: steps.validate.outputs.should_deploy == 'true'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const branch = '${{ steps.get_branch.outputs.branch }}';
+            const branch = '${{ steps.validate.outputs.branch }}';
             // pass requested_by so the main workflow check can trust who requested the deploy
             await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,
@@ -145,7 +161,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.issue.number,
-              body: `🚀 Deploy triggered for branch \`${{ steps.get_branch.outputs.branch }}\` by @${context.actor}. (You can follow progress in Actions.)`
+              body: `🚀 Deploy triggered for branch \`${{ steps.validate.outputs.branch }}\` by @${context.actor}. (You can follow progress in Actions.)`
             });
 
       - name: Add failure comment
@@ -158,5 +174,5 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.issue.number,
-              body: `❌ Failed to trigger deploy for branch \`${{ steps.get_branch.outputs.branch }}\`. Make sure you have permission or use the manual deploy link in the PR comment.`
+              body: `❌ Failed to trigger deploy. Make sure you have permission and that the PR comes from an internal branch rather than a third-party contributor.`
             });


### PR DESCRIPTION
## Summary
This PR reduces unnecessary integration CI on pull requests and blocks deploy-by-comment for third-party contributor PRs.

## Changes
- add a `determine_scope` job to `.github/workflows/ci-test-integration.yml`
- keep full integration coverage on pushes to `master` and `dev`
- on pull requests, run only the mapped integration batches when changes are limited to specific `test-integration` suites
- skip integration entirely for clearly unrelated docs, tooling, and workflow-only changes
- fall back to a full integration run for shared runtime code and any unclassified changes
- stop adding the manual deploy comment for third-party contributor PRs
- block `/deploy` comment-triggered deploys for third-party contributor PRs
- tighten `/deploy` handling so only the exact command triggers deployment

## Validation
- parsed both workflow files with Ruby YAML loading
- `git diff --check`

## Notes
The integration scoping is intentionally conservative: unknown or shared runtime changes still run the full integration suite.
