### PR TITLE
feat: execute cranks with PDA

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3512,6 +3512,7 @@ name = "magicblock-magic-program-api"
 version = "0.8.7"
 dependencies = [
  "bincode",
+ "const-crypto",
  "serde",
  "solana-program",
  "solana-signature",

--- a/magicblock-account-cloner/src/lib.rs
+++ b/magicblock-account-cloner/src/lib.rs
@@ -287,7 +287,6 @@ impl ChainlinkCloner {
                 iterations: i64::MAX,
                 instructions: vec![schedule_commit_ix],
             },
-            &[pubkey, MAGIC_CONTEXT_PUBKEY, validator_authority_id()],
         )
     }
 

--- a/magicblock-magic-program-api/Cargo.toml
+++ b/magicblock-magic-program-api/Cargo.toml
@@ -10,6 +10,9 @@ edition.workspace = true
 
 [dependencies]
 solana-program = ">=1.16, <3.0.0"
-solana-signature = { workspace = true, default-features = false, features = ["serde"] }
+solana-signature = { workspace = true, default-features = false, features = [
+    "serde",
+] }
 bincode = "^1.3.3"
 serde = { version = "^1.0.228", features = ["derive"] }
+const-crypto = "0.3.0"

--- a/magicblock-magic-program-api/src/instruction.rs
+++ b/magicblock-magic-program-api/src/instruction.rs
@@ -307,8 +307,9 @@ pub enum MagicBlockInstruction {
     /// Executes a crank
     ///
     /// # Account references
-    /// - **0.**   `[SIGNER]`  Crank signer PDA
-    /// - **1..n** `[]`        Accounts to execute the instructions on
+    /// - **0.**   `[SIGNER]`  Validator authority
+    /// - **1.**   `[]`        Crank signer PDA
+    /// - **2..n** `[]`        Accounts required by the embedded instructions
     ExecuteCrank { instructions: Vec<Instruction> },
 }
 

--- a/magicblock-magic-program-api/src/instruction.rs
+++ b/magicblock-magic-program-api/src/instruction.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
-use solana_program::pubkey::Pubkey;
+use solana_program::{instruction::Instruction, pubkey::Pubkey};
 
 use crate::args::{
     AddActionCallbackArgs, MagicBaseIntentArgs, MagicIntentBundleArgs,
@@ -303,6 +303,13 @@ pub enum MagicBlockInstruction {
     /// - **0.** `[SIGNER]`  Validator Authority
     /// - **1.** `[WRITE]`   Account to evict
     EvictAccount { pubkey: Pubkey },
+
+    /// Executes a crank
+    ///
+    /// # Account references
+    /// - **0.**   `[SIGNER]`  Crank signer PDA
+    /// - **1..n** `[]`        Accounts to execute the instructions on
+    ExecuteCrank { instructions: Vec<Instruction> },
 }
 
 impl MagicBlockInstruction {

--- a/magicblock-magic-program-api/src/lib.rs
+++ b/magicblock-magic-program-api/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod args;
 pub mod instruction;
+pub mod pda;
 pub mod response;
 
 pub use solana_program::{declare_id, pubkey, pubkey::Pubkey};
@@ -23,9 +24,3 @@ pub const MAGIC_CONTEXT_SIZE: usize = 1024 * 1024 * 5; // 5 MB
 /// Rent rate for ephemeral accounts: 32 lamports per byte.
 /// This is ~109x cheaper than Solana's base rent (3,480 lamports/byte).
 pub const EPHEMERAL_RENT_PER_BYTE: u64 = 32;
-
-pub const CRANK_SEED: &[u8] = b"crank-executor";
-const CRANK_SIGNER_PDA: ([u8; 32], u8) =
-    const_crypto::ed25519::derive_program_address(&[CRANK_SEED], ID.as_array());
-pub const CRANK_SIGNER: Pubkey = Pubkey::new_from_array(CRANK_SIGNER_PDA.0);
-pub const CRANK_SIGNER_BUMP: u8 = CRANK_SIGNER_PDA.1;

--- a/magicblock-magic-program-api/src/lib.rs
+++ b/magicblock-magic-program-api/src/lib.rs
@@ -23,3 +23,9 @@ pub const MAGIC_CONTEXT_SIZE: usize = 1024 * 1024 * 5; // 5 MB
 /// Rent rate for ephemeral accounts: 32 lamports per byte.
 /// This is ~109x cheaper than Solana's base rent (3,480 lamports/byte).
 pub const EPHEMERAL_RENT_PER_BYTE: u64 = 32;
+
+pub const CRANK_SEED: &[u8] = b"crank-executor";
+const CRANK_SIGNER_PDA: ([u8; 32], u8) =
+    const_crypto::ed25519::derive_program_address(&[CRANK_SEED], ID.as_array());
+pub const CRANK_SIGNER: Pubkey = Pubkey::new_from_array(CRANK_SIGNER_PDA.0);
+pub const CRANK_SIGNER_BUMP: u8 = CRANK_SIGNER_PDA.1;

--- a/magicblock-magic-program-api/src/pda.rs
+++ b/magicblock-magic-program-api/src/pda.rs
@@ -1,0 +1,10 @@
+use solana_program::pubkey::Pubkey;
+
+pub const CRANK_SEED: &[u8] = b"crank-executor";
+const CRANK_SIGNER_PDA: ([u8; 32], u8) =
+    const_crypto::ed25519::derive_program_address(
+        &[CRANK_SEED],
+        crate::ID.as_array(),
+    );
+pub const CRANK_SIGNER: Pubkey = Pubkey::new_from_array(CRANK_SIGNER_PDA.0);
+pub const CRANK_SIGNER_BUMP: u8 = CRANK_SIGNER_PDA.1;

--- a/magicblock-task-scheduler/src/service.rs
+++ b/magicblock-task-scheduler/src/service.rs
@@ -347,18 +347,15 @@ impl TaskSchedulerService {
         let blockhash = self.block.load().blockhash;
         // Execute unsigned transactions
         // We prepend a noop instruction to make each transaction unique.
-        let noop_instruction = InstructionUtils::noop_instruction(
-            self.tx_counter.fetch_add(1, Ordering::Relaxed),
-        );
+        let ixs = [
+            InstructionUtils::noop_instruction(
+                self.tx_counter.fetch_add(1, Ordering::Relaxed),
+            ),
+            InstructionUtils::execute_task_instruction(instructions),
+        ];
         let tx = Transaction::new(
             &[validator_authority()],
-            Message::new(
-                &[noop_instruction]
-                    .into_iter()
-                    .chain(instructions)
-                    .collect::<Vec<_>>(),
-                Some(&validator_authority_id()),
-            ),
+            Message::new(&ixs, Some(&validator_authority_id())),
             blockhash,
         );
 

--- a/programs/magicblock/src/magicblock_processor.rs
+++ b/programs/magicblock/src/magicblock_processor.rs
@@ -14,7 +14,9 @@ use crate::{
     },
     mutate_accounts::process_mutate_accounts,
     process_scheduled_commit_sent,
-    schedule_task::{process_cancel_task, process_schedule_task},
+    schedule_task::{
+        process_cancel_task, process_execute_crank, process_schedule_task,
+    },
     schedule_transactions::{
         process_accept_scheduled_commits, process_add_action_callback,
         process_schedule_commit, process_schedule_commit_finalize,
@@ -214,6 +216,9 @@ declare_process_instruction!(
                 remote_slot,
                 authority,
             ),
+            ExecuteCrank { instructions } => {
+                process_execute_crank(signers, invoke_context, instructions)
+            }
         }
     }
 );

--- a/programs/magicblock/src/schedule_task/mod.rs
+++ b/programs/magicblock/src/schedule_task/mod.rs
@@ -1,5 +1,7 @@
 mod process_cancel_task;
+mod process_execute_task;
 mod process_schedule_task;
 
 pub(crate) use process_cancel_task::*;
+pub(crate) use process_execute_task::*;
 pub(crate) use process_schedule_task::*;

--- a/programs/magicblock/src/schedule_task/mod.rs
+++ b/programs/magicblock/src/schedule_task/mod.rs
@@ -23,20 +23,20 @@ pub(crate) fn validate_cranks_instructions(
             if account.is_signer && account.pubkey.ne(&CRANK_SIGNER) {
                 ic_msg!(
                     invoke_context,
-                    "ScheduleTask: only the crank signer PDA can be a signer in cranks (invalid signer: '{}')",
+                    "Crank ERR: only the crank signer PDA can be a signer in cranks (invalid signer: '{}')",
                     account.pubkey,
                 );
                 return Err(InstructionError::MissingRequiredSignature);
             } else if account.is_writable && account.pubkey.eq(&CRANK_SIGNER) {
                 ic_msg!(
                     invoke_context,
-                    "ScheduleTask: the crank signer PDA cannot be a writable account in cranks",
+                    "Crank ERR: the crank signer PDA cannot be a writable account in cranks",
                 );
                 return Err(InstructionError::Immutable);
             } else if account.pubkey.eq(&validator_authority_id()) {
                 ic_msg!(
                     invoke_context,
-                    "ScheduleTask: the validator authority cannot be used in cranks",
+                    "Crank ERR: the validator authority cannot be used in cranks",
                 );
                 return Err(InstructionError::IncorrectAuthority);
             }

--- a/programs/magicblock/src/schedule_task/mod.rs
+++ b/programs/magicblock/src/schedule_task/mod.rs
@@ -2,6 +2,45 @@ mod process_cancel_task;
 mod process_execute_task;
 mod process_schedule_task;
 
+use magicblock_magic_program_api::pda::CRANK_SIGNER;
 pub(crate) use process_cancel_task::*;
 pub(crate) use process_execute_task::*;
 pub(crate) use process_schedule_task::*;
+use solana_instruction::{error::InstructionError, Instruction};
+use solana_log_collector::ic_msg;
+use solana_program_runtime::invoke_context::InvokeContext;
+
+use crate::validator::validator_authority_id;
+
+// Assert that the task instructions do not have signers aside from the crank signer
+// Assert they don't use the validator either
+pub(crate) fn validate_cranks_instructions(
+    invoke_context: &mut InvokeContext,
+    instructions: &[Instruction],
+) -> Result<(), InstructionError> {
+    for instruction in instructions {
+        for account in &instruction.accounts {
+            if account.is_signer && account.pubkey.ne(&CRANK_SIGNER) {
+                ic_msg!(
+                    invoke_context,
+                    "ScheduleTask: only the crank signer PDA can be a signer in cranks (invalid signer: '{}')",
+                    account.pubkey,
+                );
+                return Err(InstructionError::MissingRequiredSignature);
+            } else if account.is_writable && account.pubkey.eq(&CRANK_SIGNER) {
+                ic_msg!(
+                    invoke_context,
+                    "ScheduleTask: the crank signer PDA cannot be a writable account in cranks",
+                );
+                return Err(InstructionError::Immutable);
+            } else if account.pubkey.eq(&validator_authority_id()) {
+                ic_msg!(
+                    invoke_context,
+                    "ScheduleTask: the validator authority cannot be used in cranks",
+                );
+                return Err(InstructionError::IncorrectAuthority);
+            }
+        }
+    }
+    Ok(())
+}

--- a/programs/magicblock/src/schedule_task/process_execute_task.rs
+++ b/programs/magicblock/src/schedule_task/process_execute_task.rs
@@ -57,7 +57,7 @@ pub(crate) fn process_execute_crank(
         );
         return Err(InstructionError::IncorrectAuthority);
     }
-    if !signers.contains(&validator_pubkey) {
+    if !signers.contains(validator_pubkey) {
         ic_msg!(
             invoke_context,
             "ExecuteCrank ERR: validator pubkey {} is not in signers",

--- a/programs/magicblock/src/schedule_task/process_execute_task.rs
+++ b/programs/magicblock/src/schedule_task/process_execute_task.rs
@@ -1,0 +1,187 @@
+use std::collections::HashSet;
+
+use magicblock_magic_program_api::CRANK_SIGNER;
+use solana_instruction::{error::InstructionError, Instruction};
+use solana_log_collector::ic_msg;
+use solana_program_runtime::invoke_context::InvokeContext;
+use solana_pubkey::Pubkey;
+
+use crate::utils::accounts::get_instruction_pubkey_with_idx;
+
+pub(crate) fn process_execute_crank(
+    _signers: HashSet<Pubkey>,
+    invoke_context: &mut InvokeContext,
+    instructions: Vec<Instruction>,
+) -> Result<(), InstructionError> {
+    const CRANK_SIGNER_IDX: u16 = 0;
+
+    let transaction_context = &invoke_context.transaction_context.clone();
+    let ix_ctx = transaction_context.get_current_instruction_context()?;
+    let ix_accs_len = ix_ctx.get_number_of_instruction_accounts() as usize;
+    const ACCOUNTS_START: usize = CRANK_SIGNER_IDX as usize + 1;
+
+    // Assert MagicBlock program
+    ix_ctx
+        .find_index_of_program_account(transaction_context, &crate::id())
+        .ok_or_else(|| {
+            ic_msg!(
+                invoke_context,
+                "ExecuteCrank ERR: Magic program account not found"
+            );
+            InstructionError::UnsupportedProgramId
+        })?;
+
+    // Assert enough accounts
+    if ix_accs_len < ACCOUNTS_START {
+        ic_msg!(
+            invoke_context,
+            "ExecuteCrank ERR: not enough accounts to execute crank ({}), need crank signer and instructions",
+            ix_accs_len
+        );
+        return Err(InstructionError::NotEnoughAccountKeys);
+    }
+
+    // Assert Crank signer is provided
+    let crank_signer_pubkey =
+        get_instruction_pubkey_with_idx(transaction_context, CRANK_SIGNER_IDX)?;
+    if crank_signer_pubkey != &CRANK_SIGNER {
+        ic_msg!(
+            invoke_context,
+            "ExecuteCrank ERR: crank signer pubkey {} is not the expected Crank signer",
+            crank_signer_pubkey
+        );
+        return Err(InstructionError::InvalidSeeds);
+    }
+
+    let len = instructions.len();
+    for ix in instructions {
+        invoke_context.native_invoke(ix.into(), &[CRANK_SIGNER])?;
+    }
+
+    ic_msg!(invoke_context, "Executed crank with {} instructions", len);
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use magicblock_magic_program_api::args::ScheduleTaskArgs;
+    use solana_account::AccountSharedData;
+    use solana_sdk_ids::system_program;
+
+    use super::*;
+    use crate::{
+        test_utils::process_instruction,
+        utils::instruction_utils::InstructionUtils,
+    };
+
+    #[test]
+    fn test_execute_task_simple() {
+        let ix = InstructionUtils::execute_task_instruction(vec![
+            InstructionUtils::noop_instruction(0),
+        ]);
+        let transaction_accounts = vec![(
+            CRANK_SIGNER,
+            AccountSharedData::new(0, 0, &system_program::id()),
+        )];
+        process_instruction(
+            &ix.data,
+            transaction_accounts,
+            ix.accounts,
+            Ok(()),
+        );
+    }
+
+    #[test]
+    fn test_execute_task_complex() {
+        let payer = Pubkey::new_unique();
+        let ix = InstructionUtils::execute_task_instruction(vec![
+            InstructionUtils::schedule_task_instruction(
+                &payer,
+                ScheduleTaskArgs {
+                    task_id: 0,
+                    execution_interval_millis: 1,
+                    iterations: 1,
+                    instructions: vec![InstructionUtils::noop_instruction(0)],
+                },
+            ),
+        ]);
+        let transaction_accounts = vec![
+            (
+                CRANK_SIGNER,
+                AccountSharedData::new(0, 0, &system_program::id()),
+            ),
+            (
+                payer,
+                AccountSharedData::new(1000000, 0, &system_program::id()),
+            ),
+        ];
+        process_instruction(
+            &ix.data,
+            transaction_accounts,
+            ix.accounts,
+            Ok(()),
+        );
+    }
+
+    #[test]
+    fn fail_execute_task_without_crank_signer() {
+        let ix = InstructionUtils::execute_task_instruction(vec![
+            InstructionUtils::noop_instruction(0),
+        ]);
+        let transaction_accounts = vec![(
+            CRANK_SIGNER,
+            AccountSharedData::new(0, 0, &system_program::id()),
+        )];
+        process_instruction(
+            &ix.data,
+            transaction_accounts,
+            vec![],
+            Err(InstructionError::NotEnoughAccountKeys),
+        );
+    }
+
+    #[test]
+    fn fail_execute_task_wrong_crank_signer() {
+        let ix = InstructionUtils::execute_task_instruction(vec![
+            InstructionUtils::noop_instruction(0),
+        ]);
+        let wrong_crank_signer = Pubkey::new_unique();
+        let transaction_accounts = vec![(
+            wrong_crank_signer,
+            AccountSharedData::new(0, 0, &system_program::id()),
+        )];
+        process_instruction(
+            &ix.data,
+            transaction_accounts,
+            ix.accounts,
+            Err(InstructionError::InvalidSeeds),
+        );
+    }
+
+    #[test]
+    fn fail_execute_task_missing_accounts() {
+        let payer = Pubkey::new_unique();
+        let ix = InstructionUtils::execute_task_instruction(vec![
+            InstructionUtils::schedule_task_instruction(
+                &payer,
+                ScheduleTaskArgs {
+                    task_id: 0,
+                    execution_interval_millis: 1,
+                    iterations: 1,
+                    instructions: vec![InstructionUtils::noop_instruction(0)],
+                },
+            ),
+        ]);
+        let transaction_accounts = vec![(
+            CRANK_SIGNER,
+            AccountSharedData::new(0, 0, &system_program::id()),
+        )];
+        process_instruction(
+            &ix.data,
+            transaction_accounts,
+            ix.accounts,
+            Err(InstructionError::MissingAccount),
+        );
+    }
+}

--- a/programs/magicblock/src/schedule_task/process_execute_task.rs
+++ b/programs/magicblock/src/schedule_task/process_execute_task.rs
@@ -7,6 +7,7 @@ use solana_program_runtime::invoke_context::InvokeContext;
 use solana_pubkey::Pubkey;
 
 use crate::{
+    schedule_task::validate_cranks_instructions,
     utils::accounts::get_instruction_pubkey_with_idx,
     validator::validator_authority_id,
 };
@@ -77,6 +78,10 @@ pub(crate) fn process_execute_crank(
         );
         return Err(InstructionError::InvalidSeeds);
     }
+
+    // Already validated when scheduling the task.
+    // This check prevents the validator from manually sending transactions disguised as cranks.
+    validate_cranks_instructions(invoke_context, &instructions)?;
 
     let len = instructions.len();
     for ix in instructions {
@@ -293,5 +298,61 @@ mod test {
             ix.accounts,
             Err(InstructionError::MissingAccount),
         );
+    }
+
+    #[test]
+    fn fail_execute_task_with_invalid_instructions() {
+        init_validator_authority_if_needed(Keypair::new());
+        let payer = Pubkey::new_unique();
+        let mut inner_ix = InstructionUtils::schedule_task_instruction(
+            &payer,
+            ScheduleTaskArgs {
+                task_id: 0,
+                execution_interval_millis: 1,
+                iterations: 1,
+                instructions: vec![InstructionUtils::noop_instruction(0)],
+            },
+        );
+
+        for (signer, writable, pubkey, expected) in [
+            (
+                true,
+                false,
+                Pubkey::new_unique(),
+                InstructionError::MissingRequiredSignature,
+            ),
+            (false, true, CRANK_SIGNER, InstructionError::Immutable),
+            (
+                false,
+                false,
+                validator_authority_id(),
+                InstructionError::IncorrectAuthority,
+            ),
+        ] {
+            inner_ix.accounts[0].is_signer = signer;
+            inner_ix.accounts[0].is_writable = writable;
+            inner_ix.accounts[0].pubkey = pubkey;
+            let ix = InstructionUtils::execute_task_instruction(vec![
+                inner_ix.clone()
+            ]);
+
+            let transaction_accounts = vec![
+                (
+                    validator_authority_id(),
+                    AccountSharedData::new(0, 0, &system_program::id()),
+                ),
+                (
+                    CRANK_SIGNER,
+                    AccountSharedData::new(0, 0, &system_program::id()),
+                ),
+            ];
+
+            process_instruction(
+                &ix.data,
+                transaction_accounts,
+                ix.accounts,
+                Err(expected),
+            );
+        }
     }
 }

--- a/programs/magicblock/src/schedule_task/process_execute_task.rs
+++ b/programs/magicblock/src/schedule_task/process_execute_task.rs
@@ -97,6 +97,7 @@ pub(crate) fn process_execute_crank(
 mod test {
     use magicblock_magic_program_api::args::ScheduleTaskArgs;
     use solana_account::AccountSharedData;
+    use solana_instruction::AccountMeta;
     use solana_keypair::Keypair;
     use solana_sdk_ids::system_program;
 
@@ -106,6 +107,12 @@ mod test {
         utils::instruction_utils::InstructionUtils,
         validator::init_validator_authority_if_needed,
     };
+
+    pub fn complex_ix(payer: Pubkey) -> Instruction {
+        let mut ix = InstructionUtils::noop_instruction(0);
+        ix.accounts.push(AccountMeta::new(payer, false));
+        ix
+    }
 
     #[test]
     fn test_execute_task_simple() {
@@ -135,17 +142,8 @@ mod test {
     fn test_execute_task_complex() {
         init_validator_authority_if_needed(Keypair::new());
         let payer = Pubkey::new_unique();
-        let ix = InstructionUtils::execute_task_instruction(vec![
-            InstructionUtils::schedule_task_instruction(
-                &payer,
-                ScheduleTaskArgs {
-                    task_id: 0,
-                    execution_interval_millis: 1,
-                    iterations: 1,
-                    instructions: vec![InstructionUtils::noop_instruction(0)],
-                },
-            ),
-        ]);
+        let ix =
+            InstructionUtils::execute_task_instruction(vec![complex_ix(payer)]);
         let transaction_accounts = vec![
             (
                 validator_authority_id(),
@@ -271,17 +269,8 @@ mod test {
     fn fail_execute_task_missing_accounts() {
         init_validator_authority_if_needed(Keypair::new());
         let payer = Pubkey::new_unique();
-        let ix = InstructionUtils::execute_task_instruction(vec![
-            InstructionUtils::schedule_task_instruction(
-                &payer,
-                ScheduleTaskArgs {
-                    task_id: 0,
-                    execution_interval_millis: 1,
-                    iterations: 1,
-                    instructions: vec![InstructionUtils::noop_instruction(0)],
-                },
-            ),
-        ]);
+        let ix =
+            InstructionUtils::execute_task_instruction(vec![complex_ix(payer)]);
         let transaction_accounts = vec![
             (
                 validator_authority_id(),

--- a/programs/magicblock/src/schedule_task/process_execute_task.rs
+++ b/programs/magicblock/src/schedule_task/process_execute_task.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 
 pub(crate) fn process_execute_crank(
-    _signers: HashSet<Pubkey>,
+    signers: HashSet<Pubkey>,
     invoke_context: &mut InvokeContext,
     instructions: Vec<Instruction>,
 ) -> Result<(), InstructionError> {
@@ -53,6 +53,14 @@ pub(crate) fn process_execute_crank(
         ic_msg!(
             invoke_context,
             "ExecuteCrank ERR: validator pubkey {} is not the expected validator",
+            validator_pubkey
+        );
+        return Err(InstructionError::IncorrectAuthority);
+    }
+    if !signers.contains(&validator_pubkey) {
+        ic_msg!(
+            invoke_context,
+            "ExecuteCrank ERR: validator pubkey {} is not in signers",
             validator_pubkey
         );
         return Err(InstructionError::MissingRequiredSignature);
@@ -176,6 +184,56 @@ mod test {
             transaction_accounts,
             vec![],
             Err(InstructionError::NotEnoughAccountKeys),
+        );
+    }
+
+    #[test]
+    fn fail_execute_task_wrong_validator() {
+        init_validator_authority_if_needed(Keypair::new());
+        let ix = InstructionUtils::execute_task_instruction(vec![
+            InstructionUtils::noop_instruction(0),
+        ]);
+        let wrong_validator = Pubkey::new_unique();
+        let transaction_accounts = vec![
+            (
+                wrong_validator,
+                AccountSharedData::new(0, 0, &system_program::id()),
+            ),
+            (
+                CRANK_SIGNER,
+                AccountSharedData::new(0, 0, &system_program::id()),
+            ),
+        ];
+        process_instruction(
+            &ix.data,
+            transaction_accounts,
+            ix.accounts,
+            Err(InstructionError::IncorrectAuthority),
+        );
+    }
+
+    #[test]
+    fn fail_execute_task_validator_not_in_signers() {
+        init_validator_authority_if_needed(Keypair::new());
+        let mut ix = InstructionUtils::execute_task_instruction(vec![
+            InstructionUtils::noop_instruction(0),
+        ]);
+        ix.accounts[0].is_signer = false;
+        let transaction_accounts = vec![
+            (
+                validator_authority_id(),
+                AccountSharedData::new(0, 0, &system_program::id()),
+            ),
+            (
+                CRANK_SIGNER,
+                AccountSharedData::new(0, 0, &system_program::id()),
+            ),
+        ];
+        process_instruction(
+            &ix.data,
+            transaction_accounts,
+            ix.accounts,
+            Err(InstructionError::MissingRequiredSignature),
         );
     }
 

--- a/programs/magicblock/src/schedule_task/process_execute_task.rs
+++ b/programs/magicblock/src/schedule_task/process_execute_task.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use magicblock_magic_program_api::CRANK_SIGNER;
+use magicblock_magic_program_api::pda::CRANK_SIGNER;
 use solana_instruction::{error::InstructionError, Instruction};
 use solana_log_collector::ic_msg;
 use solana_program_runtime::invoke_context::InvokeContext;

--- a/programs/magicblock/src/schedule_task/process_execute_task.rs
+++ b/programs/magicblock/src/schedule_task/process_execute_task.rs
@@ -6,14 +6,18 @@ use solana_log_collector::ic_msg;
 use solana_program_runtime::invoke_context::InvokeContext;
 use solana_pubkey::Pubkey;
 
-use crate::utils::accounts::get_instruction_pubkey_with_idx;
+use crate::{
+    utils::accounts::get_instruction_pubkey_with_idx,
+    validator::validator_authority_id,
+};
 
 pub(crate) fn process_execute_crank(
     _signers: HashSet<Pubkey>,
     invoke_context: &mut InvokeContext,
     instructions: Vec<Instruction>,
 ) -> Result<(), InstructionError> {
-    const CRANK_SIGNER_IDX: u16 = 0;
+    const VALIDATOR_IDX: u16 = 0;
+    const CRANK_SIGNER_IDX: u16 = 1;
 
     let transaction_context = &invoke_context.transaction_context.clone();
     let ix_ctx = transaction_context.get_current_instruction_context()?;
@@ -39,6 +43,19 @@ pub(crate) fn process_execute_crank(
             ix_accs_len
         );
         return Err(InstructionError::NotEnoughAccountKeys);
+    }
+
+    // Assert Validator is signer
+    // Only the validator can execute a crank
+    let validator_pubkey =
+        get_instruction_pubkey_with_idx(transaction_context, VALIDATOR_IDX)?;
+    if validator_pubkey != &validator_authority_id() {
+        ic_msg!(
+            invoke_context,
+            "ExecuteCrank ERR: validator pubkey {} is not the expected validator",
+            validator_pubkey
+        );
+        return Err(InstructionError::MissingRequiredSignature);
     }
 
     // Assert Crank signer is provided
@@ -67,23 +84,32 @@ pub(crate) fn process_execute_crank(
 mod test {
     use magicblock_magic_program_api::args::ScheduleTaskArgs;
     use solana_account::AccountSharedData;
+    use solana_keypair::Keypair;
     use solana_sdk_ids::system_program;
 
     use super::*;
     use crate::{
         test_utils::process_instruction,
         utils::instruction_utils::InstructionUtils,
+        validator::init_validator_authority_if_needed,
     };
 
     #[test]
     fn test_execute_task_simple() {
+        init_validator_authority_if_needed(Keypair::new());
         let ix = InstructionUtils::execute_task_instruction(vec![
             InstructionUtils::noop_instruction(0),
         ]);
-        let transaction_accounts = vec![(
-            CRANK_SIGNER,
-            AccountSharedData::new(0, 0, &system_program::id()),
-        )];
+        let transaction_accounts = vec![
+            (
+                validator_authority_id(),
+                AccountSharedData::new(0, 0, &system_program::id()),
+            ),
+            (
+                CRANK_SIGNER,
+                AccountSharedData::new(0, 0, &system_program::id()),
+            ),
+        ];
         process_instruction(
             &ix.data,
             transaction_accounts,
@@ -94,6 +120,7 @@ mod test {
 
     #[test]
     fn test_execute_task_complex() {
+        init_validator_authority_if_needed(Keypair::new());
         let payer = Pubkey::new_unique();
         let ix = InstructionUtils::execute_task_instruction(vec![
             InstructionUtils::schedule_task_instruction(
@@ -107,6 +134,10 @@ mod test {
             ),
         ]);
         let transaction_accounts = vec![
+            (
+                validator_authority_id(),
+                AccountSharedData::new(0, 0, &system_program::id()),
+            ),
             (
                 CRANK_SIGNER,
                 AccountSharedData::new(0, 0, &system_program::id()),
@@ -126,13 +157,20 @@ mod test {
 
     #[test]
     fn fail_execute_task_without_crank_signer() {
+        init_validator_authority_if_needed(Keypair::new());
         let ix = InstructionUtils::execute_task_instruction(vec![
             InstructionUtils::noop_instruction(0),
         ]);
-        let transaction_accounts = vec![(
-            CRANK_SIGNER,
-            AccountSharedData::new(0, 0, &system_program::id()),
-        )];
+        let transaction_accounts = vec![
+            (
+                validator_authority_id(),
+                AccountSharedData::new(0, 0, &system_program::id()),
+            ),
+            (
+                CRANK_SIGNER,
+                AccountSharedData::new(0, 0, &system_program::id()),
+            ),
+        ];
         process_instruction(
             &ix.data,
             transaction_accounts,
@@ -143,14 +181,21 @@ mod test {
 
     #[test]
     fn fail_execute_task_wrong_crank_signer() {
+        init_validator_authority_if_needed(Keypair::new());
         let ix = InstructionUtils::execute_task_instruction(vec![
             InstructionUtils::noop_instruction(0),
         ]);
         let wrong_crank_signer = Pubkey::new_unique();
-        let transaction_accounts = vec![(
-            wrong_crank_signer,
-            AccountSharedData::new(0, 0, &system_program::id()),
-        )];
+        let transaction_accounts = vec![
+            (
+                validator_authority_id(),
+                AccountSharedData::new(0, 0, &system_program::id()),
+            ),
+            (
+                wrong_crank_signer,
+                AccountSharedData::new(0, 0, &system_program::id()),
+            ),
+        ];
         process_instruction(
             &ix.data,
             transaction_accounts,
@@ -161,6 +206,7 @@ mod test {
 
     #[test]
     fn fail_execute_task_missing_accounts() {
+        init_validator_authority_if_needed(Keypair::new());
         let payer = Pubkey::new_unique();
         let ix = InstructionUtils::execute_task_instruction(vec![
             InstructionUtils::schedule_task_instruction(
@@ -173,10 +219,16 @@ mod test {
                 },
             ),
         ]);
-        let transaction_accounts = vec![(
-            CRANK_SIGNER,
-            AccountSharedData::new(0, 0, &system_program::id()),
-        )];
+        let transaction_accounts = vec![
+            (
+                validator_authority_id(),
+                AccountSharedData::new(0, 0, &system_program::id()),
+            ),
+            (
+                CRANK_SIGNER,
+                AccountSharedData::new(0, 0, &system_program::id()),
+            ),
+        ];
         process_instruction(
             &ix.data,
             transaction_accounts,

--- a/programs/magicblock/src/schedule_task/process_schedule_task.rs
+++ b/programs/magicblock/src/schedule_task/process_schedule_task.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use magicblock_core::tls::ExecutionTlsStash;
 use magicblock_magic_program_api::{
     args::{ScheduleTaskArgs, ScheduleTaskRequest, TaskRequest},
-    CRANK_SIGNER,
+    pda::CRANK_SIGNER,
 };
 use solana_instruction::error::InstructionError;
 use solana_log_collector::ic_msg;

--- a/programs/magicblock/src/schedule_task/process_schedule_task.rs
+++ b/programs/magicblock/src/schedule_task/process_schedule_task.rs
@@ -10,7 +10,10 @@ use solana_log_collector::ic_msg;
 use solana_program_runtime::invoke_context::InvokeContext;
 use solana_pubkey::Pubkey;
 
-use crate::utils::accounts::get_instruction_pubkey_with_idx;
+use crate::{
+    utils::accounts::get_instruction_pubkey_with_idx,
+    validator::validator_authority_id,
+};
 
 pub(crate) fn process_schedule_task(
     signers: HashSet<Pubkey>,
@@ -76,6 +79,7 @@ pub(crate) fn process_schedule_task(
     }
 
     // Assert that the task instructions do not have signers aside from the crank signer
+    // Assert they don't use the validator either
     for instruction in &args.instructions {
         for account in &instruction.accounts {
             if account.is_signer && account.pubkey.ne(&CRANK_SIGNER) {
@@ -91,6 +95,12 @@ pub(crate) fn process_schedule_task(
                     "ScheduleTask: the crank signer PDA cannot be a writable account in cranks",
                 );
                 return Err(InstructionError::Immutable);
+            } else if account.pubkey.eq(&validator_authority_id()) {
+                ic_msg!(
+                    invoke_context,
+                    "ScheduleTask: the validator authority cannot be used in cranks",
+                );
+                return Err(InstructionError::IncorrectAuthority);
             }
         }
     }
@@ -243,6 +253,26 @@ mod test {
             tx_accs,
             ix.accounts,
             Err(InstructionError::MissingRequiredSignature),
+        );
+    }
+
+    #[test]
+    fn fail_process_schedule_task_with_validator_authority() {
+        let (payer, mut pdas, transaction_accounts) = setup_accounts(0);
+        pdas.push(validator_authority_id());
+        let args = ScheduleTaskArgs {
+            task_id: 1,
+            execution_interval_millis: 1000,
+            iterations: 1,
+            instructions: vec![create_complex_ix(&pdas, false, false)],
+        };
+        let ix =
+            InstructionUtils::schedule_task_instruction(&payer.pubkey(), args);
+        process_instruction(
+            &ix.data,
+            transaction_accounts,
+            ix.accounts,
+            Err(InstructionError::IncorrectAuthority),
         );
     }
 

--- a/programs/magicblock/src/schedule_task/process_schedule_task.rs
+++ b/programs/magicblock/src/schedule_task/process_schedule_task.rs
@@ -1,9 +1,8 @@
 use std::collections::HashSet;
 
 use magicblock_core::tls::ExecutionTlsStash;
-use magicblock_magic_program_api::{
-    args::{ScheduleTaskArgs, ScheduleTaskRequest, TaskRequest},
-    pda::CRANK_SIGNER,
+use magicblock_magic_program_api::args::{
+    ScheduleTaskArgs, ScheduleTaskRequest, TaskRequest,
 };
 use solana_instruction::error::InstructionError;
 use solana_log_collector::ic_msg;
@@ -11,8 +10,8 @@ use solana_program_runtime::invoke_context::InvokeContext;
 use solana_pubkey::Pubkey;
 
 use crate::{
+    schedule_task::validate_cranks_instructions,
     utils::accounts::get_instruction_pubkey_with_idx,
-    validator::validator_authority_id,
 };
 
 pub(crate) fn process_schedule_task(
@@ -90,32 +89,7 @@ pub(crate) fn process_schedule_task(
         return Err(InstructionError::InvalidInstructionData);
     }
 
-    // Assert that the task instructions do not have signers aside from the crank signer
-    // Assert they don't use the validator either
-    for instruction in &args.instructions {
-        for account in &instruction.accounts {
-            if account.is_signer && account.pubkey.ne(&CRANK_SIGNER) {
-                ic_msg!(
-                    invoke_context,
-                    "ScheduleTask: only the crank signer PDA can be a signer in cranks (invalid signer: '{}')",
-                    account.pubkey,
-                );
-                return Err(InstructionError::MissingRequiredSignature);
-            } else if account.is_writable && account.pubkey.eq(&CRANK_SIGNER) {
-                ic_msg!(
-                    invoke_context,
-                    "ScheduleTask: the crank signer PDA cannot be a writable account in cranks",
-                );
-                return Err(InstructionError::Immutable);
-            } else if account.pubkey.eq(&validator_authority_id()) {
-                ic_msg!(
-                    invoke_context,
-                    "ScheduleTask: the validator authority cannot be used in cranks",
-                );
-                return Err(InstructionError::IncorrectAuthority);
-            }
-        }
-    }
+    validate_cranks_instructions(invoke_context, &args.instructions)?;
 
     let schedule_request = ScheduleTaskRequest {
         id: args.task_id,
@@ -150,7 +124,9 @@ mod test {
     use crate::{
         test_utils::{process_instruction, COUNTER_PROGRAM_ID},
         utils::instruction_utils::InstructionUtils,
-        validator::generate_validator_authority_if_needed,
+        validator::{
+            generate_validator_authority_if_needed, validator_authority_id,
+        },
     };
 
     fn create_simple_ix() -> Instruction {

--- a/programs/magicblock/src/schedule_task/process_schedule_task.rs
+++ b/programs/magicblock/src/schedule_task/process_schedule_task.rs
@@ -1,18 +1,16 @@
 use std::collections::HashSet;
 
 use magicblock_core::tls::ExecutionTlsStash;
-use magicblock_magic_program_api::args::{
-    ScheduleTaskArgs, ScheduleTaskRequest, TaskRequest,
+use magicblock_magic_program_api::{
+    args::{ScheduleTaskArgs, ScheduleTaskRequest, TaskRequest},
+    CRANK_SIGNER,
 };
 use solana_instruction::error::InstructionError;
 use solana_log_collector::ic_msg;
 use solana_program_runtime::invoke_context::InvokeContext;
 use solana_pubkey::Pubkey;
 
-use crate::{
-    utils::accounts::get_instruction_pubkey_with_idx,
-    validator::effective_validator_authority_id,
-};
+use crate::utils::accounts::get_instruction_pubkey_with_idx;
 
 pub(crate) fn process_schedule_task(
     signers: HashSet<Pubkey>,
@@ -77,17 +75,22 @@ pub(crate) fn process_schedule_task(
         return Err(InstructionError::InvalidInstructionData);
     }
 
-    // Assert that the task instructions do not have signers aside from the validator authority
-    let val_id = effective_validator_authority_id();
+    // Assert that the task instructions do not have signers aside from the crank signer
     for instruction in &args.instructions {
         for account in &instruction.accounts {
-            if account.is_signer && account.pubkey.ne(&val_id) {
+            if account.is_signer && account.pubkey.ne(&CRANK_SIGNER) {
                 ic_msg!(
                     invoke_context,
-                    "ScheduleTask: only the validator authority can be a signer in cranks and '{}' is not the validator.",
+                    "ScheduleTask: only the crank signer PDA can be a signer in cranks (invalid signer: '{}')",
                     account.pubkey,
                 );
                 return Err(InstructionError::MissingRequiredSignature);
+            } else if account.is_writable && account.pubkey.eq(&CRANK_SIGNER) {
+                ic_msg!(
+                    invoke_context,
+                    "ScheduleTask: the crank signer PDA cannot be a writable account in cranks",
+                );
+                return Err(InstructionError::Immutable);
             }
         }
     }
@@ -177,11 +180,8 @@ mod test {
             iterations: 1,
             instructions: vec![create_simple_ix()],
         };
-        let ix = InstructionUtils::schedule_task_instruction(
-            &payer.pubkey(),
-            args,
-            &[],
-        );
+        let ix =
+            InstructionUtils::schedule_task_instruction(&payer.pubkey(), args);
 
         (transaction_accounts, ix)
     }
@@ -199,11 +199,8 @@ mod test {
             iterations: 1,
             instructions: vec![create_complex_ix(&pdas, writable, signer)],
         };
-        let ix = InstructionUtils::schedule_task_instruction(
-            &payer.pubkey(),
-            args,
-            &pdas,
-        );
+        let ix =
+            InstructionUtils::schedule_task_instruction(&payer.pubkey(), args);
 
         (transaction_accounts, ix)
     }
@@ -275,18 +272,15 @@ mod test {
 
     #[test]
     fn fail_process_schedule_empty_task() {
-        let (payer, pdas, transaction_accounts) = setup_accounts(0);
+        let (payer, _pdas, transaction_accounts) = setup_accounts(0);
         let args = ScheduleTaskArgs {
             task_id: 1,
             execution_interval_millis: 1000,
             iterations: 1,
             instructions: vec![],
         };
-        let ix = InstructionUtils::schedule_task_instruction(
-            &payer.pubkey(),
-            args,
-            &pdas,
-        );
+        let ix =
+            InstructionUtils::schedule_task_instruction(&payer.pubkey(), args);
         process_instruction(
             &ix.data,
             transaction_accounts,
@@ -297,18 +291,15 @@ mod test {
 
     #[test]
     fn test_process_schedule_task_with_invalid_iterations() {
-        let (payer, pdas, transaction_accounts) = setup_accounts(0);
+        let (payer, _pdas, transaction_accounts) = setup_accounts(0);
         let args = ScheduleTaskArgs {
             task_id: 1,
             execution_interval_millis: 1000,
             iterations: -100,
             instructions: vec![create_simple_ix()],
         };
-        let ix = InstructionUtils::schedule_task_instruction(
-            &payer.pubkey(),
-            args,
-            &pdas,
-        );
+        let ix =
+            InstructionUtils::schedule_task_instruction(&payer.pubkey(), args);
         process_instruction(
             &ix.data,
             transaction_accounts,

--- a/programs/magicblock/src/schedule_task/process_schedule_task.rs
+++ b/programs/magicblock/src/schedule_task/process_schedule_task.rs
@@ -352,7 +352,7 @@ mod test {
 
     #[test]
     fn test_process_schedule_task_with_invalid_execution_interval() {
-        let (payer, pdas, transaction_accounts) = setup_accounts(0);
+        let (payer, _pdas, transaction_accounts) = setup_accounts(0);
         for execution_interval_millis in [-12345, 0, u32::MAX as i64 + 1] {
             let args = ScheduleTaskArgs {
                 task_id: 1,
@@ -363,7 +363,6 @@ mod test {
             let ix = InstructionUtils::schedule_task_instruction(
                 &payer.pubkey(),
                 args,
-                &pdas,
             );
             process_instruction(
                 &ix.data,

--- a/programs/magicblock/src/utils/instruction_utils.rs
+++ b/programs/magicblock/src/utils/instruction_utils.rs
@@ -277,20 +277,16 @@ impl InstructionUtils {
             AccountMeta::new_readonly(validator_authority_id(), true),
             AccountMeta::new_readonly(CRANK_SIGNER, false),
         ];
-        account_metas.extend(instructions.iter().flat_map(|i| {
-            [
-                vec![AccountMeta::new(i.program_id, false)],
-                i.accounts
-                    .iter()
-                    .map(|a| AccountMeta {
-                        pubkey: a.pubkey,
-                        is_signer: a.is_signer,
-                        is_writable: a.is_writable,
-                    })
-                    .collect::<Vec<_>>(),
-            ]
-            .concat()
-        }));
+        for instruction in &instructions {
+            account_metas.push(AccountMeta::new(instruction.program_id, false));
+            account_metas.extend(instruction.accounts.iter().map(|account| {
+                AccountMeta {
+                    pubkey: account.pubkey,
+                    is_signer: account.is_signer,
+                    is_writable: account.is_writable,
+                }
+            }));
+        }
         Instruction::new_with_bincode(
             crate::id(),
             &MagicBlockInstruction::ExecuteCrank { instructions },

--- a/programs/magicblock/src/utils/instruction_utils.rs
+++ b/programs/magicblock/src/utils/instruction_utils.rs
@@ -283,7 +283,7 @@ impl InstructionUtils {
             account_metas.extend(instruction.accounts.iter().map(|account| {
                 AccountMeta {
                     pubkey: account.pubkey,
-                    is_signer: account.is_signer,
+                    is_signer: false,
                     is_writable: account.is_writable,
                 }
             }));

--- a/programs/magicblock/src/utils/instruction_utils.rs
+++ b/programs/magicblock/src/utils/instruction_utils.rs
@@ -273,8 +273,10 @@ impl InstructionUtils {
     pub fn execute_task_instruction(
         instructions: Vec<Instruction>,
     ) -> Instruction {
-        let mut account_metas =
-            vec![AccountMeta::new_readonly(CRANK_SIGNER, false)];
+        let mut account_metas = vec![
+            AccountMeta::new_readonly(validator_authority_id(), true),
+            AccountMeta::new_readonly(CRANK_SIGNER, false),
+        ];
         account_metas.extend(instructions.iter().flat_map(|i| {
             [
                 vec![AccountMeta::new(i.program_id, false)],

--- a/programs/magicblock/src/utils/instruction_utils.rs
+++ b/programs/magicblock/src/utils/instruction_utils.rs
@@ -9,7 +9,7 @@ use magicblock_magic_program_api::{
         AccountModification, AccountModificationForInstruction,
         MagicBlockInstruction,
     },
-    MAGIC_CONTEXT_PUBKEY,
+    CRANK_SIGNER, MAGIC_CONTEXT_PUBKEY,
 };
 use solana_hash::Hash;
 use solana_instruction::{AccountMeta, Instruction};
@@ -223,23 +223,17 @@ impl InstructionUtils {
     pub fn schedule_task(
         payer: &Keypair,
         args: ScheduleTaskArgs,
-        accounts: &[Pubkey],
         recent_blockhash: Hash,
     ) -> Transaction {
-        let ix =
-            Self::schedule_task_instruction(&payer.pubkey(), args, accounts);
+        let ix = Self::schedule_task_instruction(&payer.pubkey(), args);
         Self::into_transaction(payer, ix, recent_blockhash)
     }
 
     pub fn schedule_task_instruction(
         payer: &Pubkey,
         args: ScheduleTaskArgs,
-        accounts: &[Pubkey],
     ) -> Instruction {
-        let mut account_metas = vec![AccountMeta::new(*payer, true)];
-        for account in accounts {
-            account_metas.push(AccountMeta::new_readonly(*account, false));
-        }
+        let account_metas = vec![AccountMeta::new(*payer, true)];
 
         Instruction::new_with_bincode(
             crate::id(),
@@ -271,6 +265,43 @@ impl InstructionUtils {
             &MagicBlockInstruction::CancelTask { task_id },
             account_metas,
         )
+    }
+
+    // -----------------
+    // Execute Crank
+    // -----------------
+    pub fn execute_task_instruction(
+        instructions: Vec<Instruction>,
+    ) -> Instruction {
+        let mut account_metas =
+            vec![AccountMeta::new_readonly(CRANK_SIGNER, false)];
+        account_metas.extend(instructions.iter().flat_map(|i| {
+            [
+                vec![AccountMeta::new(i.program_id, false)],
+                i.accounts
+                    .iter()
+                    .map(|a| AccountMeta {
+                        pubkey: a.pubkey,
+                        is_signer: a.is_signer,
+                        is_writable: a.is_writable,
+                    })
+                    .collect::<Vec<_>>(),
+            ]
+            .concat()
+        }));
+        Instruction::new_with_bincode(
+            crate::id(),
+            &MagicBlockInstruction::ExecuteCrank { instructions },
+            account_metas,
+        )
+    }
+
+    pub fn execute_task(
+        instructions: Vec<Instruction>,
+        recent_blockhash: Hash,
+    ) -> Transaction {
+        let ix = Self::execute_task_instruction(instructions);
+        Self::into_transaction(&validator_authority(), ix, recent_blockhash)
     }
 
     // -----------------

--- a/programs/magicblock/src/utils/instruction_utils.rs
+++ b/programs/magicblock/src/utils/instruction_utils.rs
@@ -9,7 +9,8 @@ use magicblock_magic_program_api::{
         AccountModification, AccountModificationForInstruction,
         MagicBlockInstruction,
     },
-    CRANK_SIGNER, MAGIC_CONTEXT_PUBKEY,
+    pda::CRANK_SIGNER,
+    MAGIC_CONTEXT_PUBKEY,
 };
 use solana_hash::Hash;
 use solana_instruction::{AccountMeta, Instruction};

--- a/test-integration/Cargo.lock
+++ b/test-integration/Cargo.lock
@@ -2340,10 +2340,10 @@ dependencies = [
 
 [[package]]
 name = "guinea"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "bincode",
- "magicblock-magic-program-api 0.8.6",
+ "magicblock-magic-program-api 0.8.7",
  "serde",
  "solana-program",
 ]
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-account-cloner"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "async-trait",
  "bincode",
@@ -3437,7 +3437,7 @@ dependencies = [
  "magicblock-config",
  "magicblock-core",
  "magicblock-ledger",
- "magicblock-magic-program-api 0.8.6",
+ "magicblock-magic-program-api 0.8.7",
  "magicblock-program",
  "magicblock-rpc-client",
  "rand 0.9.2",
@@ -3459,7 +3459,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-accounts"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "async-trait",
  "magicblock-account-cloner",
@@ -3482,7 +3482,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-accounts-db"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "lmdb-rkv",
  "magicblock-config",
@@ -3498,7 +3498,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-aperture"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "agave-geyser-plugin-interface",
  "arc-swap",
@@ -3546,7 +3546,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-api"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "anyhow",
  "borsh 1.6.0",
@@ -3562,7 +3562,7 @@ dependencies = [
  "magicblock-core",
  "magicblock-delegation-program-api 0.3.0",
  "magicblock-ledger",
- "magicblock-magic-program-api 0.8.6",
+ "magicblock-magic-program-api 0.8.7",
  "magicblock-metrics",
  "magicblock-processor",
  "magicblock-program",
@@ -3603,7 +3603,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-chainlink"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -3616,7 +3616,7 @@ dependencies = [
  "magicblock-config",
  "magicblock-core",
  "magicblock-delegation-program-api 0.3.0",
- "magicblock-magic-program-api 0.8.6",
+ "magicblock-magic-program-api 0.8.7",
  "magicblock-metrics",
  "parking_lot",
  "scc",
@@ -3658,7 +3658,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-committor-program"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "borsh 1.6.0",
  "paste",
@@ -3670,7 +3670,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-committor-service"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -3715,7 +3715,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-config"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "clap",
  "derive_more",
@@ -3733,11 +3733,11 @@ dependencies = [
 
 [[package]]
 name = "magicblock-core"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "bincode",
  "flume",
- "magicblock-magic-program-api 0.8.6",
+ "magicblock-magic-program-api 0.8.7",
  "serde",
  "solana-account",
  "solana-account-decoder",
@@ -3827,7 +3827,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-ledger"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -3877,9 +3877,10 @@ dependencies = [
 
 [[package]]
 name = "magicblock-magic-program-api"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "bincode",
+ "const-crypto",
  "serde",
  "solana-program",
  "solana-signature",
@@ -3887,7 +3888,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-metrics"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "http-body-util",
  "hyper 1.8.1",
@@ -3902,7 +3903,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-processor"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "bincode",
  "magicblock-accounts-db",
@@ -3938,12 +3939,12 @@ dependencies = [
 
 [[package]]
 name = "magicblock-program"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "bincode",
  "lazy_static",
  "magicblock-core",
- "magicblock-magic-program-api 0.8.6",
+ "magicblock-magic-program-api 0.8.7",
  "num-derive",
  "num-traits",
  "parking_lot",
@@ -3972,7 +3973,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-rpc-client"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "solana-account",
  "solana-account-decoder-client-types",
@@ -3994,12 +3995,12 @@ dependencies = [
 
 [[package]]
 name = "magicblock-services"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "bincode",
  "futures-util",
  "magicblock-core",
- "magicblock-magic-program-api 0.8.6",
+ "magicblock-magic-program-api 0.8.7",
  "solana-instruction 2.2.1",
  "solana-keypair",
  "solana-message",
@@ -4015,7 +4016,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-table-mania"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "ed25519-dalek",
  "magicblock-metrics",
@@ -4041,7 +4042,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-task-scheduler"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "bincode",
  "chrono",
@@ -4067,7 +4068,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-validator-admin"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "magicblock-delegation-program-api 0.3.0",
  "magicblock-program",
@@ -4084,7 +4085,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-version"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "git-version",
  "rustc_version",
@@ -4997,7 +4998,7 @@ dependencies = [
  "bincode",
  "borsh 1.6.0",
  "ephemeral-rollups-sdk",
- "magicblock-magic-program-api 0.8.6",
+ "magicblock-magic-program-api 0.8.7",
  "serde",
  "solana-program",
 ]
@@ -5021,7 +5022,7 @@ dependencies = [
  "borsh 1.6.0",
  "ephemeral-rollups-sdk",
  "magicblock-delegation-program-api 0.3.0",
- "magicblock-magic-program-api 0.8.6",
+ "magicblock-magic-program-api 0.8.7",
  "rkyv 0.7.45",
  "solana-program",
  "static_assertions",
@@ -6052,7 +6053,7 @@ dependencies = [
  "integration-test-tools",
  "magicblock-core",
  "magicblock-delegation-program-api 0.3.0",
- "magicblock-magic-program-api 0.8.6",
+ "magicblock-magic-program-api 0.8.7",
  "magicblock-program",
  "program-schedulecommit",
  "rand 0.8.5",
@@ -6073,7 +6074,7 @@ dependencies = [
  "integration-test-tools",
  "magicblock-core",
  "magicblock-delegation-program-api 0.3.0",
- "magicblock-magic-program-api 0.8.6",
+ "magicblock-magic-program-api 0.8.7",
  "program-schedulecommit",
  "program-schedulecommit-security",
  "schedulecommit-client",
@@ -8908,7 +8909,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-proto"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "bincode",
  "bs58",
@@ -10411,7 +10412,7 @@ dependencies = [
 
 [[package]]
 name = "test-kit"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "guinea",
  "magicblock-accounts-db",
@@ -10507,7 +10508,7 @@ dependencies = [
  "integration-test-tools",
  "log",
  "magicblock-delegation-program-api 0.3.0",
- "magicblock-magic-program-api 0.8.6",
+ "magicblock-magic-program-api 0.8.7",
  "program-flexi-counter",
  "solana-rpc-client-api",
  "solana-sdk",

--- a/test-integration/test-task-scheduler/tests/test_use_crank_signer.rs
+++ b/test-integration/test-task-scheduler/tests/test_use_crank_signer.rs
@@ -1,0 +1,97 @@
+use cleanass::assert;
+use integration_test_tools::{expect, validator::cleanup};
+use magicblock_program::{
+    args::ScheduleTaskArgs, instruction_utils::InstructionUtils,
+    pda::CRANK_SIGNER,
+};
+use program_flexi_counter::{
+    instruction::FlexiCounterInstruction, state::FlexiCounter,
+};
+use solana_sdk::{
+    instruction::{AccountMeta, Instruction},
+    native_token::LAMPORTS_PER_SOL,
+    signature::Keypair,
+    signer::Signer,
+    transaction::Transaction,
+};
+use test_task_scheduler::{create_delegated_counter, setup_validator};
+
+#[test]
+fn test_use_crank_signer() {
+    let (_temp_dir, mut validator, ctx) = setup_validator();
+
+    let payer = Keypair::new();
+    let (counter_pda, _) = FlexiCounter::pda(&payer.pubkey());
+
+    expect!(
+        ctx.airdrop_chain(&payer.pubkey(), 10 * LAMPORTS_PER_SOL),
+        validator
+    );
+
+    create_delegated_counter(&ctx, &payer, &mut validator, 0);
+
+    let ephem_blockhash =
+        expect!(ctx.try_get_latest_blockhash_ephem(), validator);
+
+    // Schedule a task
+    let task_id = 9;
+    let execution_interval_millis = 10;
+    let iterations = 5;
+    let sig = expect!(
+        ctx.send_transaction_ephem_with_preflight(
+            &mut Transaction::new_signed_with_payer(
+                &[InstructionUtils::schedule_task_instruction(
+                    &payer.pubkey(),
+                    ScheduleTaskArgs {
+                        task_id,
+                        execution_interval_millis,
+                        iterations,
+                        instructions: vec![Instruction::new_with_borsh(
+                            program_flexi_counter::ID,
+                            &FlexiCounterInstruction::AddUnsigned { count: 1 },
+                            vec![
+                                AccountMeta::new(counter_pda, false),
+                                AccountMeta::new_readonly(CRANK_SIGNER, true)
+                            ],
+                        )],
+                    }
+                )],
+                Some(&payer.pubkey()),
+                &[&payer],
+                ephem_blockhash,
+            ),
+            &[&payer]
+        ),
+        validator
+    );
+    let status = expect!(ctx.get_transaction_ephem(&sig), validator);
+    expect!(
+        status
+            .transaction
+            .meta
+            .and_then(|m| m.status.ok())
+            .ok_or_else(|| anyhow::anyhow!("Transaction failed")),
+        validator
+    );
+
+    // Wait for the task to be scheduled
+    expect!(ctx.wait_for_delta_slot_ephem(10), validator);
+
+    // Check that the counter was incremented
+    let counter_account = expect!(
+        ctx.try_ephem_client().and_then(|client| client
+            .get_account(&counter_pda)
+            .map_err(|e| anyhow::anyhow!("Failed to get account: {}", e))),
+        validator
+    );
+    let counter =
+        expect!(FlexiCounter::try_decode(&counter_account.data), validator);
+    assert!(
+        counter.count == iterations as u64,
+        cleanup(&mut validator),
+        "counter.count: {}",
+        counter.count
+    );
+
+    cleanup(&mut validator);
+}


### PR DESCRIPTION
## Summary
- Introduces a new Magic Program instruction that executes crank instructions through CPI, replacing the validator signer with an immutable PDA signer.

## Compatibility
Breaking change: cranks can no longer rely on the validator pubkey to gate instructions to crank, but can instead use the CRANK_SIGNER

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Execute-Crank capability to run embedded instructions and a helper to build/send execute-task transactions.
  * Introduced a dedicated crank signer PDA for crank execution.

* **Refactor**
  * Simplified scheduling APIs by removing explicit extra account-list parameters.
  * Transaction construction now wraps inner instructions into a single execute-task instruction.

* **Bug Fixes**
  * Stricter validation to prevent improper signers, writable crank signer accounts, and invalid account layouts.

* **Tests**
  * Added unit and integration tests covering success and multiple failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->