### PR TITLE
chore: disable flaky tests

### DIFF
--- a/.github/workflows/ci-test-integration.yml
+++ b/.github/workflows/ci-test-integration.yml
@@ -64,7 +64,7 @@ jobs:
       - uses: ./magicblock-validator/.github/actions/setup-build-env
         with:
           build_cache_key_name: "magicblock-validator-ci-test-integration-${{ github.ref_name }}-${{ hashFiles('magicblock-validator/Cargo.lock') }}"
-          rust_toolchain_release: "1.84.1"
+          rust_toolchain_release: "1.91.1"
           github_access_token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ci-test-unit.yml
+++ b/.github/workflows/ci-test-unit.yml
@@ -28,6 +28,9 @@ jobs:
 
       - uses: ./magicblock-validator/.github/actions/setup-solana
 
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
+
       - name: Run unit tests
         run: |
           sudo prlimit --pid $$ --nofile=1048576:1048576

--- a/test-integration/Cargo.lock
+++ b/test-integration/Cargo.lock
@@ -2340,10 +2340,10 @@ dependencies = [
 
 [[package]]
 name = "guinea"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "bincode",
- "magicblock-magic-program-api 0.8.6",
+ "magicblock-magic-program-api 0.8.7",
  "serde",
  "solana-program",
 ]
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-account-cloner"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "async-trait",
  "bincode",
@@ -3437,7 +3437,7 @@ dependencies = [
  "magicblock-config",
  "magicblock-core",
  "magicblock-ledger",
- "magicblock-magic-program-api 0.8.6",
+ "magicblock-magic-program-api 0.8.7",
  "magicblock-program",
  "magicblock-rpc-client",
  "rand 0.9.2",
@@ -3459,7 +3459,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-accounts"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "async-trait",
  "magicblock-account-cloner",
@@ -3482,7 +3482,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-accounts-db"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "lmdb-rkv",
  "magicblock-config",
@@ -3498,7 +3498,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-aperture"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "agave-geyser-plugin-interface",
  "arc-swap",
@@ -3546,7 +3546,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-api"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "anyhow",
  "borsh 1.6.0",
@@ -3562,7 +3562,7 @@ dependencies = [
  "magicblock-core",
  "magicblock-delegation-program-api 0.3.0",
  "magicblock-ledger",
- "magicblock-magic-program-api 0.8.6",
+ "magicblock-magic-program-api 0.8.7",
  "magicblock-metrics",
  "magicblock-processor",
  "magicblock-program",
@@ -3603,7 +3603,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-chainlink"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -3616,7 +3616,7 @@ dependencies = [
  "magicblock-config",
  "magicblock-core",
  "magicblock-delegation-program-api 0.3.0",
- "magicblock-magic-program-api 0.8.6",
+ "magicblock-magic-program-api 0.8.7",
  "magicblock-metrics",
  "parking_lot",
  "scc",
@@ -3658,7 +3658,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-committor-program"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "borsh 1.6.0",
  "paste",
@@ -3670,7 +3670,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-committor-service"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -3715,7 +3715,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-config"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "clap",
  "derive_more",
@@ -3733,11 +3733,11 @@ dependencies = [
 
 [[package]]
 name = "magicblock-core"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "bincode",
  "flume",
- "magicblock-magic-program-api 0.8.6",
+ "magicblock-magic-program-api 0.8.7",
  "serde",
  "solana-account",
  "solana-account-decoder",
@@ -3827,7 +3827,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-ledger"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -3877,7 +3877,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-magic-program-api"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "bincode",
  "serde",
@@ -3887,7 +3887,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-metrics"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "http-body-util",
  "hyper 1.8.1",
@@ -3902,7 +3902,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-processor"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "bincode",
  "magicblock-accounts-db",
@@ -3938,12 +3938,12 @@ dependencies = [
 
 [[package]]
 name = "magicblock-program"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "bincode",
  "lazy_static",
  "magicblock-core",
- "magicblock-magic-program-api 0.8.6",
+ "magicblock-magic-program-api 0.8.7",
  "num-derive",
  "num-traits",
  "parking_lot",
@@ -3972,7 +3972,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-rpc-client"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "solana-account",
  "solana-account-decoder-client-types",
@@ -3994,12 +3994,12 @@ dependencies = [
 
 [[package]]
 name = "magicblock-services"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "bincode",
  "futures-util",
  "magicblock-core",
- "magicblock-magic-program-api 0.8.6",
+ "magicblock-magic-program-api 0.8.7",
  "solana-instruction 2.2.1",
  "solana-keypair",
  "solana-message",
@@ -4015,7 +4015,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-table-mania"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "ed25519-dalek",
  "magicblock-metrics",
@@ -4041,7 +4041,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-task-scheduler"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "bincode",
  "chrono",
@@ -4067,7 +4067,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-validator-admin"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "magicblock-delegation-program-api 0.3.0",
  "magicblock-program",
@@ -4084,7 +4084,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-version"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "git-version",
  "rustc_version",
@@ -4997,7 +4997,7 @@ dependencies = [
  "bincode",
  "borsh 1.6.0",
  "ephemeral-rollups-sdk",
- "magicblock-magic-program-api 0.8.6",
+ "magicblock-magic-program-api 0.8.7",
  "serde",
  "solana-program",
 ]
@@ -5021,7 +5021,7 @@ dependencies = [
  "borsh 1.6.0",
  "ephemeral-rollups-sdk",
  "magicblock-delegation-program-api 0.3.0",
- "magicblock-magic-program-api 0.8.6",
+ "magicblock-magic-program-api 0.8.7",
  "rkyv 0.7.45",
  "solana-program",
  "static_assertions",
@@ -6052,7 +6052,7 @@ dependencies = [
  "integration-test-tools",
  "magicblock-core",
  "magicblock-delegation-program-api 0.3.0",
- "magicblock-magic-program-api 0.8.6",
+ "magicblock-magic-program-api 0.8.7",
  "magicblock-program",
  "program-schedulecommit",
  "rand 0.8.5",
@@ -6073,7 +6073,7 @@ dependencies = [
  "integration-test-tools",
  "magicblock-core",
  "magicblock-delegation-program-api 0.3.0",
- "magicblock-magic-program-api 0.8.6",
+ "magicblock-magic-program-api 0.8.7",
  "program-schedulecommit",
  "program-schedulecommit-security",
  "schedulecommit-client",
@@ -8908,7 +8908,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-proto"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "bincode",
  "bs58",
@@ -10411,7 +10411,7 @@ dependencies = [
 
 [[package]]
 name = "test-kit"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "guinea",
  "magicblock-accounts-db",
@@ -10507,7 +10507,7 @@ dependencies = [
  "integration-test-tools",
  "log",
  "magicblock-delegation-program-api 0.3.0",
- "magicblock-magic-program-api 0.8.6",
+ "magicblock-magic-program-api 0.8.7",
  "program-flexi-counter",
  "solana-rpc-client-api",
  "solana-sdk",

--- a/test-integration/Makefile
+++ b/test-integration/Makefile
@@ -30,7 +30,9 @@ list-programs:
 programs: $(PROGRAMS_SO)
 
 test: $(PROGRAMS_SO)
-	$(MAKE) chainlink-prep-programs -C ./test-chainlink && \
+	if [ -z "$(RUN_TESTS)" ] || printf ',%s,' "$(RUN_TESTS)" | grep -q ',chainlink,'; then \
+		$(MAKE) chainlink-prep-programs -C ./test-chainlink; \
+	fi && \
 	RUST_BACKTRACE=1 \
 	RUST_LOG=$(RUST_LOG) \
 	cargo run --package test-runner --bin run-tests

--- a/test-integration/Makefile
+++ b/test-integration/Makefile
@@ -30,7 +30,7 @@ list-programs:
 programs: $(PROGRAMS_SO)
 
 test: $(PROGRAMS_SO)
-	if [ -z "$(RUN_TESTS)" ] || printf ',%s,' "$(RUN_TESTS)" | grep -q ',chainlink,'; then \
+	if [ -z "$(RUN_TESTS)" ] || printf ',%s,' "$(RUN_TESTS)" | grep -Eq ',(chainlink|cloning),'; then \
 		$(MAKE) chainlink-prep-programs -C ./test-chainlink; \
 	fi && \
 	RUST_BACKTRACE=1 \

--- a/test-integration/test-ledger-restore/tests/08_commit_update.rs
+++ b/test-integration/test-ledger-restore/tests/08_commit_update.rs
@@ -36,7 +36,9 @@ fn payer_keypair() -> Keypair {
 // NOTE: that most of the setup is similar to 07_commit_delegated_account.rs
 // except that we removed the intermediate checks.
 
+// Flaky integration test.
 #[test]
+#[ignore = "flaky"]
 fn test_restore_ledger_committed_and_updated_account() {
     let (_tmpdir, ledger_path) = resolve_tmp_dir(TMP_DIR_LEDGER);
     let payer = payer_keypair();

--- a/test-integration/test-ledger-restore/tests/09_restore_different_accounts_multiple_times.rs
+++ b/test-integration/test-ledger-restore/tests/09_restore_different_accounts_multiple_times.rs
@@ -39,7 +39,9 @@ fn payer_keypair() -> Keypair {
 //
 // NOTE: this same setup is repeated in ./10_readonly_update_after.rs except
 // we only check here that we can properly restore all of these accounts at all
+// Flaky integration test.
 #[test]
+#[ignore = "flaky"]
 fn test_restore_ledger_different_accounts_multiple_times() {
     init_logger!();
     let (_tmpdir, ledger_path) = resolve_tmp_dir(TMP_DIR_LEDGER);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Marked two integration tests as flaky to address intermittent test failures, preventing them from running by default in the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->