### PR TITLE
fix: more flexible wait

### DIFF
--- a/test-integration/test-task-scheduler/src/lib.rs
+++ b/test-integration/test-task-scheduler/src/lib.rs
@@ -1,4 +1,8 @@
-use std::{process::Child, str::FromStr, time::Duration};
+use std::{
+    process::Child,
+    str::FromStr,
+    time::{Duration, Instant},
+};
 
 use integration_test_tools::{
     expect,
@@ -19,8 +23,12 @@ use magicblock_config::{
     types::{network::Remote, StorageDirectory},
     ValidatorParams,
 };
-use program_flexi_counter::instruction::{
-    create_delegate_ix_with_commit_frequency_ms, create_init_ix,
+use magicblock_program::Pubkey;
+use program_flexi_counter::{
+    instruction::{
+        create_delegate_ix_with_commit_frequency_ms, create_init_ix,
+    },
+    state::FlexiCounter,
 };
 use solana_sdk::{
     signature::Keypair, signer::Signer, transaction::Transaction,
@@ -121,4 +129,28 @@ pub fn create_delegated_counter(
 
     // Wait for account to be delegated
     expect!(ctx.wait_for_delta_slot_ephem(10), validator);
+}
+
+pub fn wait_for_incremented_counter(
+    ctx: &IntegrationTestContext,
+    counter_pda: &Pubkey,
+    expected_count: u64,
+    max_timeout: Duration,
+    validator: &mut Child,
+) {
+    let now = Instant::now();
+    while now.elapsed() < max_timeout {
+        let counter_account = expect!(
+            ctx.try_ephem_client().and_then(|client| client
+                .get_account(counter_pda)
+                .map_err(|e| anyhow::anyhow!("Failed to get account: {}", e))),
+            validator
+        );
+        let counter =
+            expect!(FlexiCounter::try_decode(&counter_account.data), validator);
+        if counter.count == expected_count {
+            break;
+        }
+        expect!(ctx.wait_for_next_slot_ephem(), validator);
+    }
 }

--- a/test-integration/test-task-scheduler/src/lib.rs
+++ b/test-integration/test-task-scheduler/src/lib.rs
@@ -4,12 +4,13 @@ use std::{
     time::{Duration, Instant},
 };
 
+use cleanass::assert;
 use integration_test_tools::{
     expect,
     loaded_accounts::LoadedAccounts,
     tmpdir::resolve_tmp_dir,
     validator::{
-        start_magicblock_validator_with_config_struct_and_temp_dir,
+        cleanup, start_magicblock_validator_with_config_struct_and_temp_dir,
         TMP_DIR_CONFIG,
     },
     IntegrationTestContext,
@@ -149,8 +150,13 @@ pub fn wait_for_incremented_counter(
         let counter =
             expect!(FlexiCounter::try_decode(&counter_account.data), validator);
         if counter.count == expected_count {
-            break;
+            return;
         }
         expect!(ctx.wait_for_next_slot_ephem(), validator);
     }
+    assert!(
+        false,
+        cleanup(validator),
+        "Failed to wait for incremented counter"
+    );
 }

--- a/test-integration/test-task-scheduler/tests/test_schedule_task.rs
+++ b/test-integration/test-task-scheduler/tests/test_schedule_task.rs
@@ -1,4 +1,6 @@
-use cleanass::{assert, assert_eq};
+use std::time::Duration;
+
+use cleanass::assert_eq;
 use integration_test_tools::{expect, validator::cleanup};
 use magicblock_task_scheduler::{db::DbTask, SchedulerDatabase};
 use program_flexi_counter::{
@@ -9,7 +11,9 @@ use solana_sdk::{
     native_token::LAMPORTS_PER_SOL, signature::Keypair, signer::Signer,
     transaction::Transaction,
 };
-use test_task_scheduler::{create_delegated_counter, setup_validator};
+use test_task_scheduler::{
+    create_delegated_counter, setup_validator, wait_for_incremented_counter,
+};
 use tokio::runtime::Runtime;
 
 #[test]
@@ -64,7 +68,14 @@ fn test_schedule_task() {
     );
 
     // Wait for the task to be scheduled and executed
-    expect!(ctx.wait_for_delta_slot_ephem(10), validator);
+    // Check that the counter was incremented
+    wait_for_incremented_counter(
+        &ctx,
+        &counter_pda,
+        iterations as u64,
+        Duration::from_secs(10),
+        &mut validator,
+    );
 
     // Check that the task was scheduled in the database
     let db = expect!(SchedulerDatabase::new(db_path), validator);
@@ -110,22 +121,6 @@ fn test_schedule_task() {
         last_execution_millis: task.last_execution_millis,
     };
     assert_eq!(task, expected_task, cleanup(&mut validator));
-
-    // Check that the counter was incremented
-    let counter_account = expect!(
-        ctx.try_ephem_client().and_then(|client| client
-            .get_account(&counter_pda)
-            .map_err(|e| anyhow::anyhow!("Failed to get account: {}", e))),
-        validator
-    );
-    let counter =
-        expect!(FlexiCounter::try_decode(&counter_account.data), validator);
-    assert!(
-        counter.count == iterations as u64,
-        cleanup(&mut validator),
-        "counter.count: {}",
-        counter.count
-    );
 
     // Cancel the task
     let sig = expect!(

--- a/test-integration/test-task-scheduler/tests/test_unauthorized_reschedule.rs
+++ b/test-integration/test-task-scheduler/tests/test_unauthorized_reschedule.rs
@@ -1,4 +1,6 @@
-use cleanass::{assert, assert_eq};
+use std::time::Duration;
+
+use cleanass::assert_eq;
 use integration_test_tools::{expect, validator::cleanup};
 use magicblock_task_scheduler::{db::DbTask, SchedulerDatabase};
 use program_flexi_counter::{
@@ -8,7 +10,9 @@ use solana_sdk::{
     native_token::LAMPORTS_PER_SOL, signature::Keypair, signer::Signer,
     transaction::Transaction,
 };
-use test_task_scheduler::{create_delegated_counter, setup_validator};
+use test_task_scheduler::{
+    create_delegated_counter, setup_validator, wait_for_incremented_counter,
+};
 use tokio::runtime::Runtime;
 
 #[test]
@@ -103,7 +107,14 @@ fn test_unauthorized_reschedule() {
     );
 
     // Wait for the task to be processed
-    expect!(ctx.wait_for_delta_slot_ephem(6), validator);
+    // Check that the counter was incremented
+    wait_for_incremented_counter(
+        &ctx,
+        &counter_pda,
+        iterations as u64,
+        Duration::from_secs(10),
+        &mut validator,
+    );
 
     // Check that one task is scheduled but another one is failed to schedule
     let db = expect!(SchedulerDatabase::new(db_path), validator);
@@ -149,22 +160,6 @@ fn test_unauthorized_reschedule() {
         last_execution_millis: task.last_execution_millis,
     };
     assert_eq!(task, expected_task, cleanup(&mut validator));
-
-    // Check that the counter was incremented
-    let counter_account = expect!(
-        ctx.try_ephem_client().and_then(|client| client
-            .get_account(&counter_pda)
-            .map_err(|e| anyhow::anyhow!("Failed to get account: {}", e))),
-        validator
-    );
-    let counter =
-        expect!(FlexiCounter::try_decode(&counter_account.data), validator);
-    assert!(
-        counter.count == iterations as u64,
-        cleanup(&mut validator),
-        "counter.count: {}",
-        counter.count
-    );
 
     cleanup(&mut validator);
 }

--- a/test-integration/test-task-scheduler/tests/test_use_crank_signer.rs
+++ b/test-integration/test-task-scheduler/tests/test_use_crank_signer.rs
@@ -1,4 +1,5 @@
-use cleanass::assert;
+use std::time::Duration;
+
 use integration_test_tools::{expect, validator::cleanup};
 use magicblock_program::{
     args::ScheduleTaskArgs, instruction_utils::InstructionUtils,
@@ -14,7 +15,9 @@ use solana_sdk::{
     signer::Signer,
     transaction::Transaction,
 };
-use test_task_scheduler::{create_delegated_counter, setup_validator};
+use test_task_scheduler::{
+    create_delegated_counter, setup_validator, wait_for_incremented_counter,
+};
 
 #[test]
 fn test_use_crank_signer() {
@@ -74,23 +77,13 @@ fn test_use_crank_signer() {
         validator
     );
 
-    // Wait for the task to be scheduled
-    expect!(ctx.wait_for_delta_slot_ephem(10), validator);
-
     // Check that the counter was incremented
-    let counter_account = expect!(
-        ctx.try_ephem_client().and_then(|client| client
-            .get_account(&counter_pda)
-            .map_err(|e| anyhow::anyhow!("Failed to get account: {}", e))),
-        validator
-    );
-    let counter =
-        expect!(FlexiCounter::try_decode(&counter_account.data), validator);
-    assert!(
-        counter.count == iterations as u64,
-        cleanup(&mut validator),
-        "counter.count: {}",
-        counter.count
+    wait_for_incremented_counter(
+        &ctx,
+        &counter_pda,
+        iterations as u64,
+        Duration::from_secs(10),
+        &mut validator,
     );
 
     cleanup(&mut validator);


### PR DESCRIPTION
## Summary
- Some crank integration tests were flaky because they did not wait long enough.
- This PR polls the incremented counter instead of doing a single try.

## Compatibility
- [X] No breaking changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `wait_for_incremented_counter` testing helper function for verifying on-chain counter state with timeout-based polling.

* **Tests**
  * Refactored multiple test files to use the new counter verification helper, replacing fixed slot waits and manual account verification with robust timeout-based polling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->