### PR TITLE
feat: use getAccountInfo when ensure_accounts fetches only 1 account

### DIFF
--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -1136,26 +1136,34 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                 // its account cache. Otherwise we could just keep fetching the accounts
                 // until the context slot is high enough.
                 metrics::inc_remote_account_provider_a_count();
-                match tokio::time::timeout(
-                    RPC_CALL_TIMEOUT,
-                    rpc_client.get_multiple_accounts_with_config(
-                        &pubkeys,
-                        RpcAccountInfoConfig {
-                            commitment: Some(commitment),
-                            min_context_slot: Some(min_context_slot),
-                            encoding: Some(UiAccountEncoding::Base64Zstd),
-                            data_slice: None,
-                        },
-                    ),
-                )
+                match tokio::time::timeout(RPC_CALL_TIMEOUT, async {
+                    let config = RpcAccountInfoConfig {
+                        commitment: Some(commitment),
+                        min_context_slot: Some(min_context_slot),
+                        encoding: Some(UiAccountEncoding::Base64Zstd),
+                        data_slice: None,
+                    };
+
+                    if pubkeys.len() == 1 {
+                        rpc_client
+                            .get_account_with_config(&pubkeys[0], config)
+                            .await
+                            .map(|res| (res.context.slot, vec![res.value]))
+                    } else {
+                        rpc_client
+                            .get_multiple_accounts_with_config(&pubkeys, config)
+                            .await
+                            .map(|res| (res.context.slot, res.value))
+                    }
+                })
                 .await
                 {
                     Ok(Ok(res)) => {
-                        let slot = res.context.slot;
+                        let (slot, value) = res;
                         if slot < min_context_slot {
                             retry!("Response slot {slot} < {min_context_slot}. Retrying...");
                         } else {
-                            break res;
+                            break (slot, value);
                         }
                     }
                     Ok(Err(err)) => match err.kind {
@@ -1232,20 +1240,21 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
             };
 
             // TODO: should we retry if not or respond with an error?
-            assert!(response.context.slot >= min_context_slot);
+            let (response_slot, response_value) = response;
+            assert!(response_slot >= min_context_slot);
 
             let mut found_count = 0u64;
             let mut not_found_count = 0u64;
 
             let remote_accounts: Vec<RemoteAccount> = pubkeys
                 .iter()
-                .zip(response.value)
+                .zip(response_value)
                 .map(|(pubkey, acc)| match acc {
                     Some(value) => {
                         found_count += 1;
                         RemoteAccount::from_fresh_account(
                             value,
-                            response.context.slot,
+                            response_slot,
                             RemoteAccountUpdateSource::Fetch,
                         )
                     }
@@ -1259,13 +1268,13 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                                 executable: false,
                                 rent_epoch: 0,
                             },
-                            response.context.slot,
+                            response_slot,
                             RemoteAccountUpdateSource::Fetch,
                         )
                     }
                     None => {
                         not_found_count += 1;
-                        NotFound(response.context.slot)
+                        NotFound(response_slot)
                     }
                 })
                 .collect();
@@ -1435,6 +1444,7 @@ mod test {
         let remote_account_provider = {
             let (tx, rx) = mpsc::channel(1);
             let rpc_client = ChainRpcClientMockBuilder::new()
+                .slot(1)
                 .clock_sysvar_for_slot(1)
                 .build();
             let pubsub_client =
@@ -1524,6 +1534,8 @@ mod test {
                 RemoteAccountUpdateSource::Fetch,
             )
         );
+        assert_eq!(rpc_client.single_account_fetches(), 2);
+        assert_eq!(rpc_client.multi_account_fetches(), 0);
     }
 
     struct TestSlotConfig {

--- a/magicblock-chainlink/src/testing/rpc_client_mock.rs
+++ b/magicblock-chainlink/src/testing/rpc_client_mock.rs
@@ -114,6 +114,8 @@ impl ChainRpcClientMockBuilder {
             commitment: self.commitment,
             accounts: Arc::new(Mutex::new(self.accounts)),
             current_slot: Arc::new(AtomicU64::new(self.current_slot)),
+            single_account_fetches: Arc::<AtomicU64>::default(),
+            multi_account_fetches: Arc::<AtomicU64>::default(),
         };
         if let Some(clock_sysvar) = self.clock_sysvar {
             mock.set_clock_sysvar(clock_sysvar);
@@ -135,6 +137,8 @@ pub struct ChainRpcClientMock {
     commitment: CommitmentConfig,
     accounts: Arc<Mutex<HashMap<Pubkey, AccountAtSlot>>>,
     current_slot: Arc<AtomicU64>,
+    single_account_fetches: Arc<AtomicU64>,
+    multi_account_fetches: Arc<AtomicU64>,
 }
 
 #[cfg(any(test, feature = "dev-context"))]
@@ -144,6 +148,8 @@ impl ChainRpcClientMock {
             commitment,
             accounts: Arc::new(Mutex::new(HashMap::new())),
             current_slot: Arc::<AtomicU64>::default(),
+            single_account_fetches: Arc::<AtomicU64>::default(),
+            multi_account_fetches: Arc::<AtomicU64>::default(),
         }
     }
 
@@ -244,6 +250,14 @@ impl ChainRpcClientMock {
         trace!(slot = slot, "Setting current slot");
         self.current_slot.store(slot, Ordering::Relaxed);
     }
+
+    pub fn single_account_fetches(&self) -> u64 {
+        self.single_account_fetches.load(Ordering::Relaxed)
+    }
+
+    pub fn multi_account_fetches(&self) -> u64 {
+        self.multi_account_fetches.load(Ordering::Relaxed)
+    }
 }
 
 #[cfg(any(test, feature = "dev-context"))]
@@ -269,6 +283,7 @@ impl ChainRpcClient for ChainRpcClientMock {
         pubkey: &Pubkey,
         _config: RpcAccountInfoConfig,
     ) -> RpcResult<Option<Account>> {
+        self.single_account_fetches.fetch_add(1, Ordering::Relaxed);
         let res = if let Some(AccountAtSlot { account, slot }) =
             self.get_account_at_slot(pubkey)
         {
@@ -297,6 +312,7 @@ impl ChainRpcClient for ChainRpcClientMock {
         pubkeys: &[Pubkey],
         config: RpcAccountInfoConfig,
     ) -> RpcResult<Vec<Option<Account>>> {
+        self.multi_account_fetches.fetch_add(1, Ordering::Relaxed);
         if tracing::enabled!(tracing::Level::TRACE) {
             let pubkeys = pubkeys
                 .iter()


### PR DESCRIPTION
## Summary

- use the cheaper getAccountInfo when ensure_accounts fetches only 1 account

## Compatibility
- [ ] No breaking changes
- [ ] Config change (describe):
- [ ] Migration needed (describe):

## Testing
- [ ] tests (or explain)

## Checklist
- [ ] docs updated (if needed)
- [ ] closes #
