### PR TITLE
Try to make integration tests run in parallel

### DIFF
--- a/.github/workflows/ci-test-integration.yml
+++ b/.github/workflows/ci-test-integration.yml
@@ -39,22 +39,7 @@ jobs:
   run_integration_tests:
     needs: build
     runs-on: ubuntu-latest-m
-    strategy:
-      matrix:
-        batch_tests:
-          - "schedulecommit"
-          - "chainlink"
-          - "cloning"
-          - "restore_ledger"
-          - "magicblock_api"
-          - "config"
-          - "table_mania"
-          - "committor"
-          - "pubsub"
-          - "schedule_intents"
-          - "task-scheduler"
-      fail-fast: false
-    name: Integration Tests - ${{ matrix.batch_tests }}
+    name: Integration Tests
     steps:
       - name: Checkout this magicblock-validator
         uses: actions/checkout@v5
@@ -70,7 +55,7 @@ jobs:
 
       - uses: ./magicblock-validator/.github/actions/setup-solana
 
-      - name: Run integration tests - ${{ matrix.batch_tests }}
+      - name: Run integration tests
         run: |
           sudo prlimit --pid $$ --nofile=1048576:1048576
           sudo sysctl fs.inotify.max_user_instances=1280
@@ -78,5 +63,3 @@ jobs:
           make ci-test-integration
         shell: bash
         working-directory: magicblock-validator
-        env:
-          RUN_TESTS: ${{ matrix.batch_tests }}

--- a/magicblock-chainlink/src/testing/chain_pubsub.rs
+++ b/magicblock-chainlink/src/testing/chain_pubsub.rs
@@ -8,7 +8,7 @@ use crate::{
         chain_pubsub_actor::ChainPubsubActor,
         pubsub_common::{ChainPubsubActorMessage, SubscriptionUpdate},
     },
-    testing::utils::{PUBSUB_URL, RPC_URL},
+    testing::utils::{pubsub_url, rpc_url},
 };
 
 pub async fn setup_actor_and_client() -> (
@@ -18,14 +18,14 @@ pub async fn setup_actor_and_client() -> (
 ) {
     let (tx, _) = mpsc::channel(10);
     let (actor, updates_rx) = ChainPubsubActor::new_from_url(
-        PUBSUB_URL,
+        pubsub_url(),
         "test-client",
         tx,
         CommitmentConfig::confirmed(),
     )
     .await
     .expect("failed to create ChainPubsubActor");
-    let rpc_client = RpcClient::new(RPC_URL.to_string());
+    let rpc_client = RpcClient::new(rpc_url().to_string());
     (actor, updates_rx, rpc_client)
 }
 

--- a/magicblock-chainlink/src/testing/utils.rs
+++ b/magicblock-chainlink/src/testing/utils.rs
@@ -1,6 +1,6 @@
 #![cfg(any(test, feature = "dev-context"))]
 #![allow(dead_code)]
-use std::{num::NonZeroUsize, sync::Arc};
+use std::{num::NonZeroUsize, sync::Arc, sync::OnceLock};
 
 use magicblock_config::config::LifecycleMode;
 use solana_keypair::Keypair;
@@ -16,8 +16,24 @@ use crate::{
     },
 };
 
-pub const PUBSUB_URL: &str = "ws://localhost:7800";
-pub const RPC_URL: &str = "http://localhost:7799";
+const DEFAULT_PUBSUB_URL: &str = "ws://localhost:7800";
+const DEFAULT_RPC_URL: &str = "http://localhost:7799";
+
+fn resolve_url(env_key: &'static str, default: &str) -> String {
+    std::env::var(env_key).unwrap_or_else(|_| default.to_string())
+}
+
+pub fn pubsub_url() -> &'static str {
+    static URL: OnceLock<String> = OnceLock::new();
+    URL.get_or_init(|| resolve_url("CHAIN_WS_URL", DEFAULT_PUBSUB_URL))
+        .as_str()
+}
+
+pub fn rpc_url() -> &'static str {
+    static URL: OnceLock<String> = OnceLock::new();
+    URL.get_or_init(|| resolve_url("CHAIN_URL", DEFAULT_RPC_URL))
+        .as_str()
+}
 
 pub fn random_pubkey() -> Pubkey {
     Keypair::new().pubkey()

--- a/magicblock-committor-service/src/config.rs
+++ b/magicblock-committor-service/src/config.rs
@@ -34,8 +34,10 @@ impl ChainConfig {
     }
 
     pub fn local(compute_budget_config: ComputeBudgetConfig) -> Self {
+        let rpc_uri = std::env::var("CHAIN_URL")
+            .unwrap_or_else(|_| "http://localhost:7799".to_string());
         Self {
-            rpc_uri: "http://localhost:7799".to_string(),
+            rpc_uri,
             commitment: CommitmentConfig::processed(),
             compute_budget_config,
             actions_timeout: DEFAULT_ACTIONS_TIMEOUT,

--- a/test-integration/Cargo.lock
+++ b/test-integration/Cargo.lock
@@ -6025,6 +6025,7 @@ dependencies = [
  "async-trait",
  "borsh 1.6.0",
  "futures",
+ "integration-test-tools",
  "magicblock-committor-program",
  "magicblock-committor-service",
  "magicblock-core",
@@ -10521,6 +10522,7 @@ dependencies = [
 name = "test-table-mania"
 version = "0.0.0"
 dependencies = [
+ "integration-test-tools",
  "magicblock-rpc-client",
  "magicblock-table-mania",
  "paste",

--- a/test-integration/configs/chainlink-conf.devnet.toml
+++ b/test-integration/configs/chainlink-conf.devnet.toml
@@ -1,8 +1,9 @@
 lifecycle = "offline"
 remotes = ["devnet"]
+storage = "magicblock-test-storage/chainlink-chain"
 
 [aperture]
-listen = "0.0.0.0:7799"
+listen = "0.0.0.0:9010"
 
 [commit]
 compute-unit-price = 1_000_000
@@ -50,4 +51,4 @@ path = "../target/deploy/miniv3/program_mini.so"
 auth = "MiniV3AUTH111111111111111111111111111111111"
 
 [metrics]
-address = "0.0.0.0:9000" # Default if not specified, was disabled before but struct requires address
+address = "0.0.0.0:9110" # Default if not specified, was disabled before but struct requires address

--- a/test-integration/configs/cloning-conf.devnet.toml
+++ b/test-integration/configs/cloning-conf.devnet.toml
@@ -1,8 +1,9 @@
 lifecycle = "offline"
 remotes = ["devnet"]
+storage = "magicblock-test-storage/cloning-chain"
 
 [aperture]
-listen = "0.0.0.0:7799"
+listen = "0.0.0.0:9020"
 
 [commit]
 compute-unit-price = 1_000_000
@@ -60,4 +61,4 @@ id = "f1exzKGtdeVX3d6UXZ89cY7twiNJe9S5uq84RTA4Rq4"
 path = "../target/deploy/program_flexi_counter.so"
 
 [metrics]
-address = "0.0.0.0:9000"
+address = "0.0.0.0:9120"

--- a/test-integration/configs/cloning-conf.ephem.toml
+++ b/test-integration/configs/cloning-conf.ephem.toml
@@ -1,8 +1,9 @@
 lifecycle = "ephemeral"
-remotes = ["http://0.0.0.0:7799", "ws://0.0.0.0:7800"]
+remotes = ["http://0.0.0.0:9020"]
+storage = "magicblock-test-storage/cloning-ephem"
 
 [aperture]
-listen = "0.0.0.0:8899"
+listen = "0.0.0.0:9022"
 
 [commit]
 compute-unit-price = 1_000_000
@@ -31,4 +32,4 @@ snapshot-frequency = 1024
 reset = true
 
 [metrics]
-address = "0.0.0.0:9000"
+address = "0.0.0.0:9122"

--- a/test-integration/configs/committor-conf.devnet.toml
+++ b/test-integration/configs/committor-conf.devnet.toml
@@ -1,8 +1,9 @@
 lifecycle = "offline"
 remotes = ["devnet"]
+storage = "magicblock-test-storage/committor-chain"
 
 [aperture]
-listen = "0.0.0.0:7799"
+listen = "0.0.0.0:9050"
 
 [commit]
 compute-unit-price = 1_000_000
@@ -49,4 +50,4 @@ path = "../target/deploy/program_flexi_counter.so"
 port = 10001
 
 [metrics]
-address = "0.0.0.0:9000"
+address = "0.0.0.0:9150"

--- a/test-integration/configs/config-conf.devnet.toml
+++ b/test-integration/configs/config-conf.devnet.toml
@@ -1,8 +1,9 @@
 lifecycle = "offline"
 remotes = ["devnet"]
+storage = "magicblock-test-storage/config-chain"
 
 [aperture]
-listen = "0.0.0.0:7799"
+listen = "0.0.0.0:9070"
 
 [commit]
 compute-unit-price = 1_000_000
@@ -41,4 +42,4 @@ id = "f1exzKGtdeVX3d6UXZ89cY7twiNJe9S5uq84RTA4Rq4"
 path = "../target/deploy/program_flexi_counter.so"
 
 [metrics]
-address = "0.0.0.0:9000"
+address = "0.0.0.0:9170"

--- a/test-integration/configs/magicblock-api-chain.devnet.toml
+++ b/test-integration/configs/magicblock-api-chain.devnet.toml
@@ -1,9 +1,9 @@
-lifecycle = "ephemeral"
-remotes = ["http://127.0.0.1:9040"]
-storage = "magicblock-test-storage/magicblock-api-ephem"
+lifecycle = "offline"
+remotes = ["devnet"]
+storage = "magicblock-test-storage/magicblock-api-chain"
 
 [aperture]
-listen = "0.0.0.0:9042"
+listen = "0.0.0.0:9040"
 
 [commit]
 compute-unit-price = 1_000_000
@@ -24,10 +24,32 @@ index-size = 2048576
 max-snapshots = 7
 # how frequently (slot-wise) we should take snapshots
 snapshot-frequency = 1024
+reset = true
 
 [ledger]
 reset = true
 block-time = "50ms"
 
+[[programs]]
+id = "DELeGGvXpWV2fqJUhqcF5ZSYMS4JTLjteaAMARRSaeSh"
+path = "../schedulecommit/elfs/dlp.so"
+
+[[programs]]
+id = "DmnRGfyyftzacFb1XadYhWF6vWqXwtQk5tbr6XgR3BA1"
+path = "../schedulecommit/elfs/mdp.so"
+
+# NOTE: `cargo build-sbf` needs to run from the root to build the program
+[[programs]]
+id = "ComtrB2KEaWgXsW1dhr1xYL4Ht4Bjj3gXnnL6KMdABq"
+path = "../../target/deploy/magicblock_committor_program.so"
+
+[[programs]]
+id = "9hgprgZiRWmy8KkfvUuaVkDGrqo9GzeXMohwq6BazgUY"
+path = "../target/deploy/program_schedulecommit.so"
+
+[[programs]]
+id = "4RaQH3CUBMSMQsSHPVaww2ifeNEEuaDZjF9CUdFwr3xr"
+path = "../target/deploy/program_schedulecommit_security.so"
+
 [metrics]
-address = "0.0.0.0:9142"
+address = "0.0.0.0:9140"

--- a/test-integration/configs/pubsub-chain.devnet.toml
+++ b/test-integration/configs/pubsub-chain.devnet.toml
@@ -1,9 +1,9 @@
-lifecycle = "ephemeral"
-remotes = ["http://127.0.0.1:9040"]
-storage = "magicblock-test-storage/magicblock-api-ephem"
+lifecycle = "offline"
+remotes = ["devnet"]
+storage = "magicblock-test-storage/pubsub-chain"
 
 [aperture]
-listen = "0.0.0.0:9042"
+listen = "0.0.0.0:9060"
 
 [commit]
 compute-unit-price = 1_000_000
@@ -29,5 +29,17 @@ snapshot-frequency = 1024
 reset = true
 block-time = "50ms"
 
+[[programs]]
+id = "DELeGGvXpWV2fqJUhqcF5ZSYMS4JTLjteaAMARRSaeSh"
+path = "../schedulecommit/elfs/dlp.so"
+
+[[programs]]
+id = "9hgprgZiRWmy8KkfvUuaVkDGrqo9GzeXMohwq6BazgUY"
+path = "../target/deploy/program_schedulecommit.so"
+
+[[programs]]
+id = "4RaQH3CUBMSMQsSHPVaww2ifeNEEuaDZjF9CUdFwr3xr"
+path = "../target/deploy/program_schedulecommit_security.so"
+
 [metrics]
-address = "0.0.0.0:9142"
+address = "0.0.0.0:9160"

--- a/test-integration/configs/pubsub-ephem.toml
+++ b/test-integration/configs/pubsub-ephem.toml
@@ -1,12 +1,15 @@
 lifecycle = "ephemeral"
-remotes = ["http://127.0.0.1:9040"]
-storage = "magicblock-test-storage/magicblock-api-ephem"
+remotes = ["http://0.0.0.0:9060"]
+storage = "magicblock-test-storage/pubsub-ephem"
 
 [aperture]
-listen = "0.0.0.0:9042"
+listen = "0.0.0.0:9062"
 
 [commit]
 compute-unit-price = 1_000_000
+
+[chainlink]
+max-monitored-accounts = 300
 
 [accountsdb]
 # size of the main storage, we have to preallocate in advance
@@ -27,7 +30,6 @@ snapshot-frequency = 1024
 
 [ledger]
 reset = true
-block-time = "50ms"
 
 [metrics]
-address = "0.0.0.0:9142"
+address = "0.0.0.0:9162"

--- a/test-integration/configs/restore-ledger-conf.devnet.toml
+++ b/test-integration/configs/restore-ledger-conf.devnet.toml
@@ -1,8 +1,9 @@
 lifecycle = "offline"
 remotes = ["devnet"]
+storage = "magicblock-test-storage/restore-ledger-chain"
 
 [aperture]
-listen = "0.0.0.0:7799"
+listen = "0.0.0.0:9030"
 
 [commit]
 compute-unit-price = 1_000_000
@@ -45,4 +46,4 @@ id = "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
 path = "../programs/memo/memo.so"
 
 [metrics]
-address = "0.0.0.0:9000"
+address = "0.0.0.0:9130"

--- a/test-integration/configs/schedule-intents-chain.devnet.toml
+++ b/test-integration/configs/schedule-intents-chain.devnet.toml
@@ -1,9 +1,9 @@
-lifecycle = "ephemeral"
-remotes = ["http://127.0.0.1:9040"]
-storage = "magicblock-test-storage/magicblock-api-ephem"
+lifecycle = "offline"
+remotes = ["devnet"]
+storage = "magicblock-test-storage/schedule-intents-chain"
 
 [aperture]
-listen = "0.0.0.0:9042"
+listen = "0.0.0.0:9080"
 
 [commit]
 compute-unit-price = 1_000_000
@@ -29,5 +29,17 @@ snapshot-frequency = 1024
 reset = true
 block-time = "50ms"
 
+[[programs]]
+id = "DELeGGvXpWV2fqJUhqcF5ZSYMS4JTLjteaAMARRSaeSh"
+path = "../schedulecommit/elfs/dlp.so"
+
+[[programs]]
+id = "ComtrB2KEaWgXsW1dhr1xYL4Ht4Bjj3gXnnL6KMdABq"
+path = "../../target/deploy/magicblock_committor_program.so"
+
+[[programs]]
+id = "f1exzKGtdeVX3d6UXZ89cY7twiNJe9S5uq84RTA4Rq4"
+path = "../target/deploy/program_flexi_counter.so"
+
 [metrics]
-address = "0.0.0.0:9142"
+address = "0.0.0.0:9180"

--- a/test-integration/configs/schedule-intents-ephem.toml
+++ b/test-integration/configs/schedule-intents-ephem.toml
@@ -1,23 +1,23 @@
 lifecycle = "ephemeral"
-remotes = ["http://127.0.0.1:9040"]
-storage = "magicblock-test-storage/magicblock-api-ephem"
+remotes = ["http://0.0.0.0:9080"]
+storage = "magicblock-test-storage/schedule-intents-ephem"
 
 [aperture]
-listen = "0.0.0.0:9042"
+listen = "0.0.0.0:9082"
 
 [commit]
 compute-unit-price = 1_000_000
 
 [accountsdb]
 # size of the main storage, we have to preallocate in advance
-# it's advised to set this value based on formula 1KB * N * 3,
-# where N is the number of accounts expected to be stored in
+# it's advised to set this value based on formula 1KB * N * 3, 
+# where N is the number of accounts expected to be stored in 
 # database, e.g. for million accounts this would be 3GB
 database-size = 1048576000 # 1GB
 # minimal indivisible unit of addressing in main storage
 # offsets are calculated in terms of blocks
 block-size = "block256" # possible values block128 | block256 | block512
-# size of index file, we have to preallocate,
+# size of index file, we have to preallocate, 
 # can be as low as 1% of main storage size, but setting it to higher values won't hurt
 index-size = 2048576
 # max number of snapshots to keep around
@@ -27,7 +27,6 @@ snapshot-frequency = 1024
 
 [ledger]
 reset = true
-block-time = "50ms"
 
 [metrics]
-address = "0.0.0.0:9142"
+address = "0.0.0.0:9182"

--- a/test-integration/configs/schedule-task.devnet.toml
+++ b/test-integration/configs/schedule-task.devnet.toml
@@ -1,8 +1,9 @@
 lifecycle = "offline"
 remotes = ["devnet"]
+storage = "magicblock-test-storage/schedule-task-chain"
 
 [aperture]
-listen = "0.0.0.0:7799"
+listen = "0.0.0.0:9090"
 
 [commit]
 compute-unit-price = 1_000_000
@@ -23,4 +24,4 @@ id = "DmnRGfyyftzacFb1XadYhWF6vWqXwtQk5tbr6XgR3BA1"
 path = "../schedulecommit/elfs/mdp.so"
 
 [metrics]
-address = "0.0.0.0:9000"
+address = "0.0.0.0:9190"

--- a/test-integration/configs/schedule-task.ephem.toml
+++ b/test-integration/configs/schedule-task.ephem.toml
@@ -1,5 +1,5 @@
 lifecycle = "ephemeral"
-remotes = ["http://0.0.0.0:7799", "ws://0.0.0.0:7800"]
+remotes = ["http://0.0.0.0:7799"]
 
 [aperture]
 listen = "0.0.0.0:8899"

--- a/test-integration/configs/schedulecommit-conf-fees.ephem.toml
+++ b/test-integration/configs/schedulecommit-conf-fees.ephem.toml
@@ -1,8 +1,9 @@
 lifecycle = "ephemeral"
-remotes = ["http://0.0.0.0:7799", "ws://0.0.0.0:7800"]
+remotes = ["http://0.0.0.0:9000"]
+storage = "magicblock-test-storage/schedulecommit-ephem"
 
 [aperture]
-listen = "0.0.0.0:8899"
+listen = "0.0.0.0:9002"
 
 [commit]
 compute-unit-price = 1_000_000
@@ -39,4 +40,4 @@ id = "4RaQH3CUBMSMQsSHPVaww2ifeNEEuaDZjF9CUdFwr3xr"
 path = "test-integration/target/deploy/program_schedulecommit_security.so"
 
 [metrics]
-address = "0.0.0.0:9000"
+address = "0.0.0.0:9102"

--- a/test-integration/configs/schedulecommit-conf.devnet.toml
+++ b/test-integration/configs/schedulecommit-conf.devnet.toml
@@ -1,8 +1,9 @@
 lifecycle = "offline"
 remotes = ["devnet"]
+storage = "magicblock-test-storage/schedulecommit-chain"
 
 [aperture]
-listen = "0.0.0.0:7799"
+listen = "0.0.0.0:9000"
 
 [commit]
 compute-unit-price = 1_000_000
@@ -51,4 +52,4 @@ id = "4RaQH3CUBMSMQsSHPVaww2ifeNEEuaDZjF9CUdFwr3xr"
 path = "../target/deploy/program_schedulecommit_security.so"
 
 [metrics]
-address = "0.0.0.0:9000"
+address = "0.0.0.0:9100"

--- a/test-integration/configs/schedulecommit-conf.ephem.toml
+++ b/test-integration/configs/schedulecommit-conf.ephem.toml
@@ -1,5 +1,5 @@
 lifecycle = "ephemeral"
-remotes = ["http://0.0.0.0:7799", "ws://0.0.0.0:7800"]
+remotes = ["http://0.0.0.0:7799"]
 
 [aperture]
 listen = "0.0.0.0:8899"

--- a/test-integration/test-chainlink/src/ixtest_context.rs
+++ b/test-integration/test-chainlink/src/ixtest_context.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use integration_test_tools::dlp_interface;
+use integration_test_tools::{dlp_interface, IntegrationTestContext};
 use magicblock_chainlink::{
     accounts_bank::mock::AccountsBankStub,
     cloner::{AccountCloneRequest, Cloner, DelegationActions},
@@ -56,7 +56,6 @@ pub struct IxtestContext {
     pub validator_kp: Arc<Keypair>,
 }
 
-const RPC_URL: &str = "http://localhost:7799";
 pub const TEST_AUTHORITY: [u8; 64] = [
     251, 62, 129, 184, 107, 49, 62, 184, 1, 147, 178, 128, 185, 157, 247, 92,
     56, 158, 145, 53, 51, 226, 202, 96, 178, 248, 195, 133, 133, 237, 237, 146,
@@ -82,11 +81,11 @@ impl IxtestContext {
         let (fetch_cloner, remote_account_provider) = {
             let endpoints_vec = vec![
                 Endpoint::Rpc {
-                    url: RPC_URL.to_string(),
+                    url: IntegrationTestContext::url_chain().to_string(),
                     label: "test-rpc".to_string(),
                 },
                 Endpoint::WebSocket {
-                    url: "ws://localhost:7800".to_string(),
+                    url: IntegrationTestContext::ws_url_chain().to_string(),
                     label: "test-ws".to_string(),
                 },
             ];
@@ -400,6 +399,9 @@ impl IxtestContext {
     }
 
     pub fn get_rpc_client(commitment: CommitmentConfig) -> RpcClient {
-        RpcClient::new_with_commitment(RPC_URL.to_string(), commitment)
+        RpcClient::new_with_commitment(
+            IntegrationTestContext::url_chain().to_string(),
+            commitment,
+        )
     }
 }

--- a/test-integration/test-chainlink/tests/chain_pubsub_client.rs
+++ b/test-integration/test-chainlink/tests/chain_pubsub_client.rs
@@ -11,7 +11,7 @@ use magicblock_chainlink::{
     },
     testing::{
         init_logger,
-        utils::{airdrop, random_pubkey, PUBSUB_URL, RPC_URL},
+        utils::{airdrop, pubsub_url, random_pubkey, rpc_url},
     },
 };
 use solana_pubkey::Pubkey;
@@ -26,7 +26,7 @@ async fn setup() -> (ChainPubsubClientImpl, mpsc::Receiver<SubscriptionUpdate>)
     init_logger();
     let (tx, _) = mpsc::channel(10);
     let client = ChainPubsubClientImpl::try_new_from_url(
-        PUBSUB_URL,
+        pubsub_url(),
         "test-pubsub".to_string(),
         tx,
         CommitmentConfig::confirmed(),
@@ -117,7 +117,7 @@ async fn ixtest_chain_pubsub_client_clock() {
 #[tokio::test]
 async fn ixtest_chain_pubsub_client_airdropping() {
     let rpc_client = RpcClient::new_with_commitment(
-        RPC_URL.to_string(),
+        rpc_url().to_string(),
         CommitmentConfig::confirmed(),
     );
     let (client, mut updates) = setup().await;

--- a/test-integration/test-chainlink/tests/ix_programs.rs
+++ b/test-integration/test-chainlink/tests/ix_programs.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use integration_test_tools::IntegrationTestContext;
 use magicblock_chainlink::{
     assert_data_has_size, assert_loaded_program_with_size,
     assert_subscribed_without_loaderv3_program_data_account,
@@ -32,9 +33,11 @@ use test_chainlink::{
 };
 use tracing::*;
 
-const RPC_URL: &str = "http://localhost:7799";
 fn get_rpc_client(commitment: CommitmentConfig) -> RpcClient {
-    RpcClient::new_with_commitment(RPC_URL.to_string(), commitment)
+    RpcClient::new_with_commitment(
+        IntegrationTestContext::url_chain().to_string(),
+        commitment,
+    )
 }
 
 fn pretty_bytes(bytes: usize) -> String {

--- a/test-integration/test-chainlink/tests/ix_remote_account_provider.rs
+++ b/test-integration/test-chainlink/tests/ix_remote_account_provider.rs
@@ -10,7 +10,7 @@ use magicblock_chainlink::{
         airdrop, await_next_slot, current_slot, dump_remote_account_lamports,
         dump_remote_account_update_source, get_remote_account_lamports,
         get_remote_account_update_sources, init_logger, random_pubkey,
-        sleep_ms, PUBSUB_URL, RPC_URL,
+        pubsub_url, rpc_url, sleep_ms,
     },
     AccountFetchOrigin,
 };
@@ -28,11 +28,11 @@ async fn init_remote_account_provider(
     let (fwd_tx, _fwd_rx) = mpsc::channel(100);
     let endpoints_vec = vec![
         Endpoint::Rpc {
-            url: RPC_URL.to_string(),
+            url: rpc_url().to_string(),
             label: "test-rpc".to_string(),
         },
         Endpoint::WebSocket {
-            url: PUBSUB_URL.to_string(),
+            url: pubsub_url().to_string(),
             label: "test-ws".to_string(),
         },
     ];

--- a/test-integration/test-committor-service/Cargo.toml
+++ b/test-integration/test-committor-service/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 [dev-dependencies]
 async-trait = { workspace = true }
 borsh = { workspace = true }
+integration-test-tools = { workspace = true }
 tracing = { workspace = true }
 futures = { workspace = true }
 magicblock-core = { workspace = true }

--- a/test-integration/test-committor-service/tests/common.rs
+++ b/test-integration/test-committor-service/tests/common.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use async_trait::async_trait;
+use integration_test_tools::IntegrationTestContext;
 use magicblock_committor_service::{
     intent_executor::{
         task_info_fetcher::{
@@ -38,7 +39,7 @@ use solana_sdk::{
 
 // Helper function to create a test RPC client
 pub async fn create_test_client() -> MagicblockRpcClient {
-    let url = "http://localhost:7799".to_string();
+    let url = IntegrationTestContext::url_chain().to_string();
     let rpc_client =
         RpcClient::new_with_commitment(url, CommitmentConfig::confirmed());
 

--- a/test-integration/test-committor-service/tests/test_ix_commit_local.rs
+++ b/test-integration/test-committor-service/tests/test_ix_commit_local.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use borsh::to_vec;
+use integration_test_tools::IntegrationTestContext;
 use magicblock_committor_service::{
     config::ChainConfig,
     intent_executor::{error::IntentExecutorError, ExecutionOutput},
@@ -950,7 +951,8 @@ async fn ix_commit_local(
     assert_eq!(execution_outputs.len(), intent_bundles.len());
     service.release_common_pubkeys().await.unwrap();
 
-    let rpc_client = RpcClient::new("http://localhost:7799".to_string());
+    let rpc_client =
+        RpcClient::new(IntegrationTestContext::url_chain().to_string());
     let mut strategies = ExpectedStrategies::new();
     for (execution_result, base_intent) in execution_outputs
         .into_iter()

--- a/test-integration/test-committor-service/tests/utils/transactions.rs
+++ b/test-integration/test-committor-service/tests/utils/transactions.rs
@@ -1,3 +1,4 @@
+use integration_test_tools::IntegrationTestContext;
 use solana_account::Account;
 use solana_pubkey::Pubkey;
 use solana_rpc_client::nonblocking::rpc_client::RpcClient;
@@ -157,7 +158,8 @@ pub async fn init_and_delegate_account_on_chain(
     bytes: u64,
     label: Option<String>,
 ) -> (Pubkey, Account) {
-    let rpc_client = RpcClient::new("http://localhost:7799".to_string());
+    let rpc_client =
+        RpcClient::new(IntegrationTestContext::url_chain().to_string());
 
     rpc_client
         .request_airdrop(&counter_auth.pubkey(), 777 * LAMPORTS_PER_SOL)
@@ -256,7 +258,8 @@ pub async fn init_and_delegate_account_on_chain(
 pub async fn init_and_delegate_order_book_on_chain(
     payer: &Keypair,
 ) -> (Pubkey, Account) {
-    let rpc_client = RpcClient::new("http://localhost:7799".to_string());
+    let rpc_client =
+        RpcClient::new(IntegrationTestContext::url_chain().to_string());
 
     rpc_client
         .request_airdrop(&payer.pubkey(), 777 * LAMPORTS_PER_SOL)
@@ -317,7 +320,8 @@ pub async fn init_and_delegate_order_book_on_chain(
 pub async fn fund_validator_auth_and_ensure_validator_fees_vault(
     validator_auth: &Keypair,
 ) {
-    let rpc_client = RpcClient::new("http://localhost:7799".to_string());
+    let rpc_client =
+        RpcClient::new(IntegrationTestContext::url_chain().to_string());
     rpc_client
         .request_airdrop(&validator_auth.pubkey(), 777 * LAMPORTS_PER_SOL)
         .await

--- a/test-integration/test-magicblock-api/src/lib.rs
+++ b/test-integration/test-magicblock-api/src/lib.rs
@@ -25,6 +25,7 @@ pub fn start_devnet_validator_with_config(config_name: &str) -> Child {
         None,
         &Default::default(),
         "CHAIN",
+        "magicblock_api",
     ) {
         Some(validator) => validator,
         None => {

--- a/test-integration/test-magicblock-api/tests/test_claim_fees.rs
+++ b/test-integration/test-magicblock-api/tests/test_claim_fees.rs
@@ -14,7 +14,6 @@ use solana_sdk::{
 };
 
 // Test constants
-const DEVNET_URL: &str = "http://127.0.0.1:7799";
 const TEST_FEE_AMOUNT: u64 = 1_000_000;
 const INITIAL_AIRDROP_AMOUNT: u64 = 5_000_000_000;
 const CONFIRMATION_WAIT_MS: u64 = 500;
@@ -64,7 +63,7 @@ fn test_add_fees_to_vault() {
     println!("Adding test fees to vault...");
 
     let rpc_client = RpcClient::new_with_commitment(
-        DEVNET_URL,
+        IntegrationTestContext::url_chain().to_string(),
         CommitmentConfig::confirmed(),
     );
 
@@ -110,7 +109,7 @@ fn test_claim_fees_transaction() {
     println!("Testing actual claim fees transaction...");
 
     let rpc_client = RpcClient::new_with_commitment(
-        DEVNET_URL,
+        IntegrationTestContext::url_chain().to_string(),
         CommitmentConfig::confirmed(),
     );
 
@@ -152,7 +151,7 @@ fn test_claim_fees_rpc_connection() {
     println!("Testing RPC connection...");
 
     let rpc_client = RpcClient::new_with_commitment(
-        DEVNET_URL,
+        IntegrationTestContext::url_chain().to_string(),
         CommitmentConfig::confirmed(),
     );
 
@@ -167,7 +166,7 @@ fn test_validator_claim_fees() {
 
     // 3. Fund the validator for transaction fees
     let client = RpcClient::new_with_commitment(
-        DEVNET_URL,
+        IntegrationTestContext::url_chain().to_string(),
         CommitmentConfig::confirmed(),
     );
     IntegrationTestContext::airdrop(

--- a/test-integration/test-magicblock-api/tests/test_domain_registry.rs
+++ b/test-integration/test-magicblock-api/tests/test_domain_registry.rs
@@ -23,8 +23,6 @@ lazy_static! {
     static ref VALIDATOR_KEYPAIR: Arc<Keypair> = Arc::new(Keypair::new());
 }
 
-const DEVNET_URL: &str = "http://localhost:7799";
-
 fn get_validator_info() -> ErRecord {
     ErRecord::V0(RecordV0 {
         identity: VALIDATOR_KEYPAIR.pubkey(),
@@ -42,7 +40,8 @@ fn get_validator_info() -> ErRecord {
 
 fn test_registration() {
     let validator_info = get_validator_info();
-    let domain_manager = DomainRegistryManager::new(DEVNET_URL);
+    let domain_manager =
+        DomainRegistryManager::new(IntegrationTestContext::url_chain());
     domain_manager
         .handle_registration(&VALIDATOR_KEYPAIR, validator_info.clone())
         .expect("Failed to register");
@@ -64,7 +63,8 @@ fn test_sync() {
         }
     }
 
-    let domain_manager = DomainRegistryManager::new(DEVNET_URL);
+    let domain_manager =
+        DomainRegistryManager::new(IntegrationTestContext::url_chain());
     domain_manager
         .sync(&VALIDATOR_KEYPAIR, &validator_info)
         .expect("Failed to sync");
@@ -77,7 +77,8 @@ fn test_sync() {
 }
 
 fn test_unregister() {
-    let domain_manager = DomainRegistryManager::new(DEVNET_URL);
+    let domain_manager =
+        DomainRegistryManager::new(IntegrationTestContext::url_chain());
     domain_manager
         .unregister(&VALIDATOR_KEYPAIR)
         .expect("Failed to unregister");
@@ -93,7 +94,7 @@ fn test_unregister() {
 #[test]
 fn test_domain_registry() {
     let client = RpcClient::new_with_commitment(
-        DEVNET_URL,
+        IntegrationTestContext::url_chain().to_string(),
         CommitmentConfig::confirmed(),
     );
     IntegrationTestContext::airdrop(

--- a/test-integration/test-pubsub/src/lib.rs
+++ b/test-integration/test-pubsub/src/lib.rs
@@ -14,8 +14,6 @@ use solana_sdk::{
 };
 use tracing::*;
 
-const VALIDATOR_WS: &str = "ws://127.0.0.1:8900";
-
 pub struct PubSubEnv {
     /// Account we delegated into ephem
     pub account1: Keypair,
@@ -30,9 +28,10 @@ impl PubSubEnv {
     pub async fn new() -> Self {
         let ctx = IntegrationTestContext::try_new().unwrap();
 
-        let ws_client = PubsubClient::new(VALIDATOR_WS)
-            .await
-            .expect("failed to connect to ER validator via websocket");
+        let ws_client =
+            PubsubClient::new(IntegrationTestContext::ws_url_ephem())
+                .await
+                .expect("failed to connect to ER validator via websocket");
 
         let payer_chain = Keypair::new();
         let account1 = Keypair::new();

--- a/test-integration/test-runner/bin/run_tests.rs
+++ b/test-integration/test-runner/bin/run_tests.rs
@@ -3,11 +3,12 @@ use std::{
     io,
     path::Path,
     process::{self, Output},
+    thread,
 };
 
 use integration_test_tools::{
     loaded_accounts::LoadedAccounts,
-    toml_to_args::ProgramLoader,
+    toml_to_args::{rpc_port_from_config, ProgramLoader},
     validator::{
         resolve_workspace_dir, start_magic_block_validator_with_config,
         start_test_validator_with_config, TestRunnerPaths,
@@ -19,78 +20,71 @@ use test_runner::{
     env_config::TestConfigViaEnvVars,
     signal::wait_for_ctrlc,
 };
+use test_runner::cleanup::kill_validators;
+
+// Helper macro that registers a list of tests executed each on a separate thread
+macro_rules! register_tests {
+    ($scope:expr, ($($arg:expr),* $(,)?), { $($rule:tt)* }) => {{
+        let mut handles = Vec::new();
+        register_tests!(@rules $scope, ($($arg),*), handles, $($rule)*);
+        handles
+    }};
+
+    (@rules $scope:expr, $args:tt, $handles:ident,) => {};
+
+    // Single-label: function returns `Result<Output, _>`.
+    (@rules $scope:expr, ($($arg:expr),*), $handles:ident,
+        $func:path => $label:ident $(, $($rest:tt)*)?
+    ) => {
+        $handles.push($scope.spawn(|| {
+            let out = $func($($arg),*)
+                .expect(concat!(stringify!($label), " panicked"));
+            vec![(stringify!($label), out)]
+        }));
+        register_tests!(@rules $scope, ($($arg),*), $handles, $($($rest)*)?);
+    };
+
+    // Tuple-label: function returns `Result<(Output, Output, ...), _>`.
+    (@rules $scope:expr, ($($arg:expr),*), $handles:ident,
+        $func:path => ($($label:ident),+ $(,)?) $(, $($rest:tt)*)?
+    ) => {
+        $handles.push($scope.spawn(|| {
+            let ($($label),+) = $func($($arg),*)
+                .expect(concat!(stringify!($func), " panicked"));
+            vec![$((stringify!($label), $label)),+]
+        }));
+        register_tests!(@rules $scope, ($($arg),*), $handles, $($($rest)*)?);
+    };
+}
 
 pub fn main() {
     let config = TestConfigViaEnvVars::default();
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
-    let Ok((security_output, scenarios_output)) =
-        run_schedule_commit_tests(&manifest_dir, &config)
-    else {
-        // If any test run panics (i.e. not just a failing test) then we bail
-        return;
-    };
-    let Ok(chainlink_output) = run_chainlink_tests(&manifest_dir, &config)
-    else {
-        return;
-    };
 
-    let Ok(cloning_output) = run_cloning_tests(&manifest_dir, &config) else {
-        return;
-    };
+    let results: Vec<(&'static str, Output)> = thread::scope(|s| {
+        let handles = register_tests!(s, (&manifest_dir, &config), {
+            run_schedule_commit_tests => (security, scenarios),
+            run_chainlink_tests => chainlink,
+            run_cloning_tests => cloning,
+            run_restore_ledger_tests => restore_ledger,
+            run_magicblock_api_tests => magicblock_api,
+            run_table_mania_and_committor_tests => (table_mania, committor),
+            run_magicblock_pubsub_tests => magicblock_pubsub,
+            run_config_tests => config,
+            run_schedule_intents_tests => schedule_intents,
+            run_task_scheduler_tests => task_scheduler,
+        });
 
-    let Ok(restore_ledger_output) =
-        run_restore_ledger_tests(&manifest_dir, &config)
-    else {
-        return;
-    };
+        handles
+            .into_iter()
+            .flat_map(|h| h.join().expect("handler thread panicked"))
+            .collect()
+    });
 
-    let Ok(magicblock_api_output) =
-        run_magicblock_api_tests(&manifest_dir, &config)
-    else {
-        return;
-    };
-
-    let Ok((table_mania_output, committor_output)) =
-        run_table_mania_and_committor_tests(&manifest_dir, &config)
-    else {
-        return;
-    };
-
-    let Ok(magicblock_pubsub_output) =
-        run_magicblock_pubsub_tests(&manifest_dir, &config)
-    else {
-        return;
-    };
-
-    let Ok(config_output) = run_config_tests(&manifest_dir, &config) else {
-        return;
-    };
-
-    let Ok(schedule_intents_output) =
-        run_schedule_intents_tests(&manifest_dir, &config)
-    else {
-        return;
-    };
-
-    let Ok(task_scheduler_output) =
-        run_task_scheduler_tests(&manifest_dir, &config)
-    else {
-        return;
-    };
-
-    // Assert that all tests passed
-    assert_cargo_tests_passed(security_output, "security");
-    assert_cargo_tests_passed(scenarios_output, "scenarios");
-    assert_cargo_tests_passed(chainlink_output, "chainlink");
-    assert_cargo_tests_passed(cloning_output, "cloning");
-    assert_cargo_tests_passed(restore_ledger_output, "restore_ledger");
-    assert_cargo_tests_passed(magicblock_api_output, "magicblock_api");
-    assert_cargo_tests_passed(table_mania_output, "table_mania");
-    assert_cargo_tests_passed(committor_output, "committor");
-    assert_cargo_tests_passed(magicblock_pubsub_output, "magicblock_pubsub");
-    assert_cargo_tests_passed(config_output, "config");
-    assert_cargo_tests_passed(schedule_intents_output, "schedule_intents");
-    assert_cargo_tests_passed(task_scheduler_output, "task_scheduler");
+    for (name, output) in results {
+        assert_cargo_tests_passed(output, name);
+    }
+    kill_validators();
 }
 
 fn success_output() -> Output {
@@ -120,6 +114,7 @@ fn run_restore_ledger_tests(
         "restore-ledger-conf.devnet.toml",
         ValidatorCluster::Chain(None),
         &loaded_chain_accounts,
+        TEST_NAME,
     ) {
         Some(validator) => validator,
         None => {
@@ -138,8 +133,13 @@ fn run_restore_ledger_tests(
             "Running restore ledger tests in {}",
             test_restore_ledger_dir
         );
-        let output = match run_test(test_restore_ledger_dir, Default::default())
-        {
+        let output = match run_test(
+            test_restore_ledger_dir,
+            RunTestConfig {
+                chain_config: Some("restore-ledger-conf.devnet.toml"),
+                ..Default::default()
+            },
+        ) {
             Ok(output) => output,
             Err(err) => {
                 eprintln!("Failed to run restore ledger tests: {:?}", err);
@@ -191,6 +191,7 @@ fn run_chainlink_tests(
         "chainlink-conf.devnet.toml",
         ValidatorCluster::Chain(None),
         &loaded_chain_accounts,
+        TEST_NAME,
     ) {
         Some(validator) => validator,
         None => {
@@ -203,7 +204,13 @@ fn run_chainlink_tests(
         let test_chainlink_dir =
             format!("{}/../{}", manifest_dir, "test-chainlink");
         eprintln!("Running chainlink tests in {}", test_chainlink_dir);
-        let output = match run_test(test_chainlink_dir, Default::default()) {
+        let output = match run_test(
+            test_chainlink_dir,
+            RunTestConfig {
+                chain_config: Some("chainlink-conf.devnet.toml"),
+                ..Default::default()
+            },
+        ) {
             Ok(output) => output,
             Err(err) => {
                 eprintln!("Failed to run chainlink tests: {:?}", err);
@@ -242,6 +249,7 @@ fn run_table_mania_and_committor_tests(
         "committor-conf.devnet.toml",
         ValidatorCluster::Chain(None),
         &loaded_chain_accounts,
+        COMMITTOR_TEST,
     ) {
         Some(validator) => validator,
         None => {
@@ -265,7 +273,13 @@ fn run_table_mania_and_committor_tests(
             let test_table_mania_dir =
                 format!("{}/../{}", manifest_dir, "test-table-mania");
 
-            match run_test(test_table_mania_dir, Default::default()) {
+            match run_test(
+                test_table_mania_dir,
+                RunTestConfig {
+                    chain_config: Some("committor-conf.devnet.toml"),
+                    ..Default::default()
+                },
+            ) {
                 Ok(output) => output,
                 Err(err) => {
                     eprintln!("Failed to run table-mania: {:?}", err);
@@ -284,7 +298,10 @@ fn run_table_mania_and_committor_tests(
             eprintln!("Running committor tests in {}", test_committor_dir);
             match run_test(
                 test_committor_dir,
-                RunTestConfig::default(),
+                RunTestConfig {
+                    chain_config: Some("committor-conf.devnet.toml"),
+                    ..Default::default()
+                },
                 // RunTestConfig {
                 //     package: Some("schedulecommit-committor-service"),
                 //     test_file: Some("test_ix_commit_local"),
@@ -336,6 +353,7 @@ fn run_schedule_commit_tests(
         "schedulecommit-conf.devnet.toml",
         ValidatorCluster::Chain(None),
         &loaded_chain_accounts,
+        TEST_NAME,
     ) {
         Some(validator) => validator,
         None => {
@@ -347,6 +365,7 @@ fn run_schedule_commit_tests(
         "schedulecommit-conf-fees.ephem.toml",
         ValidatorCluster::Ephem,
         &loaded_chain_accounts,
+        TEST_NAME,
     ) {
         Some(validator) => validator,
         None => {
@@ -372,24 +391,33 @@ fn run_schedule_commit_tests(
         let test_security_dir =
             format!("{}/../{}", manifest_dir, "schedulecommit/test-security");
         eprintln!("Running security tests in {}", test_security_dir);
-        let test_security_output =
-            match run_test(test_security_dir, Default::default()) {
-                Ok(output) => output,
-                Err(err) => {
-                    eprintln!("Failed to run security: {:?}", err);
-                    cleanup_validators(
-                        &mut ephem_validator,
-                        &mut devnet_validator,
-                    );
-                    return Err(err.into());
-                }
-            };
+        let test_security_output = match run_test(
+            test_security_dir,
+            RunTestConfig {
+                chain_config: Some("schedulecommit-conf.devnet.toml"),
+                ephem_config: Some("schedulecommit-conf-fees.ephem.toml"),
+                ..Default::default()
+            },
+        ) {
+            Ok(output) => output,
+            Err(err) => {
+                eprintln!("Failed to run security: {:?}", err);
+                cleanup_validators(&mut ephem_validator, &mut devnet_validator);
+                return Err(err.into());
+            }
+        };
 
         eprintln!("======== RUNNING SCENARIOS TESTS ========");
         let test_scenarios_dir =
             format!("{}/../{}", manifest_dir, "schedulecommit/test-scenarios");
-        let test_scenarios_output =
-            match run_test(test_scenarios_dir, Default::default()) {
+        let test_scenarios_output = match run_test(
+            test_scenarios_dir,
+            RunTestConfig {
+                chain_config: Some("schedulecommit-conf.devnet.toml"),
+                ephem_config: Some("schedulecommit-conf-fees.ephem.toml"),
+                ..Default::default()
+            },
+        ) {
                 Ok(output) => output,
                 Err(err) => {
                     eprintln!("Failed to run scenarios: {:?}", err);
@@ -443,6 +471,7 @@ fn run_cloning_tests(
         "cloning-conf.devnet.toml",
         ValidatorCluster::Chain(Some(ProgramLoader::UpgradeableProgram)),
         &loaded_chain_accounts,
+        TEST_NAME,
     ) {
         Some(validator) => validator,
         None => {
@@ -454,6 +483,7 @@ fn run_cloning_tests(
         "cloning-conf.ephem.toml",
         ValidatorCluster::Ephem,
         &loaded_chain_accounts,
+        TEST_NAME,
     ) {
         Some(validator) => validator,
         None => {
@@ -472,11 +502,16 @@ fn run_cloning_tests(
         eprintln!("Running cloning tests in {}", test_cloning_dir);
         let output = match run_test(
             test_cloning_dir,
-            RunTestConfig::default(),
+            RunTestConfig {
+                chain_config: Some("cloning-conf.devnet.toml"),
+                ephem_config: Some("cloning-conf.ephem.toml"),
+                ..Default::default()
+            },
             // RunTestConfig {
             //     package: Some("test-cloning"),
             //     test_file: Some("10_post_delegation_token_transfer"),
             //     test_fn_name: None,
+            //     ..Default::default()
             // },
         ) {
             Ok(output) => output,
@@ -507,9 +542,10 @@ fn run_magicblock_api_tests(
     }
 
     let start_devnet_validator = || match start_validator(
-        "schedulecommit-conf.devnet.toml",
+        "magicblock-api-chain.devnet.toml",
         ValidatorCluster::Chain(None),
         &LoadedAccounts::with_delegation_program_test_authority(),
+        TEST_NAME,
     ) {
         Some(validator) => validator,
         None => {
@@ -521,6 +557,7 @@ fn run_magicblock_api_tests(
         "api-conf.ephem.toml",
         ValidatorCluster::Ephem,
         &LoadedAccounts::with_delegation_program_test_authority(),
+        TEST_NAME,
     ) {
         Some(validator) => validator,
         None => {
@@ -537,7 +574,15 @@ fn run_magicblock_api_tests(
         let test_dir = format!("{}/../{}", manifest_dir, "test-magicblock-api");
         eprintln!("Running magicblock-api tests in {}", test_dir);
 
-        let output = run_test(test_dir, Default::default()).map_err(|err| {
+        let output = run_test(
+            test_dir,
+            RunTestConfig {
+                chain_config: Some("magicblock-api-chain.devnet.toml"),
+                ephem_config: Some("api-conf.ephem.toml"),
+                ..Default::default()
+            },
+        )
+        .map_err(|err| {
             eprintln!("Failed to magicblock api tests: {:?}", err);
             cleanup_validators(&mut ephem_validator, &mut devnet_validator);
             err
@@ -567,9 +612,10 @@ fn run_magicblock_pubsub_tests(
         LoadedAccounts::with_delegation_program_test_authority();
 
     let start_devnet_validator = || match start_validator(
-        "validator-offline.devnet.toml",
+        "pubsub-chain.devnet.toml",
         ValidatorCluster::Chain(None),
         &loaded_chain_accounts,
+        TEST_NAME,
     ) {
         Some(validator) => validator,
         None => {
@@ -577,9 +623,10 @@ fn run_magicblock_pubsub_tests(
         }
     };
     let start_ephem_validator = || match start_validator(
-        "cloning-conf.ephem.toml",
+        "pubsub-ephem.toml",
         ValidatorCluster::Ephem,
         &loaded_chain_accounts,
+        TEST_NAME,
     ) {
         Some(validator) => validator,
         None => {
@@ -596,7 +643,15 @@ fn run_magicblock_pubsub_tests(
         let test_dir = format!("{}/../{}", manifest_dir, "test-pubsub");
         eprintln!("Running magicblock pubsub tests in {}", test_dir);
 
-        let output = run_test(test_dir, Default::default()).map_err(|err| {
+        let output = run_test(
+            test_dir,
+            RunTestConfig {
+                chain_config: Some("pubsub-chain.devnet.toml"),
+                ephem_config: Some("pubsub-ephem.toml"),
+                ..Default::default()
+            },
+        )
+        .map_err(|err| {
             eprintln!("Failed to magicblock pubsub tests: {:?}", err);
             cleanup_validators(&mut ephem_validator, &mut devnet_validator);
             err
@@ -629,6 +684,7 @@ fn run_config_tests(
         "config-conf.devnet.toml",
         ValidatorCluster::Chain(Some(ProgramLoader::UpgradeableProgram)),
         &loaded_chain_accounts,
+        TEST_NAME,
     ) {
         Some(validator) => validator,
         None => {
@@ -643,7 +699,13 @@ fn run_config_tests(
 
         let test_config_dir = format!("{}/../{}", manifest_dir, "test-config");
         eprintln!("Running config tests in {}", test_config_dir);
-        let output = match run_test(test_config_dir, Default::default()) {
+        let output = match run_test(
+            test_config_dir,
+            RunTestConfig {
+                chain_config: Some("config-conf.devnet.toml"),
+                ..Default::default()
+            },
+        ) {
             Ok(output) => output,
             Err(err) => {
                 eprintln!("Failed to run config tests: {:?}", err);
@@ -672,9 +734,10 @@ fn run_schedule_intents_tests(
     let loaded_chain_accounts =
         LoadedAccounts::with_delegation_program_test_authority();
     let start_devnet_validator = || match start_validator(
-        "config-conf.devnet.toml",
+        "schedule-intents-chain.devnet.toml",
         ValidatorCluster::Chain(None),
         &loaded_chain_accounts,
+        TEST_NAME,
     ) {
         Some(validator) => validator,
         None => {
@@ -682,9 +745,10 @@ fn run_schedule_intents_tests(
         }
     };
     let start_ephem_validator = || match start_validator(
-        "schedulecommit-conf.ephem.frequent-commits.toml",
+        "schedule-intents-ephem.toml",
         ValidatorCluster::Ephem,
         &loaded_chain_accounts,
+        TEST_NAME,
     ) {
         Some(validator) => validator,
         None => {
@@ -703,13 +767,18 @@ fn run_schedule_intents_tests(
         eprintln!("Running schedule intents tests in {}", test_intents_dir);
         let test_output = match run_test(
             test_intents_dir,
-            RunTestConfig::default(),
+            RunTestConfig {
+                chain_config: Some("schedule-intents-chain.devnet.toml"),
+                ephem_config: Some("schedule-intents-ephem.toml"),
+                ..Default::default()
+            },
             // RunTestConfig {
             //     package: Some("test-schedule-intent"),
             //     test_file: Some("test_schedule_intents"),
             //     test_fn_name: Some(
             //         "test_intent_bundle_commit_and_commit_finalize",
             //     ),
+            //     ..Default::default()
             // },
         ) {
             Ok(output) => output,
@@ -746,6 +815,7 @@ fn run_task_scheduler_tests(
         "schedule-task.devnet.toml",
         ValidatorCluster::Chain(Some(ProgramLoader::UpgradeableProgram)),
         &loaded_chain_accounts,
+        TEST_NAME,
     ) {
         Some(validator) => validator,
         None => {
@@ -761,7 +831,13 @@ fn run_task_scheduler_tests(
         let test_dir = format!("{}/../{}", manifest_dir, "test-task-scheduler");
         eprintln!("Running task scheduler tests in {}", test_dir);
 
-        let output = match run_test(test_dir, Default::default()) {
+        let output = match run_test(
+            test_dir,
+            RunTestConfig {
+                chain_config: Some("schedule-task.devnet.toml"),
+                ..Default::default()
+            },
+        ) {
             Ok(output) => output,
             Err(err) => {
                 eprintln!("Failed to run task scheduler tests: {:?}", err);
@@ -802,6 +878,14 @@ struct RunTestConfig<'a> {
     package: Option<&'a str>,
     test_file: Option<&'a str>,
     test_fn_name: Option<&'a str>,
+    /// Chain TOML config filename (relative to configs/). When set,
+    /// `[aperture].listen` is resolved and exported as CHAIN_URL/CHAIN_WS_URL
+    /// on the cargo test child process so tests reach the correct port
+    /// without racing on process-wide env vars.
+    chain_config: Option<&'a str>,
+    /// Ephem TOML config filename (relative to configs/). Resolved into
+    /// EPHEM_URL/EPHEM_WS_URL on the cargo test child process.
+    ephem_config: Option<&'a str>,
 }
 
 fn run_test(
@@ -814,6 +898,16 @@ fn run_test(
         std::env::var("RUST_LOG").unwrap_or_else(|_| "info".to_string()),
     )
     .arg("test");
+    if let Some(chain_config) = config.chain_config {
+        let port = rpc_port_from_config(&resolve_paths(chain_config).config_path);
+        cmd.env("CHAIN_URL", format!("http://127.0.0.1:{port}"))
+            .env("CHAIN_WS_URL", format!("ws://127.0.0.1:{}", port + 1));
+    }
+    if let Some(ephem_config) = config.ephem_config {
+        let port = rpc_port_from_config(&resolve_paths(ephem_config).config_path);
+        cmd.env("EPHEM_URL", format!("http://127.0.0.1:{port}"))
+            .env("EPHEM_WS_URL", format!("ws://127.0.0.1:{}", port + 1));
+    }
     if let Some(package) = config.package {
         cmd.arg("-p").arg(package);
     }
@@ -866,6 +960,7 @@ fn start_validator(
     config_file: &str,
     cluster: ValidatorCluster,
     loaded_chain_accounts: &LoadedAccounts,
+    suite_name: &str,
 ) -> Option<process::Child> {
     let log_suffix = cluster.log_suffix();
     let test_runner_paths = resolve_paths(config_file);
@@ -879,6 +974,7 @@ fn start_validator(
                 program_loader,
                 loaded_chain_accounts,
                 log_suffix,
+                suite_name,
             )
         }
         _ => start_magic_block_validator_with_config(

--- a/test-integration/test-runner/bin/run_tests.rs
+++ b/test-integration/test-runner/bin/run_tests.rs
@@ -57,9 +57,19 @@ macro_rules! register_tests {
     };
 }
 
+struct ValidatorCleanupGuard;
+
+impl Drop for ValidatorCleanupGuard {
+    fn drop(&mut self) {
+        kill_validators();
+    }
+}
+
 pub fn main() {
     let config = TestConfigViaEnvVars::default();
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+
+    let _validator_cleanup = ValidatorCleanupGuard;
 
     let results: Vec<(&'static str, Output)> = thread::scope(|s| {
         let handles = register_tests!(s, (&manifest_dir, &config), {
@@ -84,7 +94,6 @@ pub fn main() {
     for (name, output) in results {
         assert_cargo_tests_passed(output, name);
     }
-    kill_validators();
 }
 
 fn success_output() -> Output {

--- a/test-integration/test-runner/src/cleanup.rs
+++ b/test-integration/test-runner/src/cleanup.rs
@@ -6,12 +6,10 @@ pub fn cleanup_validators(
 ) {
     cleanup_validator(ephem_validator, "ephemeral");
     cleanup_validator(devnet_validator, "devnet");
-    kill_validators();
 }
 
 pub fn cleanup_devnet_only(devnet_validator: &mut Child) {
     cleanup_validator(devnet_validator, "devnet");
-    kill_validators();
 }
 
 pub fn cleanup_validator(validator: &mut Child, label: &str) {
@@ -33,7 +31,7 @@ fn kill_process(name: &str) {
         .unwrap();
 }
 
-fn kill_validators() {
+pub fn kill_validators() {
     // Makes sure all the magicblock-validator + solana test validators  are really killed
     kill_process("magicblock-validator");
     kill_process("solana-test-validator");

--- a/test-integration/test-table-mania/Cargo.toml
+++ b/test-integration/test-table-mania/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 
 [dev-dependencies]
+integration-test-tools = { workspace = true }
 tracing = { workspace = true }
 magicblock-rpc-client = { workspace = true }
 magicblock-table-mania = { workspace = true, features = [

--- a/test-integration/test-table-mania/tests/ix_lookup_table.rs
+++ b/test-integration/test-table-mania/tests/ix_lookup_table.rs
@@ -1,3 +1,4 @@
+use integration_test_tools::IntegrationTestContext;
 use magicblock_rpc_client::MagicblockRpcClient;
 use magicblock_table_mania::{
     find_open_tables, LookupTableRc, TableManiaComputeBudgets,
@@ -23,7 +24,7 @@ pub async fn setup_lookup_table(
 ) -> (MagicblockRpcClient, LookupTableRc) {
     let rpc_client = {
         let client = RpcClient::new_with_commitment(
-            "http://localhost:7799".to_string(),
+            IntegrationTestContext::url_chain().to_string(),
             CommitmentConfig::confirmed(),
         );
         MagicblockRpcClient::from(client)

--- a/test-integration/test-table-mania/tests/utils/mod.rs
+++ b/test-integration/test-table-mania/tests/utils/mod.rs
@@ -1,5 +1,6 @@
 use std::time::{Duration, Instant};
 
+use integration_test_tools::IntegrationTestContext;
 use magicblock_rpc_client::MagicblockRpcClient;
 use magicblock_table_mania::{GarbageCollectorConfig, TableMania};
 use solana_rpc_client::nonblocking::rpc_client::RpcClient;
@@ -20,7 +21,7 @@ pub async fn sleep_millis(millis: u64) {
 pub async fn setup_table_mania(validator_auth: &Keypair) -> TableMania {
     let rpc_client = {
         let client = RpcClient::new_with_commitment(
-            "http://localhost:7799".to_string(),
+            IntegrationTestContext::url_chain().to_string(),
             CommitmentConfig::processed(),
         );
         MagicblockRpcClient::from(client)

--- a/test-integration/test-tools/src/integration_test_context.rs
+++ b/test-integration/test-tools/src/integration_test_context.rs
@@ -1,6 +1,11 @@
 #![allow(clippy::result_large_err)]
 
-use std::{str::FromStr, thread::sleep, time::Duration};
+use std::{
+    str::FromStr,
+    sync::OnceLock,
+    thread::sleep,
+    time::Duration,
+};
 
 use anyhow::{Context, Result};
 use borsh::BorshDeserialize;
@@ -42,9 +47,14 @@ use crate::{
     },
 };
 
-const URL_CHAIN: &str = "http://localhost:7799";
-const WS_URL_CHAIN: &str = "ws://localhost:7800";
-const URL_EPHEM: &str = "http://localhost:8899";
+const DEFAULT_URL_CHAIN: &str = "http://localhost:7799";
+const DEFAULT_WS_URL_CHAIN: &str = "ws://localhost:7800";
+const DEFAULT_URL_EPHEM: &str = "http://localhost:8899";
+const DEFAULT_WS_URL_EPHEM: &str = "ws://localhost:8900";
+
+fn resolve_url(env_key: &'static str, default: &str) -> String {
+    std::env::var(env_key).unwrap_or_else(|_| default.to_string())
+}
 
 fn async_rpc_client(
     rpc_client: &RpcClient,
@@ -114,10 +124,14 @@ impl IntegrationTestContext {
     }
 
     pub fn try_new() -> Result<Self> {
-        Self::try_new_with_ephem_port(8899)
+        Self::try_new_with_ephem_url(Self::url_ephem().to_string())
     }
 
     pub fn try_new_with_ephem_port(port: u16) -> Result<Self> {
+        Self::try_new_with_ephem_url(Self::url_local_ephem_at_port(port))
+    }
+
+    fn try_new_with_ephem_url(ephem_url: String) -> Result<Self> {
         color_backtrace::install();
 
         let commitment = CommitmentConfig::confirmed();
@@ -126,10 +140,8 @@ impl IntegrationTestContext {
             Self::url_chain().to_string(),
             commitment,
         );
-        let ephem_client = RpcClient::new_with_commitment(
-            Self::url_local_ephem_at_port(port).to_string(),
-            commitment,
-        );
+        let ephem_client =
+            RpcClient::new_with_commitment(ephem_url, commitment);
         let validator_identity = ephem_client.get_identity()?;
 
         Ok(Self {
@@ -1266,16 +1278,27 @@ impl IntegrationTestContext {
     // RPC Clients
     // -----------------
     pub fn url_ephem() -> &'static str {
-        URL_EPHEM
+        static URL: OnceLock<String> = OnceLock::new();
+        URL.get_or_init(|| resolve_url("EPHEM_URL", DEFAULT_URL_EPHEM))
+            .as_str()
+    }
+    pub fn ws_url_ephem() -> &'static str {
+        static URL: OnceLock<String> = OnceLock::new();
+        URL.get_or_init(|| resolve_url("EPHEM_WS_URL", DEFAULT_WS_URL_EPHEM))
+            .as_str()
     }
     pub fn url_local_ephem_at_port(port: u16) -> String {
         format!("http://localhost:{}", port)
     }
     pub fn url_chain() -> &'static str {
-        URL_CHAIN
+        static URL: OnceLock<String> = OnceLock::new();
+        URL.get_or_init(|| resolve_url("CHAIN_URL", DEFAULT_URL_CHAIN))
+            .as_str()
     }
     pub fn ws_url_chain() -> &'static str {
-        WS_URL_CHAIN
+        static URL: OnceLock<String> = OnceLock::new();
+        URL.get_or_init(|| resolve_url("CHAIN_WS_URL", DEFAULT_WS_URL_CHAIN))
+            .as_str()
     }
 
     // -----------------

--- a/test-integration/test-tools/src/toml_to_args.rs
+++ b/test-integration/test-tools/src/toml_to_args.rs
@@ -47,21 +47,48 @@ fn extract_port_from_listen(listen: &str) -> &str {
 pub fn config_to_args(
     config_path: &PathBuf,
     program_loader: Option<ProgramLoader>,
+    rpc_port: u16,
+    suite_name: &str,
 ) -> Vec<String> {
     let config = parse_config(config_path);
     let program_loader = program_loader.unwrap_or_default();
 
-    let listen = config
-        .aperture
-        .as_ref()
-        .map(|a| a.listen.as_str())
-        .unwrap_or("127.0.0.1:8899");
-    let port = extract_port_from_listen(listen);
+    // Default ports (faucet 9900, gossip 8000, dynamic 1024-65535) collide
+    // when multiple chain validators run concurrently. Derive unique, non-
+    // overlapping port zones from rpc_port (which is already unique per suite
+    // via the TOML configs, spaced by 10).
+    let faucet_port = rpc_port
+        .checked_add(1000)
+        .expect("rpc_port + 1000 overflows u16");
+    let gossip_port = rpc_port
+        .checked_sub(200)
+        .expect("rpc_port - 200 underflows u16");
+    // Solana requires a minimum dynamic-port-range (~26 ports). Give each
+    // suite 50 ports, allocated by its "slot" — derived from rpc_port which
+    // is spaced by 10 starting at 9000 in the TOML configs.
+    let slot = rpc_port
+        .checked_sub(9000)
+        .expect("rpc_port must be >= 9000")
+        / 10;
+    let dyn_start = 11000u16
+        .checked_add(slot.checked_mul(50).expect("slot * 50 overflows u16"))
+        .expect("dynamic-port-range start overflows u16");
+    let dyn_end = dyn_start
+        .checked_add(49)
+        .expect("dynamic-port-range end overflows u16");
 
     let mut args = vec![
         "--log".to_string(),
         "--rpc-port".to_string(),
-        port.to_string(),
+        rpc_port.to_string(),
+        "--faucet-port".to_string(),
+        faucet_port.to_string(),
+        "--gossip-port".to_string(),
+        gossip_port.to_string(),
+        "--dynamic-port-range".to_string(),
+        format!("{dyn_start}-{dyn_end}"),
+        "--ledger".to_string(),
+        format!("test-ledger/{suite_name}"),
         "-r".to_string(),
         "--limit-ledger-size".to_string(),
         "10000".to_string(),

--- a/test-integration/test-tools/src/validator.rs
+++ b/test-integration/test-tools/src/validator.rs
@@ -72,6 +72,7 @@ pub fn start_test_validator_with_config(
     program_loader: Option<ProgramLoader>,
     loaded_accounts: &LoadedAccounts,
     log_suffix: &str,
+    suite_name: &str,
 ) -> Option<process::Child> {
     let TestRunnerPaths {
         config_path,
@@ -80,7 +81,15 @@ pub fn start_test_validator_with_config(
     } = test_runner_paths;
 
     let port = rpc_port_from_config(config_path);
-    let mut args = config_to_args(config_path, program_loader);
+    let mut args = config_to_args(config_path, program_loader, port, suite_name);
+
+    let ledger_path = root_dir.join("test-ledger").join(suite_name);
+    fs::create_dir_all(&ledger_path).unwrap_or_else(|err| {
+        panic!(
+            "Failed to create ledger directory '{}': {err}",
+            ledger_path.display()
+        )
+    });
 
     let accounts_dir = workspace_dir.join("configs").join("accounts");
     let accounts = [


### PR DESCRIPTION
## Summary
  - Attempt to run all integration tests in parallel in run_tests.rs                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      
  - CI matrix is no longer needed as single runner runs all of the tests in their own thread                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               
  - Added non-conflicting config files for magic-block and Solana validator                                                                                                                                                                                                                                                                                                                                                                                                                                                                 

This unfortunately doesn't nicely work due to some test constrains and behaviors - e.g. how long response is awaited before making the test as failed - in congested setup where there are many independent validators running in parallel some deadlines are not met. Also, some of the tests are flaky (e.g. 02_commit_and_undelegate.rs failing sporadically before this change).
It's been assumed that each test requires independent Solana or/and magicblock validator (since the original config files are different and have e.g. different programs laid out), thus validator has its own dir path + unique port(s) for rpc/ws and gossip/airdrops/etc.

## Compatibility
- [ ] No breaking changes
- [ ] Config change (describe):
- [ ] Migration needed (describe):

## Testing
- [ ] tests (or explain)

## Checklist
- [ ] docs updated (if needed)
- [ ] closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored integration test runner to execute test suites in parallel instead of sequentially.
  * Updated test configuration infrastructure to support dynamic endpoint and URL resolution via environment variables with sensible defaults.
  * Reorganized service port assignments across test configurations for improved isolation and resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->