### PR TITLE
feat: cache empty accounts for get/multiple account info

### DIFF
--- a/magicblock-aperture/src/requests/http/get_account_info.rs
+++ b/magicblock-aperture/src/requests/http/get_account_info.rs
@@ -33,6 +33,7 @@ impl HttpDispatcher {
         let account = self
             .read_account_with_ensure(&pubkey)
             .await
+            .filter(|acc| !Self::account_should_render_as_null(acc))
             // `LockedAccount` provides a race-free read of the account data before encoding.
             .map(|acc| {
                 LockedAccount::new(pubkey, acc).ui_encode(encoding, slice)

--- a/magicblock-aperture/src/requests/http/get_multiple_accounts.rs
+++ b/magicblock-aperture/src/requests/http/get_multiple_accounts.rs
@@ -32,8 +32,12 @@ impl HttpDispatcher {
             .iter()
             .zip(self.read_accounts_with_ensure(&pubkeys).await.into_iter())
             .map(|(pubkey, acc)| {
-                acc.map(|a| {
-                    LockedAccount::new(*pubkey, a).ui_encode(encoding, slice)
+                acc.filter(|account| {
+                    !Self::account_should_render_as_null(account)
+                })
+                .map(|account| {
+                    LockedAccount::new(*pubkey, account)
+                        .ui_encode(encoding, slice)
                 })
             })
             .collect::<Vec<_>>();

--- a/magicblock-aperture/src/requests/http/mod.rs
+++ b/magicblock-aperture/src/requests/http/mod.rs
@@ -117,6 +117,7 @@ impl HttpDispatcher {
         &self,
         pubkey: &Pubkey,
     ) -> Option<AccountSharedData> {
+        let mark_empty_if_not_found = [*pubkey];
         let _timer = ENSURE_ACCOUNTS_TIME
             .with_label_values(&["account"])
             .start_timer();
@@ -124,7 +125,7 @@ impl HttpDispatcher {
             .chainlink
             .ensure_accounts(
                 &[*pubkey],
-                None,
+                Some(&mark_empty_if_not_found),
                 AccountFetchOrigin::GetAccount,
                 None,
             )
@@ -152,7 +153,7 @@ impl HttpDispatcher {
             .chainlink
             .ensure_accounts(
                 pubkeys,
-                None,
+                Some(pubkeys),
                 AccountFetchOrigin::GetMultipleAccounts,
                 None,
             )

--- a/magicblock-aperture/src/requests/http/mod.rs
+++ b/magicblock-aperture/src/requests/http/mod.rs
@@ -13,7 +13,7 @@ use magicblock_core::link::transactions::{
 };
 use magicblock_metrics::metrics::{AccountFetchOrigin, ENSURE_ACCOUNTS_TIME};
 use prelude::JsonBody;
-use solana_account::AccountSharedData;
+use solana_account::{AccountSharedData, ReadableAccount};
 use solana_pubkey::Pubkey;
 use solana_transaction::{
     sanitized::SanitizedTransaction, versioned::VersionedTransaction,
@@ -32,6 +32,8 @@ pub(crate) type HandlerResult = RpcResult<Response<JsonBody>>;
 // indices fit within a packet-bounded pubkey table (1232 / 32 = 38).
 const MAX_RUNTIME_PROGRAM_ID_INDEX_EXCLUSIVE: usize =
     1232 / size_of::<Pubkey>();
+const SYSTEM_PROGRAM_ID: Pubkey =
+    Pubkey::from_str_const("11111111111111111111111111111111");
 
 /// An enum to efficiently represent a request body, avoiding allocation
 /// for single-chunk bodies (which are almost always the case)
@@ -110,6 +112,16 @@ pub(crate) async fn extract_bytes(
 ///
 /// This block contains common helper methods used by various RPC request handlers.
 impl HttpDispatcher {
+    // Heuristic to render synthetic empty placeholder accounts as JSON-RPC null.
+    fn account_should_render_as_null(account: &AccountSharedData) -> bool {
+        account.lamports() == 0
+            && account.data().is_empty()
+            && !account.delegated()
+            && !account.undelegating()
+            && !account.confined()
+            && account.owner() == &SYSTEM_PROGRAM_ID
+    }
+
     /// Fetches an account's data from the `AccountsDb` filling it in from chain
     /// as needed.
     #[instrument(skip_all)]

--- a/magicblock-aperture/tests/accounts.rs
+++ b/magicblock-aperture/tests/accounts.rs
@@ -33,6 +33,27 @@ async fn test_get_account_info() {
         .expect("rpc request for non-existent account failed");
     assert_eq!(nonexistent.context.slot, env.latest_slot());
     assert_eq!(nonexistent.value, None, "account should not exist");
+
+    // Repeated lookup should continue to render the synthetic empty placeholder
+    // as JSON-RPC null after the ensure path has populated the bank.
+    let missing_pubkey = Pubkey::new_unique();
+    let first_miss = env
+        .rpc
+        .get_account_with_commitment(&missing_pubkey, Default::default())
+        .await
+        .expect("first rpc request for non-existent account failed");
+    let second_miss = env
+        .rpc
+        .get_account_with_commitment(&missing_pubkey, Default::default())
+        .await
+        .expect("second rpc request for non-existent account failed");
+    assert_eq!(first_miss.context.slot, env.latest_slot());
+    assert_eq!(second_miss.context.slot, env.latest_slot());
+    assert_eq!(first_miss.value, None, "first lookup should return null");
+    assert_eq!(
+        second_miss.value, None,
+        "repeated lookup should still return null"
+    );
 }
 
 /// Verifies `getMultipleAccounts` for both existing and non-existent accounts.
@@ -63,6 +84,44 @@ async fn test_get_multiple_accounts() {
     assert!(
         nonexistent.iter().all(Option::is_none),
         "non-existent accounts should not be found"
+    );
+
+    // Mixed existing and non-existent accounts should preserve ordering and
+    // still render synthetic empty placeholders as JSON-RPC null.
+    let missing_pubkey = Pubkey::new_unique();
+    let mixed = env
+        .rpc
+        .get_multiple_accounts(&[acc1.pubkey, missing_pubkey, acc2.pubkey])
+        .await
+        .expect(
+            "rpc request for mixed existing and non-existent accounts failed",
+        );
+    assert_eq!(
+        mixed.len(),
+        3,
+        "should return one entry per requested pubkey"
+    );
+    assert!(
+        accounts_equal(
+            mixed[0]
+                .as_ref()
+                .expect("existing first account should be returned"),
+            &acc1.account
+        ),
+        "first result should match the first requested account"
+    );
+    assert_eq!(
+        mixed[1], None,
+        "missing middle account should render as null"
+    );
+    assert!(
+        accounts_equal(
+            mixed[2]
+                .as_ref()
+                .expect("existing last account should be returned"),
+            &acc2.account
+        ),
+        "last result should match the last requested account"
     );
 }
 


### PR DESCRIPTION
## Summary

Updates aperture account reads so `getAccountInfo` and `getMultipleAccounts` use the same empty-if-not-found ensure behavior as transaction preparation while still returning JSON-RPC `null` for synthetic empty accounts.

## Details

This change makes RPC account reads populate the bank with empty placeholders when the remote fetch confirms an account is missing, which keeps the read path aligned with the existing transaction-preparation behavior.

It also centralizes the aperture-side heuristic for recognizing those synthetic empty placeholders and converts them back to `null` in both single-account and multi-account RPC responses so client-visible behavior stays unchanged for missing accounts.

### magicblock-aperture

Adds regression coverage for repeated `getAccountInfo` misses and mixed `getMultipleAccounts` requests so the response shape, ordering, and `null` rendering stay stable after the bank has cached a miss.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed account information endpoints to properly return `null` for empty system-owned accounts in both single and multiple account queries, ensuring consistent JSON-RPC behavior.

* **Tests**
  * Added test coverage to verify proper `null` handling for missing and empty accounts in account information queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->