### PR TITLE
fix: changed crank signer to be derived from Crank program id

### DIFF
--- a/magicblock-magic-program-api/src/pda.rs
+++ b/magicblock-magic-program-api/src/pda.rs
@@ -4,7 +4,7 @@ pub const CRANK_SEED: &[u8] = b"crank-executor";
 const CRANK_SIGNER_PDA: ([u8; 32], u8) =
     const_crypto::ed25519::derive_program_address(
         &[CRANK_SEED],
-        crate::ID.as_array(),
+        crate::CRANK_PROGRAM_ID.as_array(),
     );
 pub const CRANK_SIGNER: Pubkey = Pubkey::new_from_array(CRANK_SIGNER_PDA.0);
 pub const CRANK_SIGNER_BUMP: u8 = CRANK_SIGNER_PDA.1;


### PR DESCRIPTION
<!--
PR title must match:
  type(scope): summary
Types: feat|fix|docs|chore|refactor|test|perf|ci|build
Examples:
  fix: avoid panic on empty slot
  feat(rpc): add getFoo endpoint
-->

## Summary
Crank PDA signs within Crank program, while derived from `magic-program` ID

## Compatibility
- [ ] No breaking changes
- [ ] Config change (describe):
- [ ] Migration needed (describe):

## Testing
- [ ] tests (or explain)

## Checklist
- [ ] docs updated (if needed)
- [ ] closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the internal account derivation mechanism to use a different program identifier source, ensuring correct computation of associated accounts while maintaining system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->