### PR TITLE
feat: use backfill for triton

### DIFF
--- a/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/actor.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/actor.rs
@@ -495,12 +495,12 @@ impl<H: StreamHandle, S: StreamFactory<H>> ChainLaserActor<H, S> {
 
     /// Computes a `from_slot` for backfilling based on the
     /// current chain slot. Returns `None` if backfilling is not
-    /// supported or the slot is still 0.
+    /// supported or the slot is still `0` (i.e. uninitialized).
     fn compute_from_slot(&self) -> Option<u64> {
         if !self.slots.supports_backfill {
             return None;
         }
-        Some(self.slots.chain_slot.compute_from_slot())
+        self.slots.chain_slot.compute_from_slot()
     }
 
     /// Handles an update from any subscription stream.

--- a/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/actor.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/actor.rs
@@ -496,11 +496,38 @@ impl<H: StreamHandle, S: StreamFactory<H>> ChainLaserActor<H, S> {
     /// Computes a `from_slot` for backfilling based on the
     /// current chain slot. Returns `None` if backfilling is not
     /// supported or the slot is still `0` (i.e. uninitialized).
+    ///
+    /// Logs the chosen mode so operators can distinguish:
+    /// - "backfill not supported" (endpoint flag)
+    /// - "backfill skipped (chain_slot still 0)" (bootstrap window)
+    /// - "backfill from <slot>" (normal operation)
     fn compute_from_slot(&self) -> Option<u64> {
         if !self.slots.supports_backfill {
+            trace!(
+                client_id = %self.client_id,
+                "compute_from_slot: backfill not supported by endpoint, \
+                 from_slot=None",
+            );
             return None;
         }
-        self.slots.chain_slot.compute_from_slot()
+        match self.slots.chain_slot.compute_from_slot() {
+            None => {
+                debug!(
+                    client_id = %self.client_id,
+                    "compute_from_slot: chain_slot still 0, creating \
+                     subscription without from_slot (degraded backfill)",
+                );
+                None
+            }
+            Some(slot) => {
+                trace!(
+                    client_id = %self.client_id,
+                    from_slot = slot,
+                    "compute_from_slot: using normal backfill",
+                );
+                Some(slot)
+            }
+        }
     }
 
     /// Handles an update from any subscription stream.

--- a/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/stream_manager.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/stream_manager.rs
@@ -1676,6 +1676,43 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn test_optimize_sets_from_slot_none_when_chain_slot_zero() {
+        use std::sync::{atomic::AtomicU64, Arc};
+
+        use crate::remote_account_provider::chain_slot::ChainSlot;
+
+        let chain_slot = ChainSlot::new(Arc::new(AtomicU64::new(0)));
+        let factory = MockStreamFactory::new();
+        let mut mgr = StreamManager::new(
+            test_config(),
+            factory.clone(),
+            Some(chain_slot),
+            "test".to_string(),
+        );
+
+        mgr.account_subscribe(&make_pubkeys(5), &COMMITMENT, Some(42))
+            .await
+            .unwrap();
+
+        let reqs_before = factory.captured_requests().len();
+        mgr.optimize(&COMMITMENT).await.unwrap();
+
+        let optimize_reqs: Vec<_> = factory
+            .captured_requests()
+            .into_iter()
+            .skip(reqs_before)
+            .collect();
+        assert!(!optimize_reqs.is_empty());
+        for req in &optimize_reqs {
+            assert_eq!(
+                req.from_slot, None,
+                "optimized streams should have from_slot=None \
+                 when chain_slot is still 0",
+            );
+        }
+    }
+
     // ---------------------------------------------------------
     // 12. next_update Stream Updates
     // ---------------------------------------------------------

--- a/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/stream_manager.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/stream_manager.rs
@@ -405,7 +405,9 @@ impl<S: StreamHandle, SF: StreamFactory<S>> StreamManager<S, SF> {
     /// current chain slot. Returns `None` if no chain slot
     /// tracker is available
     fn compute_from_slot(&self) -> Option<u64> {
-        self.chain_slot.as_ref().map(ChainSlot::compute_from_slot)
+        self.chain_slot
+            .as_ref()
+            .and_then(ChainSlot::compute_from_slot)
     }
 
     /// Emits the current optimized/unoptimized stream counts as

--- a/magicblock-chainlink/src/remote_account_provider/chain_slot.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_slot.rs
@@ -53,3 +53,35 @@ impl ChainSlot {
         Some(current.saturating_sub(Self::MAX_SLOTS_SUB_ACTIVATION))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{atomic::AtomicU64, Arc};
+
+    use super::*;
+
+    fn make(slot: u64) -> ChainSlot {
+        ChainSlot::new(Arc::new(AtomicU64::new(slot)))
+    }
+
+    #[test]
+    fn returns_none_when_slot_is_zero() {
+        let cs = make(0);
+        assert_eq!(cs.compute_from_slot(), None);
+    }
+
+    #[test]
+    fn returns_subtracted_slot_when_slot_is_nonzero() {
+        let cs = make(1000);
+        assert_eq!(
+            cs.compute_from_slot(),
+            Some(1000 - ChainSlot::MAX_SLOTS_SUB_ACTIVATION),
+        );
+    }
+
+    #[test]
+    fn saturates_at_zero_when_slot_below_window() {
+        let cs = make(1);
+        assert_eq!(cs.compute_from_slot(), Some(0));
+    }
+}

--- a/magicblock-chainlink/src/remote_account_provider/chain_slot.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_slot.rs
@@ -40,8 +40,16 @@ impl ChainSlot {
 
     /// Computes a `from_slot` for backfilling based on the current
     /// chain slot.
-    pub fn compute_from_slot(&self) -> u64 {
+    ///
+    /// Returns `None` while the slot is still `0`, i.e. before any
+    /// real slot update has been observed. In that case the caller
+    /// must treat backfill as temporarily unavailable for this
+    /// subscription instead of sending `from_slot = 0`.
+    pub fn compute_from_slot(&self) -> Option<u64> {
         let current = self.load();
-        current.saturating_sub(Self::MAX_SLOTS_SUB_ACTIVATION)
+        if current == 0 {
+            return None;
+        }
+        Some(current.saturating_sub(Self::MAX_SLOTS_SUB_ACTIVATION))
     }
 }

--- a/magicblock-chainlink/src/remote_account_provider/endpoint.rs
+++ b/magicblock-chainlink/src/remote_account_provider/endpoint.rs
@@ -104,7 +104,8 @@ impl TryFrom<&Remote> for Endpoint {
                     ))
                 })?;
 
-                let supports_backfill = is_helius_laser_url(&url);
+                let supports_backfill =
+                    is_helius_laser_url(&url) || is_triton_url(&url);
                 Ok(Endpoint::Grpc {
                     url,
                     label,


### PR DESCRIPTION
## Summary

Triton gRPC now supports backfill via the `from_slot` as helius does.
We now use that feature for triton as well.

Additionally this PR fixes a race condition where we did not have a chain_slot by the time we
make the first subscription and thus used `0` which triggered an error with the Triton
provider.
Instead we now fall back to _no backfill_ behavior for subscriptions made _before_ we have the
first `chain_slot`.

## Details

### Return Option from compute_from_slot

Changed `ChainSlot::compute_from_slot()` to return `Option<u64>` instead of `u64`. It now
returns `None` while chain slot is still `0` (uninitialized), indicating backfill is
temporarily unavailable. This prevents sending `from_slot=0` which would bypass the backfill
optimization.

### Targeted observability for degraded path

Enhanced `ChainLaserActor::compute_from_slot()` logging to distinguish three scenarios:
- Backfill not supported by endpoint (trace level)
- Backfill skipped due to chain slot still being 0 (debug level)
- Normal backfill operation with computed slot (trace level)

This helps operators debug bootstrap window behavior and identify when degraded backfill is in effect.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of slot computation for uninitialized chain states
  * Fixed optional value processing in stream management operations

* **New Features**
  * Extended endpoint support to enable backfill capabilities for additional gRPC endpoint types

* **Tests**
  * Added comprehensive test coverage for slot computation scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->