### PR TITLE
feat: invoke CommitFinalize by default instead of Commit+Finalize

### DIFF
--- a/magicblock-committor-service/src/intent_executor/error.rs
+++ b/magicblock-committor-service/src/intent_executor/error.rs
@@ -263,8 +263,11 @@ impl TransactionStrategyExecutionError {
                 };
 
                 match (task, instruction_err) {
-                    (BaseTaskImpl::Commit(_), instruction_err) => match instruction_err
-                    {
+                    (
+                        BaseTaskImpl::Commit(_)
+                        | BaseTaskImpl::CommitFinalize(_),
+                        instruction_err,
+                    ) => match instruction_err {
                         InstructionError::Custom(NONCE_OUT_OF_ORDER) => Ok(
                             TransactionStrategyExecutionError::CommitIDError(
                                 tx_err_helper(InstructionError::Custom(

--- a/magicblock-committor-service/src/intent_executor/mod.rs
+++ b/magicblock-committor-service/src/intent_executor/mod.rs
@@ -45,7 +45,7 @@ use crate::{
     },
     persist::{CommitStatus, CommitStatusSignatures, IntentPersister},
     tasks::{
-        task_builder::{TaskBuilderImpl, TasksBuilder},
+        task_builder::{CommitExecutionMode, TaskBuilderImpl},
         task_strategist::{
             StrategyExecutionMode, TaskStrategist, TransactionStrategy,
         },
@@ -56,6 +56,9 @@ use crate::{
     },
     utils::persist_status_update_by_message_set,
 };
+
+const DEFAULT_COMMIT_EXECUTION_MODE: CommitExecutionMode =
+    CommitExecutionMode::CommitFinalize;
 
 #[derive(Clone, Copy, Debug)]
 pub enum ExecutionOutput {
@@ -214,10 +217,11 @@ where
             // Build tasks for commit stage
             // TODO (snawaz): it's actually MagicBaseIntent::BaseActions scenario, not Commit
             // scenario, so the related code needs little bit of refactoring and proper renaming.
-            let commit_tasks = TaskBuilderImpl::commit_tasks(
+            let commit_tasks = TaskBuilderImpl::commit_tasks_with_mode(
                 &self.task_info_fetcher,
                 &intent_bundle,
                 persister,
+                DEFAULT_COMMIT_EXECUTION_MODE,
             )
             .await?;
 
@@ -239,14 +243,16 @@ where
 
         // Build tasks for commit & finalize stages
         let (commit_tasks, finalize_tasks) = {
-            let commit_tasks_fut = TaskBuilderImpl::commit_tasks(
+            let commit_tasks_fut = TaskBuilderImpl::commit_tasks_with_mode(
                 &self.task_info_fetcher,
                 &intent_bundle,
                 persister,
+                DEFAULT_COMMIT_EXECUTION_MODE,
             );
-            let finalize_tasks_fut = TaskBuilderImpl::finalize_tasks(
+            let finalize_tasks_fut = TaskBuilderImpl::finalize_tasks_with_mode(
                 &self.task_info_fetcher,
                 &intent_bundle,
+                DEFAULT_COMMIT_EXECUTION_MODE,
             );
             let (commit_tasks, finalize_tasks) =
                 join(commit_tasks_fut, finalize_tasks_fut).await;

--- a/magicblock-committor-service/src/intent_executor/mod.rs
+++ b/magicblock-committor-service/src/intent_executor/mod.rs
@@ -45,7 +45,7 @@ use crate::{
     },
     persist::{CommitStatus, CommitStatusSignatures, IntentPersister},
     tasks::{
-        task_builder::{CommitExecutionMode, TaskBuilderImpl},
+        task_builder::{TaskBuilderImpl, TasksBuilder},
         task_strategist::{
             StrategyExecutionMode, TaskStrategist, TransactionStrategy,
         },
@@ -56,9 +56,6 @@ use crate::{
     },
     utils::persist_status_update_by_message_set,
 };
-
-const DEFAULT_COMMIT_EXECUTION_MODE: CommitExecutionMode =
-    CommitExecutionMode::CommitFinalize;
 
 #[derive(Clone, Copy, Debug)]
 pub enum ExecutionOutput {
@@ -217,11 +214,10 @@ where
             // Build tasks for commit stage
             // TODO (snawaz): it's actually MagicBaseIntent::BaseActions scenario, not Commit
             // scenario, so the related code needs little bit of refactoring and proper renaming.
-            let commit_tasks = TaskBuilderImpl::commit_tasks_with_mode(
+            let commit_tasks = TaskBuilderImpl::commit_tasks(
                 &self.task_info_fetcher,
                 &intent_bundle,
                 persister,
-                DEFAULT_COMMIT_EXECUTION_MODE,
             )
             .await?;
 
@@ -243,16 +239,14 @@ where
 
         // Build tasks for commit & finalize stages
         let (commit_tasks, finalize_tasks) = {
-            let commit_tasks_fut = TaskBuilderImpl::commit_tasks_with_mode(
+            let commit_tasks_fut = TaskBuilderImpl::commit_tasks(
                 &self.task_info_fetcher,
                 &intent_bundle,
                 persister,
-                DEFAULT_COMMIT_EXECUTION_MODE,
             );
-            let finalize_tasks_fut = TaskBuilderImpl::finalize_tasks_with_mode(
+            let finalize_tasks_fut = TaskBuilderImpl::finalize_tasks(
                 &self.task_info_fetcher,
                 &intent_bundle,
-                DEFAULT_COMMIT_EXECUTION_MODE,
             );
             let (commit_tasks, finalize_tasks) =
                 join(commit_tasks_fut, finalize_tasks_fut).await;

--- a/magicblock-committor-service/src/intent_executor/mod.rs
+++ b/magicblock-committor-service/src/intent_executor/mod.rs
@@ -373,6 +373,7 @@ where
         execution_report: &mut IntentExecutionReport,
         persister: &Option<P>,
     ) -> IntentExecutorResult<ExecutionOutput> {
+        let skip_finalize_stage = finalize_strategy.optimized_tasks.is_empty();
         let mut executor = TwoStageExecutor::new(
             self.authority.insecure_clone(),
             commit_strategy,
@@ -393,6 +394,10 @@ where
             persister,
         )
         .await?;
+
+        if skip_finalize_stage {
+            return Ok(ExecutionOutput::SingleStage(commit_signature));
+        }
 
         let mut finalize_executor = executor.done(commit_signature);
         let finalize_signature = execute_with_timeout(

--- a/magicblock-committor-service/src/intent_executor/single_stage_executor.rs
+++ b/magicblock-committor-service/src/intent_executor/single_stage_executor.rs
@@ -22,10 +22,7 @@ use crate::{
         IntentExecutionReport,
     },
     persist::{IntentPersister, IntentPersisterImpl},
-    tasks::{
-        commit_task::CommitTask, task_strategist::TransactionStrategy,
-        BaseTaskImpl, FinalizeTask,
-    },
+    tasks::{task_strategist::TransactionStrategy, BaseTaskImpl, FinalizeTask},
     transaction_preparator::TransactionPreparator,
 };
 
@@ -217,12 +214,31 @@ where
             ) => {
                 let optimized_tasks =
                     self.transaction_strategy.optimized_tasks.as_slice();
-                if let Some(BaseTaskImpl::Commit(task)) = err
+                if let Some(task) = err
                     .task_index()
                     .and_then(|index| optimized_tasks.get(index as usize))
                 {
+                    let delegated_account = match task {
+                        BaseTaskImpl::Commit(task) => {
+                            task.committed_account.pubkey
+                        }
+                        BaseTaskImpl::CommitFinalize(task) => {
+                            task.committed_account.pubkey
+                        }
+                        _ => {
+                            error!(
+                                task_index = err.task_index(),
+                                optimized_tasks_len = optimized_tasks.len(),
+                                error = ?err,
+                                "RPC returned unexpected task index"
+                            );
+                            return Ok(ControlFlow::Break(()));
+                        }
+                    };
                     self.handle_unfinalized_account_error(
-                        signature, task, transaction_preparator
+                        signature,
+                        delegated_account,
+                        transaction_preparator,
                     )
                     .await
                 } else {
@@ -262,13 +278,11 @@ where
     async fn handle_unfinalized_account_error<T: TransactionPreparator>(
         &self,
         failed_signature: &Option<Signature>,
-        task: &CommitTask,
+        delegated_account: Pubkey,
         transaction_preparator: &T,
     ) -> IntentExecutorResult<ControlFlow<(), TransactionStrategy>> {
-        let finalize_task: BaseTaskImpl = FinalizeTask {
-            delegated_account: task.committed_account.pubkey,
-        }
-        .into();
+        let finalize_task: BaseTaskImpl =
+            FinalizeTask { delegated_account }.into();
         prepare_and_execute_strategy(
             &self.intent_client,
             &self.authority,

--- a/magicblock-committor-service/src/intent_executor/single_stage_executor.rs
+++ b/magicblock-committor-service/src/intent_executor/single_stage_executor.rs
@@ -214,27 +214,14 @@ where
             ) => {
                 let optimized_tasks =
                     self.transaction_strategy.optimized_tasks.as_slice();
-                if let Some(task) = err
+                if let Some(delegated_account) = err
                     .task_index()
                     .and_then(|index| optimized_tasks.get(index as usize))
-                {
-                    let delegated_account = match task {
-                        BaseTaskImpl::Commit(task) => {
-                            task.committed_account.pubkey
-                        }
-                        BaseTaskImpl::CommitFinalize(task) => {
-                            task.committed_account.pubkey
-                        }
-                        _ => {
-                            error!(
-                                task_index = err.task_index(),
-                                optimized_tasks_len = optimized_tasks.len(),
-                                error = ?err,
-                                "RPC returned unexpected task index"
-                            );
-                            return Ok(ControlFlow::Break(()));
-                        }
-                    };
+                    .and_then(|task| match task {
+                        BaseTaskImpl::Commit(task) => Some(task.committed_account.pubkey),
+                        BaseTaskImpl::CommitFinalize(task) => Some(task.committed_account.pubkey),
+                        _ => None,
+                    }) {
                     self.handle_unfinalized_account_error(
                         signature,
                         delegated_account,

--- a/magicblock-committor-service/src/intent_executor/two_stage_executor.rs
+++ b/magicblock-committor-service/src/intent_executor/two_stage_executor.rs
@@ -203,26 +203,13 @@ where
                 let optimized_tasks =
                     self.state.commit_strategy.optimized_tasks.as_slice();
                 let task_index = err.task_index();
-                if let Some(task) = task_index
+                if let Some(delegated_account) = task_index
                     .and_then(|index| optimized_tasks.get(index as usize))
-                {
-                    let delegated_account = match task {
-                        BaseTaskImpl::Commit(task) => {
-                            task.committed_account.pubkey
-                        }
-                        BaseTaskImpl::CommitFinalize(task) => {
-                            task.committed_account.pubkey
-                        }
-                        _ => {
-                            error!(
-                                task_index = ?task_index,
-                                optimized_tasks_len = optimized_tasks.len(),
-                                error = ?err,
-                                "RPC returned unexpected task index"
-                            );
-                            return Ok(ControlFlow::Break(()));
-                        }
-                    };
+                    .and_then(|task| match task {
+                        BaseTaskImpl::Commit(task) => Some(task.committed_account.pubkey),
+                        BaseTaskImpl::CommitFinalize(task) => Some(task.committed_account.pubkey),
+                        _ => None,
+                    }) {
                     self.handle_unfinalized_account_error(
                         signature,
                         delegated_account,

--- a/magicblock-committor-service/src/intent_executor/two_stage_executor.rs
+++ b/magicblock-committor-service/src/intent_executor/two_stage_executor.rs
@@ -23,10 +23,7 @@ use crate::{
         IntentExecutionReport,
     },
     persist::{IntentPersister, IntentPersisterImpl},
-    tasks::{
-        commit_task::CommitTask, task_strategist::TransactionStrategy,
-        BaseTaskImpl, FinalizeTask,
-    },
+    tasks::{task_strategist::TransactionStrategy, BaseTaskImpl, FinalizeTask},
     transaction_preparator::TransactionPreparator,
 };
 
@@ -206,10 +203,31 @@ where
                 let optimized_tasks =
                     self.state.commit_strategy.optimized_tasks.as_slice();
                 let task_index = err.task_index();
-                if let Some(BaseTaskImpl::Commit(task)) = task_index
+                if let Some(task) = task_index
                     .and_then(|index| optimized_tasks.get(index as usize))
                 {
-                    self.handle_unfinalized_account_error(signature, task, transaction_preparator)
+                    let delegated_account = match task {
+                        BaseTaskImpl::Commit(task) => {
+                            task.committed_account.pubkey
+                        }
+                        BaseTaskImpl::CommitFinalize(task) => {
+                            task.committed_account.pubkey
+                        }
+                        _ => {
+                            error!(
+                                task_index = ?task_index,
+                                optimized_tasks_len = optimized_tasks.len(),
+                                error = ?err,
+                                "RPC returned unexpected task index"
+                            );
+                            return Ok(ControlFlow::Break(()));
+                        }
+                    };
+                    self.handle_unfinalized_account_error(
+                        signature,
+                        delegated_account,
+                        transaction_preparator,
+                    )
                     .await
                 } else {
                     error!(
@@ -261,13 +279,11 @@ where
     async fn handle_unfinalized_account_error<T: TransactionPreparator>(
         &self,
         failed_signature: &Option<Signature>,
-        task: &CommitTask,
+        delegated_account: Pubkey,
         transaction_preparator: &T,
     ) -> IntentExecutorResult<ControlFlow<(), TransactionStrategy>> {
-        let finalize_task: BaseTaskImpl = FinalizeTask {
-            delegated_account: task.committed_account.pubkey,
-        }
-        .into();
+        let finalize_task: BaseTaskImpl =
+            FinalizeTask { delegated_account }.into();
         prepare_and_execute_strategy(
             &self.intent_client,
             &self.authority,

--- a/magicblock-committor-service/src/intent_executor/utils.rs
+++ b/magicblock-committor-service/src/intent_executor/utils.rs
@@ -70,20 +70,18 @@ pub(in crate::intent_executor) async fn handle_commit_id_error<
     committed_pubkeys: &[Pubkey],
     strategy: &mut TransactionStrategy,
 ) -> Result<TransactionStrategy, TaskBuilderError> {
-    let commit_tasks: Vec<_> = strategy
+    let min_context_slot = strategy
         .optimized_tasks
-        .iter_mut()
-        .filter_map(|task| {
-            if let BaseTaskImpl::Commit(commit_task) = task {
-                Some(commit_task)
-            } else {
-                None
-            }
-        })
-        .collect();
-    let min_context_slot = commit_tasks
         .iter()
-        .map(|task| task.committed_account.remote_slot)
+        .filter_map(|task| match task {
+            BaseTaskImpl::Commit(commit_task) => {
+                Some(commit_task.committed_account.remote_slot)
+            }
+            BaseTaskImpl::CommitFinalize(commit_finalize_task) => {
+                Some(commit_finalize_task.committed_account.remote_slot)
+            }
+            _ => None,
+        })
         .max()
         .unwrap_or_default();
 
@@ -98,18 +96,40 @@ pub(in crate::intent_executor) async fn handle_commit_id_error<
     // Here we find the broken tasks and reset them
     // Broken tasks are prepared incorrectly so they have to be cleaned up
     let mut to_cleanup = Vec::new();
-    for task in commit_tasks {
-        let Some(commit_id) = commit_ids.get(&task.committed_account.pubkey)
-        else {
-            continue;
-        };
-        if commit_id == &task.commit_id {
-            continue;
-        }
+    for task in &mut strategy.optimized_tasks {
+        match task {
+            BaseTaskImpl::Commit(commit_task) => {
+                let Some(commit_id) =
+                    commit_ids.get(&commit_task.committed_account.pubkey)
+                else {
+                    continue;
+                };
+                if commit_id == &commit_task.commit_id {
+                    continue;
+                }
 
-        // Handle invalid tasks
-        to_cleanup.push(BaseTaskImpl::Commit(task.clone()));
-        task.reset_commit_id(*commit_id);
+                // Handle invalid tasks
+                to_cleanup.push(BaseTaskImpl::Commit(commit_task.clone()));
+                commit_task.reset_commit_id(*commit_id);
+            }
+            BaseTaskImpl::CommitFinalize(commit_finalize_task) => {
+                let Some(commit_id) = commit_ids
+                    .get(&commit_finalize_task.committed_account.pubkey)
+                else {
+                    continue;
+                };
+                if commit_id == &commit_finalize_task.commit_id {
+                    continue;
+                }
+
+                // Handle invalid tasks
+                to_cleanup.push(BaseTaskImpl::CommitFinalize(
+                    commit_finalize_task.clone(),
+                ));
+                commit_finalize_task.reset_commit_id(*commit_id);
+            }
+            _ => {}
+        }
     }
 
     let old_alts = strategy.dummy_revaluate_alts(authority);

--- a/magicblock-committor-service/src/tasks/task_builder.rs
+++ b/magicblock-committor-service/src/tasks/task_builder.rs
@@ -20,7 +20,7 @@ use crate::{
     tasks::{
         commit_task::{CommitDelivery, CommitTask},
         BaseActionTask, BaseActionTaskV1, BaseActionTaskV2, BaseTaskImpl,
-        CommitFinalizeTask, FinalizeTask, UndelegateTask,
+        CommitFinalizeTask, UndelegateTask,
     },
 };
 
@@ -99,12 +99,12 @@ impl TaskBuilderImpl {
 
     async fn fetch_commit_nonces<C: TaskInfoFetcher>(
         task_info_fetcher: &Arc<C>,
-        accounts: &[(bool, bool, CommittedAccount)],
+        accounts: &[CommittedAccount],
         min_context_slot: u64,
     ) -> TaskInfoFetcherResult<HashMap<Pubkey, u64>> {
         let committed_pubkeys = accounts
             .iter()
-            .map(|(_, _, account)| account.pubkey)
+            .map(|account| account.pubkey)
             .collect::<Vec<_>>();
 
         task_info_fetcher
@@ -114,15 +114,15 @@ impl TaskBuilderImpl {
 
     async fn fetch_diffable_accounts<C: TaskInfoFetcher>(
         task_info_fetcher: &Arc<C>,
-        accounts: &[(bool, bool, CommittedAccount)],
+        accounts: &[CommittedAccount],
         min_context_slot: u64,
     ) -> TaskInfoFetcherResult<HashMap<Pubkey, Account>> {
         let diffable_pubkeys = accounts
             .iter()
-            .filter(|(_, _, account)| {
+            .filter(|account| {
                 account.account.data.len() > COMMIT_STATE_SIZE_THRESHOLD
             })
-            .map(|(_, _, account)| account.pubkey)
+            .map(|account| account.pubkey)
             .collect::<Vec<_>>();
 
         task_info_fetcher
@@ -171,46 +171,23 @@ impl TasksBuilder for TaskBuilderImpl {
             intent_bundle.standalone_actions().as_slice(),
         ));
 
-        let committed_accounts =
-            intent_bundle.get_commit_intent_accounts().cloned();
-        let undelegated_accounts =
-            intent_bundle.get_undelegate_intent_accounts().cloned();
-        let commit_finalize_accounts =
-            intent_bundle.get_commit_finalize_intent_accounts().cloned();
-        let commit_finalize_and_undelegate_accounts = intent_bundle
-            .get_commit_finalize_and_undelegate_intent_accounts()
-            .cloned();
-
-        let flagged_accounts: Vec<_> = [
-            (false, false, committed_accounts),
-            (true, false, undelegated_accounts),
-            (false, true, commit_finalize_accounts),
-            (true, true, commit_finalize_and_undelegate_accounts),
-        ]
-        .into_iter()
-        .flat_map(|(allow_undelegation, finalize, accounts)| {
-            accounts
-                .into_iter()
-                .flatten()
-                .map(move |account| (allow_undelegation, finalize, account))
-        })
-        .collect();
+        let committed_accounts = intent_bundle.get_all_committed_accounts();
 
         // Get commit nonces and base accounts
-        let min_context_slot = flagged_accounts
+        let min_context_slot = committed_accounts
             .iter()
-            .map(|(_, _, account)| account.remote_slot)
+            .map(|account| account.remote_slot)
             .max()
             .unwrap_or(0);
         let (commit_ids, base_accounts) = tokio::join!(
             Self::fetch_commit_nonces(
                 task_info_fetcher,
-                &flagged_accounts,
+                &committed_accounts,
                 min_context_slot
             ),
             Self::fetch_diffable_accounts(
                 task_info_fetcher,
-                &flagged_accounts,
+                &committed_accounts,
                 min_context_slot
             )
         );
@@ -222,37 +199,122 @@ impl TasksBuilder for TaskBuilderImpl {
         });
 
         // Persist commit ids for commitees
-        commit_ids
-            .iter()
-            .for_each(|(pubkey, commit_id) | {
-                if let Err(err) = persister.set_commit_id(intent_bundle.id, pubkey, *commit_id) {
-                    error!(intent_id = intent_bundle.id, pubkey = %pubkey, error = ?err, "Failed to persist commit id");
-                }
-            });
+        for (pubkey, commit_id) in &commit_ids {
+            if let Err(err) =
+                persister.set_commit_id(intent_bundle.id, pubkey, *commit_id)
+            {
+                error!(
+                    intent_id = intent_bundle.id,
+                    pubkey = %pubkey,
+                    error = ?err,
+                    "Failed to persist commit id"
+                );
+            }
+        }
 
-        // Create commit tasks
-        let commit_tasks_iter = flagged_accounts.into_iter().map(
-            |(allow_undelegation, finalize, account)| {
-                let commit_id = commit_ids
-                    .get(&account.pubkey)
-                    .copied()
-                    .unwrap_or_else(|| {
-                        // This shall not ever happen since TaskInfoFetcher
-                        // returns commit ids for all pubkeys or throws
-                        // If it does occur, it will be patched and retried by IntentExecutor
-                        error!(pubkey = %account.pubkey, "Commit id absent for pubkey");
-                        0
-                    });
-                let base_account = base_accounts.remove(&account.pubkey);
+        fn create_commit_finalize_task(
+            intent_id: u64,
+            commit_ids: &HashMap<Pubkey, u64>,
+            base_accounts: &mut HashMap<Pubkey, Account>,
+            allow_undelegation: bool,
+            account: &CommittedAccount,
+        ) -> BaseTaskImpl {
+            let commit_id =
+                commit_ids.get(&account.pubkey).copied().unwrap_or_else(|| {
+                    // This shall not ever happen since TaskInfoFetcher
+                    // returns commit ids for all pubkeys or throws
+                    // If it does occur, it will be patched and retried by IntentExecutor
+                    error!(
+                        intent_id,
+                        pubkey = %account.pubkey,
+                        "Commit id absent for pubkey"
+                    );
+                    0
+                });
+            let base_account = base_accounts.remove(&account.pubkey);
 
-                 if finalize {
-                     Self::create_commit_finalize_task(commit_id, allow_undelegation, account.clone(), base_account).into()
-                 } else {
-                     Self::create_commit_task(commit_id, allow_undelegation, account.clone(), base_account).into()
-                 }
-            },
-        );
-        tasks.extend(commit_tasks_iter);
+            TaskBuilderImpl::create_commit_finalize_task(
+                commit_id,
+                allow_undelegation,
+                account.clone(),
+                base_account,
+            )
+            .into()
+        }
+
+        fn extend_commit_finalize_tasks(
+            tasks: &mut Vec<BaseTaskImpl>,
+            commit: &CommitType,
+            allow_undelegation: bool,
+            intent_id: u64,
+            commit_ids: &HashMap<Pubkey, u64>,
+            base_accounts: &mut HashMap<Pubkey, Account>,
+        ) {
+            let committed_accounts = commit.get_committed_accounts();
+            for account in committed_accounts {
+                tasks.push(create_commit_finalize_task(
+                    intent_id,
+                    commit_ids,
+                    base_accounts,
+                    allow_undelegation,
+                    account,
+                ));
+            }
+
+            if let CommitType::WithBaseActions { base_actions, .. } = commit {
+                tasks
+                    .extend(TaskBuilderImpl::create_action_tasks(base_actions));
+            }
+        }
+
+        if let Some(ref value) = intent_bundle.intent_bundle.commit {
+            extend_commit_finalize_tasks(
+                &mut tasks,
+                value,
+                false,
+                intent_bundle.id,
+                &commit_ids,
+                &mut base_accounts,
+            );
+        }
+
+        if let Some(ref value) =
+            intent_bundle.intent_bundle.commit_and_undelegate
+        {
+            extend_commit_finalize_tasks(
+                &mut tasks,
+                &value.commit_action,
+                true,
+                intent_bundle.id,
+                &commit_ids,
+                &mut base_accounts,
+            );
+        }
+
+        if let Some(ref value) = intent_bundle.intent_bundle.commit_finalize {
+            extend_commit_finalize_tasks(
+                &mut tasks,
+                value,
+                false,
+                intent_bundle.id,
+                &commit_ids,
+                &mut base_accounts,
+            );
+        }
+
+        if let Some(ref value) =
+            intent_bundle.intent_bundle.commit_finalize_and_undelegate
+        {
+            extend_commit_finalize_tasks(
+                &mut tasks,
+                &value.commit_action,
+                true,
+                intent_bundle.id,
+                &commit_ids,
+                &mut base_accounts,
+            );
+        }
+
         Ok(tasks)
     }
 
@@ -261,14 +323,6 @@ impl TasksBuilder for TaskBuilderImpl {
         info_fetcher: &Arc<C>,
         intent_bundle: &ScheduledIntentBundle,
     ) -> TaskBuilderResult<Vec<BaseTaskImpl>> {
-        // Helper to create a finalize task
-        fn finalize_task(account: &CommittedAccount) -> BaseTaskImpl {
-            FinalizeTask {
-                delegated_account: account.pubkey,
-            }
-            .into()
-        }
-
         // Helper to create an undelegate task
         fn undelegate_task(
             account: &CommittedAccount,
@@ -280,28 +334,6 @@ impl TasksBuilder for TaskBuilderImpl {
                 rent_reimbursement: *rent_reimbursement,
             }
             .into()
-        }
-
-        // Helper to process commit types
-        fn create_finalize_tasks(commit: &CommitType) -> Vec<BaseTaskImpl> {
-            match commit {
-                CommitType::Standalone(accounts) => {
-                    accounts.iter().map(finalize_task).collect()
-                }
-                CommitType::WithBaseActions {
-                    committed_accounts,
-                    base_actions,
-                } => {
-                    let mut tasks = committed_accounts
-                        .iter()
-                        .map(finalize_task)
-                        .collect::<Vec<_>>();
-                    tasks.extend(TaskBuilderImpl::create_action_tasks(
-                        base_actions,
-                    ));
-                    tasks
-                }
-            }
         }
 
         async fn create_undelegate_tasks<C: TaskInfoFetcher>(
@@ -343,14 +375,9 @@ impl TasksBuilder for TaskBuilderImpl {
         let mut tasks = Vec::new();
         let mut futures = Vec::with_capacity(2);
 
-        if let Some(ref value) = intent_bundle.intent_bundle.commit {
-            tasks.extend(create_finalize_tasks(value));
-        }
-
         if let Some(ref value) =
             intent_bundle.intent_bundle.commit_and_undelegate
         {
-            tasks.extend(create_finalize_tasks(&value.commit_action));
             futures.push(create_undelegate_tasks(value, info_fetcher));
         }
 
@@ -384,3 +411,119 @@ impl TaskBuilderError {
 }
 
 pub type TaskBuilderResult<T, E = TaskBuilderError> = Result<T, E>;
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashMap, sync::Arc};
+
+    use solana_account::Account;
+    use solana_pubkey::Pubkey;
+
+    use super::*;
+    use crate::{
+        intent_execution_manager::intent_scheduler::create_test_intent,
+        intent_executor::task_info_fetcher::{
+            TaskInfoFetcher, TaskInfoFetcherResult,
+        },
+        persist::IntentPersisterImpl,
+    };
+
+    struct MockInfoFetcher;
+
+    #[async_trait::async_trait]
+    impl TaskInfoFetcher for MockInfoFetcher {
+        async fn fetch_next_commit_nonces(
+            &self,
+            pubkeys: &[Pubkey],
+            _: u64,
+        ) -> TaskInfoFetcherResult<HashMap<Pubkey, u64>> {
+            Ok(pubkeys
+                .iter()
+                .enumerate()
+                .map(|(index, pubkey)| (*pubkey, index as u64))
+                .collect())
+        }
+
+        async fn fetch_current_commit_nonces(
+            &self,
+            pubkeys: &[Pubkey],
+            _: u64,
+        ) -> TaskInfoFetcherResult<HashMap<Pubkey, u64>> {
+            Ok(pubkeys.iter().map(|pubkey| (*pubkey, 0)).collect())
+        }
+
+        async fn fetch_rent_reimbursements(
+            &self,
+            pubkeys: &[Pubkey],
+            _: u64,
+        ) -> TaskInfoFetcherResult<Vec<Pubkey>> {
+            Ok(pubkeys.iter().map(|_| Pubkey::new_unique()).collect())
+        }
+
+        async fn get_base_accounts(
+            &self,
+            _: &[Pubkey],
+            _: u64,
+        ) -> TaskInfoFetcherResult<HashMap<Pubkey, Account>> {
+            Ok(Default::default())
+        }
+    }
+
+    #[tokio::test]
+    async fn commit_intent_uses_commit_finalize_without_finalize_task() {
+        let pubkey = Pubkey::new_unique();
+        let intent = create_test_intent(1, &[pubkey], false);
+        let info_fetcher = Arc::new(MockInfoFetcher);
+
+        let commit_tasks = TaskBuilderImpl::commit_tasks(
+            &info_fetcher,
+            &intent,
+            &None::<IntentPersisterImpl>,
+        )
+        .await
+        .unwrap();
+        let finalize_tasks =
+            TaskBuilderImpl::finalize_tasks(&info_fetcher, &intent)
+                .await
+                .unwrap();
+
+        assert!(matches!(
+            commit_tasks.as_slice(),
+            [BaseTaskImpl::CommitFinalize(task)]
+                if task.committed_account.pubkey == pubkey
+                    && !task.allow_undelegation
+        ));
+        assert!(finalize_tasks.is_empty());
+    }
+
+    #[tokio::test]
+    async fn commit_and_undelegate_uses_commit_finalize_then_undelegate() {
+        let pubkey = Pubkey::new_unique();
+        let intent = create_test_intent(1, &[pubkey], true);
+        let info_fetcher = Arc::new(MockInfoFetcher);
+
+        let commit_tasks = TaskBuilderImpl::commit_tasks(
+            &info_fetcher,
+            &intent,
+            &None::<IntentPersisterImpl>,
+        )
+        .await
+        .unwrap();
+        let finalize_tasks =
+            TaskBuilderImpl::finalize_tasks(&info_fetcher, &intent)
+                .await
+                .unwrap();
+
+        assert!(matches!(
+            commit_tasks.as_slice(),
+            [BaseTaskImpl::CommitFinalize(task)]
+                if task.committed_account.pubkey == pubkey
+                    && task.allow_undelegation
+        ));
+        assert!(matches!(
+            finalize_tasks.as_slice(),
+            [BaseTaskImpl::Undelegate(task)]
+                if task.delegated_account == pubkey
+        ));
+    }
+}

--- a/magicblock-committor-service/src/tasks/task_builder.rs
+++ b/magicblock-committor-service/src/tasks/task_builder.rs
@@ -20,7 +20,7 @@ use crate::{
     tasks::{
         commit_task::{CommitDelivery, CommitTask},
         BaseActionTask, BaseActionTaskV1, BaseActionTaskV2, BaseTaskImpl,
-        CommitFinalizeTask, UndelegateTask,
+        CommitFinalizeTask, FinalizeTask, UndelegateTask,
     },
 };
 
@@ -40,9 +40,18 @@ pub trait TasksBuilder {
     ) -> TaskBuilderResult<Vec<BaseTaskImpl>>;
 }
 
-/// V1 Task builder
-/// V1: Actions are part of finalize tx
+/// Builds base-layer tasks for scheduled intents.
+/// In [`CommitExecutionMode::SeparateCommitAndFinalize`], commit actions stay in
+/// the finalize stage. In [`CommitExecutionMode::CommitFinalize`], they run
+/// after the combined commit-finalize task.
 pub struct TaskBuilderImpl;
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum CommitExecutionMode {
+    SeparateCommitAndFinalize,
+    #[default]
+    CommitFinalize,
+}
 
 // Accounts larger than COMMIT_STATE_SIZE_THRESHOLD use CommitDiff to
 // reduce instruction size. Below this threshold, the commit is sent
@@ -156,15 +165,16 @@ impl TaskBuilderImpl {
             delivery: delivery_details,
         }
     }
-}
 
-#[async_trait]
-impl TasksBuilder for TaskBuilderImpl {
     /// Returns [`BaseTaskImpl`]s for Commit stage
-    async fn commit_tasks<C: TaskInfoFetcher, P: IntentPersister>(
+    pub async fn commit_tasks_with_mode<
+        C: TaskInfoFetcher,
+        P: IntentPersister,
+    >(
         task_info_fetcher: &Arc<C>,
         intent_bundle: &ScheduledIntentBundle,
         persister: &Option<P>,
+        mode: CommitExecutionMode,
     ) -> TaskBuilderResult<Vec<BaseTaskImpl>> {
         let mut tasks = Vec::new();
         tasks.extend(Self::create_action_tasks(
@@ -242,76 +252,133 @@ impl TasksBuilder for TaskBuilderImpl {
             .into()
         }
 
-        fn extend_commit_finalize_tasks(
+        fn create_commit_task(
+            intent_id: u64,
+            commit_ids: &HashMap<Pubkey, u64>,
+            base_accounts: &mut HashMap<Pubkey, Account>,
+            allow_undelegation: bool,
+            account: &CommittedAccount,
+        ) -> BaseTaskImpl {
+            let commit_id =
+                commit_ids.get(&account.pubkey).copied().unwrap_or_else(|| {
+                    // This shall not ever happen since TaskInfoFetcher
+                    // returns commit ids for all pubkeys or throws
+                    // If it does occur, it will be patched and retried by IntentExecutor
+                    error!(
+                        intent_id,
+                        pubkey = %account.pubkey,
+                        "Commit id absent for pubkey"
+                    );
+                    0
+                });
+            let base_account = base_accounts.remove(&account.pubkey);
+
+            TaskBuilderImpl::create_commit_task(
+                commit_id,
+                allow_undelegation,
+                account.clone(),
+                base_account,
+            )
+            .into()
+        }
+
+        fn extend_commit_tasks(
             tasks: &mut Vec<BaseTaskImpl>,
             commit: &CommitType,
             allow_undelegation: bool,
             intent_id: u64,
             commit_ids: &HashMap<Pubkey, u64>,
             base_accounts: &mut HashMap<Pubkey, Account>,
+            use_commit_finalize: bool,
+            include_base_actions: bool,
         ) {
             let committed_accounts = commit.get_committed_accounts();
             for account in committed_accounts {
-                tasks.push(create_commit_finalize_task(
-                    intent_id,
-                    commit_ids,
-                    base_accounts,
-                    allow_undelegation,
-                    account,
-                ));
+                let task = if use_commit_finalize {
+                    create_commit_finalize_task(
+                        intent_id,
+                        commit_ids,
+                        base_accounts,
+                        allow_undelegation,
+                        account,
+                    )
+                } else {
+                    create_commit_task(
+                        intent_id,
+                        commit_ids,
+                        base_accounts,
+                        allow_undelegation,
+                        account,
+                    )
+                };
+                tasks.push(task);
             }
 
-            if let CommitType::WithBaseActions { base_actions, .. } = commit {
+            if include_base_actions {
+                let CommitType::WithBaseActions { base_actions, .. } = commit
+                else {
+                    return;
+                };
                 tasks
                     .extend(TaskBuilderImpl::create_action_tasks(base_actions));
             }
         }
 
+        let use_commit_finalize = mode == CommitExecutionMode::CommitFinalize;
+
         if let Some(ref value) = intent_bundle.intent_bundle.commit {
-            extend_commit_finalize_tasks(
+            extend_commit_tasks(
                 &mut tasks,
                 value,
                 false,
                 intent_bundle.id,
                 &commit_ids,
                 &mut base_accounts,
+                use_commit_finalize,
+                use_commit_finalize,
             );
         }
 
         if let Some(ref value) =
             intent_bundle.intent_bundle.commit_and_undelegate
         {
-            extend_commit_finalize_tasks(
+            extend_commit_tasks(
                 &mut tasks,
                 &value.commit_action,
                 true,
                 intent_bundle.id,
                 &commit_ids,
                 &mut base_accounts,
+                use_commit_finalize,
+                use_commit_finalize,
             );
         }
 
         if let Some(ref value) = intent_bundle.intent_bundle.commit_finalize {
-            extend_commit_finalize_tasks(
+            extend_commit_tasks(
                 &mut tasks,
                 value,
                 false,
                 intent_bundle.id,
                 &commit_ids,
                 &mut base_accounts,
+                true,
+                true,
             );
         }
 
         if let Some(ref value) =
             intent_bundle.intent_bundle.commit_finalize_and_undelegate
         {
-            extend_commit_finalize_tasks(
+            extend_commit_tasks(
                 &mut tasks,
                 &value.commit_action,
                 true,
                 intent_bundle.id,
                 &commit_ids,
                 &mut base_accounts,
+                true,
+                true,
             );
         }
 
@@ -319,10 +386,19 @@ impl TasksBuilder for TaskBuilderImpl {
     }
 
     /// Returns [`Task`]s for Finalize stage
-    async fn finalize_tasks<C: TaskInfoFetcher>(
+    pub async fn finalize_tasks_with_mode<C: TaskInfoFetcher>(
         info_fetcher: &Arc<C>,
         intent_bundle: &ScheduledIntentBundle,
+        mode: CommitExecutionMode,
     ) -> TaskBuilderResult<Vec<BaseTaskImpl>> {
+        // Helper to create a finalize task
+        fn finalize_task(account: &CommittedAccount) -> BaseTaskImpl {
+            FinalizeTask {
+                delegated_account: account.pubkey,
+            }
+            .into()
+        }
+
         // Helper to create an undelegate task
         fn undelegate_task(
             account: &CommittedAccount,
@@ -334,6 +410,28 @@ impl TasksBuilder for TaskBuilderImpl {
                 rent_reimbursement: *rent_reimbursement,
             }
             .into()
+        }
+
+        // Helper to process commit types
+        fn create_finalize_tasks(commit: &CommitType) -> Vec<BaseTaskImpl> {
+            match commit {
+                CommitType::Standalone(accounts) => {
+                    accounts.iter().map(finalize_task).collect()
+                }
+                CommitType::WithBaseActions {
+                    committed_accounts,
+                    base_actions,
+                } => {
+                    let mut tasks = committed_accounts
+                        .iter()
+                        .map(finalize_task)
+                        .collect::<Vec<_>>();
+                    tasks.extend(TaskBuilderImpl::create_action_tasks(
+                        base_actions,
+                    ));
+                    tasks
+                }
+            }
         }
 
         async fn create_undelegate_tasks<C: TaskInfoFetcher>(
@@ -375,9 +473,18 @@ impl TasksBuilder for TaskBuilderImpl {
         let mut tasks = Vec::new();
         let mut futures = Vec::with_capacity(2);
 
+        if mode == CommitExecutionMode::SeparateCommitAndFinalize {
+            if let Some(ref value) = intent_bundle.intent_bundle.commit {
+                tasks.extend(create_finalize_tasks(value));
+            }
+        }
+
         if let Some(ref value) =
             intent_bundle.intent_bundle.commit_and_undelegate
         {
+            if mode == CommitExecutionMode::SeparateCommitAndFinalize {
+                tasks.extend(create_finalize_tasks(&value.commit_action));
+            }
             futures.push(create_undelegate_tasks(value, info_fetcher));
         }
 
@@ -390,6 +497,35 @@ impl TasksBuilder for TaskBuilderImpl {
         tasks.extend(try_join_all(futures).await?.into_iter().flatten());
 
         Ok(tasks)
+    }
+}
+
+#[async_trait]
+impl TasksBuilder for TaskBuilderImpl {
+    async fn commit_tasks<C: TaskInfoFetcher, P: IntentPersister>(
+        task_info_fetcher: &Arc<C>,
+        intent_bundle: &ScheduledIntentBundle,
+        persister: &Option<P>,
+    ) -> TaskBuilderResult<Vec<BaseTaskImpl>> {
+        Self::commit_tasks_with_mode(
+            task_info_fetcher,
+            intent_bundle,
+            persister,
+            CommitExecutionMode::default(),
+        )
+        .await
+    }
+
+    async fn finalize_tasks<C: TaskInfoFetcher>(
+        info_fetcher: &Arc<C>,
+        intent_bundle: &ScheduledIntentBundle,
+    ) -> TaskBuilderResult<Vec<BaseTaskImpl>> {
+        Self::finalize_tasks_with_mode(
+            info_fetcher,
+            intent_bundle,
+            CommitExecutionMode::default(),
+        )
+        .await
     }
 }
 
@@ -524,6 +660,77 @@ mod tests {
             finalize_tasks.as_slice(),
             [BaseTaskImpl::Undelegate(task)]
                 if task.delegated_account == pubkey
+        ));
+    }
+
+    #[tokio::test]
+    async fn separate_commit_mode_uses_commit_then_finalize_tasks() {
+        let pubkey = Pubkey::new_unique();
+        let intent = create_test_intent(1, &[pubkey], false);
+        let info_fetcher = Arc::new(MockInfoFetcher);
+
+        let commit_tasks = TaskBuilderImpl::commit_tasks_with_mode(
+            &info_fetcher,
+            &intent,
+            &None::<IntentPersisterImpl>,
+            CommitExecutionMode::SeparateCommitAndFinalize,
+        )
+        .await
+        .unwrap();
+        let finalize_tasks = TaskBuilderImpl::finalize_tasks_with_mode(
+            &info_fetcher,
+            &intent,
+            CommitExecutionMode::SeparateCommitAndFinalize,
+        )
+        .await
+        .unwrap();
+
+        assert!(matches!(
+            commit_tasks.as_slice(),
+            [BaseTaskImpl::Commit(task)]
+                if task.committed_account.pubkey == pubkey
+                    && !task.allow_undelegation
+        ));
+        assert!(matches!(
+            finalize_tasks.as_slice(),
+            [BaseTaskImpl::Finalize(task)]
+                if task.delegated_account == pubkey
+        ));
+    }
+
+    #[tokio::test]
+    async fn separate_commit_mode_uses_finalize_then_undelegate() {
+        let pubkey = Pubkey::new_unique();
+        let intent = create_test_intent(1, &[pubkey], true);
+        let info_fetcher = Arc::new(MockInfoFetcher);
+
+        let commit_tasks = TaskBuilderImpl::commit_tasks_with_mode(
+            &info_fetcher,
+            &intent,
+            &None::<IntentPersisterImpl>,
+            CommitExecutionMode::SeparateCommitAndFinalize,
+        )
+        .await
+        .unwrap();
+        let finalize_tasks = TaskBuilderImpl::finalize_tasks_with_mode(
+            &info_fetcher,
+            &intent,
+            CommitExecutionMode::SeparateCommitAndFinalize,
+        )
+        .await
+        .unwrap();
+
+        assert!(matches!(
+            commit_tasks.as_slice(),
+            [BaseTaskImpl::Commit(task)]
+                if task.committed_account.pubkey == pubkey
+                    && task.allow_undelegation
+        ));
+        assert!(matches!(
+            finalize_tasks.as_slice(),
+            [BaseTaskImpl::Finalize(finalize), BaseTaskImpl::Undelegate(undelegate)]
+                if finalize.delegated_account == pubkey
+                    && undelegate.delegated_account == pubkey
         ));
     }
 }

--- a/magicblock-committor-service/src/tasks/task_builder.rs
+++ b/magicblock-committor-service/src/tasks/task_builder.rs
@@ -48,9 +48,9 @@ pub struct TaskBuilderImpl;
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub enum CommitExecutionMode {
-    SeparateCommitAndFinalize,
     #[default]
     CommitFinalize,
+    SeparateCommitAndFinalize,
 }
 
 // Accounts larger than COMMIT_STATE_SIZE_THRESHOLD use CommitDiff to
@@ -282,6 +282,7 @@ impl TaskBuilderImpl {
             .into()
         }
 
+        #[allow(clippy::too_many_arguments)]
         fn extend_commit_tasks(
             tasks: &mut Vec<BaseTaskImpl>,
             commit: &CommitType,

--- a/magicblock-committor-service/src/tasks/task_builder.rs
+++ b/magicblock-committor-service/src/tasks/task_builder.rs
@@ -46,12 +46,21 @@ pub trait TasksBuilder {
 /// after the combined commit-finalize task.
 pub struct TaskBuilderImpl;
 
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum CommitExecutionMode {
-    #[default]
+    ///
+    /// Execute CommitFinalize as single instruction
+    ///
     CommitFinalize,
+
+    ///
+    /// Execute Commit and Finalize as two separate instructions
+    ///
     SeparateCommitAndFinalize,
 }
+
+pub const DEFAULT_COMMIT_EXECUTION_MODE: CommitExecutionMode =
+    CommitExecutionMode::CommitFinalize;
 
 // Accounts larger than COMMIT_STATE_SIZE_THRESHOLD use CommitDiff to
 // reduce instruction size. Below this threshold, the commit is sent
@@ -512,7 +521,7 @@ impl TasksBuilder for TaskBuilderImpl {
             task_info_fetcher,
             intent_bundle,
             persister,
-            CommitExecutionMode::default(),
+            DEFAULT_COMMIT_EXECUTION_MODE,
         )
         .await
     }
@@ -524,7 +533,7 @@ impl TasksBuilder for TaskBuilderImpl {
         Self::finalize_tasks_with_mode(
             info_fetcher,
             intent_bundle,
-            CommitExecutionMode::default(),
+            DEFAULT_COMMIT_EXECUTION_MODE,
         )
         .await
     }

--- a/magicblock-committor-service/src/tasks/task_strategist.rs
+++ b/magicblock-committor-service/src/tasks/task_strategist.rs
@@ -128,6 +128,15 @@ impl TaskStrategist {
     ) -> TaskStrategistResult<StrategyExecutionMode> {
         const MAX_UNITED_TASKS_LEN: usize = 22;
 
+        if commit_tasks.is_empty() || finalize_tasks.is_empty() {
+            let strategy = TaskStrategist::build_strategy(
+                [commit_tasks, finalize_tasks].concat(),
+                authority,
+                persister,
+            )?;
+            return Ok(StrategyExecutionMode::SingleStage(strategy));
+        }
+
         // We can unite in 1 tx a lot of commits
         // but then there's a possibility of hitting CPI limit, aka
         // MaxInstructionTraceLengthExceeded error.
@@ -891,8 +900,41 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_build_two_stage_mode_no_alts() {
+    async fn test_build_single_stage_mode_commit_and_undelegate_no_alts() {
         let pubkeys: [_; 3] = std::array::from_fn(|_| Pubkey::new_unique());
+        let intent = create_test_intent(0, &pubkeys, true);
+
+        let info_fetcher = Arc::new(MockInfoFetcher);
+        let commit_task = TaskBuilderImpl::commit_tasks(
+            &info_fetcher,
+            &intent,
+            &None::<IntentPersisterImpl>,
+        )
+        .await
+        .unwrap();
+        let finalize_task =
+            TaskBuilderImpl::finalize_tasks(&info_fetcher, &intent)
+                .await
+                .unwrap();
+
+        let execution_mode = TaskStrategist::build_execution_strategy(
+            commit_task,
+            finalize_task,
+            &Pubkey::new_unique(),
+            &None::<IntentPersisterImpl>,
+        )
+        .expect("Execution mode created");
+
+        let StrategyExecutionMode::SingleStage(value) = execution_mode else {
+            panic!("Unexpected execution mode");
+        };
+        assert!(!value.uses_alts());
+    }
+
+    #[tokio::test]
+    async fn test_build_two_stage_mode_for_large_commit_and_undelegate_bundle()
+    {
+        let pubkeys: [_; 12] = std::array::from_fn(|_| Pubkey::new_unique());
         let intent = create_test_intent(0, &pubkeys, true);
 
         let info_fetcher = Arc::new(MockInfoFetcher);
@@ -923,8 +965,8 @@ mod tests {
         else {
             panic!("Unexpected execution mode");
         };
-        assert!(!commit_stage.uses_alts());
-        assert!(!finalize_stage.uses_alts());
+        assert_eq!(commit_stage.optimized_tasks.len(), 12);
+        assert_eq!(finalize_stage.optimized_tasks.len(), 12);
     }
 
     #[tokio::test]

--- a/magicblock-committor-service/src/tasks/task_strategist.rs
+++ b/magicblock-committor-service/src/tasks/task_strategist.rs
@@ -128,7 +128,8 @@ impl TaskStrategist {
     ) -> TaskStrategistResult<StrategyExecutionMode> {
         const MAX_UNITED_TASKS_LEN: usize = 22;
 
-        if commit_tasks.is_empty() || finalize_tasks.is_empty() {
+        // CommitFinalize mode already performs finalization in the commit stage.
+        if finalize_tasks.is_empty() {
             let strategy = TaskStrategist::build_strategy(
                 [commit_tasks, finalize_tasks].concat(),
                 authority,

--- a/test-integration/test-committor-service/tests/test_intent_executor.rs
+++ b/test-integration/test-committor-service/tests/test_intent_executor.rs
@@ -341,7 +341,7 @@ async fn test_action_error_parsing() {
 #[tokio::test]
 async fn test_cpi_limits_error_parsing() {
     const COUNTER_SIZE: u64 = 102;
-    const COUNTER_NUM: u64 = 10;
+    const COUNTER_NUM: u64 = 12;
 
     let TestEnv {
         fixture,
@@ -761,7 +761,7 @@ async fn test_commit_id_and_action_errors_recovery() {
 #[tokio::test]
 async fn test_cpi_limits_error_recovery() {
     const COUNTER_SIZE: u64 = 102;
-    const COUNTER_NUM: u64 = 10;
+    const COUNTER_NUM: u64 = 12;
 
     let TestEnv {
         fixture,
@@ -860,8 +860,8 @@ async fn test_cpi_limits_error_recovery() {
 #[tokio::test]
 async fn test_commit_id_actions_cpi_limit_errors_recovery() {
     const COUNTER_SIZE: u64 = 102;
-    // COUNTER_NUM = 10 or larger result in CpiLimitError even with 2 stage execution
-    const COUNTER_NUM: u64 = 9;
+    // COUNTER_NUM = 13 or larger result in FailedToFitError
+    const COUNTER_NUM: u64 = 12;
 
     let TestEnv {
         fixture,
@@ -947,7 +947,12 @@ async fn test_commit_id_actions_cpi_limit_errors_recovery() {
         res.is_ok(),
         "Expected recovery from CommitID, Actions, and CpiLimit errors"
     );
-    assert_eq!(patched_errors.len(), 3, "Only 3 patches expected");
+    assert_eq!(
+        patched_errors.len(),
+        3,
+        "Only 3 patches expected: {:?}",
+        patched_errors
+    );
     assert!(matches!(
         res.unwrap(),
         ExecutionOutput::TwoStage {
@@ -1012,6 +1017,7 @@ async fn test_commit_id_actions_cpi_limit_errors_recovery() {
 }
 
 #[tokio::test]
+#[ignore = "CommitFinalize cannot have unfinalized account"]
 async fn test_commit_unfinalized_account_recovery() {
     let TestEnv {
         fixture,
@@ -1091,6 +1097,7 @@ async fn test_commit_unfinalized_account_recovery() {
 }
 
 #[tokio::test]
+#[ignore = "CommitFinalize cannot have unfinalized account"]
 async fn test_commit_unfinalized_account_recovery_two_stage() {
     let TestEnv {
         fixture,

--- a/test-integration/test-committor-service/tests/test_ix_commit_local.rs
+++ b/test-integration/test-committor-service/tests/test_ix_commit_local.rs
@@ -178,24 +178,23 @@ async fn test_ix_commit_order_book_change_100_bytes() {
 }
 
 #[tokio::test]
-async fn test_ix_commit_order_book_change_671_bytes() {
+async fn test_ix_commit_order_book_change_switch_strategy_at_n_bytes() {
     commit_book_order_account(
-        671,
-        CommitStrategy::DiffArgs,
+        794, // this can change such that strategy == CommitStrategy::DiffArgs
+        CommitStrategy::DiffArgs, // this must NOT change
         ScheduleCommitType::Commit,
     )
     .await;
-}
 
-#[tokio::test]
-async fn test_ix_commit_order_book_change_681_bytes() {
-    // We cannot use 680 as changed_len because that both 680 and 681 produce encoded tx
-    // of size 1644 (which is the max limit), but while the size of raw bytes for 680 is within
-    // 1232 limit, the size for 681 exceeds by 1 (1233). That is why we used
-    // 681 as changed_len where CommitStrategy goes from Args to FromBuffer.
+    // We cannot use 795 as changed_len even though it is the minimum number at which it should switch
+    // from DiffArgs (794) to DiffBuffer (795). Both 794 and 795 produce encoded-tx of size 1644 which
+    // is within limit (MAX_ENCODED_TRANSACTION_SIZE) but 795 is later rejected because the actual
+    // tx-size is 1233 (that indicates MAX_ENCODED_TRANSACTION_SIZE is an incorrect threashold).
+    // Anyway, 796 produces encoded-tx of size > 1644, and thus it becomes DiffBuffer.
+
     commit_book_order_account(
-        681,
-        CommitStrategy::DiffBuffer,
+        796, // this can change such thatu strategy == CommitStrategy::DiffBuffer
+        CommitStrategy::DiffBuffer, // this must NOT change
         ScheduleCommitType::Commit,
     )
     .await;
@@ -486,10 +485,7 @@ async fn test_commit_5_accounts_1kb_bundle_size_3_undelegate_all() {
 async fn test_commit_5_accounts_1kb_bundle_size_4() {
     commit_5_accounts_1kb(
         4,
-        expect_strategies(&[
-            (CommitStrategy::DiffArgs, 1),
-            (CommitStrategy::DiffBufferWithLookupTable, 4),
-        ]),
+        expect_strategies(&[(CommitStrategy::DiffArgs, 5)]),
         ScheduleCommitType::Commit,
     )
     .await;
@@ -499,10 +495,7 @@ async fn test_commit_5_accounts_1kb_bundle_size_4() {
 async fn test_commit_5_accounts_1kb_bundle_size_4_undelegate_all() {
     commit_5_accounts_1kb(
         4,
-        expect_strategies(&[
-            (CommitStrategy::DiffArgs, 1),
-            (CommitStrategy::DiffBufferWithLookupTable, 4),
-        ]),
+        expect_strategies(&[(CommitStrategy::DiffArgs, 5)]),
         ScheduleCommitType::CommitAndUndelegate,
     )
     .await;
@@ -512,7 +505,7 @@ async fn test_commit_5_accounts_1kb_bundle_size_4_undelegate_all() {
 async fn test_commit_5_accounts_1kb_bundle_size_5_undelegate_all() {
     commit_5_accounts_1kb(
         5,
-        expect_strategies(&[(CommitStrategy::DiffBufferWithLookupTable, 5)]),
+        expect_strategies(&[(CommitStrategy::DiffArgs, 5)]),
         ScheduleCommitType::CommitAndUndelegate,
     )
     .await;
@@ -532,7 +525,7 @@ async fn test_commit_20_accounts_1kb_bundle_size_3() {
 async fn test_commit_20_accounts_1kb_bundle_size_4() {
     commit_20_accounts_1kb(
         4,
-        expect_strategies(&[(CommitStrategy::DiffBufferWithLookupTable, 20)]),
+        expect_strategies(&[(CommitStrategy::DiffArgs, 20)]),
         ScheduleCommitType::Commit,
     )
     .await;
@@ -597,7 +590,8 @@ async fn test_commit_20_accounts_1kb_bundle_size_8() {
         expect_strategies(&[
             // Four accounts don't make it into the bundles of size 8, but
             // that bundle also needs lookup tables
-            (CommitStrategy::DiffBufferWithLookupTable, 20),
+            (CommitStrategy::DiffArgs, 4),
+            (CommitStrategy::DiffBufferWithLookupTable, 16),
         ]),
         ScheduleCommitType::Commit,
     )
@@ -639,7 +633,7 @@ async fn test_ix_execute_intent_bundle_commit_and_cau_simultaneously_union_of_ac
         &[1024, 2048],
         &[],
         &[1024, 2048],
-        expect_strategies(&[(CommitStrategy::DiffBufferWithLookupTable, 4)]),
+        expect_strategies(&[(CommitStrategy::DiffArgs, 4)]),
     )
     .await;
 }
@@ -650,7 +644,7 @@ async fn test_ix_execute_intent_bundle_commit_three_accounts_cau_one_account() {
         &[512, 512, 512],
         &[],
         &[512],
-        expect_strategies(&[(CommitStrategy::DiffBufferWithLookupTable, 4)]),
+        expect_strategies(&[(CommitStrategy::DiffArgs, 4)]),
     )
     .await;
 }
@@ -1004,6 +998,24 @@ async fn ix_commit_local(
             committed_accounts.is_some() || undelegated_accounts.is_some();
         let has_commit_finalize_flow = committed_finalize_accounts.is_some()
             || commit_finalized_and_undelegated_accounts.is_some();
+
+        debug!("has_commit_flow: {}", has_commit_flow);
+        debug!("has_commit_finalize_flow: {}", has_commit_finalize_flow);
+
+        //
+        // Workaround:
+        //
+        // Since now all Commits default to CommitFinalize (see #1174) even if from
+        // user's perspective it is ScheduleCommit (or ScheduleCommitAndUndelegate),
+        // has_commit_flow == true actually means has_commit_finalize_flow == true
+        // and has_commit_flow is always false.
+        //
+        let has_commit_finalize_flow =
+            has_commit_finalize_flow || has_commit_flow;
+        let has_commit_flow = false;
+
+        // if-block is logicall here for the time being, even though it will not
+        // be executed.
         if has_commit_flow {
             assert!(
                 tx_logs_contain(&rpc_client, &commit_signature, "CommitState")

--- a/test-integration/test-committor-service/tests/utils/transactions.rs
+++ b/test-integration/test-committor-service/tests/utils/transactions.rs
@@ -177,22 +177,20 @@ pub async fn tx_logs_contain(
     signature: &Signature,
     needle: &str,
 ) -> bool {
-    fetch_tx_logs(rpc_client, signature)
-        .await
-        .iter()
-        .any(|log| {
-            // Lots of existing tests pass "CommitState" as needle argument to this function, but since now CommitTask
-            // could invoke CommitState or CommitDiff depending on the size of the account, we also look for "CommitDiff"
-            // in the logs when needle == CommitState. It's easier to make this little adjustment here than computing
-            // the decision and passing either CommitState or CommitDiff from the tests themselves.
-            if needle == "CommitState" {
-                log.contains(needle)
-                    || log.contains("CommitDiff")
-                    || log.contains("CommitFinalize")
-            } else {
-                log.contains(needle)
-            }
-        })
+    let logs = fetch_tx_logs(rpc_client, signature).await;
+    logs.iter().any(|log| {
+        // Lots of existing tests pass "CommitState" as needle argument to this function, but since now CommitTask
+        // could invoke CommitState or CommitDiff depending on the size of the account, we also look for "CommitDiff"
+        // in the logs when needle == CommitState. It's easier to make this little adjustment here than computing
+        // the decision and passing either CommitState or CommitDiff from the tests themselves.
+        if needle == "CommitState" {
+            log.contains(needle)
+                || log.contains("CommitDiff")
+                || log.contains("CommitFinalize")
+        } else {
+            log.contains(needle)
+        }
+    })
 }
 
 /// This needs to be run for each test that required a new counter to be delegated


### PR DESCRIPTION
This PR changes (non-breaking) scheduled commits to use the DLP `CommitFinalize` instruction instead of executing separate `Commit` and `Finalize` instructions. 

- The user-facing behavior stays the same: a scheduled commit still commits the account state to base and finalizes it. 
- For commit-and-undelegate flows, the undelegate step is still preserved after commit-finalize.

## Naming problem

`MagicBlockInstruction::ScheduleCommit` was already a misleading name because it **never** meant _"commit only"_; it always scheduled a commit followed by finalize. But now, with this PR, the codebase feels even more misleading because the underlying DLP operation is now explicitly `CommitFinalize` while we also have `Commit` (which also executes `Finalize` implicitly). 

### Possible fix

Rename the existing `ScheduleCommit` to `ScheduleCommitFinalize` since that is what it actually does (even before this PR). Rename the currently _unused_ `ScheduleCommitFinalize` enum slot to `ScheduleCommit` (or `ScheduleCommitOnly`) and **leave it unimplemented for now because commit-only scheduling semantics are not yet clear and we never supported that**. This keeps the enum shape stable while making the active API naming accurate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an execution-mode option to choose combined commit+finalize vs separate flows
  * Finalize stage is skipped automatically when no finalize work is needed, reducing overhead

* **Bug Fixes**
  * Consistent error mapping so finalize-related tasks surface the same transaction errors as commit tasks
  * Improved recovery and logging for unfinalized-account and commit-nonce/id error cases

* **Tests**
  * Updated unit/integration tests for single- vs two-stage behavior; increased CPI-limit thresholds and marked two commit-unfinalized-account recovery tests as ignored
<!-- end of auto-generated comment: release notes by coderabbit.ai -->