### PR TITLE
fix: cache known-empty eATAs and never subscribe SPL Token program

### DIFF
--- a/magicblock-chainlink/src/chainlink/blacklisted_accounts.rs
+++ b/magicblock-chainlink/src/chainlink/blacklisted_accounts.rs
@@ -77,9 +77,7 @@ pub fn native_program_accounts() -> HashSet<Pubkey> {
     blacklisted_programs
 }
 
-/// Programs that must never be subscribed to via `subscribe_program`.
-/// They own a vast number of accounts on chain and a program-wide
-/// subscription would flood the validator with unrelated updates.
+/// High-cardinality programs skipped for program-wide subscriptions.
 pub fn programs_not_to_subscribe() -> HashSet<Pubkey> {
     let mut programs = HashSet::new();
     programs.insert(TOKEN_PROGRAM_ID);

--- a/magicblock-chainlink/src/chainlink/blacklisted_accounts.rs
+++ b/magicblock-chainlink/src/chainlink/blacklisted_accounts.rs
@@ -1,5 +1,8 @@
 use std::collections::HashSet;
 
+use magicblock_core::token_programs::{
+    ASSOCIATED_TOKEN_PROGRAM_ID, TOKEN_PROGRAM_ID,
+};
 use magicblock_magic_program_api::{self as magic_program};
 use solana_pubkey::Pubkey;
 use solana_sdk_ids::{
@@ -72,4 +75,15 @@ pub fn native_program_accounts() -> HashSet<Pubkey> {
     blacklisted_programs.insert(vote::ID);
     blacklisted_programs.insert(zk_elgamal_proof_program::ID);
     blacklisted_programs
+}
+
+/// Programs that must never be subscribed to via `subscribe_program`.
+/// They own a vast number of accounts on chain and a program-wide
+/// subscription would flood the validator with unrelated updates.
+pub fn programs_not_to_subscribe() -> HashSet<Pubkey> {
+    let mut programs = HashSet::new();
+    programs.insert(TOKEN_PROGRAM_ID);
+    programs.insert(spl_token_2022::id());
+    programs.insert(ASSOCIATED_TOKEN_PROGRAM_ID);
+    programs
 }

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{hash_map, HashSet},
+    num::NonZeroUsize,
     sync::{
         atomic::{AtomicU64, Ordering},
         Arc, Mutex,
@@ -10,6 +11,7 @@ use std::{
 use dlp_api::{
     pda::delegation_record_pda_from_delegated_account, state::DelegationRecord,
 };
+use lru::LruCache;
 use magicblock_accounts_db::traits::AccountsBank;
 use magicblock_config::config::AllowedProgram;
 use magicblock_core::token_programs::{
@@ -51,7 +53,9 @@ use super::errors::{ChainlinkError, ChainlinkResult};
 use crate::{
     chainlink::{
         account_still_undelegating_on_chain::account_still_undelegating_on_chain,
-        blacklisted_accounts::blacklisted_accounts,
+        blacklisted_accounts::{
+            blacklisted_accounts, programs_not_to_subscribe,
+        },
     },
     cloner::{
         errors::{ClonerError, ClonerResult},
@@ -99,6 +103,18 @@ where
     /// all programs are allowed.
     allowed_programs: Option<HashSet<Pubkey>>,
 
+    /// Programs that must never be passed to `subscribe_program` because
+    /// they own enough accounts to flood the validator with updates
+    /// (SPL Token, Token-2022, Associated Token Account program).
+    programs_not_to_subscribe: HashSet<Pubkey>,
+
+    /// Bounded negative cache of derived eATA pubkeys that we already
+    /// observed to be non-existent on chain. Used by the ATA-side
+    /// projection path to skip redundant RPC fetches for ATAs that have
+    /// no corresponding eATA. Real eATAs that materialise later are
+    /// still picked up through the eATA-side subscription update path.
+    known_empty_eatas: Arc<Mutex<LruCache<Pubkey, ()>>>,
+
     /// Tracks in-flight clone operations per (pubkey, slot).
     /// The first caller to claim a key becomes the owner and performs
     /// the actual clone. Subsequent callers become waiters and receive
@@ -110,6 +126,11 @@ where
         >,
     >,
 }
+
+/// Capacity of the negative cache for known-empty eATAs.
+/// Sized to comfortably cover the working set of unique ATAs a busy
+/// validator clones over its lifetime while keeping memory bounded.
+const KNOWN_EMPTY_EATAS_CAPACITY: usize = 100_000;
 
 /// Manual Clone impl: `#[derive(Clone)]` would add `V: Clone, C: Clone`
 /// bounds that are not satisfied (`AccountsBank` and `Cloner` don't
@@ -132,6 +153,8 @@ where
             validator_keypair: Arc::clone(&self.validator_keypair),
             blacklisted_accounts: self.blacklisted_accounts.clone(),
             allowed_programs: self.allowed_programs.clone(),
+            programs_not_to_subscribe: self.programs_not_to_subscribe.clone(),
+            known_empty_eatas: self.known_empty_eatas.clone(),
             pending_clones: self.pending_clones.clone(),
         }
     }
@@ -171,6 +194,11 @@ where
             fetch_count: Arc::new(AtomicU64::new(0)),
             blacklisted_accounts,
             allowed_programs,
+            programs_not_to_subscribe: programs_not_to_subscribe(),
+            known_empty_eatas: Arc::new(Mutex::new(LruCache::new(
+                NonZeroUsize::new(KNOWN_EMPTY_EATAS_CAPACITY)
+                    .expect("KNOWN_EMPTY_EATAS_CAPACITY must be non-zero"),
+            ))),
             pending_clones: Arc::new(Mutex::new(hash_map::HashMap::new())),
         });
 
@@ -928,7 +956,11 @@ where
 
                                 // For accounts delegated to us, subscribe to the original owner
                                 // program for undelegation update resilience.
-                                if account.delegated() {
+                                if account.delegated()
+                                    && !self
+                                        .programs_not_to_subscribe
+                                        .contains(&delegation_record.owner)
+                                {
                                     // Fire-and-forget to avoid blocking subscription updates.
                                     let provider =
                                         self.remote_account_provider.clone();
@@ -1062,6 +1094,23 @@ where
         })
     }
 
+    fn is_known_empty_eata(&self, eata_pubkey: &Pubkey) -> bool {
+        let mut cache = self
+            .known_empty_eatas
+            .lock()
+            .expect("known_empty_eatas mutex poisoned");
+        // `get` promotes on hit so frequently revisited entries stay warm.
+        cache.get(eata_pubkey).is_some()
+    }
+
+    fn mark_eata_empty(&self, eata_pubkey: Pubkey) {
+        let mut cache = self
+            .known_empty_eatas
+            .lock()
+            .expect("known_empty_eatas mutex poisoned");
+        cache.put(eata_pubkey, ());
+    }
+
     async fn maybe_project_ata_from_subscription_update(
         &self,
         ata_pubkey: Pubkey,
@@ -1079,6 +1128,15 @@ where
         else {
             return (ata_account, None);
         };
+
+        // If we have already observed this eATA to be non-existent, skip
+        // the upstream RPC fetch. The eATA-side subscription update path
+        // (see `maybe_build_projected_ata_clone_request_from_eata_sub_update`)
+        // will project the ATA on its own if the eATA materialises later,
+        // so this cache does not need explicit invalidation.
+        if self.is_known_empty_eata(&eata_pubkey) {
+            return (ata_account, None);
+        }
 
         if let Err(err) = self.subscribe_to_account(&eata_pubkey).await {
             warn!(
@@ -1114,6 +1172,7 @@ where
         };
 
         let Some(eata_account) = eata_account else {
+            self.mark_eata_empty(eata_pubkey);
             return (ata_account, None);
         };
 

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -104,18 +104,10 @@ where
     /// all programs are allowed.
     allowed_programs: Option<HashSet<Pubkey>>,
 
-    /// Programs that must never be passed to `subscribe_program` because
-    /// they own enough accounts to flood the validator with updates
-    /// (SPL Token, Token-2022, Associated Token Account program).
+    /// Programs too broad for `subscribe_program`.
     programs_not_to_subscribe: HashSet<Pubkey>,
 
-    /// Bounded negative cache of derived eATA pubkeys that we already
-    /// observed to be non-existent on chain. Used by the ATA-side
-    /// projection path to skip redundant RPC fetches for ATAs that have
-    /// no corresponding eATA. Real eATAs that materialise later are
-    /// still picked up through the eATA-side subscription update path.
-    /// Wrapped in a `parking_lot::Mutex` to avoid poisoning semantics on
-    /// the hot path.
+    /// Negative cache for derived eATAs confirmed missing on chain.
     known_empty_eatas: Arc<PlMutex<LruCache<Pubkey, ()>>>,
 
     /// Tracks in-flight clone operations per (pubkey, slot).
@@ -130,16 +122,10 @@ where
     >,
 }
 
-/// Capacity of the negative cache for known-empty eATAs.
-/// Sized to comfortably cover the working set of unique ATAs a busy
-/// validator clones over its lifetime while keeping memory bounded.
-/// Built as a `NonZeroUsize` at compile time so the constructor does
-/// not need a runtime `.expect`.
+/// Negative-cache capacity for known-empty eATAs.
 const KNOWN_EMPTY_EATAS_CAPACITY: NonZeroUsize =
     match NonZeroUsize::new(100_000) {
         Some(n) => n,
-        // SAFETY: 100_000 is a non-zero literal so this branch is unreachable
-        // and the compiler evaluates the `match` at build time.
         None => panic!("KNOWN_EMPTY_EATAS_CAPACITY must be non-zero"),
     };
 
@@ -1105,9 +1091,6 @@ where
     }
 
     fn is_known_empty_eata(&self, eata_pubkey: &Pubkey) -> bool {
-        // `parking_lot::Mutex` does not poison; `lock()` returns the guard
-        // directly so no `unwrap`/`expect` is needed on the hot path.
-        // `get` promotes on hit so frequently revisited entries stay warm.
         self.known_empty_eatas.lock().get(eata_pubkey).is_some()
     }
 
@@ -1133,14 +1116,8 @@ where
             return (ata_account, None);
         };
 
-        // Always (re)subscribe to the derived eATA. The call is idempotent
-        // and, importantly, promotes the entry in the subscription LRU so it
-        // does not get evicted under churn. We need the subscription to stay
-        // alive even when the negative cache below short-circuits the fetch:
-        // if the eATA is created later, the eATA-side subscription update
-        // path (`maybe_build_projected_ata_clone_request_from_eata_sub_update`)
-        // is what projects the ATA, so losing the subscription would mean
-        // missing that creation event.
+        // Re-subscribe before cache checks; this keeps the subscription LRU
+        // warm and lets later eATA creation reach the projection path.
         let subscribed = match self.subscribe_to_account(&eata_pubkey).await {
             Ok(()) => true,
             Err(err) => {
@@ -1153,9 +1130,7 @@ where
             }
         };
 
-        // If we have already observed this eATA to be non-existent, skip
-        // the upstream RPC fetch. The subscription above keeps us live to
-        // any future creation, so this cache needs no explicit invalidation.
+        // Known-empty eATAs skip the fetch; the live subscription covers later creation.
         if self.is_known_empty_eata(&eata_pubkey) {
             return (ata_account, None);
         }
@@ -1174,11 +1149,7 @@ where
         {
             Ok(mut accounts) => {
                 let popped = accounts.pop();
-                // Only a `NotFound` from a successful fetch is authoritative
-                // evidence that the eATA does not exist on chain. Any other
-                // shape (`Found` whose freshness check fails, missing entry,
-                // or a fetch error below) is treated as transient so we keep
-                // retrying on subsequent updates.
+                // Only `NotFound` proves absence; stale, missing, or failed fetches retry later.
                 let nf = matches!(popped, Some(RemoteAccount::NotFound(_)));
                 let fresh = popped.and_then(|a| a.fresh_account());
                 (fresh, nf)
@@ -1194,11 +1165,7 @@ where
         };
 
         let Some(eata_account) = eata_account else {
-            // Cache the eATA as empty only when we are confident:
-            //   1. the upstream confirmed it as `NotFound` (not a transient
-            //      RPC/timeout error), and
-            //   2. our subscription is actually live, so the eATA-side path
-            //      will deliver any future creation event.
+            // Cache absence only after a confirmed NotFound and live subscription.
             if definitively_not_found && subscribed {
                 self.mark_eata_empty(eata_pubkey);
             }

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -1116,6 +1116,9 @@ where
             return (ata_account, None);
         };
 
+        let was_watching =
+            self.remote_account_provider.is_watching(&eata_pubkey);
+
         // Re-subscribe before cache checks; this keeps the subscription LRU
         // warm and lets later eATA creation reach the projection path.
         let subscribed = match self.subscribe_to_account(&eata_pubkey).await {
@@ -1130,8 +1133,9 @@ where
             }
         };
 
-        // Known-empty eATAs skip the fetch; the live subscription covers later creation.
-        if self.is_known_empty_eata(&eata_pubkey) {
+        // Known-empty eATAs skip the fetch only if the subscription was already live.
+        if was_watching && subscribed && self.is_known_empty_eata(&eata_pubkey)
+        {
             return (ata_account, None);
         }
 

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -1129,21 +1129,27 @@ where
             return (ata_account, None);
         };
 
-        // If we have already observed this eATA to be non-existent, skip
-        // the upstream RPC fetch. The eATA-side subscription update path
-        // (see `maybe_build_projected_ata_clone_request_from_eata_sub_update`)
-        // will project the ATA on its own if the eATA materialises later,
-        // so this cache does not need explicit invalidation.
-        if self.is_known_empty_eata(&eata_pubkey) {
-            return (ata_account, None);
-        }
-
+        // Always (re)subscribe to the derived eATA. The call is idempotent
+        // and, importantly, promotes the entry in the subscription LRU so it
+        // does not get evicted under churn. We need the subscription to stay
+        // alive even when the negative cache below short-circuits the fetch:
+        // if the eATA is created later, the eATA-side subscription update
+        // path (`maybe_build_projected_ata_clone_request_from_eata_sub_update`)
+        // is what projects the ATA, so losing the subscription would mean
+        // missing that creation event.
         if let Err(err) = self.subscribe_to_account(&eata_pubkey).await {
             warn!(
                 pubkey = %eata_pubkey,
                 error = ?err,
                 "Failed to subscribe to derived eATA"
             );
+        }
+
+        // If we have already observed this eATA to be non-existent, skip
+        // the upstream RPC fetch. The subscription above keeps us live to
+        // any future creation, so this cache needs no explicit invalidation.
+        if self.is_known_empty_eata(&eata_pubkey) {
+            return (ata_account, None);
         }
 
         let eata_account = match self

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -19,6 +19,7 @@ use magicblock_core::token_programs::{
     MaybeIntoAta, EATA_PROGRAM_ID,
 };
 use magicblock_metrics::metrics::{self, AccountFetchOrigin};
+use parking_lot::Mutex as PlMutex;
 use scc::{hash_map::Entry, HashMap};
 use solana_account::{AccountSharedData, ReadableAccount};
 use solana_keypair::Keypair;
@@ -113,7 +114,9 @@ where
     /// projection path to skip redundant RPC fetches for ATAs that have
     /// no corresponding eATA. Real eATAs that materialise later are
     /// still picked up through the eATA-side subscription update path.
-    known_empty_eatas: Arc<Mutex<LruCache<Pubkey, ()>>>,
+    /// Wrapped in a `parking_lot::Mutex` to avoid poisoning semantics on
+    /// the hot path.
+    known_empty_eatas: Arc<PlMutex<LruCache<Pubkey, ()>>>,
 
     /// Tracks in-flight clone operations per (pubkey, slot).
     /// The first caller to claim a key becomes the owner and performs
@@ -195,7 +198,7 @@ where
             blacklisted_accounts,
             allowed_programs,
             programs_not_to_subscribe: programs_not_to_subscribe(),
-            known_empty_eatas: Arc::new(Mutex::new(LruCache::new(
+            known_empty_eatas: Arc::new(PlMutex::new(LruCache::new(
                 NonZeroUsize::new(KNOWN_EMPTY_EATAS_CAPACITY)
                     .expect("KNOWN_EMPTY_EATAS_CAPACITY must be non-zero"),
             ))),
@@ -1095,20 +1098,14 @@ where
     }
 
     fn is_known_empty_eata(&self, eata_pubkey: &Pubkey) -> bool {
-        let mut cache = self
-            .known_empty_eatas
-            .lock()
-            .expect("known_empty_eatas mutex poisoned");
+        // `parking_lot::Mutex` does not poison; `lock()` returns the guard
+        // directly so no `unwrap`/`expect` is needed on the hot path.
         // `get` promotes on hit so frequently revisited entries stay warm.
-        cache.get(eata_pubkey).is_some()
+        self.known_empty_eatas.lock().get(eata_pubkey).is_some()
     }
 
     fn mark_eata_empty(&self, eata_pubkey: Pubkey) {
-        let mut cache = self
-            .known_empty_eatas
-            .lock()
-            .expect("known_empty_eatas mutex poisoned");
-        cache.put(eata_pubkey, ());
+        self.known_empty_eatas.lock().put(eata_pubkey, ());
     }
 
     async fn maybe_project_ata_from_subscription_update(
@@ -1137,13 +1134,17 @@ where
         // path (`maybe_build_projected_ata_clone_request_from_eata_sub_update`)
         // is what projects the ATA, so losing the subscription would mean
         // missing that creation event.
-        if let Err(err) = self.subscribe_to_account(&eata_pubkey).await {
-            warn!(
-                pubkey = %eata_pubkey,
-                error = ?err,
-                "Failed to subscribe to derived eATA"
-            );
-        }
+        let subscribed = match self.subscribe_to_account(&eata_pubkey).await {
+            Ok(()) => true,
+            Err(err) => {
+                warn!(
+                    pubkey = %eata_pubkey,
+                    error = ?err,
+                    "Failed to subscribe to derived eATA"
+                );
+                false
+            }
+        };
 
         // If we have already observed this eATA to be non-existent, skip
         // the upstream RPC fetch. The subscription above keeps us live to
@@ -1152,7 +1153,7 @@ where
             return (ata_account, None);
         }
 
-        let eata_account = match self
+        let (eata_account, definitively_not_found) = match self
             .remote_account_provider
             .try_get_multi_until_slots_match(
                 &[eata_pubkey],
@@ -1165,7 +1166,15 @@ where
             .await
         {
             Ok(mut accounts) => {
-                accounts.pop().and_then(|account| account.fresh_account())
+                let popped = accounts.pop();
+                // Only a `NotFound` from a successful fetch is authoritative
+                // evidence that the eATA does not exist on chain. Any other
+                // shape (`Found` whose freshness check fails, missing entry,
+                // or a fetch error below) is treated as transient so we keep
+                // retrying on subsequent updates.
+                let nf = matches!(popped, Some(RemoteAccount::NotFound(_)));
+                let fresh = popped.and_then(|a| a.fresh_account());
+                (fresh, nf)
             }
             Err(err) => {
                 debug!(
@@ -1173,12 +1182,19 @@ where
                     error = ?err,
                     "Failed to fetch eATA for projection"
                 );
-                None
+                (None, false)
             }
         };
 
         let Some(eata_account) = eata_account else {
-            self.mark_eata_empty(eata_pubkey);
+            // Cache the eATA as empty only when we are confident:
+            //   1. the upstream confirmed it as `NotFound` (not a transient
+            //      RPC/timeout error), and
+            //   2. our subscription is actually live, so the eATA-side path
+            //      will deliver any future creation event.
+            if definitively_not_found && subscribed {
+                self.mark_eata_empty(eata_pubkey);
+            }
             return (ata_account, None);
         };
 

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -133,7 +133,15 @@ where
 /// Capacity of the negative cache for known-empty eATAs.
 /// Sized to comfortably cover the working set of unique ATAs a busy
 /// validator clones over its lifetime while keeping memory bounded.
-const KNOWN_EMPTY_EATAS_CAPACITY: usize = 100_000;
+/// Built as a `NonZeroUsize` at compile time so the constructor does
+/// not need a runtime `.expect`.
+const KNOWN_EMPTY_EATAS_CAPACITY: NonZeroUsize =
+    match NonZeroUsize::new(100_000) {
+        Some(n) => n,
+        // SAFETY: 100_000 is a non-zero literal so this branch is unreachable
+        // and the compiler evaluates the `match` at build time.
+        None => panic!("KNOWN_EMPTY_EATAS_CAPACITY must be non-zero"),
+    };
 
 /// Manual Clone impl: `#[derive(Clone)]` would add `V: Clone, C: Clone`
 /// bounds that are not satisfied (`AccountsBank` and `Cloner` don't
@@ -199,8 +207,7 @@ where
             allowed_programs,
             programs_not_to_subscribe: programs_not_to_subscribe(),
             known_empty_eatas: Arc::new(PlMutex::new(LruCache::new(
-                NonZeroUsize::new(KNOWN_EMPTY_EATAS_CAPACITY)
-                    .expect("KNOWN_EMPTY_EATAS_CAPACITY must be non-zero"),
+                KNOWN_EMPTY_EATAS_CAPACITY,
             ))),
             pending_clones: Arc::new(Mutex::new(hash_map::HashMap::new())),
         });

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/pipeline.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/pipeline.rs
@@ -351,8 +351,14 @@ where
                         &delegation_record,
                     );
 
-                    // Collect unique owner programs to subscribe concurrently after the loop
-                    if account.delegated() {
+                    // Collect unique owner programs to subscribe concurrently after the loop.
+                    // Skip programs that own too many accounts to safely receive program-wide
+                    // updates (e.g. SPL Token), since that would flood the validator.
+                    if account.delegated()
+                        && !this
+                            .programs_not_to_subscribe
+                            .contains(&delegation_record.owner)
+                    {
                         owner_programs_to_subscribe
                             .insert(delegation_record.owner);
                     }

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/pipeline.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/pipeline.rs
@@ -351,9 +351,7 @@ where
                         &delegation_record,
                     );
 
-                    // Collect unique owner programs to subscribe concurrently after the loop.
-                    // Skip programs that own too many accounts to safely receive program-wide
-                    // updates (e.g. SPL Token), since that would flood the validator.
+                    // Skip high-cardinality owner programs such as SPL Token.
                     if account.delegated()
                         && !this
                             .programs_not_to_subscribe

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -3777,6 +3777,7 @@ async fn test_project_ata_skips_repeat_fetch_for_known_empty_eata() {
     // upstream fetch returns NotFound, which is the case the negative
     // cache must short-circuit on subsequent updates.
     let FetcherTestCtx {
+        remote_account_provider,
         rpc_client,
         subscription_tx,
         ..
@@ -3786,6 +3787,7 @@ async fn test_project_ata_skips_repeat_fetch_for_known_empty_eata() {
         validator_keypair.insecure_clone(),
     )
     .await;
+    let eata_pubkey = derive_eata(&wallet_owner, &mint);
 
     use crate::remote_account_provider::{
         RemoteAccount, RemoteAccountUpdateSource,
@@ -3829,14 +3831,27 @@ async fn test_project_ata_skips_repeat_fetch_for_known_empty_eata() {
         "first ATA update should trigger an upstream eATA fetch"
     );
 
+    // After the first update the eATA must be subscribed so that we get
+    // notified if it ever materialises on chain.
+    assert!(
+        remote_account_provider.is_watching(&eata_pubkey),
+        "eATA must be subscribed after the first ATA update"
+    );
+
     // Second update for the same ATA: must be served by the negative
-    // cache without issuing any new upstream fetch.
+    // cache without issuing any new upstream fetch, but must keep the
+    // eATA subscription alive (idempotent re-subscribe promotes the LRU
+    // entry so it does not get evicted under churn).
     send_update().await;
     tokio::time::sleep(Duration::from_millis(150)).await;
     assert_eq!(
         rpc_client.single_account_fetches(),
         after_first,
         "subsequent ATA updates for an already-known-empty eATA must not refetch"
+    );
+    assert!(
+        remote_account_provider.is_watching(&eata_pubkey),
+        "eATA subscription must persist across cache-hit ATA updates"
     );
 }
 

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -3780,6 +3780,7 @@ async fn test_project_ata_skips_repeat_fetch_for_known_empty_eata() {
         remote_account_provider,
         rpc_client,
         subscription_tx,
+        fetch_cloner,
         ..
     } = setup(
         [(ata_pubkey, ata_account.clone())],
@@ -3815,16 +3816,18 @@ async fn test_project_ata_skips_repeat_fetch_for_known_empty_eata() {
     const TIMEOUT: std::time::Duration = Duration::from_millis(500);
 
     // First update: triggers a real eATA fetch which returns NotFound and
-    // marks the eATA as known-empty.
+    // marks the eATA as known-empty. We poll the cache predicate itself
+    // rather than the fetch counter so the readiness signal cannot fire
+    // before `mark_eata_empty` has run.
     let baseline_fetches = rpc_client.single_account_fetches();
     send_update().await;
     tokio::time::timeout(TIMEOUT, async {
-        while rpc_client.single_account_fetches() == baseline_fetches {
+        while !fetch_cloner.is_known_empty_eata(&eata_pubkey) {
             tokio::time::sleep(POLL_INTERVAL).await;
         }
     })
     .await
-    .expect("timed out waiting for initial eATA fetch");
+    .expect("timed out waiting for known-empty eATA cache entry");
     let after_first = rpc_client.single_account_fetches();
     assert!(
         after_first > baseline_fetches,

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -3773,9 +3773,7 @@ async fn test_project_ata_skips_repeat_fetch_for_known_empty_eata() {
     let ata_pubkey = derive_ata(&wallet_owner, &mint);
     let ata_account = create_ata_account(&wallet_owner, &mint);
 
-    // Note: the eATA is intentionally NOT present in the mock RPC so the
-    // upstream fetch returns NotFound, which is the case the negative
-    // cache must short-circuit on subsequent updates.
+    // Leave the eATA absent so the first fetch returns NotFound.
     let FetcherTestCtx {
         remote_account_provider,
         rpc_client,
@@ -3815,10 +3813,7 @@ async fn test_project_ata_skips_repeat_fetch_for_known_empty_eata() {
     const POLL_INTERVAL: std::time::Duration = Duration::from_millis(10);
     const TIMEOUT: std::time::Duration = Duration::from_millis(500);
 
-    // First update: triggers a real eATA fetch which returns NotFound and
-    // marks the eATA as known-empty. We poll the cache predicate itself
-    // rather than the fetch counter so the readiness signal cannot fire
-    // before `mark_eata_empty` has run.
+    // Poll the cache entry, not the fetch counter, to avoid racing mark_eata_empty.
     let baseline_fetches = rpc_client.single_account_fetches();
     send_update().await;
     tokio::time::timeout(TIMEOUT, async {
@@ -3834,17 +3829,13 @@ async fn test_project_ata_skips_repeat_fetch_for_known_empty_eata() {
         "first ATA update should trigger an upstream eATA fetch"
     );
 
-    // After the first update the eATA must be subscribed so that we get
-    // notified if it ever materialises on chain.
+    // The subscription must still catch later eATA creation.
     assert!(
         remote_account_provider.is_watching(&eata_pubkey),
         "eATA must be subscribed after the first ATA update"
     );
 
-    // Second update for the same ATA: must be served by the negative
-    // cache without issuing any new upstream fetch, but must keep the
-    // eATA subscription alive (idempotent re-subscribe promotes the LRU
-    // entry so it does not get evicted under churn).
+    // Cache hits should avoid refetching while preserving the subscription.
     send_update().await;
     tokio::time::sleep(Duration::from_millis(150)).await;
     assert_eq!(
@@ -3889,7 +3880,7 @@ async fn test_delegated_account_owned_by_token_program_does_not_subscribe_progra
     )
     .await;
 
-    // Delegation record reports SPL Token as the original owner program.
+    // Use SPL Token as the delegated owner.
     add_delegation_record_for(
         &rpc_client,
         account_pubkey,
@@ -3908,7 +3899,7 @@ async fn test_delegated_account_owned_by_token_program_does_not_subscribe_progra
         .await;
     assert!(result.is_ok());
 
-    // Give the fire-and-forget subscribe task a chance to run.
+    // Let the spawned subscription task run.
     tokio::time::sleep(Duration::from_millis(100)).await;
 
     let pubsub_client = remote_account_provider.pubsub_client();

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -3776,6 +3776,7 @@ async fn test_project_ata_skips_repeat_fetch_for_known_empty_eata() {
     // Leave the eATA absent so the first fetch returns NotFound.
     let FetcherTestCtx {
         remote_account_provider,
+        accounts_bank,
         rpc_client,
         subscription_tx,
         fetch_cloner,
@@ -3792,7 +3793,7 @@ async fn test_project_ata_skips_repeat_fetch_for_known_empty_eata() {
         RemoteAccount, RemoteAccountUpdateSource,
     };
 
-    let send_update = || {
+    let send_update = |slot| {
         let ata_account = ata_account.clone();
         let subscription_tx = subscription_tx.clone();
         async move {
@@ -3801,7 +3802,7 @@ async fn test_project_ata_skips_repeat_fetch_for_known_empty_eata() {
                     pubkey: ata_pubkey,
                     account: RemoteAccount::from_fresh_account(
                         ata_account,
-                        CURRENT_SLOT,
+                        slot,
                         RemoteAccountUpdateSource::Subscription,
                     ),
                 })
@@ -3815,7 +3816,7 @@ async fn test_project_ata_skips_repeat_fetch_for_known_empty_eata() {
 
     // Poll the cache entry, not the fetch counter, to avoid racing mark_eata_empty.
     let baseline_fetches = rpc_client.single_account_fetches();
-    send_update().await;
+    send_update(CURRENT_SLOT).await;
     tokio::time::timeout(TIMEOUT, async {
         while !fetch_cloner.is_known_empty_eata(&eata_pubkey) {
             tokio::time::sleep(POLL_INTERVAL).await;
@@ -3836,8 +3837,18 @@ async fn test_project_ata_skips_repeat_fetch_for_known_empty_eata() {
     );
 
     // Cache hits should avoid refetching while preserving the subscription.
-    send_update().await;
-    tokio::time::sleep(Duration::from_millis(150)).await;
+    const SECOND_SLOT: u64 = CURRENT_SLOT + 1;
+    send_update(SECOND_SLOT).await;
+    tokio::time::timeout(TIMEOUT, async {
+        while accounts_bank
+            .get_account(&ata_pubkey)
+            .is_none_or(|account| account.remote_slot() < SECOND_SLOT)
+        {
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+    })
+    .await
+    .expect("timed out waiting for banked ATA subscription update");
     assert_eq!(
         rpc_client.single_account_fetches(),
         after_first,

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -3761,3 +3761,143 @@ async fn test_delegated_eata_update_does_not_override_undelegating_ata_in_bank()
         "Undelegating ATA amount should keep local state",
     );
 }
+
+#[tokio::test]
+async fn test_project_ata_skips_repeat_fetch_for_known_empty_eata() {
+    init_logger();
+    let validator_keypair = Keypair::new();
+    let wallet_owner = random_pubkey();
+    let mint = random_pubkey();
+    const CURRENT_SLOT: u64 = 100;
+
+    let ata_pubkey = derive_ata(&wallet_owner, &mint);
+    let ata_account = create_ata_account(&wallet_owner, &mint);
+
+    // Note: the eATA is intentionally NOT present in the mock RPC so the
+    // upstream fetch returns NotFound, which is the case the negative
+    // cache must short-circuit on subsequent updates.
+    let FetcherTestCtx {
+        rpc_client,
+        subscription_tx,
+        ..
+    } = setup(
+        [(ata_pubkey, ata_account.clone())],
+        CURRENT_SLOT,
+        validator_keypair.insecure_clone(),
+    )
+    .await;
+
+    use crate::remote_account_provider::{
+        RemoteAccount, RemoteAccountUpdateSource,
+    };
+
+    let send_update = || {
+        let ata_account = ata_account.clone();
+        let subscription_tx = subscription_tx.clone();
+        async move {
+            subscription_tx
+                .send(ForwardedSubscriptionUpdate {
+                    pubkey: ata_pubkey,
+                    account: RemoteAccount::from_fresh_account(
+                        ata_account,
+                        CURRENT_SLOT,
+                        RemoteAccountUpdateSource::Subscription,
+                    ),
+                })
+                .await
+                .unwrap();
+        }
+    };
+
+    const POLL_INTERVAL: std::time::Duration = Duration::from_millis(10);
+    const TIMEOUT: std::time::Duration = Duration::from_millis(500);
+
+    // First update: triggers a real eATA fetch which returns NotFound and
+    // marks the eATA as known-empty.
+    let baseline_fetches = rpc_client.single_account_fetches();
+    send_update().await;
+    tokio::time::timeout(TIMEOUT, async {
+        while rpc_client.single_account_fetches() == baseline_fetches {
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+    })
+    .await
+    .expect("timed out waiting for initial eATA fetch");
+    let after_first = rpc_client.single_account_fetches();
+    assert!(
+        after_first > baseline_fetches,
+        "first ATA update should trigger an upstream eATA fetch"
+    );
+
+    // Second update for the same ATA: must be served by the negative
+    // cache without issuing any new upstream fetch.
+    send_update().await;
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    assert_eq!(
+        rpc_client.single_account_fetches(),
+        after_first,
+        "subsequent ATA updates for an already-known-empty eATA must not refetch"
+    );
+}
+
+#[tokio::test]
+async fn test_delegated_account_owned_by_token_program_does_not_subscribe_program(
+) {
+    use magicblock_core::token_programs::TOKEN_PROGRAM_ID;
+
+    init_logger();
+    let validator_keypair = Keypair::new();
+    let validator_pubkey = validator_keypair.pubkey();
+    const CURRENT_SLOT: u64 = 100;
+
+    let account_pubkey = random_pubkey();
+    let account = Account {
+        lamports: 1_000_000,
+        data: vec![1, 2, 3, 4],
+        owner: dlp_api::id(),
+        executable: false,
+        rent_epoch: 0,
+    };
+
+    let FetcherTestCtx {
+        remote_account_provider,
+        rpc_client,
+        fetch_cloner,
+        ..
+    } = setup(
+        [(account_pubkey, account.clone())],
+        CURRENT_SLOT,
+        validator_keypair.insecure_clone(),
+    )
+    .await;
+
+    // Delegation record reports SPL Token as the original owner program.
+    add_delegation_record_for(
+        &rpc_client,
+        account_pubkey,
+        validator_pubkey,
+        TOKEN_PROGRAM_ID,
+    );
+
+    let result = fetch_cloner
+        .fetch_and_clone_accounts(
+            &[account_pubkey],
+            None,
+            None,
+            AccountFetchOrigin::GetAccount,
+            None,
+        )
+        .await;
+    assert!(result.is_ok());
+
+    // Give the fire-and-forget subscribe task a chance to run.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let pubsub_client = remote_account_provider.pubsub_client();
+    let subscribed_programs = pubsub_client.subscribed_program_ids();
+    assert!(
+        !subscribed_programs.contains(&TOKEN_PROGRAM_ID),
+        "must never subscribe to SPL Token program (owns too many accounts), got: {:?}",
+        subscribed_programs
+    );
+}


### PR DESCRIPTION
## Summary

Two related fixes in `fetch_cloner` that together eliminate the dominant source of upstream JSON-RPC traffic from the validator (observed at ~21 not-found fetches/s, peaking around ~111/s = the `400k req/h` we were seeing on the upstream provider — 99.8% of all upstream account fetches with a 0% find rate):

- **Negative cache for known-empty eATAs.** Every subscription update for any SPL ATA used to fire a fresh `try_get_multi_until_slots_match(... ProjectAta)` for the derived eATA. The vast majority of cloned ATAs (wSOL ATAs, memecoin ATAs from active trader/sniper bots) have no corresponding eATA on chain, so each update produced a guaranteed not-found upstream call. We now keep a bounded LRU set of eATA pubkeys that have already been observed as non-existent and short-circuit the fetch on subsequent updates. **Crucially, the cache check happens *after* the (idempotent) `subscribe_to_account(eata)` call**, so the subscription LRU entry keeps getting promoted on every ATA update — if the eATA is created on chain later, the existing eATA-side subscription path (`maybe_build_projected_ata_clone_request_from_eata_sub_update`) projects the ATA without us needing to invalidate the cache.

- **Never subscribe to SPL Token / Token-2022 / Associated-Token-Account programs.** The existing blacklist (`native_program_accounts`) didn't cover these.

### Live evidence (mainnet-usa, before fix)

```
mbv_account_fetches_found_count{origin="project_ata"}     0
mbv_account_fetches_not_found_count{origin="project_ata"} 6,969,110
project_ata share of all upstream fetches                 99.8%
```

Hot accounts in the validator log decode to wSOL ATAs and pump.fun memecoin ATAs across a small cluster of trader wallets — nothing delegation-related, just incidental ATAs that the validator cloned and stayed subscribed to.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optimized subscription handling to avoid subscribing to core token programs.
  * Added a bounded negative cache for empty associated token accounts to skip redundant fetches.

* **Tests**
  * Added tests covering caching behavior for empty associated token accounts.
  * Added tests ensuring delegated accounts owned by token programs do not trigger subscriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->