### PR TITLE
chore: improve crank reliability over temporary failures

### DIFF
--- a/magicblock-task-scheduler/src/db.rs
+++ b/magicblock-task-scheduler/src/db.rs
@@ -181,6 +181,23 @@ impl SchedulerDatabase {
         Ok(())
     }
 
+    pub async fn move_task_to_failed(
+        &self,
+        task_id: i64,
+        error: String,
+    ) -> TaskSchedulerResult<()> {
+        let mut conn = self.conn.lock().await;
+        let tx = conn.transaction()?;
+        tx.execute("DELETE FROM tasks WHERE id = ?", [task_id])?;
+        tx.execute(
+            "INSERT INTO failed_tasks (timestamp, task_id, error) VALUES (?, ?, ?)",
+            params![Utc::now().timestamp_millis(), task_id, error],
+        )?;
+        tx.commit()?;
+
+        Ok(())
+    }
+
     pub async fn unschedule_task(
         &self,
         task_id: i64,

--- a/magicblock-task-scheduler/src/service.rs
+++ b/magicblock-task-scheduler/src/service.rs
@@ -30,6 +30,10 @@ use crate::{
     errors::{TaskSchedulerError, TaskSchedulerResult},
 };
 
+const MAX_TASK_EXECUTION_RETRIES: u32 = 10;
+const TASK_EXECUTION_RETRY_BASE_DELAY: Duration = Duration::from_millis(100);
+const TASK_EXECUTION_RETRY_MAX_DELAY: Duration = Duration::from_secs(5);
+
 pub struct TaskSchedulerService {
     /// Database for persisting tasks
     db: SchedulerDatabase,
@@ -43,6 +47,8 @@ pub struct TaskSchedulerService {
     task_queue: DelayQueue<DbTask>,
     /// Map of task IDs to their corresponding keys in the task queue
     task_queue_keys: HashMap<i64, Key>,
+    /// Number of consecutive failed execution attempts for each task
+    task_execution_retries: HashMap<i64, u32>,
     /// Counter used to make each transaction unique
     tx_counter: AtomicU64,
     /// Token used to cancel the task scheduler
@@ -96,6 +102,7 @@ impl TaskSchedulerService {
             block,
             task_queue: DelayQueue::new(),
             task_queue_keys: HashMap::new(),
+            task_execution_retries: HashMap::new(),
             tx_counter: AtomicU64::default(),
             token,
             min_interval: config.min_interval,
@@ -209,6 +216,7 @@ impl TaskSchedulerService {
         let Some(task) = self.db.get_task(cancel_request.task_id).await? else {
             // Task not found in the database, cleanup the queue
             self.remove_task_from_queue(cancel_request.task_id);
+            self.task_execution_retries.remove(&cancel_request.task_id);
             return Ok(());
         };
 
@@ -234,7 +242,7 @@ impl TaskSchedulerService {
         // we would have to fetch the transaction via its signature to see
         // if it succeeded or failed.
         // However that should not happen here, but on a separate task
-        // If any instruction fails, the task is cancelled
+        // If sending the transaction fails, the task is retried in run().
         debug!("Executed task {} with signature {}", task.id, sig);
 
         if task.executions_left > 1 {
@@ -277,6 +285,7 @@ impl TaskSchedulerService {
 
         self.db.insert_task(&task).await?;
         self.remove_task_from_queue(task.id);
+        self.task_execution_retries.remove(&task.id);
         let key = self
             .task_queue
             .insert(task.clone(), Duration::from_millis(0));
@@ -291,6 +300,7 @@ impl TaskSchedulerService {
         task_id: i64,
     ) -> TaskSchedulerResult<()> {
         self.remove_task_from_queue(task_id);
+        self.task_execution_retries.remove(&task_id);
         self.db.remove_task(task_id).await?;
         debug!("Removed task {} from database", task_id);
 
@@ -303,12 +313,13 @@ impl TaskSchedulerService {
                 Some(task) = self.task_queue.next() => {
                     let task = task.get_ref();
                     self.task_queue_keys.remove(&task.id);
-                    if let Err(e) = self.execute_task(task).await {
-                        error!("Failed to execute task {}: {}", task.id, e);
-
-                        // If any instruction fails, the task is cancelled
-                        self.db.remove_task(task.id).await?;
-                        self.db.insert_failed_task(task.id, format!("{:?}", e)).await?;
+                    match self.execute_task(task).await {
+                        Ok(()) => {
+                            self.task_execution_retries.remove(&task.id);
+                        }
+                        Err(e) => {
+                            self.handle_failed_task_execution(task, e).await?;
+                        }
                     }
                 }
                 Some(task) = self.scheduled_tasks.recv() => {
@@ -338,6 +349,70 @@ impl TaskSchedulerService {
         if let Some(key) = self.task_queue_keys.remove(&task_id) {
             self.task_queue.remove(&key);
         }
+    }
+
+    async fn handle_failed_task_execution(
+        &mut self,
+        task: &DbTask,
+        error: TaskSchedulerError,
+    ) -> TaskSchedulerResult<()> {
+        debug!("Failed to execute task {}: {}", task.id, error);
+
+        if !is_retryable_task_execution_error(&error) {
+            return self.record_failed_task(task, error).await;
+        }
+
+        let retries = self
+            .task_execution_retries
+            .get(&task.id)
+            .copied()
+            .unwrap_or_default();
+        if retries >= MAX_TASK_EXECUTION_RETRIES {
+            return self.record_failed_task(task, error).await;
+        }
+
+        let retries = retries + 1;
+        self.task_execution_retries.insert(task.id, retries);
+        let delay = self.task_execution_retry_delay(retries);
+        debug!(
+            task_id = task.id,
+            retry = retries,
+            max_retries = MAX_TASK_EXECUTION_RETRIES,
+            delay_ms = delay.as_millis(),
+            error = %error,
+            "Retrying failed task execution"
+        );
+
+        let key = self.task_queue.insert(task.clone(), delay);
+        self.task_queue_keys.insert(task.id, key);
+
+        Ok(())
+    }
+
+    async fn record_failed_task(
+        &mut self,
+        task: &DbTask,
+        error: TaskSchedulerError,
+    ) -> TaskSchedulerResult<()> {
+        self.task_execution_retries.remove(&task.id);
+        self.remove_task_from_queue(task.id);
+        self.db.remove_task(task.id).await?;
+        self.db
+            .insert_failed_task(task.id, format!("{:?}", error))
+            .await?;
+
+        Ok(())
+    }
+
+    fn task_execution_retry_delay(&self, retry: u32) -> Duration {
+        let multiplier = 1u32
+            .checked_shl(retry.saturating_sub(1))
+            .unwrap_or(u32::MAX);
+        self.slot_interval
+            .max(TASK_EXECUTION_RETRY_BASE_DELAY)
+            .checked_mul(multiplier)
+            .unwrap_or(TASK_EXECUTION_RETRY_MAX_DELAY)
+            .min(TASK_EXECUTION_RETRY_MAX_DELAY)
     }
 
     async fn process_transaction(
@@ -371,6 +446,11 @@ fn is_valid_task_interval(interval: i64) -> bool {
     interval > 0 && interval < u32::MAX as i64
 }
 
+fn is_retryable_task_execution_error(error: &TaskSchedulerError) -> bool {
+    // `process_transaction` maps Solana send and verification failures to Rpc.
+    matches!(error, TaskSchedulerError::Rpc(_))
+}
+
 #[cfg(test)]
 mod tests {
     use magicblock_program::{
@@ -396,6 +476,7 @@ mod tests {
             block: LatestBlock::default(),
             task_queue: DelayQueue::new(),
             task_queue_keys: HashMap::new(),
+            task_execution_retries: HashMap::new(),
             tx_counter: AtomicU64::default(),
             token: CancellationToken::new(),
             min_interval: Duration::from_millis(1000),
@@ -477,6 +558,7 @@ mod tests {
             block: LatestBlock::default(),
             task_queue: DelayQueue::new(),
             task_queue_keys: HashMap::new(),
+            task_execution_retries: HashMap::new(),
             tx_counter: AtomicU64::default(),
             token: CancellationToken::new(),
             min_interval: Duration::from_millis(1000),

--- a/magicblock-task-scheduler/src/service.rs
+++ b/magicblock-task-scheduler/src/service.rs
@@ -394,12 +394,11 @@ impl TaskSchedulerService {
         task: &DbTask,
         error: TaskSchedulerError,
     ) -> TaskSchedulerResult<()> {
+        self.db
+            .move_task_to_failed(task.id, format!("{:?}", error))
+            .await?;
         self.task_execution_retries.remove(&task.id);
         self.remove_task_from_queue(task.id);
-        self.db.remove_task(task.id).await?;
-        self.db
-            .insert_failed_task(task.id, format!("{:?}", error))
-            .await?;
 
         Ok(())
     }

--- a/test-integration/test-task-scheduler/tests/test_schedule_error.rs
+++ b/test-integration/test-task-scheduler/tests/test_schedule_error.rs
@@ -77,7 +77,7 @@ fn test_schedule_error() {
         let failed_tasks =
             expect!(runtime.block_on(db.get_failed_tasks()), validator);
         if failed_tasks.len() == 1
-            || started.elapsed() >= Duration::from_secs(25)
+            || started.elapsed() >= Duration::from_secs(45)
         {
             break failed_tasks;
         }

--- a/test-integration/test-task-scheduler/tests/test_schedule_error.rs
+++ b/test-integration/test-task-scheduler/tests/test_schedule_error.rs
@@ -1,3 +1,8 @@
+use std::{
+    thread::sleep,
+    time::{Duration, Instant},
+};
+
 use cleanass::{assert, assert_eq};
 use integration_test_tools::{expect, validator::cleanup};
 use magicblock_task_scheduler::SchedulerDatabase;
@@ -64,12 +69,20 @@ fn test_schedule_error() {
         validator
     );
 
-    // Wait for the task to be scheduled and executed
-    expect!(ctx.wait_for_delta_slot_ephem(10), validator);
-
-    // Check that the task was scheduled in the database
+    // Check that the task eventually exhausts retries
     let db = expect!(SchedulerDatabase::new(db_path), validator);
     let runtime = expect!(Runtime::new(), validator);
+    let started = Instant::now();
+    let failed_tasks = loop {
+        let failed_tasks =
+            expect!(runtime.block_on(db.get_failed_tasks()), validator);
+        if failed_tasks.len() == 1
+            || started.elapsed() >= Duration::from_secs(25)
+        {
+            break failed_tasks;
+        }
+        sleep(Duration::from_millis(200));
+    };
 
     let failed_scheduling =
         expect!(runtime.block_on(db.get_failed_schedulings()), validator);
@@ -81,8 +94,6 @@ fn test_schedule_error() {
         failed_scheduling,
     );
 
-    let failed_tasks =
-        expect!(runtime.block_on(db.get_failed_tasks()), validator);
     assert_eq!(
         failed_tasks.len(),
         1,
@@ -122,6 +133,8 @@ fn test_schedule_error() {
     );
 
     // Cancel the task
+    let ephem_blockhash =
+        expect!(ctx.try_get_latest_blockhash_ephem(), validator);
     let sig = expect!(
         ctx.send_transaction_ephem_with_preflight(
             &mut Transaction::new_signed_with_payer(


### PR DESCRIPTION
## Summary

-

## Compatibility
- [x] No breaking changes
- [ ] Config change (describe):
- [ ] Migration needed (describe):

## Testing
- [ ] tests (or explain)

## Checklist
- [ ] docs updated (if needed)
- [ ] closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Task execution failures now trigger automatic retries with exponential backoff and a retry limit for transient errors instead of immediate cancellation.
  * Permanently failed tasks are reliably recorded and removed from active scheduling.

* **Tests**
  * Integration test updated to poll for failed-task state and verify retry/failure behavior and cancellation flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->