### PR TITLE
fix: gate DLP program updates by delegation authority

### DIFF
--- a/magicblock-chainlink/src/chainlink/fetch_cloner/delegation.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/delegation.rs
@@ -103,7 +103,10 @@ where
 {
     let is_confined = delegation_record.authority.eq(&Pubkey::default());
     let is_delegated_to_us =
-        delegation_record.authority.eq(&this.validator_pubkey) || is_confined;
+        crate::delegation_record::is_delegated_to_validator_or_confined(
+            &delegation_record.authority,
+            &this.validator_pubkey,
+        );
     let is_raw_eata = parse_raw_eata_pda(
         &account_pubkey,
         account.data(),
@@ -154,8 +157,10 @@ where
     C: Cloner,
 {
     let is_delegated_to_us =
-        delegation_record.authority.eq(&this.validator_pubkey)
-            || delegation_record.authority.eq(&Pubkey::default());
+        crate::delegation_record::is_delegated_to_validator_or_confined(
+            &delegation_record.authority,
+            &this.validator_pubkey,
+        );
 
     (!is_delegated_to_us).then_some(delegation_record.authority)
 }

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -700,9 +700,11 @@ where
             return false;
         };
 
-        let is_delegated_to_us = deleg_record.authority
-            == self.validator_pubkey
-            || deleg_record.authority == Pubkey::default();
+        let is_delegated_to_us =
+            crate::delegation_record::is_delegated_to_validator_or_confined(
+                &deleg_record.authority,
+                &self.validator_pubkey,
+            );
         if !is_delegated_to_us {
             trace!(
                 pubkey = %pubkey,
@@ -1678,8 +1680,10 @@ where
 
             let delegated_on_chain =
                 deleg_record.as_ref().is_some_and(|(dr, _)| {
-                    dr.authority.eq(&self.validator_pubkey)
-                        || dr.authority.eq(&Pubkey::default())
+                    crate::delegation_record::is_delegated_to_validator_or_confined(
+                        &dr.authority,
+                        &self.validator_pubkey,
+                    )
                 });
             let deleg_record = deleg_record.map(|el| el.0);
             if !account_still_undelegating_on_chain(

--- a/magicblock-chainlink/src/chainlink/mod.rs
+++ b/magicblock-chainlink/src/chainlink/mod.rs
@@ -127,6 +127,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
             endpoints,
             commitment,
             tx,
+            validator_pubkey,
             &config.remote_account_provider,
         )
         .await?;

--- a/magicblock-chainlink/src/delegation_record.rs
+++ b/magicblock-chainlink/src/delegation_record.rs
@@ -270,7 +270,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn transport_gate_matrix() {
+    async fn should_forward_dlp_program_update_matrix() {
         let delegated_account_pubkey = Pubkey::new_unique();
         let delegation_record_pubkey =
             delegation_record_pda_from_delegated_account(

--- a/magicblock-chainlink/src/delegation_record.rs
+++ b/magicblock-chainlink/src/delegation_record.rs
@@ -60,6 +60,10 @@ pub(crate) async fn fetch_delegation_record_header<T: ChainRpcClient>(
         return Ok(None);
     };
 
+    if account.data.len() < DelegationRecord::size_with_discriminator() {
+        return Ok(None);
+    }
+
     parse_delegation_record_header(&account.data)
         .map(Some)
         .ok_or(FetchError::Deserialize)

--- a/magicblock-chainlink/src/delegation_record.rs
+++ b/magicblock-chainlink/src/delegation_record.rs
@@ -5,7 +5,9 @@ use solana_pubkey::Pubkey;
 use solana_rpc_client_api::config::RpcAccountInfoConfig;
 use tracing::{debug, trace};
 
-use crate::remote_account_provider::ChainRpcClient;
+use crate::remote_account_provider::{
+    pubsub_common::is_internal_dlp_account_data, ChainRpcClient,
+};
 
 pub(crate) fn is_delegated_to_validator_or_confined(
     authority: &Pubkey,
@@ -14,7 +16,6 @@ pub(crate) fn is_delegated_to_validator_or_confined(
     authority == validator_pubkey || authority == &Pubkey::default()
 }
 
-#[allow(dead_code)]
 pub(crate) fn parse_delegation_record_header(
     data: &[u8],
 ) -> Option<DelegationRecord> {
@@ -30,7 +31,6 @@ pub(crate) fn parse_delegation_record_header(
     .ok()
 }
 
-#[allow(dead_code)]
 pub(crate) async fn fetch_delegation_record_header<T: ChainRpcClient>(
     rpc_client: &T,
     delegated_account_pubkey: Pubkey,
@@ -54,13 +54,12 @@ pub(crate) async fn fetch_delegation_record_header<T: ChainRpcClient>(
     parse_delegation_record_header(&account.data)
 }
 
-#[allow(dead_code)]
 pub(crate) async fn should_forward_dlp_program_update<T: ChainRpcClient>(
     rpc_client: &T,
     validator_pubkey: &Pubkey,
     delegated_account_pubkey: Pubkey,
     owner: &Pubkey,
-    is_internal_dlp_account: bool,
+    account_data: &[u8],
     min_context_slot: u64,
     is_directly_subscribed: bool,
 ) -> bool {
@@ -71,7 +70,7 @@ pub(crate) async fn should_forward_dlp_program_update<T: ChainRpcClient>(
         trace!(pubkey = %delegated_account_pubkey, owner = %owner, "Dropping non-DLP program update");
         return false;
     }
-    if is_internal_dlp_account {
+    if is_internal_dlp_account_data(account_data) {
         trace!(pubkey = %delegated_account_pubkey, "Dropping internal DLP program update");
         return false;
     }
@@ -291,6 +290,7 @@ mod tests {
             .build();
 
         let delegated_account = make_dlp_owned_delegated_account_payload();
+        let internal_data = serialize_valid_delegation_record(validator_pubkey);
 
         assert!(
             should_forward_dlp_program_update(
@@ -298,7 +298,7 @@ mod tests {
                 &validator_pubkey,
                 delegated_account_pubkey,
                 &delegated_account.owner,
-                false,
+                delegated_account.data.as_slice(),
                 10,
                 true,
             )
@@ -312,7 +312,7 @@ mod tests {
                 &validator_pubkey,
                 delegated_account_pubkey,
                 &delegated_account.owner,
-                false,
+                delegated_account.data.as_slice(),
                 10,
                 false,
             )
@@ -341,7 +341,7 @@ mod tests {
                 &validator_pubkey,
                 delegated_account_pubkey,
                 &delegated_account.owner,
-                false,
+                delegated_account.data.as_slice(),
                 10,
                 false,
             )
@@ -356,7 +356,7 @@ mod tests {
                 &validator_pubkey,
                 delegated_account_pubkey,
                 &delegated_account.owner,
-                true,
+                internal_data.as_slice(),
                 10,
                 false,
             )

--- a/magicblock-chainlink/src/delegation_record.rs
+++ b/magicblock-chainlink/src/delegation_record.rs
@@ -65,11 +65,7 @@ pub(crate) async fn should_forward_dlp_program_update<T: ChainRpcClient>(
     owner: &Pubkey,
     account_data: &[u8],
     min_context_slot: u64,
-    is_directly_subscribed: bool,
 ) -> bool {
-    if is_directly_subscribed {
-        return true;
-    }
     if owner != &dlp_api::id() {
         trace!(pubkey = %delegated_account_pubkey, owner = %owner, "Dropping non-DLP program update");
         return false;
@@ -304,21 +300,6 @@ mod tests {
                 &delegated_account.owner,
                 delegated_account.data.as_slice(),
                 10,
-                true,
-            )
-            .await
-        );
-        assert_eq!(rpc_client.single_account_fetches(), 0);
-
-        assert!(
-            should_forward_dlp_program_update(
-                &rpc_client,
-                &validator_pubkey,
-                delegated_account_pubkey,
-                &delegated_account.owner,
-                delegated_account.data.as_slice(),
-                10,
-                false,
             )
             .await
         );
@@ -347,7 +328,6 @@ mod tests {
                 &delegated_account.owner,
                 delegated_account.data.as_slice(),
                 10,
-                false,
             )
             .await
         );
@@ -362,7 +342,6 @@ mod tests {
                 &delegated_account.owner,
                 internal_data.as_slice(),
                 10,
-                false,
             )
             .await
         );

--- a/magicblock-chainlink/src/delegation_record.rs
+++ b/magicblock-chainlink/src/delegation_record.rs
@@ -52,7 +52,7 @@ pub(crate) async fn fetch_delegation_record_header<T: ChainRpcClient>(
         .value?;
 
     if account.data.len() < DelegationRecord::size_with_discriminator() {
-        return Ok(None);
+        return None;
     }
 
     parse_delegation_record_header(&account.data)

--- a/magicblock-chainlink/src/delegation_record.rs
+++ b/magicblock-chainlink/src/delegation_record.rs
@@ -1,0 +1,54 @@
+use dlp_api::{
+    pda::delegation_record_pda_from_delegated_account, state::DelegationRecord,
+};
+use solana_pubkey::Pubkey;
+use solana_rpc_client_api::config::RpcAccountInfoConfig;
+
+use crate::remote_account_provider::ChainRpcClient;
+
+pub(crate) fn is_delegated_to_validator_or_confined(
+    authority: &Pubkey,
+    validator_pubkey: &Pubkey,
+) -> bool {
+    authority == validator_pubkey || authority == &Pubkey::default()
+}
+
+#[allow(dead_code)]
+pub(crate) fn parse_delegation_record_header(
+    data: &[u8],
+) -> Option<DelegationRecord> {
+    let delegation_record_size = DelegationRecord::size_with_discriminator();
+    if data.len() < delegation_record_size {
+        return None;
+    }
+
+    DelegationRecord::try_from_bytes_with_discriminator(
+        &data[..delegation_record_size],
+    )
+    .copied()
+    .ok()
+}
+
+#[allow(dead_code)]
+pub(crate) async fn fetch_delegation_record_header<T: ChainRpcClient>(
+    rpc_client: &T,
+    delegated_account_pubkey: Pubkey,
+    min_context_slot: u64,
+) -> Option<DelegationRecord> {
+    let delegation_record_pubkey =
+        delegation_record_pda_from_delegated_account(&delegated_account_pubkey);
+    let account = rpc_client
+        .get_account_with_config(
+            &delegation_record_pubkey,
+            RpcAccountInfoConfig {
+                commitment: Some(rpc_client.commitment()),
+                min_context_slot: Some(min_context_slot),
+                ..Default::default()
+            },
+        )
+        .await
+        .ok()?
+        .value?;
+
+    parse_delegation_record_header(&account.data)
+}

--- a/magicblock-chainlink/src/delegation_record.rs
+++ b/magicblock-chainlink/src/delegation_record.rs
@@ -2,8 +2,8 @@ use dlp_api::{
     pda::delegation_record_pda_from_delegated_account, state::DelegationRecord,
 };
 use solana_pubkey::Pubkey;
-use solana_rpc_client_api::config::RpcAccountInfoConfig;
-use tracing::{debug, trace};
+use solana_rpc_client_api::{client_error, config::RpcAccountInfoConfig};
+use tracing::{debug, trace, warn};
 
 use crate::remote_account_provider::{
     pubsub_common::is_internal_dlp_account_data, ChainRpcClient,
@@ -31,14 +31,20 @@ pub(crate) fn parse_delegation_record_header(
     .ok()
 }
 
+#[derive(Debug)]
+pub(crate) enum FetchError {
+    Transport(client_error::Error),
+    Deserialize,
+}
+
 pub(crate) async fn fetch_delegation_record_header<T: ChainRpcClient>(
     rpc_client: &T,
     delegated_account_pubkey: Pubkey,
     min_context_slot: u64,
-) -> Option<DelegationRecord> {
+) -> Result<Option<DelegationRecord>, FetchError> {
     let delegation_record_pubkey =
         delegation_record_pda_from_delegated_account(&delegated_account_pubkey);
-    let account = rpc_client
+    let Some(account) = rpc_client
         .get_account_with_config(
             &delegation_record_pubkey,
             RpcAccountInfoConfig {
@@ -48,14 +54,19 @@ pub(crate) async fn fetch_delegation_record_header<T: ChainRpcClient>(
             },
         )
         .await
-        .ok()?
-        .value?;
+        .map_err(FetchError::Transport)?
+        .value
+    else {
+        return Ok(None);
+    };
 
     if account.data.len() < DelegationRecord::size_with_discriminator() {
-        return None;
+        return Ok(None);
     }
 
     parse_delegation_record_header(&account.data)
+        .map(Some)
+        .ok_or(FetchError::Deserialize)
 }
 
 pub(crate) async fn should_forward_dlp_program_update<T: ChainRpcClient>(
@@ -75,15 +86,26 @@ pub(crate) async fn should_forward_dlp_program_update<T: ChainRpcClient>(
         return false;
     }
 
-    let Some(record) = fetch_delegation_record_header(
+    let record = match fetch_delegation_record_header(
         rpc_client,
         delegated_account_pubkey,
         min_context_slot,
     )
     .await
-    else {
-        trace!(pubkey = %delegated_account_pubkey, slot = min_context_slot, "Dropping DLP program update without delegation record");
-        return false;
+    {
+        Ok(Some(record)) => record,
+        Ok(None) => {
+            trace!(pubkey = %delegated_account_pubkey, slot = min_context_slot, "Dropping DLP program update without delegation record");
+            return false;
+        }
+        Err(FetchError::Transport(err)) => {
+            warn!(pubkey = %delegated_account_pubkey, slot = min_context_slot, error = %err, "Dropping DLP program update after delegation record fetch error");
+            return false;
+        }
+        Err(FetchError::Deserialize) => {
+            warn!(pubkey = %delegated_account_pubkey, slot = min_context_slot, "Dropping DLP program update after invalid delegation record data");
+            return false;
+        }
     };
 
     if is_delegated_to_validator_or_confined(
@@ -190,29 +212,29 @@ mod tests {
         };
 
         let missing_client = ChainRpcClientMockBuilder::new().slot(10).build();
-        assert_eq!(
+        assert!(matches!(
             fetch_delegation_record_header(
                 &missing_client,
                 delegated_account_pubkey,
                 10,
             )
             .await,
-            None
-        );
+            Ok(None)
+        ));
 
         let stale_client = ChainRpcClientMockBuilder::new()
             .slot(5)
             .account(delegation_record_pubkey, valid_account.clone())
             .build();
-        assert_eq!(
+        assert!(matches!(
             fetch_delegation_record_header(
                 &stale_client,
                 delegated_account_pubkey,
                 10,
             )
             .await,
-            None
-        );
+            Err(FetchError::Transport(_))
+        ));
 
         let short_client = ChainRpcClientMockBuilder::new()
             .slot(10)
@@ -227,15 +249,15 @@ mod tests {
                 },
             )
             .build();
-        assert_eq!(
+        assert!(matches!(
             fetch_delegation_record_header(
                 &short_client,
                 delegated_account_pubkey,
                 10,
             )
             .await,
-            None
-        );
+            Ok(None)
+        ));
 
         let invalid_client = ChainRpcClientMockBuilder::new()
             .slot(10)
@@ -254,15 +276,15 @@ mod tests {
                 },
             )
             .build();
-        assert_eq!(
+        assert!(matches!(
             fetch_delegation_record_header(
                 &invalid_client,
                 delegated_account_pubkey,
                 10,
             )
             .await,
-            None
-        );
+            Err(FetchError::Deserialize)
+        ));
     }
 
     #[tokio::test]

--- a/magicblock-chainlink/src/delegation_record.rs
+++ b/magicblock-chainlink/src/delegation_record.rs
@@ -3,6 +3,7 @@ use dlp_api::{
 };
 use solana_pubkey::Pubkey;
 use solana_rpc_client_api::config::RpcAccountInfoConfig;
+use tracing::{debug, trace};
 
 use crate::remote_account_provider::ChainRpcClient;
 
@@ -51,4 +52,316 @@ pub(crate) async fn fetch_delegation_record_header<T: ChainRpcClient>(
         .value?;
 
     parse_delegation_record_header(&account.data)
+}
+
+#[allow(dead_code)]
+pub(crate) async fn should_forward_dlp_program_update<T: ChainRpcClient>(
+    rpc_client: &T,
+    validator_pubkey: &Pubkey,
+    delegated_account_pubkey: Pubkey,
+    owner: &Pubkey,
+    is_internal_dlp_account: bool,
+    min_context_slot: u64,
+    is_directly_subscribed: bool,
+) -> bool {
+    if is_directly_subscribed {
+        return true;
+    }
+    if owner != &dlp_api::id() {
+        trace!(pubkey = %delegated_account_pubkey, owner = %owner, "Dropping non-DLP program update");
+        return false;
+    }
+    if is_internal_dlp_account {
+        trace!(pubkey = %delegated_account_pubkey, "Dropping internal DLP program update");
+        return false;
+    }
+
+    let Some(record) = fetch_delegation_record_header(
+        rpc_client,
+        delegated_account_pubkey,
+        min_context_slot,
+    )
+    .await
+    else {
+        trace!(pubkey = %delegated_account_pubkey, slot = min_context_slot, "Dropping DLP program update without delegation record");
+        return false;
+    };
+
+    if is_delegated_to_validator_or_confined(
+        &record.authority,
+        validator_pubkey,
+    ) {
+        true
+    } else {
+        debug!(pubkey = %delegated_account_pubkey, authority = %record.authority, "Dropping DLP program update delegated elsewhere");
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use dlp_api::pda::delegation_record_pda_from_delegated_account;
+    use solana_account::Account;
+    use solana_pubkey::Pubkey;
+
+    use super::*;
+    use crate::testing::rpc_client_mock::ChainRpcClientMockBuilder;
+
+    fn serialize_valid_delegation_record(authority: Pubkey) -> Vec<u8> {
+        let record = DelegationRecord {
+            owner: Pubkey::new_unique(),
+            authority,
+            commit_frequency_ms: 1_000,
+            delegation_slot: 42,
+            lamports: 1_000_000,
+        };
+        let mut data = vec![0; DelegationRecord::size_with_discriminator()];
+        record.to_bytes_with_discriminator(&mut data).unwrap();
+        data
+    }
+
+    fn append_trailing_bytes(mut data: Vec<u8>, trailing: &[u8]) -> Vec<u8> {
+        data.extend_from_slice(trailing);
+        data
+    }
+
+    fn make_dlp_owned_non_internal_account_data() -> Vec<u8> {
+        vec![0xde, 0xad, 0xbe, 0xef]
+    }
+
+    fn make_dlp_owned_delegated_account_payload() -> Account {
+        Account {
+            lamports: 1,
+            data: make_dlp_owned_non_internal_account_data(),
+            owner: dlp_api::id(),
+            executable: false,
+            rent_epoch: 0,
+        }
+    }
+
+    #[test]
+    fn predicate_matrix() {
+        let validator_pubkey = Pubkey::new_unique();
+        assert!(is_delegated_to_validator_or_confined(
+            &validator_pubkey,
+            &validator_pubkey
+        ));
+        assert!(is_delegated_to_validator_or_confined(
+            &Pubkey::default(),
+            &validator_pubkey
+        ));
+        assert!(!is_delegated_to_validator_or_confined(
+            &Pubkey::new_unique(),
+            &validator_pubkey
+        ));
+    }
+
+    #[test]
+    fn parse_header_accepts_trailing_bytes() {
+        let authority = Pubkey::new_unique();
+        let record = DelegationRecord {
+            owner: Pubkey::new_unique(),
+            authority,
+            commit_frequency_ms: 7,
+            delegation_slot: 9,
+            lamports: 11,
+        };
+        let mut data = vec![0; DelegationRecord::size_with_discriminator()];
+        record.to_bytes_with_discriminator(&mut data).unwrap();
+        let data = append_trailing_bytes(data, &[1, 2, 3, 4]);
+
+        assert_eq!(parse_delegation_record_header(&data), Some(record));
+    }
+
+    #[tokio::test]
+    async fn fetch_header_handles_missing_stale_short_and_invalid() {
+        let delegated_account_pubkey = Pubkey::new_unique();
+        let delegation_record_pubkey =
+            delegation_record_pda_from_delegated_account(
+                &delegated_account_pubkey,
+            );
+        let validator_pubkey = Pubkey::new_unique();
+        let valid_record = serialize_valid_delegation_record(validator_pubkey);
+        let valid_account = Account {
+            lamports: 1,
+            data: valid_record.clone(),
+            owner: dlp_api::id(),
+            executable: false,
+            rent_epoch: 0,
+        };
+
+        let missing_client = ChainRpcClientMockBuilder::new().slot(10).build();
+        assert_eq!(
+            fetch_delegation_record_header(
+                &missing_client,
+                delegated_account_pubkey,
+                10,
+            )
+            .await,
+            None
+        );
+
+        let stale_client = ChainRpcClientMockBuilder::new()
+            .slot(5)
+            .account(delegation_record_pubkey, valid_account.clone())
+            .build();
+        assert_eq!(
+            fetch_delegation_record_header(
+                &stale_client,
+                delegated_account_pubkey,
+                10,
+            )
+            .await,
+            None
+        );
+
+        let short_client = ChainRpcClientMockBuilder::new()
+            .slot(10)
+            .account(
+                delegation_record_pubkey,
+                Account {
+                    lamports: 1,
+                    data: vec![1, 2, 3],
+                    owner: dlp_api::id(),
+                    executable: false,
+                    rent_epoch: 0,
+                },
+            )
+            .build();
+        assert_eq!(
+            fetch_delegation_record_header(
+                &short_client,
+                delegated_account_pubkey,
+                10,
+            )
+            .await,
+            None
+        );
+
+        let invalid_client = ChainRpcClientMockBuilder::new()
+            .slot(10)
+            .account(
+                delegation_record_pubkey,
+                Account {
+                    lamports: 1,
+                    data: {
+                        let mut data = valid_record;
+                        data[0] ^= 0xff;
+                        data
+                    },
+                    owner: dlp_api::id(),
+                    executable: false,
+                    rent_epoch: 0,
+                },
+            )
+            .build();
+        assert_eq!(
+            fetch_delegation_record_header(
+                &invalid_client,
+                delegated_account_pubkey,
+                10,
+            )
+            .await,
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn transport_gate_matrix() {
+        let delegated_account_pubkey = Pubkey::new_unique();
+        let delegation_record_pubkey =
+            delegation_record_pda_from_delegated_account(
+                &delegated_account_pubkey,
+            );
+        let validator_pubkey = Pubkey::new_unique();
+        let delegated_elsewhere = Pubkey::new_unique();
+
+        let rpc_client = ChainRpcClientMockBuilder::new()
+            .slot(10)
+            .account(
+                delegation_record_pubkey,
+                Account {
+                    lamports: 1,
+                    data: serialize_valid_delegation_record(validator_pubkey),
+                    owner: dlp_api::id(),
+                    executable: false,
+                    rent_epoch: 0,
+                },
+            )
+            .build();
+
+        let delegated_account = make_dlp_owned_delegated_account_payload();
+
+        assert!(
+            should_forward_dlp_program_update(
+                &rpc_client,
+                &validator_pubkey,
+                delegated_account_pubkey,
+                &delegated_account.owner,
+                false,
+                10,
+                true,
+            )
+            .await
+        );
+        assert_eq!(rpc_client.single_account_fetches(), 0);
+
+        assert!(
+            should_forward_dlp_program_update(
+                &rpc_client,
+                &validator_pubkey,
+                delegated_account_pubkey,
+                &delegated_account.owner,
+                false,
+                10,
+                false,
+            )
+            .await
+        );
+        assert_eq!(rpc_client.single_account_fetches(), 1);
+
+        let elsewhere_rpc = ChainRpcClientMockBuilder::new()
+            .slot(10)
+            .account(
+                delegation_record_pubkey,
+                Account {
+                    lamports: 1,
+                    data: serialize_valid_delegation_record(
+                        delegated_elsewhere,
+                    ),
+                    owner: dlp_api::id(),
+                    executable: false,
+                    rent_epoch: 0,
+                },
+            )
+            .build();
+        assert!(
+            !should_forward_dlp_program_update(
+                &elsewhere_rpc,
+                &validator_pubkey,
+                delegated_account_pubkey,
+                &delegated_account.owner,
+                false,
+                10,
+                false,
+            )
+            .await
+        );
+        assert_eq!(elsewhere_rpc.single_account_fetches(), 1);
+
+        let internal_rpc = ChainRpcClientMockBuilder::new().slot(10).build();
+        assert!(
+            !should_forward_dlp_program_update(
+                &internal_rpc,
+                &validator_pubkey,
+                delegated_account_pubkey,
+                &delegated_account.owner,
+                true,
+                10,
+                false,
+            )
+            .await
+        );
+        assert_eq!(internal_rpc.single_account_fetches(), 0);
+    }
 }

--- a/magicblock-chainlink/src/delegation_record.rs
+++ b/magicblock-chainlink/src/delegation_record.rs
@@ -355,6 +355,32 @@ mod tests {
         );
         assert_eq!(elsewhere_rpc.single_account_fetches(), 1);
 
+        let unconfined_rpc = ChainRpcClientMockBuilder::new()
+            .slot(10)
+            .account(
+                delegation_record_pubkey,
+                Account {
+                    lamports: 1,
+                    data: serialize_valid_delegation_record(Pubkey::default()),
+                    owner: dlp_api::id(),
+                    executable: false,
+                    rent_epoch: 0,
+                },
+            )
+            .build();
+        assert!(
+            should_forward_dlp_program_update(
+                &unconfined_rpc,
+                &validator_pubkey,
+                delegated_account_pubkey,
+                &delegated_account.owner,
+                delegated_account.data.as_slice(),
+                10,
+            )
+            .await
+        );
+        assert_eq!(unconfined_rpc.single_account_fetches(), 1);
+
         let internal_rpc = ChainRpcClientMockBuilder::new().slot(10).build();
         assert!(
             !should_forward_dlp_program_update(

--- a/magicblock-chainlink/src/delegation_record.rs
+++ b/magicblock-chainlink/src/delegation_record.rs
@@ -51,6 +51,10 @@ pub(crate) async fn fetch_delegation_record_header<T: ChainRpcClient>(
         .ok()?
         .value?;
 
+    if account.data.len() < DelegationRecord::size_with_discriminator() {
+        return Ok(None);
+    }
+
     parse_delegation_record_header(&account.data)
 }
 

--- a/magicblock-chainlink/src/delegation_record.rs
+++ b/magicblock-chainlink/src/delegation_record.rs
@@ -60,10 +60,6 @@ pub(crate) async fn fetch_delegation_record_header<T: ChainRpcClient>(
         return Ok(None);
     };
 
-    if account.data.len() < DelegationRecord::size_with_discriminator() {
-        return Ok(None);
-    }
-
     parse_delegation_record_header(&account.data)
         .map(Some)
         .ok_or(FetchError::Deserialize)

--- a/magicblock-chainlink/src/lib.rs
+++ b/magicblock-chainlink/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod accounts_bank;
 pub mod chainlink;
 pub mod cloner;
+pub mod delegation_record;
 pub mod remote_account_provider;
 pub mod submux;
 

--- a/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/actor.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/actor.rs
@@ -783,7 +783,6 @@ impl<H: StreamHandle, S: StreamFactory<H>> ChainLaserActor<H, S> {
                     &owner,
                     &account.data,
                     slot,
-                    false,
                 )
                 .await
         };

--- a/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/actor.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/actor.rs
@@ -35,8 +35,8 @@ use crate::remote_account_provider::{
     chain_rpc_client::{ChainRpcClient, ChainRpcClientImpl},
     chain_slot::ChainSlot,
     pubsub_common::{
-        is_internal_dlp_account_data, ChainPubsubActorMessage,
-        MESSAGE_CHANNEL_SIZE, SUBSCRIPTION_UPDATE_CHANNEL_SIZE,
+        ChainPubsubActorMessage, MESSAGE_CHANNEL_SIZE,
+        SUBSCRIPTION_UPDATE_CHANNEL_SIZE,
     },
     RemoteAccountProviderError, RemoteAccountProviderResult,
     SubscriptionUpdate,
@@ -781,7 +781,7 @@ impl<H: StreamHandle, S: StreamFactory<H>> ChainLaserActor<H, S> {
                     &self.validator_pubkey,
                     pubkey,
                     &owner,
-                    is_internal_dlp_account_data(&account.data),
+                    &account.data,
                     slot,
                     false,
                 )

--- a/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/actor.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/actor.rs
@@ -122,6 +122,8 @@ pub struct ChainLaserActor<H: StreamHandle, S: StreamFactory<H>> {
     /// RPC client for diagnostics (e.g., fetching slot when
     /// falling behind)
     rpc_client: ChainRpcClientImpl,
+    /// Validator identity used for delegated-to-us gating
+    validator_pubkey: Pubkey,
     /// Duration for the time-based optimization interval
     optimization_interval_duration: Duration,
 }
@@ -135,6 +137,7 @@ impl ChainLaserActor<super::StreamHandleImpl, super::StreamFactoryImpl> {
         commitment: SolanaCommitmentLevel,
         abort_sender: mpsc::Sender<()>,
         slots: Slots,
+        validator_pubkey: Pubkey,
         rpc_client: ChainRpcClientImpl,
         grpc_config: &GrpcConfig,
     ) -> (
@@ -162,17 +165,20 @@ impl ChainLaserActor<super::StreamHandleImpl, super::StreamFactoryImpl> {
             commitment,
             abort_sender,
             slots,
+            validator_pubkey,
             rpc_client,
             grpc_config,
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         client_id: &str,
         laser_client_config: LaserstreamConfig,
         commitment: SolanaCommitmentLevel,
         abort_sender: mpsc::Sender<()>,
         slots: Slots,
+        validator_pubkey: Pubkey,
         rpc_client: ChainRpcClientImpl,
         grpc_config: &GrpcConfig,
     ) -> (
@@ -188,6 +194,7 @@ impl ChainLaserActor<super::StreamHandleImpl, super::StreamFactoryImpl> {
             commitment,
             abort_sender,
             slots,
+            validator_pubkey,
             rpc_client,
             grpc_config,
         )
@@ -196,12 +203,14 @@ impl ChainLaserActor<super::StreamHandleImpl, super::StreamFactoryImpl> {
 
 impl<H: StreamHandle, S: StreamFactory<H>> ChainLaserActor<H, S> {
     /// Create actor with a custom stream factory (for testing)
+    #[allow(clippy::too_many_arguments)]
     pub fn with_stream_factory(
         client_id: &str,
         stream_factory: S,
         commitment: SolanaCommitmentLevel,
         abort_sender: mpsc::Sender<()>,
         slots: Slots,
+        validator_pubkey: Pubkey,
         rpc_client: ChainRpcClientImpl,
         grpc_config: &GrpcConfig,
     ) -> (
@@ -241,8 +250,10 @@ impl<H: StreamHandle, S: StreamFactory<H>> ChainLaserActor<H, S> {
             slots,
             client_id: client_id.to_string(),
             rpc_client,
+            validator_pubkey,
             optimization_interval_duration,
         };
+        let _ = me.validator_pubkey;
 
         (
             me,

--- a/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/actor.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/actor.rs
@@ -772,10 +772,21 @@ impl<H: StreamHandle, S: StreamFactory<H>> ChainLaserActor<H, S> {
             );
         }
 
-        let should_forward = self.stream_manager.is_subscribed(&pubkey)
-            || matches!(source, AccountUpdateSource::Program)
-                && owner.eq(&dlp_api::id())
-                && !is_internal_dlp_account_data(&account.data);
+        let should_forward = if self.stream_manager.is_subscribed(&pubkey) {
+            true
+        } else {
+            matches!(source, AccountUpdateSource::Program)
+                && crate::delegation_record::should_forward_dlp_program_update(
+                    &self.rpc_client,
+                    &self.validator_pubkey,
+                    pubkey,
+                    &owner,
+                    is_internal_dlp_account_data(&account.data),
+                    slot,
+                    false,
+                )
+                .await
+        };
         if !should_forward {
             return;
         }

--- a/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/actor.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/actor.rs
@@ -253,8 +253,6 @@ impl<H: StreamHandle, S: StreamFactory<H>> ChainLaserActor<H, S> {
             validator_pubkey,
             optimization_interval_duration,
         };
-        let _ = me.validator_pubkey;
-
         (
             me,
             messages_sender,

--- a/magicblock-chainlink/src/remote_account_provider/chain_laser_client.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_laser_client.rs
@@ -67,6 +67,7 @@ impl ChainLaserClientImpl {
         commitment: CommitmentLevel,
         abort_sender: mpsc::Sender<()>,
         slots: Slots,
+        validator_pubkey: Pubkey,
         rpc_client: ChainRpcClientImpl,
         grpc_config: &GrpcConfig,
     ) -> Self {
@@ -79,6 +80,7 @@ impl ChainLaserClientImpl {
                 commitment,
                 abort_sender,
                 slots,
+                validator_pubkey,
                 rpc_client,
                 grpc_config,
             );

--- a/magicblock-chainlink/src/remote_account_provider/chain_pubsub_actor.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_pubsub_actor.rs
@@ -35,6 +35,7 @@ use super::{
     pubsub_connection_pool::PubSubConnectionPool,
 };
 use crate::remote_account_provider::{
+    chain_rpc_client::ChainRpcClientImpl,
     pubsub_common::{
         is_internal_dlp_account_data, AccountSubscription,
         ChainPubsubActorMessage, PubsubClientConfig, SubscriptionUpdate,
@@ -75,6 +76,10 @@ pub struct ChainPubsubActor {
     is_connected: Arc<AtomicBool>,
     /// Channel used to signal connection issues to the submux
     abort_sender: mpsc::Sender<()>,
+    /// Validator identity used for delegated-to-us gating
+    validator_pubkey: Pubkey,
+    /// RPC client used for delegation-record lookups
+    rpc_client: ChainRpcClientImpl,
 }
 
 impl Drop for ChainPubsubActor {
@@ -89,16 +94,27 @@ impl ChainPubsubActor {
         client_id: &str,
         abort_sender: mpsc::Sender<()>,
         commitment: CommitmentConfig,
+        validator_pubkey: Pubkey,
+        rpc_client: ChainRpcClientImpl,
     ) -> RemoteAccountProviderResult<(Self, mpsc::Receiver<SubscriptionUpdate>)>
     {
         let config = PubsubClientConfig::from_url(pubsub_url, commitment);
-        Self::new(client_id, abort_sender, config).await
+        Self::new(
+            client_id,
+            abort_sender,
+            config,
+            validator_pubkey,
+            rpc_client,
+        )
+        .await
     }
 
     pub async fn new(
         client_id: &str,
         abort_sender: mpsc::Sender<()>,
         pubsub_client_config: PubsubClientConfig,
+        validator_pubkey: Pubkey,
+        rpc_client: ChainRpcClientImpl,
     ) -> RemoteAccountProviderResult<(Self, mpsc::Receiver<SubscriptionUpdate>)>
     {
         let url = pubsub_client_config.pubsub_url.clone();
@@ -136,6 +152,8 @@ impl ChainPubsubActor {
             client_id: client_id.to_string(),
             is_connected: Arc::new(AtomicBool::new(true)),
             abort_sender,
+            validator_pubkey,
+            rpc_client,
         };
         me.start_worker(messages_receiver);
 
@@ -213,6 +231,8 @@ impl ChainPubsubActor {
         let client_id = self.client_id.clone();
         let is_connected = self.is_connected.clone();
         let abort_sender = self.abort_sender.clone();
+        let validator_pubkey = self.validator_pubkey;
+        let rpc_client = self.rpc_client.clone();
         tokio::spawn(async move {
             let mut pending_messages = FuturesUnordered::new();
             loop {
@@ -236,6 +256,8 @@ impl ChainPubsubActor {
                                 &client_id,
                                 is_connected,
                                 shutdown_token.clone(),
+                                validator_pubkey,
+                                rpc_client.clone(),
                                 msg
                             ));
                         } else {
@@ -252,7 +274,7 @@ impl ChainPubsubActor {
     }
 
     #[allow(clippy::too_many_arguments)]
-    #[instrument(skip(subscriptions, program_subs, pubsub_connection, subscription_updates_sender, pubsub_client_config, abort_sender, is_connected, shutdown_token, msg), fields(client_id = %client_id))]
+    #[instrument(skip(subscriptions, program_subs, pubsub_connection, subscription_updates_sender, pubsub_client_config, abort_sender, is_connected, shutdown_token, validator_pubkey, rpc_client, msg), fields(client_id = %client_id))]
     async fn handle_msg(
         subscriptions: Arc<Mutex<HashMap<Pubkey, AccountSubscription>>>,
         program_subs: Arc<Mutex<HashMap<Pubkey, AccountSubscription>>>,
@@ -263,6 +285,8 @@ impl ChainPubsubActor {
         client_id: &str,
         is_connected: Arc<AtomicBool>,
         shutdown_token: CancellationToken,
+        validator_pubkey: Pubkey,
+        rpc_client: ChainRpcClientImpl,
         msg: ChainPubsubActorMessage,
     ) {
         fn send_ok(
@@ -379,6 +403,8 @@ impl ChainPubsubActor {
                     is_connected,
                     commitment_config,
                     client_id,
+                    validator_pubkey,
+                    rpc_client,
                 )
                 .await;
             }
@@ -607,6 +633,8 @@ impl ChainPubsubActor {
         is_connected: Arc<AtomicBool>,
         commitment_config: CommitmentConfig,
         client_id: &str,
+        validator_pubkey: Pubkey,
+        rpc_client: ChainRpcClientImpl,
     ) {
         if program_subs
             .lock()
@@ -718,15 +746,29 @@ impl ChainPubsubActor {
                                     acc_pubkey,
                                     rpc_response,
                                 ));
-                                let should_forward = is_directly_subscribed
-                                    || program_pubkey.eq(&dlp_api::id())
-                                        && sub_update.account.as_ref().is_some_and(
-                                            |account| {
-                                                !is_internal_dlp_account_data(
-                                                    &account.data,
-                                                )
-                                            },
-                                        );
+                                let should_forward = if is_directly_subscribed {
+                                    true
+                                } else if !program_pubkey.eq(&dlp_api::id()) {
+                                    false
+                                } else if let Some(account) = sub_update.account.as_ref() {
+                                    if is_internal_dlp_account_data(&account.data) {
+                                        false
+                                    } else {
+                                        match crate::delegation_record::fetch_delegation_record_header(&rpc_client, acc_pubkey, sub_update.slot).await {
+                                            Some(record) if crate::delegation_record::is_delegated_to_validator_or_confined(&record.authority, &validator_pubkey) => true,
+                                            Some(record) => {
+                                                debug!(pubkey = %acc_pubkey, authority = %record.authority, "Dropping DLP program update delegated elsewhere");
+                                                false
+                                            }
+                                            None => {
+                                                debug!(pubkey = %acc_pubkey, slot = sub_update.slot, "Dropping DLP program update without delegation record");
+                                                false
+                                            }
+                                        }
+                                    }
+                                } else {
+                                    false
+                                };
 
                                 if should_forward {
                                     if acc_pubkey != clock::ID {

--- a/magicblock-chainlink/src/remote_account_provider/chain_pubsub_actor.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_pubsub_actor.rs
@@ -758,7 +758,6 @@ impl ChainPubsubActor {
                                         &account.owner,
                                         &account.data,
                                         sub_update.slot,
-                                        false,
                                     )
                                     .await
                                 } else {

--- a/magicblock-chainlink/src/remote_account_provider/chain_pubsub_actor.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_pubsub_actor.rs
@@ -37,9 +37,9 @@ use super::{
 use crate::remote_account_provider::{
     chain_rpc_client::ChainRpcClientImpl,
     pubsub_common::{
-        is_internal_dlp_account_data, AccountSubscription,
-        ChainPubsubActorMessage, PubsubClientConfig, SubscriptionUpdate,
-        MESSAGE_CHANNEL_SIZE, SUBSCRIPTION_UPDATE_CHANNEL_SIZE,
+        AccountSubscription, ChainPubsubActorMessage, PubsubClientConfig,
+        SubscriptionUpdate, MESSAGE_CHANNEL_SIZE,
+        SUBSCRIPTION_UPDATE_CHANNEL_SIZE,
     },
     pubsub_connection::PubsubConnectionImpl,
     DEFAULT_SUBSCRIPTION_RETRIES,
@@ -756,7 +756,7 @@ impl ChainPubsubActor {
                                         &validator_pubkey,
                                         acc_pubkey,
                                         &account.owner,
-                                        is_internal_dlp_account_data(&account.data),
+                                        &account.data,
                                         sub_update.slot,
                                         false,
                                     )

--- a/magicblock-chainlink/src/remote_account_provider/chain_pubsub_actor.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_pubsub_actor.rs
@@ -751,21 +751,16 @@ impl ChainPubsubActor {
                                 } else if !program_pubkey.eq(&dlp_api::id()) {
                                     false
                                 } else if let Some(account) = sub_update.account.as_ref() {
-                                    if is_internal_dlp_account_data(&account.data) {
-                                        false
-                                    } else {
-                                        match crate::delegation_record::fetch_delegation_record_header(&rpc_client, acc_pubkey, sub_update.slot).await {
-                                            Some(record) if crate::delegation_record::is_delegated_to_validator_or_confined(&record.authority, &validator_pubkey) => true,
-                                            Some(record) => {
-                                                debug!(pubkey = %acc_pubkey, authority = %record.authority, "Dropping DLP program update delegated elsewhere");
-                                                false
-                                            }
-                                            None => {
-                                                debug!(pubkey = %acc_pubkey, slot = sub_update.slot, "Dropping DLP program update without delegation record");
-                                                false
-                                            }
-                                        }
-                                    }
+                                    crate::delegation_record::should_forward_dlp_program_update(
+                                        &rpc_client,
+                                        &validator_pubkey,
+                                        acc_pubkey,
+                                        &account.owner,
+                                        is_internal_dlp_account_data(&account.data),
+                                        sub_update.slot,
+                                        false,
+                                    )
+                                    .await
                                 } else {
                                     false
                                 };

--- a/magicblock-chainlink/src/remote_account_provider/chain_pubsub_client.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_pubsub_client.rs
@@ -98,12 +98,16 @@ impl ChainPubsubClientImpl {
         abort_sender: mpsc::Sender<()>,
         commitment: CommitmentConfig,
         resubscription_delay: Duration,
+        validator_pubkey: Pubkey,
+        rpc_client: crate::remote_account_provider::chain_rpc_client::ChainRpcClientImpl,
     ) -> RemoteAccountProviderResult<Self> {
         let (actor, updates) = ChainPubsubActor::new_from_url(
             pubsub_url,
             &client_id,
             abort_sender,
             commitment,
+            validator_pubkey,
+            rpc_client,
         )
         .await?;
         let current_resub_delay_ms =

--- a/magicblock-chainlink/src/remote_account_provider/chain_updates_client.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_updates_client.rs
@@ -28,12 +28,14 @@ pub enum ChainUpdatesClient {
 }
 
 impl ChainUpdatesClient {
+    #[allow(clippy::too_many_arguments)]
     pub async fn try_new_from_endpoint(
         endpoint: &Endpoint,
         commitment: CommitmentConfig,
         abort_sender: mpsc::Sender<()>,
         chain_slot: Arc<AtomicU64>,
         resubscription_delay: std::time::Duration,
+        validator_pubkey: Pubkey,
         rpc_client: ChainRpcClientImpl,
         grpc_config: &GrpcConfig,
     ) -> RemoteAccountProviderResult<Self> {
@@ -54,6 +56,8 @@ impl ChainUpdatesClient {
                         abort_sender,
                         commitment,
                         resubscription_delay,
+                        validator_pubkey,
+                        rpc_client,
                     )
                     .await?,
                 ))
@@ -82,6 +86,7 @@ impl ChainUpdatesClient {
                         commitment.commitment,
                         abort_sender,
                         slots,
+                        validator_pubkey,
                         rpc_client,
                         grpc_config,
                     ),

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -170,6 +170,7 @@ impl
         endpoints: &Endpoints,
         commitment: CommitmentConfig,
         subscription_forwarder: mpsc::Sender<ForwardedSubscriptionUpdate>,
+        validator_pubkey: Pubkey,
         config: &RemoteAccountProviderConfig,
     ) -> ChainlinkResult<
         Option<
@@ -189,6 +190,7 @@ impl
                 endpoints,
                 commitment,
                 subscription_forwarder,
+                validator_pubkey,
                 config,
             )
             .await?;
@@ -316,6 +318,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
         endpoints: &Endpoints,
         commitment: CommitmentConfig,
         subscription_forwarder: mpsc::Sender<ForwardedSubscriptionUpdate>,
+        validator_pubkey: Pubkey,
         config: &RemoteAccountProviderConfig,
     ) -> RemoteAccountProviderResult<
         RemoteAccountProvider<
@@ -359,6 +362,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                     abort_tx,
                     chain_slot,
                     resubscription_delay,
+                    validator_pubkey,
                     rpc_client,
                     &grpc_cfg,
                 )

--- a/magicblock-chainlink/src/testing/chain_pubsub.rs
+++ b/magicblock-chainlink/src/testing/chain_pubsub.rs
@@ -17,11 +17,18 @@ pub async fn setup_actor_and_client() -> (
     RpcClient,
 ) {
     let (tx, _) = mpsc::channel(10);
+    let validator_pubkey = Pubkey::new_unique();
+    let rpc_client = crate::remote_account_provider::chain_rpc_client::ChainRpcClientImpl::new_from_url(
+        RPC_URL,
+        CommitmentConfig::confirmed(),
+    );
     let (actor, updates_rx) = ChainPubsubActor::new_from_url(
         PUBSUB_URL,
         "test-client",
         tx,
         CommitmentConfig::confirmed(),
+        validator_pubkey,
+        rpc_client,
     )
     .await
     .expect("failed to create ChainPubsubActor");

--- a/magicblock-chainlink/src/testing/rpc_client_mock.rs
+++ b/magicblock-chainlink/src/testing/rpc_client_mock.rs
@@ -286,12 +286,22 @@ impl ChainRpcClient for ChainRpcClientMock {
         config: RpcAccountInfoConfig,
     ) -> RpcResult<Option<Account>> {
         self.single_account_fetches.fetch_add(1, Ordering::Relaxed);
+        let current_slot = self.current_slot.load(Ordering::Relaxed);
+        if let Some(min_context_slot) = config.min_context_slot {
+            if current_slot < min_context_slot {
+                return Err(client_error::ErrorKind::Custom(
+                    "minimum context slot not reached".to_string(),
+                )
+                .into());
+            }
+        }
+
         let Some(AccountAtSlot { account, slot }) =
             self.get_account_at_slot(pubkey)
         else {
             return Ok(Response {
                 context: RpcResponseContext {
-                    slot: self.current_slot.load(Ordering::Relaxed),
+                    slot: current_slot,
                     api_version: None,
                 },
                 value: None,

--- a/magicblock-chainlink/src/testing/rpc_client_mock.rs
+++ b/magicblock-chainlink/src/testing/rpc_client_mock.rs
@@ -283,30 +283,37 @@ impl ChainRpcClient for ChainRpcClientMock {
     async fn get_account_with_config(
         &self,
         pubkey: &Pubkey,
-        _config: RpcAccountInfoConfig,
+        config: RpcAccountInfoConfig,
     ) -> RpcResult<Option<Account>> {
         self.single_account_fetches.fetch_add(1, Ordering::Relaxed);
-        let res = if let Some(AccountAtSlot { account, slot }) =
+        let Some(AccountAtSlot { account, slot }) =
             self.get_account_at_slot(pubkey)
-        {
-            Response {
-                context: RpcResponseContext {
-                    slot,
-                    api_version: None,
-                },
-                value: Some(account),
-            }
-        } else {
-            Response {
+        else {
+            return Ok(Response {
                 context: RpcResponseContext {
                     slot: self.current_slot.load(Ordering::Relaxed),
                     api_version: None,
                 },
                 value: None,
-            }
+            });
         };
 
-        Ok(res)
+        if let Some(min_context_slot) = config.min_context_slot {
+            if slot < min_context_slot {
+                return Err(client_error::ErrorKind::Custom(
+                    "minimum context slot not reached".to_string(),
+                )
+                .into());
+            }
+        }
+
+        Ok(Response {
+            context: RpcResponseContext {
+                slot,
+                api_version: None,
+            },
+            value: Some(account),
+        })
     }
 
     async fn get_multiple_accounts_with_config(

--- a/test-integration/test-chainlink/src/ixtest_context.rs
+++ b/test-integration/test-chainlink/src/ixtest_context.rs
@@ -113,6 +113,7 @@ impl IxtestContext {
                     &endpoints,
                     commitment,
                     tx,
+                    validator_kp.pubkey(),
                     &config.remote_account_provider,
                 )
                 .await;

--- a/test-integration/test-chainlink/tests/chain_pubsub_client.rs
+++ b/test-integration/test-chainlink/tests/chain_pubsub_client.rs
@@ -7,6 +7,7 @@ use std::{
 use magicblock_chainlink::{
     remote_account_provider::{
         chain_pubsub_client::{ChainPubsubClient, ChainPubsubClientImpl},
+        chain_rpc_client::ChainRpcClientImpl,
         pubsub_common::SubscriptionUpdate,
     },
     testing::{
@@ -30,6 +31,11 @@ async fn setup() -> (ChainPubsubClientImpl, mpsc::Receiver<SubscriptionUpdate>)
         tx,
         CommitmentConfig::confirmed(),
         Duration::from_millis(200),
+        Pubkey::new_unique(),
+        ChainRpcClientImpl::new_from_url(
+            RPC_URL,
+            CommitmentConfig::confirmed(),
+        ),
     )
     .await
     .unwrap();

--- a/test-integration/test-chainlink/tests/ix_remote_account_provider.rs
+++ b/test-integration/test-chainlink/tests/ix_remote_account_provider.rs
@@ -44,6 +44,7 @@ async fn init_remote_account_provider(
         &endpoints,
         CommitmentConfig::confirmed(),
         fwd_tx,
+        random_pubkey(),
         &RemoteAccountProviderConfig::default_with_lifecycle_mode(
             LifecycleMode::Ephemeral,
         ),


### PR DESCRIPTION
## Summary

Tightens program-subscription based account update forwarding so that DLP-owned account updates are only delivered when the account is actually delegated to this validator (or unconfined). Previously any DLP-owned account update that was not recognized as internal DLP state would be forwarded, which added accounts delegated to other validator into the bank without setting up a direct sub.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Program-sourced account updates now consult delegation records (including validator identity and confinement) before forwarding.

* **Refactor**
  * Delegation and confinement checks consolidated into a shared decision path used across discovery and subscription flows; validator identity is threaded into update clients and actors.

* **Bug Fixes**
  * RPC account fetches honor minimum-context-slot and correctly handle missing/stale/short account data.

* **Tests**
  * Added tests for delegation decisions, header parsing, fetch edge cases, and forwarding behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->