### PR TITLE
fix: slow shutdown due to scc garbage collection

### DIFF
--- a/magicblock-aperture/src/state/cache.rs
+++ b/magicblock-aperture/src/state/cache.rs
@@ -6,6 +6,8 @@ use std::{
 
 use parking_lot::Mutex;
 
+type CacheInner<K, V> = (HashMap<K, V>, VecDeque<ExpiringRecord<K>>);
+
 /// A thread-safe, expiring cache with lazy eviction.
 ///
 /// This cache stores key-value pairs for a specified duration (time-to-live).
@@ -14,7 +16,7 @@ use parking_lot::Mutex;
 /// when a new element is inserted via the [`push`] method. There is no background
 /// thread for cleanup.
 pub(crate) struct ExpiringCache<K, V> {
-    inner: Mutex<(HashMap<K, V>, VecDeque<ExpiringRecord<K>>)>,
+    inner: Mutex<CacheInner<K, V>>,
     /// The time-to-live for each entry from its moment of creation.
     ttl: Duration,
 }

--- a/magicblock-aperture/src/state/cache.rs
+++ b/magicblock-aperture/src/state/cache.rs
@@ -1,24 +1,20 @@
 use std::{
+    collections::{HashMap, VecDeque},
     hash::Hash,
     time::{Duration, Instant},
 };
 
+use parking_lot::Mutex;
+
 /// A thread-safe, expiring cache with lazy eviction.
 ///
 /// This cache stores key-value pairs for a specified duration (time-to-live).
-/// It is designed for concurrent access using lock-free data structures.
 ///
 /// Eviction of expired entries is performed **lazily**: the cache is only cleaned
 /// when a new element is inserted via the [`push`] method. There is no background
 /// thread for cleanup.
 pub(crate) struct ExpiringCache<K, V> {
-    /// A concurrent hash map providing fast, thread-safe key-value lookups.
-    index: scc::HashMap<K, V>,
-    /// A concurrent FIFO queue tracking the creation order of entries.
-    ///
-    /// This allows for efficient, ordered checks to find and evict the oldest
-    /// (and therefore most likely to be expired) entries.
-    queue: scc::Queue<ExpiringRecord<K>>,
+    inner: Mutex<(HashMap<K, V>, VecDeque<ExpiringRecord<K>>)>,
     /// The time-to-live for each entry from its moment of creation.
     ttl: Duration,
 }
@@ -31,12 +27,11 @@ struct ExpiringRecord<K> {
     genesis: Instant,
 }
 
-impl<K: Hash + Eq + Copy + 'static, V: Clone> ExpiringCache<K, V> {
+impl<K: Hash + Eq + Clone, V: Clone> ExpiringCache<K, V> {
     /// Creates a new `ExpiringCache` with a specified time-to-live (TTL) for all entries.
     pub(crate) fn new(ttl: Duration) -> Self {
         Self {
-            index: scc::HashMap::default(),
-            queue: scc::Queue::default(),
+            inner: Mutex::new((HashMap::new(), VecDeque::new())),
             ttl,
         }
     }
@@ -55,30 +50,31 @@ impl<K: Hash + Eq + Copy + 'static, V: Clone> ExpiringCache<K, V> {
     /// Returns `true` if the key was newly inserted, or `false` if the key
     /// already existed and its value was updated.
     pub(crate) fn push(&self, key: K, value: V) -> bool {
+        let mut guard = self.inner.lock();
+        let (index, queue) = &mut *guard;
+
         // Lazily evict expired entries from the front of the queue.
-        while let Ok(Some(expired)) = self.queue.pop_if(|e| e.expired(self.ttl))
-        {
-            self.index.remove(&expired.key);
+        while let Some(record) = queue.pop_front_if(|e| e.expired(self.ttl)) {
+            index.remove(&record.key);
         }
 
         // Insert or update the key-value pair.
-        let is_new = self.index.upsert(key, value).is_none();
-
+        let is_new = index.insert(key.clone(), value).is_none();
         // If the key is new, add a corresponding record to the expiration queue.
         if is_new {
-            self.queue.push(ExpiringRecord::new(key));
+            queue.push_back(ExpiringRecord::new(key));
         }
         is_new
     }
 
     /// Retrieves a clone of the value associated with the given key, if it exists.
     pub(crate) fn get(&self, key: &K) -> Option<V> {
-        self.index.read(key, |_, v| v.clone())
+        self.inner.lock().0.get(key).cloned()
     }
 
     /// Checks if the cache contains a value for the specified key.
     pub(crate) fn contains(&self, key: &K) -> bool {
-        self.index.contains(key)
+        self.inner.lock().0.contains_key(key)
     }
 }
 
@@ -86,8 +82,10 @@ impl<K> ExpiringRecord<K> {
     /// Creates a new record, capturing the current time as its genesis timestamp.
     #[inline]
     fn new(key: K) -> Self {
-        let genesis = Instant::now();
-        Self { key, genesis }
+        Self {
+            key,
+            genesis: Instant::now(),
+        }
     }
 
     /// Returns `true` if the time elapsed since creation is greater than or equal to the TTL.


### PR DESCRIPTION
<!--
PR title must match:
  type(scope): summary
Types: feat|fix|docs|chore|refactor|test|perf|ci|build
Examples:
  fix: avoid panic on empty slot
  feat(rpc): add getFoo endpoint
-->

## Summary
PR fixes slow shutdown due to scc garbage collection. scc usage removed from `ExpiringCache` as deemed slower than standart mutex due to slow lock free Queue implementation.

### Benchmark results
```
── 1. No eviction, unique keys per thread (TTL=100s, 10k keys) ──
  scc                                       4,201,583 ops/sec  (1.90s)
  mutex                                    14,003,408 ops/sec  (571.29ms)
  hybrid (scc map + mutex queue)            9,726,751 ops/sec  (822.47ms)
  → winner: mutex
    mutex  vs hybrid : 1.44x
    mutex  vs scc    : 3.33x
    hybrid vs scc    : 2.32x

── 2. Eviction, unique keys per thread (TTL=50ms, 10k prefill) ──
  scc                                       4,284,506 ops/sec  (1.87s)
  mutex                                    15,057,969 ops/sec  (531.28ms)
  hybrid (scc map + mutex queue)            9,349,980 ops/sec  (855.62ms)
  → winner: mutex
    mutex  vs hybrid : 1.61x
    mutex  vs scc    : 3.51x
    hybrid vs scc    : 2.18x

── 3. Eviction, shared key space (TTL=50ms, 1k keys, max contention) ──
  scc                                       4,683,964 ops/sec  (1.71s)
  mutex                                    16,135,903 ops/sec  (495.79ms)
  hybrid (scc map + mutex queue)            8,600,525 ops/sec  (930.18ms)
  → winner: mutex
    mutex  vs hybrid : 1.88x
    mutex  vs scc    : 3.44x
    hybrid vs scc    : 1.84x

── 4. Pure new-key churn, shared queue pressure (TTL=50ms) ──
  scc                                       1,509,699 ops/sec  (5.30s)
  mutex                                     3,875,144 ops/sec  (2.06s)
  hybrid (scc map + mutex queue)            2,940,586 ops/sec  (2.72s)
  → winner: mutex
    mutex  vs hybrid : 1.32x
    mutex  vs scc    : 2.57x
    hybrid vs scc    : 1.95x
```

Benchmark can be found [here](https://github.com/magicblock-labs/magicblock-validator/tree/feat/ttl-cache-bench/cache-bench)

## Compatibility
- [ ] No breaking changes
- [ ] Config change (describe):
- [ ] Migration needed (describe):

## Testing
- [ ] tests (or explain)

## Checklist
- [ ] docs updated (if needed)
- [ ] closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal performance optimizations to the caching mechanism. Public functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->