### PR TITLE
Restore greedy delegated account cloning

### DIFF
--- a/magicblock-chainlink/src/delegation_record.rs
+++ b/magicblock-chainlink/src/delegation_record.rs
@@ -95,12 +95,15 @@ pub(crate) async fn should_forward_dlp_program_update<T: ChainRpcClient>(
     {
         Ok(Some(record)) => record,
         Ok(None) => {
-            trace!(pubkey = %delegated_account_pubkey, slot = min_context_slot, "Dropping DLP program update without delegation record");
-            return false;
+            // Preserve greedy cloning when the subscription update wins the race
+            // against delegation-record visibility. FetchCloner refetches the
+            // record before cloning and only receives actions for this validator.
+            trace!(pubkey = %delegated_account_pubkey, slot = min_context_slot, "Forwarding DLP program update without visible delegation record");
+            return true;
         }
         Err(FetchError::Transport(err)) => {
-            warn!(pubkey = %delegated_account_pubkey, slot = min_context_slot, error = %err, "Dropping DLP program update after delegation record fetch error");
-            return false;
+            debug!(pubkey = %delegated_account_pubkey, slot = min_context_slot, error = %err, "Forwarding DLP program update after delegation record fetch error");
+            return true;
         }
         Err(FetchError::Deserialize) => {
             warn!(pubkey = %delegated_account_pubkey, slot = min_context_slot, "Dropping DLP program update after invalid delegation record data");
@@ -354,6 +357,47 @@ mod tests {
             .await
         );
         assert_eq!(elsewhere_rpc.single_account_fetches(), 1);
+
+        let missing_record_rpc =
+            ChainRpcClientMockBuilder::new().slot(10).build();
+        assert!(
+            should_forward_dlp_program_update(
+                &missing_record_rpc,
+                &validator_pubkey,
+                delegated_account_pubkey,
+                &delegated_account.owner,
+                delegated_account.data.as_slice(),
+                10,
+            )
+            .await
+        );
+        assert_eq!(missing_record_rpc.single_account_fetches(), 1);
+
+        let stale_record_rpc = ChainRpcClientMockBuilder::new()
+            .slot(5)
+            .account(
+                delegation_record_pubkey,
+                Account {
+                    lamports: 1,
+                    data: serialize_valid_delegation_record(validator_pubkey),
+                    owner: dlp_api::id(),
+                    executable: false,
+                    rent_epoch: 0,
+                },
+            )
+            .build();
+        assert!(
+            should_forward_dlp_program_update(
+                &stale_record_rpc,
+                &validator_pubkey,
+                delegated_account_pubkey,
+                &delegated_account.owner,
+                delegated_account.data.as_slice(),
+                10,
+            )
+            .await
+        );
+        assert_eq!(stale_record_rpc.single_account_fetches(), 1);
 
         let unconfined_rpc = ChainRpcClientMockBuilder::new()
             .slot(10)

--- a/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/stream_manager.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/stream_manager.rs
@@ -126,10 +126,10 @@ pub struct StreamManager<S: StreamHandle, SF: StreamFactory<S>> {
     stream_map: StreamMap<StreamKey, LaserStream>,
 
     /// Optional chain slot tracker for computing `from_slot`
-    /// during optimization. When set, optimized streams will
+    /// during optimization and program subscriptions. When set, streams will
     /// request backfill from a lookback window before the
     /// current chain slot so that no updates are missed while
-    /// the old streams are being replaced.
+    /// the old streams are being replaced or program subscriptions are created.
     /// For [Self::account_subscribe], `from_slot` is provided by
     /// the caller (actor).
     chain_slot: Option<ChainSlot>,
@@ -650,11 +650,15 @@ impl<S: StreamHandle, SF: StreamFactory<S>> StreamManager<S, SF> {
             return Ok(());
         }
 
+        let from_slot = self.compute_from_slot();
         if let Some((mut subscribed_programs, handle)) = self.program_sub.take()
         {
             subscribed_programs.insert(program_id);
-            let request =
-                Self::build_program_request(&subscribed_programs, commitment);
+            let request = Self::build_program_request(
+                &subscribed_programs,
+                commitment,
+                from_slot,
+            );
             match write_with_retry(&handle, "program_subscribe", request).await
             {
                 Ok(()) => {
@@ -669,7 +673,11 @@ impl<S: StreamHandle, SF: StreamFactory<S>> StreamManager<S, SF> {
             let mut subscribed_programs = HashSet::new();
             subscribed_programs.insert(program_id);
             let LaserStreamWithHandle { stream, handle } = self
-                .create_program_stream(&subscribed_programs, commitment)
+                .create_program_stream(
+                    &subscribed_programs,
+                    commitment,
+                    from_slot,
+                )
                 .await?;
             self.stream_map.insert(StreamKey::Program, stream);
             self.program_sub = Some((subscribed_programs, handle));
@@ -695,6 +703,7 @@ impl<S: StreamHandle, SF: StreamFactory<S>> StreamManager<S, SF> {
     fn build_program_request(
         program_ids: &HashSet<Pubkey>,
         commitment: &CommitmentLevel,
+        from_slot: Option<u64>,
     ) -> SubscribeRequest {
         let mut accounts = HashMap::new();
         accounts.insert(
@@ -708,6 +717,7 @@ impl<S: StreamHandle, SF: StreamFactory<S>> StreamManager<S, SF> {
         SubscribeRequest {
             accounts,
             commitment: Some((*commitment).into()),
+            from_slot,
             ..Default::default()
         }
     }
@@ -717,8 +727,10 @@ impl<S: StreamHandle, SF: StreamFactory<S>> StreamManager<S, SF> {
         &mut self,
         program_ids: &HashSet<Pubkey>,
         commitment: &CommitmentLevel,
+        from_slot: Option<u64>,
     ) -> RemoteAccountProviderResult<LaserStreamWithHandle<S>> {
-        let request = Self::build_program_request(program_ids, commitment);
+        let request =
+            Self::build_program_request(program_ids, commitment, from_slot);
         self.stream_factory.subscribe(request).await
     }
 }
@@ -1608,6 +1620,36 @@ mod tests {
         assert_eq!(handle_reqs.len(), 2);
         assert_eq!(handle_reqs[0].from_slot, Some(100));
         assert_eq!(handle_reqs[1].from_slot, Some(200));
+    }
+
+    #[tokio::test]
+    async fn test_program_subscribe_uses_from_slot_with_chain_slot() {
+        use std::sync::{atomic::AtomicU64, Arc};
+
+        let current_slot: u64 = 1000;
+        let chain_slot = ChainSlot::new(Arc::new(AtomicU64::new(current_slot)));
+        let factory = MockStreamFactory::new();
+        let mut mgr = StreamManager::new(
+            test_config(),
+            factory.clone(),
+            Some(chain_slot),
+            "test".to_string(),
+        );
+        let program_id = Pubkey::new_unique();
+
+        mgr.add_program_subscription(program_id, &COMMITMENT)
+            .await
+            .unwrap();
+
+        let expected_from_slot =
+            current_slot - ChainSlot::MAX_SLOTS_SUB_ACTIVATION;
+        let reqs = factory.captured_requests();
+        assert_eq!(reqs.len(), 1);
+        assert_eq!(reqs[0].from_slot, Some(expected_from_slot));
+
+        let handle_reqs = factory.handle_requests();
+        assert_eq!(handle_reqs.len(), 1);
+        assert_eq!(handle_reqs[0].from_slot, Some(expected_from_slot));
     }
 
     #[tokio::test]

--- a/test-integration/test-cloning/tests/10_post_delegation_token_transfer.rs
+++ b/test-integration/test-cloning/tests/10_post_delegation_token_transfer.rs
@@ -42,6 +42,20 @@ fn token_balance_ephem(
 
 #[test]
 fn test_post_delegation_action_executes_spl_token_transfer_100() {
+    run_post_delegation_action_executes_spl_token_transfer(true);
+}
+
+#[test]
+fn test_post_delegation_action_is_picked_up_by_greedy_clone() {
+    // Do not fetch the delegated account from the ER. The validator should
+    // greedily clone it from the base-layer subscription update and execute
+    // the post-delegation action.
+    run_post_delegation_action_executes_spl_token_transfer(false);
+}
+
+fn run_post_delegation_action_executes_spl_token_transfer(
+    trigger_fetch: bool,
+) {
     init_logger!();
     let ctx = IntegrationTestContext::try_new().unwrap();
 
@@ -202,16 +216,18 @@ fn test_post_delegation_action_executes_spl_token_transfer_100() {
         .unwrap();
     assert!(confirmed);
 
-    // Trigger delegated account clone; this is where post-delegation actions
-    // are executed on ephem.
-    ctx.fetch_ephem_account(delegated_account.pubkey()).unwrap();
+    if trigger_fetch {
+        // Trigger delegated account clone; this is where post-delegation actions
+        // are executed on ephem.
+        ctx.fetch_ephem_account(delegated_account.pubkey()).unwrap();
+    }
 
     // Poll briefly because clone + action execution is async relative to fetch.
     let mut found = None;
-    for _ in 0..30 {
+    for _ in 0..60 {
         let bx = token_balance_ephem(&ctx, &token_x);
         let by = token_balance_ephem(&ctx, &token_y);
-        if bx == Some(0) && by == Some(100) {
+        if bx == Some(0) && by == Some(300) {
             found = Some((bx, by));
             break;
         }

--- a/test-integration/test-cloning/tests/10_post_delegation_token_transfer.rs
+++ b/test-integration/test-cloning/tests/10_post_delegation_token_transfer.rs
@@ -53,9 +53,7 @@ fn test_post_delegation_action_is_picked_up_by_greedy_clone() {
     run_post_delegation_action_executes_spl_token_transfer(false);
 }
 
-fn run_post_delegation_action_executes_spl_token_transfer(
-    trigger_fetch: bool,
-) {
+fn run_post_delegation_action_executes_spl_token_transfer(trigger_fetch: bool) {
     init_logger!();
     let ctx = IntegrationTestContext::try_new().unwrap();
 


### PR DESCRIPTION
## Summary
- restore greedy cloning for DLP-owned delegated account subscription updates when the delegation record is not yet visible or the record fetch is temporarily stale

 PR #1181 made should_forward_dlp_program_update require a visible delegation record before forwarding a
  DLP-owned account update. That is too strict: the base-layer subscription update can arrive before the
  delegation record is fetchable at the requested slot. In that race, the validator dropped the account
  update, so FetchCloner never saw it and never got a chance to greedily refetch the record, clone the
  delegated account, and execute the attached action.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Better handling of delegation program updates when delegation records are missing or temporarily unreachable — such updates are now forwarded instead of dropped.

* **Tests**
  * Expanded integration tests for post-delegation token transfers, adding a scenario that exercises optimized account fetching and adjusted polling/validation for transfer completion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/magicblock-labs/magicblock-validator/pull/1192)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->