### PR TITLE
fix: exausted cranks remaining in the DB

### DIFF
--- a/magicblock-task-scheduler/src/service.rs
+++ b/magicblock-task-scheduler/src/service.rs
@@ -124,7 +124,7 @@ impl TaskSchedulerService {
         for task in tasks {
             debug!("Task: {:?}", task);
             if !is_valid_task_interval(task.execution_interval_millis)
-                || task.executions_left < 0
+                || task.executions_left <= 0
             {
                 warn!(
                     "Task {} has an invalid parameters: (interval={}, executions_left={}). Skipping.",
@@ -258,10 +258,14 @@ impl TaskSchedulerService {
             self.task_queue_keys.insert(task.id, key);
         }
 
-        let current_time = chrono::Utc::now().timestamp_millis();
-        self.db
-            .update_task_after_execution(task.id, current_time)
-            .await?;
+        if task.executions_left <= 1 {
+            self.db.remove_task(task.id).await?;
+        } else {
+            let current_time = chrono::Utc::now().timestamp_millis();
+            self.db
+                .update_task_after_execution(task.id, current_time)
+                .await?;
+        }
 
         Ok(())
     }
@@ -274,7 +278,9 @@ impl TaskSchedulerService {
 
         // Check if the task already exists in the database
         if let Some(db_task) = self.db.get_task(task.id).await? {
-            if db_task.authority != task.authority {
+            if db_task.executions_left > 0
+                && db_task.authority != task.authority
+            {
                 return Err(TaskSchedulerError::UnauthorizedReplacing(
                     task.id,
                     db_task.authority.to_string(),
@@ -573,6 +579,114 @@ mod tests {
             loop {
                 let tasks = db.get_tasks().await?;
                 if tasks.len() == 1 {
+                    return Ok::<_, TaskSchedulerError>(());
+                }
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+        })
+        .await
+        .unwrap()
+        .unwrap();
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn test_completed_task_does_not_block_reuse_by_different_authority() {
+        magicblock_core::logger::init_for_tests();
+        generate_validator_authority_if_needed();
+
+        let (_tx, rx) = mpsc::unbounded_channel();
+        let db = SchedulerDatabase::new(":memory:").unwrap();
+        let task_id = 44;
+        db.insert_task(&DbTask {
+            id: task_id,
+            authority: Pubkey::new_unique(),
+            execution_interval_millis: 50,
+            executions_left: 0,
+            last_execution_millis: chrono::Utc::now().timestamp_millis(),
+            instructions: vec![],
+        })
+        .await
+        .unwrap();
+
+        let mut service = TaskSchedulerService {
+            db: db.clone(),
+            rpc_client: RpcClient::new("http://localhost:8899".to_string()),
+            block: LatestBlock::default(),
+            task_queue: DelayQueue::new(),
+            task_queue_keys: HashMap::new(),
+            task_execution_retries: HashMap::new(),
+            tx_counter: AtomicU64::default(),
+            token: CancellationToken::new(),
+            min_interval: Duration::from_millis(10),
+            slot_interval: Duration::from_millis(1000),
+            scheduled_tasks: rx,
+        };
+
+        let replacement_authority = Pubkey::new_unique();
+        service
+            .register_task(&ScheduleTaskRequest {
+                id: task_id,
+                authority: replacement_authority,
+                execution_interval_millis: 50,
+                iterations: 1,
+                instructions: vec![],
+            })
+            .await
+            .unwrap();
+
+        let task = db.get_task(task_id).await.unwrap().unwrap();
+        assert_eq!(task.authority, replacement_authority);
+        assert_eq!(task.executions_left, 1);
+    }
+
+    #[tokio::test]
+    async fn test_completed_tasks_are_removed_on_startup() {
+        magicblock_core::logger::init_for_tests();
+
+        let (_tx, rx) = mpsc::unbounded_channel();
+        let db = SchedulerDatabase::new(":memory:").unwrap();
+        db.insert_task(&DbTask {
+            id: 1,
+            authority: Pubkey::new_unique(),
+            execution_interval_millis: 50,
+            executions_left: 0,
+            last_execution_millis: chrono::Utc::now().timestamp_millis(),
+            instructions: vec![],
+        })
+        .await
+        .unwrap();
+        db.insert_task(&DbTask {
+            id: 2,
+            authority: Pubkey::new_unique(),
+            execution_interval_millis: 50,
+            executions_left: 1,
+            last_execution_millis: chrono::Utc::now().timestamp_millis(),
+            instructions: vec![],
+        })
+        .await
+        .unwrap();
+
+        let service = TaskSchedulerService {
+            db: db.clone(),
+            rpc_client: RpcClient::new("http://localhost:8899".to_string()),
+            block: LatestBlock::default(),
+            task_queue: DelayQueue::new(),
+            task_queue_keys: HashMap::new(),
+            task_execution_retries: HashMap::new(),
+            tx_counter: AtomicU64::default(),
+            token: CancellationToken::new(),
+            min_interval: Duration::from_millis(10),
+            slot_interval: Duration::from_millis(1000),
+            scheduled_tasks: rx,
+        };
+
+        let handle = service.start().await.unwrap();
+
+        timeout(Duration::from_secs(1), async move {
+            loop {
+                let tasks = db.get_task_ids().await?;
+                if tasks == vec![2] {
                     return Ok::<_, TaskSchedulerError>(());
                 }
                 tokio::time::sleep(Duration::from_millis(100)).await;

--- a/magicblock-task-scheduler/src/service.rs
+++ b/magicblock-task-scheduler/src/service.rs
@@ -278,9 +278,7 @@ impl TaskSchedulerService {
 
         // Check if the task already exists in the database
         if let Some(db_task) = self.db.get_task(task.id).await? {
-            if db_task.executions_left > 0
-                && db_task.authority != task.authority
-            {
+            if db_task.authority != task.authority {
                 return Err(TaskSchedulerError::UnauthorizedReplacing(
                     task.id,
                     db_task.authority.to_string(),
@@ -588,56 +586,6 @@ mod tests {
         .unwrap()
         .unwrap();
         handle.abort();
-    }
-
-    #[tokio::test]
-    async fn test_completed_task_does_not_block_reuse_by_different_authority() {
-        magicblock_core::logger::init_for_tests();
-        generate_validator_authority_if_needed();
-
-        let (_tx, rx) = mpsc::unbounded_channel();
-        let db = SchedulerDatabase::new(":memory:").unwrap();
-        let task_id = 44;
-        db.insert_task(&DbTask {
-            id: task_id,
-            authority: Pubkey::new_unique(),
-            execution_interval_millis: 50,
-            executions_left: 0,
-            last_execution_millis: chrono::Utc::now().timestamp_millis(),
-            instructions: vec![],
-        })
-        .await
-        .unwrap();
-
-        let mut service = TaskSchedulerService {
-            db: db.clone(),
-            rpc_client: RpcClient::new("http://localhost:8899".to_string()),
-            block: LatestBlock::default(),
-            task_queue: DelayQueue::new(),
-            task_queue_keys: HashMap::new(),
-            task_execution_retries: HashMap::new(),
-            tx_counter: AtomicU64::default(),
-            token: CancellationToken::new(),
-            min_interval: Duration::from_millis(10),
-            slot_interval: Duration::from_millis(1000),
-            scheduled_tasks: rx,
-        };
-
-        let replacement_authority = Pubkey::new_unique();
-        service
-            .register_task(&ScheduleTaskRequest {
-                id: task_id,
-                authority: replacement_authority,
-                execution_interval_millis: 50,
-                iterations: 1,
-                instructions: vec![],
-            })
-            .await
-            .unwrap();
-
-        let task = db.get_task(task_id).await.unwrap().unwrap();
-        assert_eq!(task.authority, replacement_authority);
-        assert_eq!(task.executions_left, 1);
     }
 
     #[tokio::test]

--- a/test-integration/test-task-scheduler/tests/test_reschedule_task.rs
+++ b/test-integration/test-task-scheduler/tests/test_reschedule_task.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use cleanass::assert_eq;
 use integration_test_tools::{expect, validator::cleanup};
-use magicblock_task_scheduler::{db::DbTask, SchedulerDatabase};
+use magicblock_task_scheduler::SchedulerDatabase;
 use program_flexi_counter::{
     instruction::{create_cancel_task_ix, create_schedule_task_ix},
     state::FlexiCounter,
@@ -110,7 +110,7 @@ fn test_reschedule_task() {
         &mut validator,
     );
 
-    // Check that the task was scheduled in the database
+    // Check that the completed task was removed from the database
     let db = expect!(SchedulerDatabase::new(db_path), validator);
     let runtime = expect!(Runtime::new(), validator);
 
@@ -135,26 +135,15 @@ fn test_reschedule_task() {
     );
 
     let tasks = expect!(runtime.block_on(db.get_task_ids()), validator);
-    assert_eq!(tasks.len(), 1, cleanup(&mut validator));
-
-    let task = wait_for_task_executions_left(
-        &db,
-        &runtime,
-        task_id,
+    assert_eq!(
+        tasks.len(),
         0,
-        Duration::from_secs(10),
-        &ctx,
-        &mut validator,
+        cleanup(&mut validator),
+        "tasks: {:?}",
+        tasks
     );
-    let expected_task = DbTask {
-        id: task_id,
-        instructions: task.instructions.clone(),
-        authority: payer.pubkey(),
-        execution_interval_millis: new_execution_interval_millis,
-        executions_left: 0,
-        last_execution_millis: task.last_execution_millis,
-    };
-    assert_eq!(task, expected_task, cleanup(&mut validator));
+    let task = expect!(runtime.block_on(db.get_task(task_id)), validator);
+    assert_eq!(task, None, cleanup(&mut validator));
 
     // Cancel the task
     let sig = expect!(
@@ -186,46 +175,4 @@ fn test_reschedule_task() {
     assert_eq!(tasks.len(), 0, cleanup(&mut validator));
 
     cleanup(&mut validator);
-}
-
-fn wait_for_task_executions_left(
-    db: &SchedulerDatabase,
-    runtime: &Runtime,
-    task_id: i64,
-    expected: i64,
-    timeout: Duration,
-    ctx: &integration_test_tools::IntegrationTestContext,
-    validator: &mut std::process::Child,
-) -> DbTask {
-    let start = std::time::Instant::now();
-    while start.elapsed() < timeout {
-        let task = expect!(
-            runtime
-                .block_on(db.get_task(task_id))
-                .ok()
-                .flatten()
-                .ok_or(anyhow::anyhow!("Task not found")),
-            validator
-        );
-        if task.executions_left == expected {
-            return task;
-        }
-
-        expect!(ctx.wait_for_next_slot_ephem(), validator);
-    }
-
-    let task = expect!(
-        runtime
-            .block_on(db.get_task(task_id))
-            .ok()
-            .flatten()
-            .ok_or(anyhow::anyhow!("Task not found")),
-        validator
-    );
-    assert_eq!(
-        task.executions_left, expected,
-        cleanup(validator),
-        "task {} executions_left: {}", task_id, task.executions_left,
-    );
-    task
 }

--- a/test-integration/test-task-scheduler/tests/test_schedule_task.rs
+++ b/test-integration/test-task-scheduler/tests/test_schedule_task.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use cleanass::assert_eq;
 use integration_test_tools::{expect, validator::cleanup};
-use magicblock_task_scheduler::{db::DbTask, SchedulerDatabase};
+use magicblock_task_scheduler::SchedulerDatabase;
 use program_flexi_counter::{
     instruction::{create_cancel_task_ix, create_schedule_task_ix},
     state::FlexiCounter,
@@ -77,7 +77,7 @@ fn test_schedule_task() {
         &mut validator,
     );
 
-    // Check that the task was scheduled in the database
+    // Check that the completed task was removed from the database
     let db = expect!(SchedulerDatabase::new(db_path), validator);
     let runtime = expect!(Runtime::new(), validator);
 
@@ -102,25 +102,15 @@ fn test_schedule_task() {
     );
 
     let tasks = expect!(runtime.block_on(db.get_task_ids()), validator);
-    assert_eq!(tasks.len(), 1, cleanup(&mut validator));
-
-    let task = expect!(
-        runtime
-            .block_on(db.get_task(task_id))
-            .ok()
-            .flatten()
-            .ok_or(anyhow::anyhow!("Task not found")),
-        validator
+    assert_eq!(
+        tasks.len(),
+        0,
+        cleanup(&mut validator),
+        "tasks: {:?}",
+        tasks
     );
-    let expected_task = DbTask {
-        id: task_id,
-        instructions: task.instructions.clone(),
-        authority: payer.pubkey(),
-        execution_interval_millis: 100,
-        executions_left: 0,
-        last_execution_millis: task.last_execution_millis,
-    };
-    assert_eq!(task, expected_task, cleanup(&mut validator));
+    let task = expect!(runtime.block_on(db.get_task(task_id)), validator);
+    assert_eq!(task, None, cleanup(&mut validator));
 
     // Cancel the task
     let sig = expect!(

--- a/test-integration/test-task-scheduler/tests/test_unauthorized_reschedule.rs
+++ b/test-integration/test-task-scheduler/tests/test_unauthorized_reschedule.rs
@@ -8,9 +8,7 @@ use solana_sdk::{
     native_token::LAMPORTS_PER_SOL, signature::Keypair, signer::Signer,
     transaction::Transaction,
 };
-use test_task_scheduler::{
-    create_delegated_counter, setup_validator,
-};
+use test_task_scheduler::{create_delegated_counter, setup_validator};
 use tokio::runtime::Runtime;
 
 #[test]
@@ -157,8 +155,7 @@ fn test_unauthorized_reschedule() {
     );
     assert_eq!(task.authority, payer.pubkey(), cleanup(&mut validator));
     assert_eq!(
-        task.execution_interval_millis,
-        execution_interval_millis,
+        task.execution_interval_millis, execution_interval_millis,
         cleanup(&mut validator)
     );
     assert!(

--- a/test-integration/test-task-scheduler/tests/test_unauthorized_reschedule.rs
+++ b/test-integration/test-task-scheduler/tests/test_unauthorized_reschedule.rs
@@ -2,16 +2,14 @@ use std::time::{Duration, Instant};
 
 use cleanass::{assert, assert_eq};
 use integration_test_tools::{expect, validator::cleanup};
-use magicblock_task_scheduler::{db::DbTask, SchedulerDatabase};
-use program_flexi_counter::{
-    instruction::create_schedule_task_ix, state::FlexiCounter,
-};
+use magicblock_task_scheduler::SchedulerDatabase;
+use program_flexi_counter::instruction::create_schedule_task_ix;
 use solana_sdk::{
     native_token::LAMPORTS_PER_SOL, signature::Keypair, signer::Signer,
     transaction::Transaction,
 };
 use test_task_scheduler::{
-    create_delegated_counter, setup_validator, wait_for_incremented_counter,
+    create_delegated_counter, setup_validator,
 };
 use tokio::runtime::Runtime;
 
@@ -22,7 +20,6 @@ fn test_unauthorized_reschedule() {
 
     let payer = Keypair::new();
     let different_payer = Keypair::new();
-    let (counter_pda, _) = FlexiCounter::pda(&payer.pubkey());
 
     expect!(
         ctx.airdrop_chain(&payer.pubkey(), 10 * LAMPORTS_PER_SOL),
@@ -42,7 +39,7 @@ fn test_unauthorized_reschedule() {
     // Schedule a task
     let task_id = 1;
     let execution_interval_millis = 100;
-    let iterations = 2;
+    let iterations = 1000;
     let sig = expect!(
         ctx.send_transaction_ephem_with_preflight(
             &mut Transaction::new_signed_with_payer(
@@ -106,16 +103,6 @@ fn test_unauthorized_reschedule() {
         validator
     );
 
-    // Wait for the task to be processed
-    // Check that the counter was incremented
-    wait_for_incremented_counter(
-        &ctx,
-        &counter_pda,
-        iterations as u64,
-        Duration::from_secs(10),
-        &mut validator,
-    );
-
     // Check that one task is scheduled but another one is failed to schedule
     let db = expect!(SchedulerDatabase::new(db_path), validator);
     let runtime = expect!(Runtime::new(), validator);
@@ -168,15 +155,18 @@ fn test_unauthorized_reschedule() {
             .ok_or(anyhow::anyhow!("Task not found")),
         validator
     );
-    let expected_task = DbTask {
-        id: task_id,
-        instructions: task.instructions.clone(),
-        authority: payer.pubkey(),
+    assert_eq!(task.authority, payer.pubkey(), cleanup(&mut validator));
+    assert_eq!(
+        task.execution_interval_millis,
         execution_interval_millis,
-        executions_left: 0,
-        last_execution_millis: task.last_execution_millis,
-    };
-    assert_eq!(task, expected_task, cleanup(&mut validator));
+        cleanup(&mut validator)
+    );
+    assert!(
+        task.executions_left > 0,
+        cleanup(&mut validator),
+        "task.executions_left: {}",
+        task.executions_left
+    );
 
     cleanup(&mut validator);
 }


### PR DESCRIPTION
## Summary

Fixes task scheduler stale completed-task rows blocking new cranks with the same ID.

  - Treats tasks DB rows as active tasks only.
  - Removes a task from the DB after its final execution instead of leaving it with executions_left = 0.
  - Purges non-active persisted tasks on scheduler startup.
  - Keeps different-authority replacement rejected while an existing task is still active.
  - Updates scheduler integration tests to assert completed tasks are removed, while reschedule and unauthorized replacement behavior remain covered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Behavior Changes**
  * Completed tasks are now automatically removed from the database after execution finishes.
  * Task IDs can be reused by different authorities once the original task completes.
  * Improved startup cleanup to remove expired tasks with zero remaining executions.

* **Improvements**
  * Enhanced task database maintenance for better resource management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/magicblock-labs/magicblock-validator/pull/1194)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->