### PR TITLE
fix: do not interact with chain in non-primary mode

### DIFF
--- a/magicblock-api/src/domain_registry_manager.rs
+++ b/magicblock-api/src/domain_registry_manager.rs
@@ -13,7 +13,7 @@ use solana_commitment_config::CommitmentConfig;
 use solana_instruction::{AccountMeta, Instruction};
 use solana_keypair::Keypair;
 use solana_pubkey::Pubkey;
-use solana_rpc_client::rpc_client::RpcClient;
+use solana_rpc_client::nonblocking::rpc_client::RpcClient;
 use solana_sdk_ids::system_program;
 use solana_signer::Signer;
 use solana_transaction::Transaction;
@@ -33,7 +33,7 @@ impl DomainRegistryManager {
         }
     }
 
-    pub fn fetch_validator_info(
+    pub async fn fetch_validator_info(
         &self,
         account_pubkey: &Pubkey,
     ) -> Result<Option<ErRecord>, Error> {
@@ -43,6 +43,7 @@ impl DomainRegistryManager {
                 account_pubkey,
                 CommitmentConfig::confirmed(),
             )
+            .await
             .context(format!(
                 "Failed to get account: {} from server: {}",
                 account_pubkey,
@@ -58,7 +59,7 @@ impl DomainRegistryManager {
             .transpose()
     }
 
-    fn register(
+    async fn register(
         &self,
         payer: &Keypair,
         validator_info: ErRecord,
@@ -69,12 +70,13 @@ impl DomainRegistryManager {
             pda,
             mdp::instructions::Instruction::Register(validator_info),
         )
+        .await
         .context("Failed to send register tx")?;
 
         Ok(())
     }
 
-    pub fn sync(
+    pub async fn sync(
         &self,
         payer: &Keypair,
         validator_info: &ErRecord,
@@ -98,6 +100,7 @@ impl DomainRegistryManager {
                 sync_info,
             )),
         )
+        .await
         .context("Could not send sync transaction")?;
 
         Ok(())
@@ -108,55 +111,57 @@ impl DomainRegistryManager {
         Pubkey::find_program_address(&seeds, &ID)
     }
 
-    pub fn unregister(&self, payer: &Keypair) -> Result<(), Error> {
+    pub async fn unregister(&self, payer: &Keypair) -> Result<(), Error> {
         let (pda, _) = Self::get_pda(&payer.pubkey());
 
         // Verify existence to avoid failed tx costs
         let _ = self
-            .fetch_validator_info(&pda)?
+            .fetch_validator_info(&pda)
+            .await?
             .ok_or(Error::NoRegisteredValidatorError)?;
         self.send_instruction(
             payer,
             pda,
             mdp::instructions::Instruction::Unregister(payer.pubkey()),
         )
+        .await
         .context("Failed to unregister")?;
 
         Ok(())
     }
 
-    pub fn handle_registration(
+    pub async fn handle_registration(
         &self,
         payer: &Keypair,
         validator_info: ErRecord,
     ) -> Result<(), Error> {
-        match self.fetch_validator_info(&validator_info.pda().0)? {
+        match self.fetch_validator_info(&validator_info.pda().0).await? {
             Some(current_validator_info) => {
                 if current_validator_info == validator_info {
                     info!("Domain registry record up to date");
                     Ok(())
                 } else {
                     info!("Domain registry record requires update");
-                    self.sync(payer, &validator_info)
+                    self.sync(payer, &validator_info).await
                 }
             }
             None => {
                 info!("Domain registry record absent, registering");
-                self.register(payer, validator_info)
+                self.register(payer, validator_info).await
             }
         }
     }
 
-    pub fn handle_registration_static(
+    pub async fn handle_registration_static(
         url: impl ToString,
         payer: &Keypair,
         validator_info: ErRecord,
     ) -> Result<(), Error> {
         let manager = DomainRegistryManager::new(url);
-        manager.handle_registration(payer, validator_info)
+        manager.handle_registration(payer, validator_info).await
     }
 
-    fn send_instruction<T: borsh::BorshSerialize>(
+    async fn send_instruction<T: borsh::BorshSerialize>(
         &self,
         payer: &Keypair,
         pda: Pubkey,
@@ -173,6 +178,7 @@ impl DomainRegistryManager {
         let recent_blockhash = self
             .client
             .get_latest_blockhash()
+            .await
             .context("Failed to get latest blockhash")?;
         let transaction = Transaction::new_signed_with_payer(
             &[instruction],
@@ -183,17 +189,18 @@ impl DomainRegistryManager {
 
         self.client
             .send_and_confirm_transaction(&transaction)
+            .await
             .context("Failed to send and confirm transaction")?;
         Ok(())
     }
 
-    pub fn handle_unregistration_static(
+    pub async fn handle_unregistration_static(
         url: impl ToString,
         payer: &Keypair,
     ) -> Result<(), Error> {
         info!("Unregistering validator from domain registry");
         let manager = DomainRegistryManager::new(url);
-        manager.unregister(payer)
+        manager.unregister(payer).await
     }
 }
 

--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -39,6 +39,7 @@ use magicblock_config::{
     ValidatorParams,
 };
 use magicblock_core::{
+    coordination_mode::CoordinationMode,
     link::{
         link,
         transactions::{SchedulerMode, TransactionSchedulerHandle},
@@ -630,18 +631,20 @@ impl MagicValidator {
         Ok(())
     }
 
-    #[instrument(skip(self), fields(identity = %self.identity))]
+    #[instrument(skip(config))]
     async fn register_validator_on_chain(
-        &self,
+        rpc_url: &str,
         config: &ChainOperationConfig,
+        block_time_ms: u64,
+        base_fee: u64,
     ) -> ApiResult<()> {
         let country_code = CountryCode::from(config.country_code.alpha3());
         let validator_keypair = validator_authority();
         let validator_info = ErRecord::V0(RecordV0 {
             identity: validator_keypair.pubkey(),
             status: ErStatus::Active,
-            block_time_ms: self.config.ledger.block_time_ms() as u16,
-            base_fee: self.config.validator.basefee as u16,
+            block_time_ms: block_time_ms as u16,
+            base_fee: base_fee as u16,
             features: FeaturesSet::default(),
             load_average: 0,
             country_code,
@@ -649,21 +652,23 @@ impl MagicValidator {
         });
 
         DomainRegistryManager::handle_registration_static(
-            self.config.rpc_url(),
+            rpc_url,
             &validator_keypair,
             validator_info,
         )
+        .await
         .map_err(|err| {
             ApiError::FailedToRegisterValidatorOnChain(err.to_string())
         })
     }
 
-    fn unregister_validator_on_chain(&self) -> ApiResult<()> {
+    async fn unregister_validator_on_chain(&self) -> ApiResult<()> {
         let validator_keypair = validator_authority();
         DomainRegistryManager::handle_unregistration_static(
             self.config.rpc_url(),
             &validator_keypair,
         )
+        .await
         .map_err(|err| {
             ApiError::FailedToUnregisterValidatorOnChain(err.to_string())
         })
@@ -792,9 +797,14 @@ impl MagicValidator {
 
     #[instrument(skip(self))]
     pub async fn start(&mut self) -> ApiResult<()> {
-        if matches!(self.config.lifecycle, LifecycleMode::Ephemeral) {
+        if matches!(self.config.lifecycle, LifecycleMode::Ephemeral)
+            && CoordinationMode::current().needs_onchain_interactions()
+        {
             let rpc_url = self.config.rpc_url().to_owned();
             let identity = self.identity;
+            let chain_operation_config = self.config.chain_operation.clone();
+            let block_time_ms = self.config.ledger.block_time_ms();
+            let base_fee = self.config.validator.basefee;
             // Ephemeral mode does a non-blocking startup balance check.
             // Intentionally fire-and-forget: the task itself exits the process on failure,
             tokio::spawn(async move {
@@ -816,9 +826,10 @@ impl MagicValidator {
                 }
 
                 let step_start = Instant::now();
-                let result =
-                    MagicValidator::ensure_magic_fee_vault_on_chain(rpc_url)
-                        .await;
+                let result = MagicValidator::ensure_magic_fee_vault_on_chain(
+                    rpc_url.clone(),
+                )
+                .await;
                 log_timing(
                     "startup_background",
                     "ensure_magic_fee_vault_on_chain",
@@ -832,16 +843,27 @@ impl MagicValidator {
                     error!("Exiting process");
                     std::process::exit(1);
                 }
+                if let Some(ref config) = chain_operation_config {
+                    let step_start = Instant::now();
+                    if let Err(error) =
+                        MagicValidator::register_validator_on_chain(
+                            &rpc_url,
+                            config,
+                            block_time_ms,
+                            base_fee,
+                        )
+                        .await
+                    {
+                        error!(%error, "Validator registration failed, exitting");
+                        std::process::exit(1);
+                    }
+                    log_timing(
+                        "startup_background",
+                        "register_validator_on_chain",
+                        step_start,
+                    );
+                }
             });
-            if let Some(ref config) = self.config.chain_operation {
-                let step_start = Instant::now();
-                self.register_validator_on_chain(config).await?;
-                log_timing(
-                    "startup",
-                    "register_validator_on_chain",
-                    step_start,
-                );
-            }
         }
 
         // Ledger processing needs to happen before anything of the below
@@ -881,6 +903,9 @@ impl MagicValidator {
             .config
             .chain_operation
             .as_ref()
+            .filter(|_| {
+                CoordinationMode::current().needs_onchain_interactions()
+            })
             .filter(|co| !co.claim_fees_frequency.is_zero())
             .map(|co| co.claim_fees_frequency)
         {
@@ -975,9 +1000,10 @@ impl MagicValidator {
 
         if self.config.chain_operation.is_some()
             && matches!(self.config.lifecycle, LifecycleMode::Ephemeral)
+            && CoordinationMode::current().needs_onchain_interactions()
         {
             let step_start = Instant::now();
-            if let Err(err) = self.unregister_validator_on_chain() {
+            if let Err(err) = self.unregister_validator_on_chain().await {
                 error!(error = ?err, "Failed to unregister");
             }
             log_timing("shutdown", "unregister_validator_on_chain", step_start);


### PR DESCRIPTION


## Summary
In non primary mode (replication) validator doesn't need to make any on chain interactions, or might even fail them, thus preventing the validator startup. This PR gates those interactions based on current mode 


## Breaking Changes
- [x] None



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Moved validator on-chain registration into a background startup task; failures are logged and cause immediate process exit.
  * Startup/shutdown of on-chain interactions (fee claiming and unregistration) now respect the current coordination mode.
  * On-chain registry operations converted to async/nonblocking, improving network responsiveness and making registration/unregistration awaitable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/magicblock-labs/magicblock-validator/pull/1195)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->