### PR TITLE
fix: use multithreaded runtime in domain registry test

### DIFF
--- a/test-integration/test-magicblock-api/tests/test_domain_registry.rs
+++ b/test-integration/test-magicblock-api/tests/test_domain_registry.rs
@@ -96,7 +96,7 @@ async fn test_unregister() {
     assert!(actual.is_none());
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_domain_registry() {
     let client = RpcClient::new_with_commitment(
         DEVNET_URL,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated domain registry integration test to run with multi-threaded Tokio runtime configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/magicblock-labs/magicblock-validator/pull/1199)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->