### PR TITLE
fix: do not voluntarily relinquish the replication lock

### DIFF
--- a/magicblock-replicator/src/nats/mod.rs
+++ b/magicblock-replicator/src/nats/mod.rs
@@ -45,7 +45,7 @@ mod cfg {
 
     // Timeouts
     pub const TTL_STREAM: Duration = Duration::from_secs(24 * 60 * 60);
-    pub const TTL_LOCK: Duration = Duration::from_secs(5);
+    pub const TTL_LOCK: Duration = Duration::from_secs(15);
     pub const ACK_WAIT: Duration = Duration::from_secs(30);
     pub const API_TIMEOUT: Duration = Duration::from_secs(2);
     pub const DUP_WINDOW: Duration = Duration::from_secs(30);

--- a/magicblock-replicator/src/nats/mod.rs
+++ b/magicblock-replicator/src/nats/mod.rs
@@ -47,7 +47,7 @@ mod cfg {
     pub const TTL_STREAM: Duration = Duration::from_secs(24 * 60 * 60);
     pub const TTL_LOCK: Duration = Duration::from_secs(15);
     pub const ACK_WAIT: Duration = Duration::from_secs(30);
-    pub const API_TIMEOUT: Duration = Duration::from_secs(2);
+    pub const API_TIMEOUT: Duration = Duration::from_secs(5);
     pub const DUP_WINDOW: Duration = Duration::from_secs(30);
 
     // Reconnect backoff (exponential: 100ms base, 5s max)

--- a/magicblock-replicator/src/service/mod.rs
+++ b/magicblock-replicator/src/service/mod.rs
@@ -48,7 +48,7 @@ use crate::{nats::Broker, Result};
 // =============================================================================
 
 pub(crate) const LOCK_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
-pub(crate) const LEADER_TIMEOUT: Duration = Duration::from_secs(5);
+pub(crate) const LEADER_TIMEOUT: Duration = Duration::from_secs(15);
 const CONSUMER_RETRY_DELAY: Duration = Duration::from_secs(1);
 
 // =============================================================================

--- a/magicblock-replicator/src/service/primary.rs
+++ b/magicblock-replicator/src/service/primary.rs
@@ -73,9 +73,6 @@ impl Primary {
                     }
                 }
                 _ = self.ctx.cancel.cancelled() => {
-                    if let Err(error) = self.producer.release().await {
-                        warn!(%error, "failed to release producer lock");
-                    }
                     info!("shutdown received, terminating primary mode");
                     return Ok(None);
                 }


### PR DESCRIPTION
This PR disables automatic relinquishment of replication lock by primary node, which should allow the leader to perform quick restart without failover to other standby nodes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased lock and API timeout durations to 15 seconds to reduce premature timeouts and give operations more time to complete.
  * Simplified primary replication shutdown flow by removing explicit lock release on shutdown, yielding cleaner and more predictable termination behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/magicblock-labs/magicblock-validator/pull/1211?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->