### PR TITLE
fix: joinset result ordering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4217,6 +4217,7 @@ dependencies = [
 name = "magicblock-rpc-client"
 version = "0.10.0"
 dependencies = [
+ "futures-util",
  "solana-account",
  "solana-account-decoder-client-types",
  "solana-address-lookup-table-interface",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4239,6 +4239,7 @@ dependencies = [
 name = "magicblock-rpc-client"
 version = "0.10.1"
 dependencies = [
+ "futures-util",
  "solana-account 3.4.0",
  "solana-account-decoder-client-types",
  "solana-address-lookup-table-interface 3.1.0",

--- a/magicblock-rpc-client/Cargo.toml
+++ b/magicblock-rpc-client/Cargo.toml
@@ -28,6 +28,7 @@ solana-address-lookup-table-interface = { workspace = true, features = [
   "bincode",
   "bytemuck",
 ] }
+futures-util = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 

--- a/magicblock-rpc-client/src/lib.rs
+++ b/magicblock-rpc-client/src/lib.rs
@@ -7,6 +7,7 @@ use std::{
     time::{Duration, Instant},
 };
 
+use futures_util::future::try_join_all;
 use solana_account::Account;
 use solana_account_decoder_client_types::UiAccountEncoding;
 use solana_address_lookup_table_interface::state::{
@@ -32,7 +33,7 @@ use solana_transaction_error::{TransactionError, TransactionResult};
 use solana_transaction_status_client_types::{
     EncodedConfirmedTransactionWithStatusMeta, UiTransactionEncoding,
 };
-use tokio::{task::JoinSet, time::sleep};
+use tokio::time::sleep;
 use tracing::*;
 
 /// The encoding to use when sending transactions
@@ -323,27 +324,17 @@ impl MagicblockRpcClient {
         max_per_fetch: Option<usize>,
     ) -> MagicBlockRpcClientResult<Vec<Option<Account>>> {
         let max_per_fetch = max_per_fetch.unwrap_or(MAX_MULTIPLE_ACCOUNTS);
-
-        let mut join_set = JoinSet::new();
-        for pubkey_chunk in pubkeys.chunks(max_per_fetch) {
-            let client = self.client.clone();
-            let pubkeys = pubkey_chunk.to_vec();
+        let futs = pubkeys.chunks(max_per_fetch).map(|pubkey_chunk| {
             let config = config.clone();
-            join_set.spawn(async move {
-                client
-                    .get_multiple_accounts_with_config(&pubkeys, config)
+            async move {
+                self.client
+                    .get_multiple_accounts_with_config(pubkey_chunk, config)
                     .await
-            });
-        }
-        let chunked_results = join_set.join_all().await;
-        let mut results = Vec::new();
-        for result in chunked_results {
-            match result {
-                Ok(accs) => results.extend(accs.value),
-                Err(err) => return Err(err.into()),
+                    .map(|r| r.value)
+                    .map_err(MagicBlockRpcClientError::from)
             }
-        }
-        Ok(results)
+        });
+        Ok(try_join_all(futs).await?.into_iter().flatten().collect())
     }
 
     pub async fn get_lookup_table_meta(

--- a/test-integration/Cargo.lock
+++ b/test-integration/Cargo.lock
@@ -4767,6 +4767,7 @@ dependencies = [
 name = "magicblock-rpc-client"
 version = "0.10.0"
 dependencies = [
+ "futures-util",
  "solana-account",
  "solana-account-decoder-client-types",
  "solana-address-lookup-table-interface",


### PR DESCRIPTION
<!--
PR title must match: type(scope): summary
Types: feat|fix|docs|chore|refactor|test|perf|ci|build
Examples:
  fix: avoid panic on empty slot
  feat(rpc): add getFoo endpoint
-->

## Summary
JoinSet returns results in **completion** order not in scheduled order, as result with 2 chunks the returns acc data could correspond to different pubkey.

## Breaking Changes
- [ ] None
- [ ] Yes — migration path described below


## Test Plan
<!-- How you verified this works. e.g., "unit tests", "ran locally against testnet", "existing tests pass" -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized concurrent account fetching operations with improved error handling semantics for faster error detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/magicblock-labs/magicblock-validator/pull/1214?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->