### PR TITLE
fix: race/order violation of intents

### DIFF
--- a/magicblock-committor-service/src/intent_execution_manager.rs
+++ b/magicblock-committor-service/src/intent_execution_manager.rs
@@ -85,26 +85,21 @@ impl<D: DB> IntentExecutionManager<D> {
             return Ok(());
         }
 
-        for el in intent_bundles {
-            let err = if let Err(err) = self.intent_sender.try_send(el) {
-                err
-            } else {
-                continue;
-            };
-
-            match err {
-                TrySendError::Closed(_) => {
-                    Err(IntentExecutionManagerError::ChannelClosed)
-                }
-                TrySendError::Full(el) => self
-                    .db
-                    .store_intent_bundle(el)
+        let mut iter = intent_bundles.into_iter();
+        let res = iter.try_for_each(|el| self.intent_sender.try_send(el));
+        match res {
+            Ok(_) => Ok(()),
+            Err(TrySendError::Closed(_)) => {
+                Err(IntentExecutionManagerError::ChannelClosed)
+            }
+            Err(TrySendError::Full(el)) => {
+                let leftovers = std::iter::once(el).chain(iter).collect();
+                self.db
+                    .store_intent_bundles(leftovers)
                     .await
-                    .map_err(IntentExecutionManagerError::from),
-            }?;
+                    .map_err(IntentExecutionManagerError::from)
+            }
         }
-
-        Ok(())
     }
 
     /// Creates a subscription for results of BaseIntent execution

--- a/magicblock-committor-service/src/intent_execution_manager.rs
+++ b/magicblock-committor-service/src/intent_execution_manager.rs
@@ -86,6 +86,8 @@ impl<D: DB> IntentExecutionManager<D> {
         }
 
         let mut iter = intent_bundles.into_iter();
+        // Treated as regular value not propagated lower
+        #[allow(clippy::result_large_err)]
         let res = iter.try_for_each(|el| self.intent_sender.try_send(el));
         match res {
             Ok(_) => Ok(()),

--- a/magicblock-committor-service/src/intent_execution_manager/db.rs
+++ b/magicblock-committor-service/src/intent_execution_manager/db.rs
@@ -18,7 +18,7 @@ pub trait DB: Send + Sync + 'static {
         intent_bundles: Vec<ScheduledIntentBundle>,
     ) -> DBResult<()>;
 
-    /// Returns intent with smallest id
+    /// Returns the oldest (first stored) intent bundle
     async fn pop_intent_bundle(
         &self,
     ) -> DBResult<Option<ScheduledIntentBundle>>;


### PR DESCRIPTION
<!--
PR title must match: type(scope): summary
Types: feat|fix|docs|chore|refactor|test|perf|ci|build
Examples:
  fix: avoid panic on empty slot
  feat(rpc): add getFoo endpoint
-->

## Summary
<!-- One sentence. Link to issue if applicable. -->
Replaced the per-item loop with try_for_each. On the first `Full` error, the failed item and all remaining items are collected and stored to DB atomically (std::iter::once(el).chain(iter)). Since try_send is synchronous there are no yield points between iterations, making the interleave impossible. 

## Breaking Changes
- [ ] None
- [x] Yes — migration path described below


## Test Plan
<!-- How you verified this works. e.g., "unit tests", "ran locally against testnet", "existing tests pass" -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved batch scheduling of intents to send more efficiently and handle channel backpressure by persisting remaining bundles when needed.

* **Documentation**
  * Clarified database docstring describing retrieval of the oldest (first stored) intent bundle.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/magicblock-labs/magicblock-validator/pull/1217?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->