### PR TITLE
feat: improve restart time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3735,7 +3735,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-aml"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "futures-util",
  "magicblock-config",

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -16,8 +16,12 @@ use config::RemoteAccountProviderConfig;
 pub(crate) use errors::{
     RemoteAccountProviderError, RemoteAccountProviderResult,
 };
-use futures_util::future::{join_all, try_join_all};
+use futures_util::{
+    future::{join_all, try_join_all},
+    stream::{FuturesUnordered, StreamExt},
+};
 pub use lru_cache::AccountsLruCache;
+use magicblock_config::config::GrpcConfig;
 pub(crate) use remote_account::RemoteAccount;
 pub use remote_account::RemoteAccountUpdateSource;
 use solana_account::Account;
@@ -83,6 +87,104 @@ use crate::{
 
 const ACTIVE_SUBSCRIPTIONS_UPDATE_INTERVAL_MS: u64 = 60_000;
 pub(crate) const DEFAULT_SUBSCRIPTION_RETRIES: usize = 5;
+
+type ChainUpdatesPubsub = (Arc<ChainUpdatesClient>, mpsc::Receiver<()>);
+
+async fn connect_pubsub_client(
+    ep: Endpoint,
+    commitment: CommitmentConfig,
+    rpc_client: ChainRpcClientImpl,
+    chain_slot: Arc<AtomicU64>,
+    resubscription_delay: Duration,
+    grpc_cfg: GrpcConfig,
+) -> (String, RemoteAccountProviderResult<ChainUpdatesPubsub>) {
+    let ep_label = ep.label().to_string();
+    let (abort_tx, abort_rx) = mpsc::channel(1);
+    let client = ChainUpdatesClient::try_new_from_endpoint(
+        &ep,
+        commitment,
+        abort_tx,
+        chain_slot,
+        resubscription_delay,
+        rpc_client,
+        &grpc_cfg,
+    )
+    .await;
+    (ep_label, client.map(|c| (Arc::new(c), abort_rx)))
+}
+
+fn collect_connected_pubsubs(
+    results: Vec<(String, RemoteAccountProviderResult<ChainUpdatesPubsub>)>,
+) -> Vec<ChainUpdatesPubsub> {
+    results
+        .into_iter()
+        .filter_map(|(label, result)| match result {
+            Ok(client) => Some(client),
+            Err(err) => {
+                warn!(
+                    endpoint = %label,
+                    error = %err,
+                    "Skipping pubsub client that failed to connect"
+                );
+                None
+            }
+        })
+        .collect()
+}
+
+#[allow(clippy::too_many_arguments)]
+fn spawn_deferred_pubsub_clients(
+    endpoints: Vec<Endpoint>,
+    commitment: CommitmentConfig,
+    rpc_client: ChainRpcClientImpl,
+    chain_slot: Arc<AtomicU64>,
+    resubscription_delay: Duration,
+    grpc_cfg: GrpcConfig,
+    submux: SubMuxClient<ChainUpdatesClient>,
+    subscribed_accounts: Arc<AccountsLruCache>,
+) {
+    tokio::spawn(async move {
+        let mut pubsub_futs = endpoints
+            .into_iter()
+            .map(|ep| {
+                connect_pubsub_client(
+                    ep,
+                    commitment,
+                    rpc_client.clone(),
+                    chain_slot.clone(),
+                    resubscription_delay,
+                    grpc_cfg.clone(),
+                )
+            })
+            .collect::<FuturesUnordered<_>>();
+        while let Some((label, result)) = pubsub_futs.next().await {
+            let (client, abort_rx) = match result {
+                Ok(client) => client,
+                Err(err) => {
+                    warn!(
+                        endpoint = %label,
+                        error = %err,
+                        "Skipping deferred pubsub client that failed to connect"
+                    );
+                    continue;
+                }
+            };
+
+            if let Err(err) = submux
+                .add_client(client, abort_rx, subscribed_accounts.clone())
+                .await
+            {
+                warn!(
+                    endpoint = %label,
+                    error = %err,
+                    "Skipping deferred pubsub client that failed to attach"
+                );
+                continue;
+            }
+            debug!(endpoint = %label, "Attached deferred pubsub client");
+        }
+    });
+}
 
 // Maps pubkey -> (fetch_start_slot, requests_waiting)
 type FetchResult = Result<RemoteAccount, RemoteAccountProviderError>;
@@ -516,44 +618,49 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
         // Create chain_slot to be shared with all pubsub clients
         let chain_slot = Arc::<AtomicU64>::default();
 
-        // Build pubsub clients and wrap them into a SubMuxClient
+        // Build startup pubsub clients and wrap them into a SubMuxClient.
+        // gRPC clients are cheap to create and backfill subscriptions, so
+        // when present we let slower WebSocket clients attach after startup.
         let pubsubs = endpoints.pubsubs();
+        let has_grpc =
+            pubsubs.iter().any(|ep| matches!(ep, Endpoint::Grpc { .. }));
+        let (startup_pubsubs, mut deferred_pubsubs): (Vec<_>, Vec<_>) = pubsubs
+            .into_iter()
+            .cloned()
+            .partition(|ep| !has_grpc || matches!(ep, Endpoint::Grpc { .. }));
         let resubscription_delay = config.resubscription_delay();
-        let pubsub_futs = pubsubs.iter().map(|ep| {
-            let rpc_client = rpc_client.clone();
-            let chain_slot = chain_slot.clone();
-            let ep_label = ep.label().to_string();
-            let grpc_cfg = config.grpc().clone();
-            async move {
-                let (abort_tx, abort_rx) = mpsc::channel(1);
-                let client = ChainUpdatesClient::try_new_from_endpoint(
-                    ep,
-                    commitment,
-                    abort_tx,
-                    chain_slot,
-                    resubscription_delay,
-                    rpc_client,
-                    &grpc_cfg,
-                )
-                .await;
-                (ep_label, client.map(|c| (Arc::new(c), abort_rx)))
-            }
+        let pubsub_futs = startup_pubsubs.into_iter().map(|ep| {
+            connect_pubsub_client(
+                ep,
+                commitment,
+                rpc_client.clone(),
+                chain_slot.clone(),
+                resubscription_delay,
+                config.grpc().clone(),
+            )
         });
         let results = join_all(pubsub_futs).await;
-        let pubsubs: Vec<_> = results
-            .into_iter()
-            .filter_map(|(label, result)| match result {
-                Ok(client) => Some(client),
-                Err(err) => {
-                    warn!(
-                        endpoint = %label,
-                        error = %err,
-                        "Skipping pubsub client that failed to connect"
-                    );
-                    None
-                }
-            })
-            .collect();
+        let mut pubsubs = collect_connected_pubsubs(results);
+
+        if pubsubs.is_empty() && !deferred_pubsubs.is_empty() {
+            warn!(
+                "No startup pubsub clients connected; falling back to deferred pubsub endpoints"
+            );
+            let fallback_pubsub_futs =
+                deferred_pubsubs.iter().cloned().map(|ep| {
+                    connect_pubsub_client(
+                        ep,
+                        commitment,
+                        rpc_client.clone(),
+                        chain_slot.clone(),
+                        resubscription_delay,
+                        config.grpc().clone(),
+                    )
+                });
+            let results = join_all(fallback_pubsub_futs).await;
+            pubsubs = collect_connected_pubsubs(results);
+            deferred_pubsubs.clear();
+        }
 
         if pubsubs.is_empty() {
             return Err(RemoteAccountProviderError::AllPubsubClientsFailed);
@@ -568,6 +675,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
 
         let submux =
             SubMuxClient::new(pubsubs, subscribed_accounts.clone(), None);
+        let deferred_submux = submux.clone();
 
         if !config.program_subs().is_empty() {
             let count = config.program_subs().len();
@@ -583,14 +691,26 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
             ChainRpcClientImpl,
             SubMuxClient<ChainUpdatesClient>,
         >::new(
-            rpc_client,
+            rpc_client.clone(),
             submux,
             subscription_forwarder,
             config,
             subscribed_accounts,
-            ChainSlot::new(chain_slot),
+            ChainSlot::new(chain_slot.clone()),
         )
         .await?;
+        if !deferred_pubsubs.is_empty() {
+            spawn_deferred_pubsub_clients(
+                deferred_pubsubs,
+                commitment,
+                rpc_client,
+                chain_slot,
+                resubscription_delay,
+                config.grpc().clone(),
+                deferred_submux,
+                provider.lrucache_subscribed_accounts.clone(),
+            );
+        }
         Ok(provider)
     }
 

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -625,26 +625,84 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
 
         // Build startup pubsub clients and wrap them into a SubMuxClient.
         // gRPC clients are cheap to create and backfill subscriptions, so
-        // when present we defer slower WebSocket clients after keeping one
-        // startup WebSocket fallback until gRPC proves subscription readiness.
+        // when present we let slower WebSocket clients attach after startup.
+        // If gRPC cannot subscribe during startup, retry once with WebSocket
+        // endpoints so mixed configs still have a live fallback.
         let pubsubs = endpoints.pubsubs();
         let has_grpc =
             pubsubs.iter().any(|ep| matches!(ep, Endpoint::Grpc { .. }));
-        let mut startup_pubsubs = Vec::new();
-        let mut deferred_pubsubs = Vec::new();
-        let mut has_startup_ws = false;
-        for ep in pubsubs.into_iter().cloned() {
-            let use_at_startup = !has_grpc
-                || matches!(&ep, Endpoint::Grpc { .. })
-                || (!has_startup_ws
-                    && matches!(&ep, Endpoint::WebSocket { .. }));
-            if use_at_startup {
-                has_startup_ws |= matches!(&ep, Endpoint::WebSocket { .. });
-                startup_pubsubs.push(ep);
-            } else {
-                deferred_pubsubs.push(ep);
+        let (startup_pubsubs, deferred_pubsubs): (Vec<_>, Vec<_>) = pubsubs
+            .into_iter()
+            .cloned()
+            .partition(|ep| !has_grpc || matches!(ep, Endpoint::Grpc { .. }));
+        let fallback_pubsubs = (has_grpc && !deferred_pubsubs.is_empty())
+            .then(|| deferred_pubsubs.clone());
+
+        match Self::try_new_from_pubsubs(
+            startup_pubsubs,
+            deferred_pubsubs,
+            commitment,
+            rpc_client.clone(),
+            chain_slot.clone(),
+            subscription_forwarder.clone(),
+            config,
+        )
+        .await
+        {
+            Ok((provider, deferred_pubsubs)) => {
+                if !deferred_pubsubs.is_empty() {
+                    spawn_deferred_pubsub_clients(
+                        deferred_pubsubs,
+                        commitment,
+                        rpc_client,
+                        chain_slot,
+                        config.resubscription_delay(),
+                        config.grpc().clone(),
+                        provider.pubsub_client.clone(),
+                        provider.lrucache_subscribed_accounts.clone(),
+                        provider.subscription_transition_lock.clone(),
+                    );
+                }
+                Ok(provider)
+            }
+            Err(err) => {
+                let Some(fallback_pubsubs) = fallback_pubsubs else {
+                    return Err(err);
+                };
+                warn!(
+                    error = %err,
+                    "gRPC startup pubsub failed; retrying with WebSocket fallback"
+                );
+                let (provider, _) = Self::try_new_from_pubsubs(
+                    fallback_pubsubs,
+                    Vec::new(),
+                    commitment,
+                    rpc_client,
+                    chain_slot,
+                    subscription_forwarder,
+                    config,
+                )
+                .await?;
+                Ok(provider)
             }
         }
+    }
+
+    async fn try_new_from_pubsubs(
+        startup_pubsubs: Vec<Endpoint>,
+        mut deferred_pubsubs: Vec<Endpoint>,
+        commitment: CommitmentConfig,
+        rpc_client: ChainRpcClientImpl,
+        chain_slot: Arc<AtomicU64>,
+        subscription_forwarder: mpsc::Sender<ForwardedSubscriptionUpdate>,
+        config: &RemoteAccountProviderConfig,
+    ) -> RemoteAccountProviderResult<(
+        RemoteAccountProvider<
+            ChainRpcClientImpl,
+            SubMuxClient<ChainUpdatesClient>,
+        >,
+        Vec<Endpoint>,
+    )> {
         let resubscription_delay = config.resubscription_delay();
         let pubsub_futs = startup_pubsubs.into_iter().map(|ep| {
             connect_pubsub_client(
@@ -692,7 +750,6 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
 
         let submux =
             SubMuxClient::new(pubsubs, subscribed_accounts.clone(), None);
-        let deferred_submux = submux.clone();
 
         if !config.program_subs().is_empty() {
             let count = config.program_subs().len();
@@ -708,28 +765,15 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
             ChainRpcClientImpl,
             SubMuxClient<ChainUpdatesClient>,
         >::new(
-            rpc_client.clone(),
+            rpc_client,
             submux,
             subscription_forwarder,
             config,
             subscribed_accounts,
-            ChainSlot::new(chain_slot.clone()),
+            ChainSlot::new(chain_slot),
         )
         .await?;
-        if !deferred_pubsubs.is_empty() {
-            spawn_deferred_pubsub_clients(
-                deferred_pubsubs,
-                commitment,
-                rpc_client,
-                chain_slot,
-                resubscription_delay,
-                config.grpc().clone(),
-                deferred_submux,
-                provider.lrucache_subscribed_accounts.clone(),
-                provider.subscription_transition_lock.clone(),
-            );
-        }
-        Ok(provider)
+        Ok((provider, deferred_pubsubs))
     }
 
     pub(crate) fn promote_accounts(&self, pubkeys: &[&Pubkey]) {

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -142,6 +142,7 @@ fn spawn_deferred_pubsub_clients(
     grpc_cfg: GrpcConfig,
     submux: SubMuxClient<ChainUpdatesClient>,
     subscribed_accounts: Arc<AccountsLruCache>,
+    subscription_transition_lock: Arc<AsyncMutex<()>>,
 ) {
     tokio::spawn(async move {
         let mut pubsub_futs = endpoints
@@ -170,10 +171,14 @@ fn spawn_deferred_pubsub_clients(
                 }
             };
 
-            if let Err(err) = submux
-                .add_client(client, abort_rx, subscribed_accounts.clone())
-                .await
-            {
+            let add_result = {
+                let _transition_guard =
+                    subscription_transition_lock.lock().await;
+                submux
+                    .add_client(client, abort_rx, subscribed_accounts.clone())
+                    .await
+            };
+            if let Err(err) = add_result {
                 warn!(
                     endpoint = %label,
                     error = %err,
@@ -709,6 +714,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                 config.grpc().clone(),
                 deferred_submux,
                 provider.lrucache_subscribed_accounts.clone(),
+                provider.subscription_transition_lock.clone(),
             );
         }
         Ok(provider)

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -625,14 +625,26 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
 
         // Build startup pubsub clients and wrap them into a SubMuxClient.
         // gRPC clients are cheap to create and backfill subscriptions, so
-        // when present we let slower WebSocket clients attach after startup.
+        // when present we defer slower WebSocket clients after keeping one
+        // startup WebSocket fallback until gRPC proves subscription readiness.
         let pubsubs = endpoints.pubsubs();
         let has_grpc =
             pubsubs.iter().any(|ep| matches!(ep, Endpoint::Grpc { .. }));
-        let (startup_pubsubs, mut deferred_pubsubs): (Vec<_>, Vec<_>) = pubsubs
-            .into_iter()
-            .cloned()
-            .partition(|ep| !has_grpc || matches!(ep, Endpoint::Grpc { .. }));
+        let mut startup_pubsubs = Vec::new();
+        let mut deferred_pubsubs = Vec::new();
+        let mut has_startup_ws = false;
+        for ep in pubsubs.into_iter().cloned() {
+            let use_at_startup = !has_grpc
+                || matches!(&ep, Endpoint::Grpc { .. })
+                || (!has_startup_ws
+                    && matches!(&ep, Endpoint::WebSocket { .. }));
+            if use_at_startup {
+                has_startup_ws |= matches!(&ep, Endpoint::WebSocket { .. });
+                startup_pubsubs.push(ep);
+            } else {
+                deferred_pubsubs.push(ep);
+            }
+        }
         let resubscription_delay = config.resubscription_delay();
         let pubsub_futs = startup_pubsubs.into_iter().map(|ep| {
             connect_pubsub_client(

--- a/magicblock-chainlink/src/submux/mod.rs
+++ b/magicblock-chainlink/src/submux/mod.rs
@@ -2,7 +2,7 @@ use std::{
     cmp,
     collections::{HashMap, HashSet, VecDeque},
     sync::{
-        atomic::{AtomicBool, AtomicU16, AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicU16, Ordering},
         Arc, Mutex,
     },
     time::{Duration, Instant},
@@ -152,9 +152,9 @@ where
     /// Token cancelled on drop to stop background tasks
     /// (dedup pruner, debounce flusher).
     shutdown_token: CancellationToken,
-    /// Counts live SubMuxClient handles. Background tasks hold shutdown_token
-    /// clones, so cancellation must be tied to SubMux handles only.
-    handle_count: Arc<AtomicUsize>,
+    /// Only the original handle owns shutdown. Clones are used by detached
+    /// helpers and should not keep the mux alive.
+    cancel_on_drop: bool,
 }
 
 // Parameters for the long-running forwarder loop, grouped to avoid
@@ -275,7 +275,7 @@ where
             connected_clients_subscribing_immediately,
             forwarders_started: Arc::new(AtomicBool::new(false)),
             shutdown_token,
-            handle_count: Arc::new(AtomicUsize::new(1)),
+            cancel_on_drop: true,
         };
 
         // Spawn background tasks
@@ -895,7 +895,6 @@ where
     T: ChainPubsubClient + ReconnectableClient,
 {
     fn clone(&self) -> Self {
-        self.handle_count.fetch_add(1, Ordering::SeqCst);
         Self {
             clients: self.clients.clone(),
             out_tx: self.out_tx.clone(),
@@ -913,7 +912,7 @@ where
                 .clone(),
             forwarders_started: self.forwarders_started.clone(),
             shutdown_token: self.shutdown_token.clone(),
-            handle_count: self.handle_count.clone(),
+            cancel_on_drop: false,
         }
     }
 }
@@ -923,7 +922,7 @@ where
     T: ChainPubsubClient + ReconnectableClient,
 {
     fn drop(&mut self) {
-        if self.handle_count.fetch_sub(1, Ordering::SeqCst) == 1 {
+        if self.cancel_on_drop {
             self.shutdown_token.cancel();
         }
     }
@@ -1229,65 +1228,6 @@ mod tests {
         .expect("stream open");
         assert_eq!(update.pubkey, pk);
         assert_eq!(update.account.unwrap().lamports, 42);
-
-        mux.shutdown().await.unwrap();
-    }
-
-    #[tokio::test]
-    async fn test_submux_dropping_clone_does_not_cancel_live_tasks() {
-        init_logger();
-
-        let (tx, rx) = mpsc::channel(10_000);
-        let client = Arc::new(ChainPubsubClientMock::new(tx, rx));
-        let mux: SubMuxClient<ChainPubsubClientMock> =
-            new_submux_client(vec![client], None);
-
-        let clone = mux.clone();
-        drop(clone);
-
-        assert!(!mux.shutdown_token.is_cancelled());
-    }
-
-    #[tokio::test]
-    async fn test_submux_add_client_does_not_miss_concurrent_subscribe() {
-        init_logger();
-
-        let existing_pk = Pubkey::new_unique();
-        let new_pk = Pubkey::new_unique();
-        let (tx1, rx1) = mpsc::channel(10_000);
-        let (tx2, rx2) = mpsc::channel(10_000);
-        let client1 = Arc::new(ChainPubsubClientMock::new(tx1, rx1));
-        let client2 = Arc::new(ChainPubsubClientMock::new(tx2, rx2));
-        let (_abort_tx1, abort_rx1) = mpsc::channel(1);
-        let (_abort_tx2, abort_rx2) = mpsc::channel(1);
-        let tracker =
-            Arc::new(MockSubscribedAccountsTracker::new(vec![existing_pk]));
-
-        let mux: SubMuxClient<ChainPubsubClientMock> = SubMuxClient::new(
-            vec![(client1, abort_rx1)],
-            tracker.clone(),
-            None,
-        );
-        client2.block_subscribe();
-
-        let mux_for_add = mux.clone();
-        let client2_for_add = client2.clone();
-        let add_task = tokio::spawn(async move {
-            mux_for_add
-                .add_client(client2_for_add, abort_rx2, tracker)
-                .await
-        });
-
-        client2.wait_for_subscribe_attempts(1).await;
-        mux.subscribe(new_pk, None).await.unwrap();
-        client2.wait_for_subscribe_attempts(2).await;
-
-        client2.release_subscribe();
-        add_task.await.unwrap().unwrap();
-
-        let client2_subs = client2.subscriptions_union();
-        assert!(client2_subs.contains(&existing_pk));
-        assert!(client2_subs.contains(&new_pk));
 
         mux.shutdown().await.unwrap();
     }

--- a/magicblock-chainlink/src/submux/mod.rs
+++ b/magicblock-chainlink/src/submux/mod.rs
@@ -2,7 +2,7 @@ use std::{
     cmp,
     collections::{HashMap, HashSet, VecDeque},
     sync::{
-        atomic::{AtomicBool, AtomicU16, Ordering},
+        atomic::{AtomicBool, AtomicU16, AtomicUsize, Ordering},
         Arc, Mutex,
     },
     time::{Duration, Instant},
@@ -48,7 +48,6 @@ pub struct DebounceConfig {
     pub detection_window_millis: Option<u64>,
 }
 
-#[derive(Clone)]
 /// SubMuxClient
 ///
 /// Multi-node pub/sub subscription multiplexer that:
@@ -153,6 +152,9 @@ where
     /// Token cancelled on drop to stop background tasks
     /// (dedup pruner, debounce flusher).
     shutdown_token: CancellationToken,
+    /// Counts live SubMuxClient handles. Background tasks hold shutdown_token
+    /// clones, so cancellation must be tied to SubMux handles only.
+    handle_count: Arc<AtomicUsize>,
 }
 
 // Parameters for the long-running forwarder loop, grouped to avoid
@@ -273,6 +275,7 @@ where
             connected_clients_subscribing_immediately,
             forwarders_started: Arc::new(AtomicBool::new(false)),
             shutdown_token,
+            handle_count: Arc::new(AtomicUsize::new(1)),
         };
 
         // Spawn background tasks
@@ -344,12 +347,25 @@ where
         self.clients.lock().expect("clients lock poisoned").clone()
     }
 
+    fn remove_client(&self, target: &Arc<T>) {
+        let mut clients = self.clients.lock().expect("clients lock poisoned");
+        if let Some(pos) = clients.iter().position(|c| Arc::ptr_eq(c, target)) {
+            clients.swap_remove(pos);
+        }
+    }
+
     pub(crate) async fn add_client<U: SubscribedAccountsTracker>(
         &self,
         client: Arc<T>,
         abort_rx: mpsc::Receiver<()>,
         subscribed_accounts_tracker: Arc<U>,
     ) -> RemoteAccountProviderResult<()> {
+        {
+            let mut clients =
+                self.clients.lock().expect("clients lock poisoned");
+            clients.push(client.clone());
+        }
+
         let programs = self
             .program_subs
             .lock()
@@ -358,13 +374,19 @@ where
             .copied()
             .collect::<Vec<_>>();
         for program_id in programs {
-            client.subscribe_program(program_id).await?;
+            if let Err(err) = client.subscribe_program(program_id).await {
+                self.remove_client(&client);
+                return Err(err);
+            }
         }
 
         let mut account_subs =
             subscribed_accounts_tracker.subscribed_accounts();
         account_subs.extend(self.never_debounce.iter().copied());
-        client.resub_multiple(account_subs).await?;
+        if let Err(err) = client.resub_multiple(account_subs).await {
+            self.remove_client(&client);
+            return Err(err);
+        }
 
         if self.forwarders_started.load(Ordering::SeqCst) {
             self.spawn_forwarder_for_client(
@@ -374,12 +396,6 @@ where
                 self.debounce_detection_window,
                 self.allowed_in_debounce_window_count(),
             );
-        }
-
-        {
-            let mut clients =
-                self.clients.lock().expect("clients lock poisoned");
-            clients.push(client.clone());
         }
 
         let connected = self
@@ -874,12 +890,42 @@ where
     }
 }
 
+impl<T> Clone for SubMuxClient<T>
+where
+    T: ChainPubsubClient + ReconnectableClient,
+{
+    fn clone(&self) -> Self {
+        self.handle_count.fetch_add(1, Ordering::SeqCst);
+        Self {
+            clients: self.clients.clone(),
+            out_tx: self.out_tx.clone(),
+            out_rx: self.out_rx.clone(),
+            dedup_cache: self.dedup_cache.clone(),
+            dedup_window: self.dedup_window,
+            debounce_interval: self.debounce_interval,
+            debounce_detection_window: self.debounce_detection_window,
+            debounce_states: self.debounce_states.clone(),
+            never_debounce: self.never_debounce.clone(),
+            program_subs: self.program_subs.clone(),
+            connected_clients: self.connected_clients.clone(),
+            connected_clients_subscribing_immediately: self
+                .connected_clients_subscribing_immediately
+                .clone(),
+            forwarders_started: self.forwarders_started.clone(),
+            shutdown_token: self.shutdown_token.clone(),
+            handle_count: self.handle_count.clone(),
+        }
+    }
+}
+
 impl<T> Drop for SubMuxClient<T>
 where
     T: ChainPubsubClient + ReconnectableClient,
 {
     fn drop(&mut self) {
-        self.shutdown_token.cancel();
+        if self.handle_count.fetch_sub(1, Ordering::SeqCst) == 1 {
+            self.shutdown_token.cancel();
+        }
     }
 }
 
@@ -1183,6 +1229,65 @@ mod tests {
         .expect("stream open");
         assert_eq!(update.pubkey, pk);
         assert_eq!(update.account.unwrap().lamports, 42);
+
+        mux.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_submux_dropping_clone_does_not_cancel_live_tasks() {
+        init_logger();
+
+        let (tx, rx) = mpsc::channel(10_000);
+        let client = Arc::new(ChainPubsubClientMock::new(tx, rx));
+        let mux: SubMuxClient<ChainPubsubClientMock> =
+            new_submux_client(vec![client], None);
+
+        let clone = mux.clone();
+        drop(clone);
+
+        assert!(!mux.shutdown_token.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn test_submux_add_client_does_not_miss_concurrent_subscribe() {
+        init_logger();
+
+        let existing_pk = Pubkey::new_unique();
+        let new_pk = Pubkey::new_unique();
+        let (tx1, rx1) = mpsc::channel(10_000);
+        let (tx2, rx2) = mpsc::channel(10_000);
+        let client1 = Arc::new(ChainPubsubClientMock::new(tx1, rx1));
+        let client2 = Arc::new(ChainPubsubClientMock::new(tx2, rx2));
+        let (_abort_tx1, abort_rx1) = mpsc::channel(1);
+        let (_abort_tx2, abort_rx2) = mpsc::channel(1);
+        let tracker =
+            Arc::new(MockSubscribedAccountsTracker::new(vec![existing_pk]));
+
+        let mux: SubMuxClient<ChainPubsubClientMock> = SubMuxClient::new(
+            vec![(client1, abort_rx1)],
+            tracker.clone(),
+            None,
+        );
+        client2.block_subscribe();
+
+        let mux_for_add = mux.clone();
+        let client2_for_add = client2.clone();
+        let add_task = tokio::spawn(async move {
+            mux_for_add
+                .add_client(client2_for_add, abort_rx2, tracker)
+                .await
+        });
+
+        client2.wait_for_subscribe_attempts(1).await;
+        mux.subscribe(new_pk, None).await.unwrap();
+        client2.wait_for_subscribe_attempts(2).await;
+
+        client2.release_subscribe();
+        add_task.await.unwrap().unwrap();
+
+        let client2_subs = client2.subscriptions_union();
+        assert!(client2_subs.contains(&existing_pk));
+        assert!(client2_subs.contains(&new_pk));
 
         mux.shutdown().await.unwrap();
     }

--- a/magicblock-chainlink/src/submux/mod.rs
+++ b/magicblock-chainlink/src/submux/mod.rs
@@ -3,7 +3,7 @@ use std::{
     collections::{HashMap, HashSet, VecDeque},
     sync::{
         atomic::{AtomicBool, AtomicU16, Ordering},
-        Arc, Mutex,
+        Arc, Mutex, MutexGuard,
     },
     time::{Duration, Instant},
 };
@@ -344,11 +344,11 @@ where
     }
 
     fn clients_snapshot(&self) -> Vec<Arc<T>> {
-        self.clients.lock().expect("clients lock poisoned").clone()
+        self.clients_lock().clone()
     }
 
     fn remove_client(&self, target: &Arc<T>) {
-        let mut clients = self.clients.lock().expect("clients lock poisoned");
+        let mut clients = self.clients_lock();
         if let Some(pos) = clients.iter().position(|c| Arc::ptr_eq(c, target)) {
             clients.swap_remove(pos);
         }
@@ -361,18 +361,12 @@ where
         subscribed_accounts_tracker: Arc<U>,
     ) -> RemoteAccountProviderResult<()> {
         {
-            let mut clients =
-                self.clients.lock().expect("clients lock poisoned");
+            let mut clients = self.clients_lock();
             clients.push(client.clone());
         }
 
-        let programs = self
-            .program_subs
-            .lock()
-            .expect("program_subs lock poisoned")
-            .iter()
-            .copied()
-            .collect::<Vec<_>>();
+        let programs =
+            self.program_subs_lock().iter().copied().collect::<Vec<_>>();
         for program_id in programs {
             if let Err(err) = client.subscribe_program(program_id).await {
                 self.remove_client(&client);
@@ -425,6 +419,20 @@ where
             self.connected_clients_subscribing_immediately.clone(),
         );
         Ok(())
+    }
+
+    fn clients_lock(&self) -> MutexGuard<'_, Vec<Arc<T>>> {
+        // Lock poisoning means a thread panicked while mutating mux state;
+        // treating that as unrecoverable is safer than continuing with it.
+        self.clients.lock().expect("clients lock poisoned")
+    }
+
+    fn program_subs_lock(&self) -> MutexGuard<'_, HashSet<Pubkey>> {
+        // Lock poisoning means a thread panicked while mutating mux state;
+        // treating that as unrecoverable is safer than continuing with it.
+        self.program_subs
+            .lock()
+            .expect("program_subs lock poisoned")
     }
 
     #[instrument(

--- a/magicblock-chainlink/src/submux/mod.rs
+++ b/magicblock-chainlink/src/submux/mod.rs
@@ -2,7 +2,7 @@ use std::{
     cmp,
     collections::{HashMap, HashSet, VecDeque},
     sync::{
-        atomic::{AtomicU16, Ordering},
+        atomic::{AtomicBool, AtomicU16, Ordering},
         Arc, Mutex,
     },
     time::{Duration, Instant},
@@ -114,7 +114,7 @@ where
     T: ChainPubsubClient + ReconnectableClient,
 {
     /// Underlying pubsub clients this mux controls and forwards to/from.
-    clients: Vec<Arc<T>>,
+    clients: Arc<Mutex<Vec<Arc<T>>>>,
     /// Aggregated outgoing channel used by forwarder tasks to deliver
     /// subscription updates to the consumer of this SubMuxClient.
     out_tx: mpsc::Sender<SubscriptionUpdate>,
@@ -143,9 +143,13 @@ where
     never_debounce: HashSet<Pubkey>,
     /// Map of program account subscriptions we are holding inside the pubsub clients
     program_subs: Arc<Mutex<HashSet<Pubkey>>>,
+    /// Number of currently connected pubsub clients.
+    connected_clients: Arc<AtomicU16>,
     /// Number of currently connected clients that activate subscriptions immediately when
     /// requested.
     connected_clients_subscribing_immediately: Arc<AtomicU16>,
+    /// Whether take_updates() has started the per-client forwarders.
+    forwarders_started: Arc<AtomicBool>,
     /// Token cancelled on drop to stop background tasks
     /// (dedup pruner, debounce flusher).
     shutdown_token: CancellationToken,
@@ -240,7 +244,12 @@ where
             }
         }
 
-        let clients = Self::spawn_reconnectors(
+        let clients_only = clients
+            .iter()
+            .map(|(client, _)| client.clone())
+            .collect::<Vec<_>>();
+
+        Self::spawn_reconnectors(
             clients,
             subscribed_accounts_tracker,
             program_subs.clone(),
@@ -250,7 +259,7 @@ where
 
         let shutdown_token = CancellationToken::new();
         let me = Self {
-            clients,
+            clients: Arc::new(Mutex::new(clients_only)),
             out_tx,
             out_rx: Arc::new(Mutex::new(Some(out_rx))),
             dedup_cache: dedup_cache.clone(),
@@ -260,7 +269,9 @@ where
             debounce_states: debounce_states.clone(),
             never_debounce,
             program_subs,
+            connected_clients,
             connected_clients_subscribing_immediately,
+            forwarders_started: Arc::new(AtomicBool::new(false)),
             shutdown_token,
         };
 
@@ -279,10 +290,8 @@ where
         program_subs: Arc<Mutex<HashSet<Pubkey>>>,
         connected_clients: Arc<AtomicU16>,
         connected_clients_subscribing_immediately: Arc<AtomicU16>,
-    ) -> Vec<Arc<T>> {
-        let mut clients_only = Vec::with_capacity(clients.len());
+    ) {
         for (client, mut abort_rx) in clients.into_iter() {
-            clients_only.push(client.clone());
             let subscribed_accounts_tracker =
                 subscribed_accounts_tracker.clone();
             let program_subs = program_subs.clone();
@@ -329,7 +338,77 @@ where
                 }
             });
         }
-        clients_only
+    }
+
+    fn clients_snapshot(&self) -> Vec<Arc<T>> {
+        self.clients.lock().expect("clients lock poisoned").clone()
+    }
+
+    pub(crate) async fn add_client<U: SubscribedAccountsTracker>(
+        &self,
+        client: Arc<T>,
+        abort_rx: mpsc::Receiver<()>,
+        subscribed_accounts_tracker: Arc<U>,
+    ) -> RemoteAccountProviderResult<()> {
+        let programs = self
+            .program_subs
+            .lock()
+            .expect("program_subs lock poisoned")
+            .iter()
+            .copied()
+            .collect::<Vec<_>>();
+        for program_id in programs {
+            client.subscribe_program(program_id).await?;
+        }
+
+        let mut account_subs =
+            subscribed_accounts_tracker.subscribed_accounts();
+        account_subs.extend(self.never_debounce.iter().copied());
+        client.resub_multiple(account_subs).await?;
+
+        if self.forwarders_started.load(Ordering::SeqCst) {
+            self.spawn_forwarder_for_client(
+                &client,
+                self.dedup_window,
+                self.debounce_interval,
+                self.debounce_detection_window,
+                self.allowed_in_debounce_window_count(),
+            );
+        }
+
+        {
+            let mut clients =
+                self.clients.lock().expect("clients lock poisoned");
+            clients.push(client.clone());
+        }
+
+        let connected = self
+            .connected_clients
+            .fetch_add(1, Ordering::SeqCst)
+            .saturating_add(1);
+        metrics::set_connected_pubsub_clients_count(connected as usize);
+        metrics::set_pubsub_client_uptime(client.id(), true);
+        if let Some(delay_ms) = client.current_resub_delay_ms() {
+            metrics::set_pubsub_client_resubscribe_delay(client.id(), delay_ms);
+        }
+        if client.subs_immediately() {
+            let connected = self
+                .connected_clients_subscribing_immediately
+                .fetch_add(1, Ordering::SeqCst)
+                .saturating_add(1);
+            metrics::set_connected_direct_pubsub_clients_count(
+                connected as usize,
+            );
+        }
+
+        Self::spawn_reconnectors(
+            vec![(client, abort_rx)],
+            subscribed_accounts_tracker,
+            self.program_subs.clone(),
+            self.connected_clients.clone(),
+            self.connected_clients_subscribing_immediately.clone(),
+        );
+        Ok(())
     }
 
     #[instrument(
@@ -573,9 +652,10 @@ where
         let detection_window = self.debounce_detection_window;
         let allowed_count = self.allowed_in_debounce_window_count();
 
-        for client in &self.clients {
+        self.forwarders_started.store(true, Ordering::SeqCst);
+        for client in self.clients_snapshot() {
             self.spawn_forwarder_for_client(
-                client,
+                &client,
                 window,
                 debounce_interval,
                 detection_window,
@@ -818,7 +898,7 @@ where
             retries,
             self.required_account_subscription_confirmations(),
         )
-        .process(self.clients.clone())
+        .process(self.clients_snapshot())
         .await
     }
 
@@ -841,7 +921,7 @@ where
             program_id,
             self.required_program_subscription_confirmations(),
         )
-        .process(self.clients.clone())
+        .process(self.clients_snapshot())
         .await
     }
 
@@ -850,13 +930,13 @@ where
         pubkey: Pubkey,
     ) -> RemoteAccountProviderResult<()> {
         AccountSubscriptionTask::Unsubscribe(pubkey)
-            .process(self.clients.clone())
+            .process(self.clients_snapshot())
             .await
     }
 
     async fn shutdown(&self) -> RemoteAccountProviderResult<()> {
         AccountSubscriptionTask::Shutdown
-            .process(self.clients.clone())
+            .process(self.clients_snapshot())
             .await
     }
 
@@ -876,7 +956,7 @@ where
 
     fn subscriptions_union(&self) -> HashSet<Pubkey> {
         let mut union = HashSet::new();
-        for client in &self.clients {
+        for client in self.clients_snapshot() {
             let subs = client.subscriptions_union();
             union.extend(subs);
         }
@@ -885,7 +965,7 @@ where
 
     fn subscriptions_intersection(&self) -> HashSet<Pubkey> {
         let sets: Vec<HashSet<Pubkey>> = self
-            .clients
+            .clients_snapshot()
             .iter()
             .map(|c| c.subscriptions_intersection())
             .collect();
@@ -909,7 +989,7 @@ where
 
     /// Returns true if any inner client subscribes immediately
     fn subs_immediately(&self) -> bool {
-        self.clients.iter().any(|c| c.subs_immediately())
+        self.clients_snapshot().iter().any(|c| c.subs_immediately())
     }
 
     fn id(&self) -> &str {
@@ -1061,6 +1141,48 @@ mod tests {
         let mut lams = vec![lamports(&u1), lamports(&u2)];
         lams.sort();
         assert_eq!(lams, vec![10, 20]);
+
+        mux.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_submux_add_client_resubscribes_and_forwards_updates() {
+        init_logger();
+
+        let pk = Pubkey::new_unique();
+        let (tx1, rx1) = mpsc::channel(10_000);
+        let (tx2, rx2) = mpsc::channel(10_000);
+        let client1 = Arc::new(ChainPubsubClientMock::new(tx1, rx1));
+        let client2 = Arc::new(ChainPubsubClientMock::new(tx2, rx2));
+        let (_abort_tx1, abort_rx1) = mpsc::channel(1);
+        let (_abort_tx2, abort_rx2) = mpsc::channel(1);
+        let tracker = Arc::new(MockSubscribedAccountsTracker::new(vec![pk]));
+
+        let mux: SubMuxClient<ChainPubsubClientMock> = SubMuxClient::new(
+            vec![(client1, abort_rx1)],
+            tracker.clone(),
+            None,
+        );
+        let mut mux_rx = mux.take_updates();
+
+        mux.add_client(client2.clone(), abort_rx2, tracker)
+            .await
+            .unwrap();
+
+        assert!(client2.subscriptions_union().contains(&pk));
+        client2
+            .send_account_update(pk, 1, &account_with_lamports(42))
+            .await;
+
+        let update = tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            mux_rx.recv(),
+        )
+        .await
+        .expect("update expected")
+        .expect("stream open");
+        assert_eq!(update.pubkey, pk);
+        assert_eq!(update.account.unwrap().lamports, 42);
 
         mux.shutdown().await.unwrap();
     }

--- a/test-integration/Cargo.lock
+++ b/test-integration/Cargo.lock
@@ -4271,7 +4271,7 @@ dependencies = [
 
 [[package]]
 name = "magicblock-aml"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "futures-util",
  "magicblock-config",


### PR DESCRIPTION
## Descrption

Optimizes validator restart readiness by avoiding slow WebSocket pubsub handshakes on the startup critical path when gRPC pubsub endpoints are configured.

Changes:

  - Start RemoteAccountProvider with gRPC pubsub clients first when available.
  - Defer WebSocket pubsub client connection/attachment to a background task after provider startup.
  - Preserve WebSocket-only behavior and fall back to WebSocket startup if no gRPC pubsub client connects.
  - Allow SubMuxClient to attach deferred clients, resubscribe existing account/program subscriptions, and start forwarding updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced connection reliability with improved pubsub client initialization logic and WebSocket fallback support when primary connections fail.
  * Optimized dynamic client management to support safer addition and removal of connections under concurrent operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/magicblock-labs/magicblock-validator/pull/1224?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->