### PR TITLE
feat: make chainlink aware of validator mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4233,6 +4233,7 @@ name = "magicblock-replicator"
 version = "0.11.1"
 dependencies = [
  "async-nats",
+ "async-trait",
  "bincode",
  "bytes",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3782,6 +3782,7 @@ dependencies = [
  "serde",
  "solana-account 3.4.0",
  "solana-account-decoder",
+ "solana-commitment-config",
  "solana-fee-structure",
  "solana-keypair",
  "solana-message 3.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3913,6 +3913,7 @@ dependencies = [
  "solana-transaction-error 3.2.0",
  "spl-token-2022-interface",
  "spl-token-interface",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",

--- a/magicblock-aperture/Cargo.toml
+++ b/magicblock-aperture/Cargo.toml
@@ -41,6 +41,7 @@ magicblock-version = { workspace = true }
 agave-geyser-plugin-interface = { workspace = true }
 solana-account = { workspace = true }
 solana-account-decoder = { workspace = true }
+solana-commitment-config = { workspace = true }
 solana-feature-set = { workspace = true }
 solana-fee-structure = { workspace = true }
 solana-keypair = { workspace = true }

--- a/magicblock-aperture/src/error.rs
+++ b/magicblock-aperture/src/error.rs
@@ -6,6 +6,8 @@ use solana_transaction_error::TransactionError;
 
 pub(crate) const TRANSACTION_SIMULATION: i16 = -32002;
 pub(crate) const TRANSACTION_VERIFICATION: i16 = -32003;
+#[allow(dead_code)]
+pub(crate) const TEMPORARILY_UNAVAILABLE: i16 = -32004;
 pub(crate) const BLOCK_NOT_FOUND: i16 = -32009;
 pub(crate) const INVALID_REQUEST: i16 = -32600;
 pub(crate) const INVALID_PARAMS: i16 = -32602;
@@ -142,6 +144,15 @@ impl RpcError {
             code: TRANSACTION_VERIFICATION,
             message: format!("transaction verification error: {error}"),
             http_status: 200,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn temporarily_unavailable<E: Display>(error: E) -> Self {
+        Self {
+            code: TEMPORARILY_UNAVAILABLE,
+            message: format!("temporarily unavailable: {error}"),
+            http_status: 503,
         }
     }
 

--- a/magicblock-aperture/src/requests/http/get_account_info.rs
+++ b/magicblock-aperture/src/requests/http/get_account_info.rs
@@ -31,8 +31,8 @@ impl HttpDispatcher {
 
         // `read_account_with_ensure` guarantees the account is clone from chain if not in database.
         let account = self
-            .read_account_with_ensure(&pubkey)
-            .await
+            .read_account_with_ensure("getAccountInfo", &pubkey)
+            .await?
             .filter(|acc| !Self::account_should_render_as_null(acc))
             // `LockedAccount` provides a race-free read of the account data before encoding.
             .map(|acc| {

--- a/magicblock-aperture/src/requests/http/get_balance.rs
+++ b/magicblock-aperture/src/requests/http/get_balance.rs
@@ -14,8 +14,8 @@ impl HttpDispatcher {
         let pubkey = some_or_err!(pubkey_bytes);
 
         let balance = self
-            .read_account_with_ensure(&pubkey)
-            .await
+            .read_account_with_ensure("getBalance", &pubkey)
+            .await?
             .map(|a| a.lamports())
             .unwrap_or_default(); // Default to 0 if account not found
 

--- a/magicblock-aperture/src/requests/http/get_delegation_status.rs
+++ b/magicblock-aperture/src/requests/http/get_delegation_status.rs
@@ -20,7 +20,9 @@ impl HttpDispatcher {
 
         // Ensure the account is present in the local AccountsDb, cloning it
         // from the reference cluster if necessary.
-        let account = self.read_account_with_ensure(&pubkey).await;
+        let account = self
+            .read_account_with_ensure("getDelegationStatus", &pubkey)
+            .await?;
 
         let is_delegated =
             account.as_ref().map(|acc| acc.delegated()).unwrap_or(false);

--- a/magicblock-aperture/src/requests/http/get_multiple_accounts.rs
+++ b/magicblock-aperture/src/requests/http/get_multiple_accounts.rs
@@ -28,9 +28,12 @@ impl HttpDispatcher {
         let encoding = config.encoding.unwrap_or(UiAccountEncoding::Base58);
         let slice = config.data_slice;
 
+        let ensured_accounts = self
+            .read_accounts_with_ensure("getMultipleAccounts", &pubkeys)
+            .await?;
         let accounts = pubkeys
             .iter()
-            .zip(self.read_accounts_with_ensure(&pubkeys).await.into_iter())
+            .zip(ensured_accounts.into_iter())
             .map(|(pubkey, acc)| {
                 acc.filter(|account| {
                     !Self::account_should_render_as_null(account)

--- a/magicblock-aperture/src/requests/http/get_token_account_balance.rs
+++ b/magicblock-aperture/src/requests/http/get_token_account_balance.rs
@@ -26,7 +26,8 @@ impl HttpDispatcher {
 
         // Fetch the target token account.
         let token_account: AccountSharedData = some_or_err!(
-            self.read_account_with_ensure(&pubkey).await,
+            self.read_account_with_ensure("getTokenAccountBalance", &pubkey)
+                .await?,
             "token account not found or is not a token account"
         );
 
@@ -42,7 +43,11 @@ impl HttpDispatcher {
 
         // Fetch the mint account to get the token's decimals.
         let mint_account: AccountSharedData = some_or_err!(
-            self.read_account_with_ensure(&mint_pubkey).await,
+            self.read_account_with_ensure(
+                "getTokenAccountBalance",
+                &mint_pubkey
+            )
+            .await?,
             "mint account not found"
         );
         let decimals =

--- a/magicblock-aperture/src/requests/http/mod.rs
+++ b/magicblock-aperture/src/requests/http/mod.rs
@@ -196,31 +196,40 @@ impl HttpDispatcher {
     #[instrument(skip_all)]
     async fn read_account_with_ensure(
         &self,
+        method: &'static str,
         pubkey: &Pubkey,
-    ) -> Option<AccountSharedData> {
-        if !self.is_primary_mode() {
-            return self.accountsdb.get_account(pubkey);
+    ) -> RpcResult<Option<AccountSharedData>> {
+        match self.aperture_routing_decision(method).await {
+            ApertureRoutingDecision::NonPrimary => {
+                Ok(self.accountsdb.get_account(pubkey))
+            }
+            ApertureRoutingDecision::PrimaryReady(_) => {
+                let mark_empty_if_not_found = [*pubkey];
+                let _timer = ENSURE_ACCOUNTS_TIME
+                    .with_label_values(&["account"])
+                    .start_timer();
+                let _ = self
+                    .chainlink
+                    .ensure_accounts(
+                        &[*pubkey],
+                        Some(&mark_empty_if_not_found),
+                        AccountFetchOrigin::GetAccount,
+                        None,
+                    )
+                    .await
+                    .inspect_err(|e| {
+                        // There is nothing we can do if fetching the account fails
+                        // Log the error and return whatever is in the accounts db
+                        debug!(error = ?e, "Failed to ensure account");
+                    });
+                Ok(self.accountsdb.get_account(pubkey))
+            }
+            ApertureRoutingDecision::PrimaryNotReady => {
+                Err(RpcError::temporarily_unavailable(format!(
+                    "{method} requires Chainlink primary readiness"
+                )))
+            }
         }
-
-        let mark_empty_if_not_found = [*pubkey];
-        let _timer = ENSURE_ACCOUNTS_TIME
-            .with_label_values(&["account"])
-            .start_timer();
-        let _ = self
-            .chainlink
-            .ensure_accounts(
-                &[*pubkey],
-                Some(&mark_empty_if_not_found),
-                AccountFetchOrigin::GetAccount,
-                None,
-            )
-            .await
-            .inspect_err(|e| {
-                // There is nothing we can do if fetching the account fails
-                // Log the error and return whatever is in the accounts db
-                debug!(error = ?e, "Failed to ensure account");
-            });
-        self.accountsdb.get_account(pubkey)
     }
 
     /// Fetches multiple account's data from the `AccountsDb` filling them in from chain
@@ -228,37 +237,44 @@ impl HttpDispatcher {
     #[instrument(skip(self, pubkeys), fields(pubkey_count = pubkeys.len()))]
     async fn read_accounts_with_ensure(
         &self,
+        method: &'static str,
         pubkeys: &[Pubkey],
-    ) -> Vec<Option<AccountSharedData>> {
-        if !self.is_primary_mode() {
-            return pubkeys
+    ) -> RpcResult<Vec<Option<AccountSharedData>>> {
+        match self.aperture_routing_decision(method).await {
+            ApertureRoutingDecision::NonPrimary => Ok(pubkeys
                 .iter()
                 .map(|pubkey| self.accountsdb.get_account(pubkey))
-                .collect();
+                .collect()),
+            ApertureRoutingDecision::PrimaryReady(_) => {
+                trace!("Ensuring accounts");
+                let _timer = ENSURE_ACCOUNTS_TIME
+                    .with_label_values(&["multi-account"])
+                    .start_timer();
+                let _ = self
+                    .chainlink
+                    .ensure_accounts(
+                        pubkeys,
+                        Some(pubkeys),
+                        AccountFetchOrigin::GetMultipleAccounts,
+                        None,
+                    )
+                    .await
+                    .inspect_err(|e| {
+                        // There is nothing we can do if fetching the accounts fails
+                        // Log the error and return whatever is in the accounts db
+                        warn!(error = ?e, "Failed to ensure accounts");
+                    });
+                Ok(pubkeys
+                    .iter()
+                    .map(|pubkey| self.accountsdb.get_account(pubkey))
+                    .collect())
+            }
+            ApertureRoutingDecision::PrimaryNotReady => {
+                Err(RpcError::temporarily_unavailable(format!(
+                    "{method} requires Chainlink primary readiness"
+                )))
+            }
         }
-
-        trace!("Ensuring accounts");
-        let _timer = ENSURE_ACCOUNTS_TIME
-            .with_label_values(&["multi-account"])
-            .start_timer();
-        let _ = self
-            .chainlink
-            .ensure_accounts(
-                pubkeys,
-                Some(pubkeys),
-                AccountFetchOrigin::GetMultipleAccounts,
-                None,
-            )
-            .await
-            .inspect_err(|e| {
-                // There is nothing we can do if fetching the accounts fails
-                // Log the error and return whatever is in the accounts db
-                warn!(error = ?e, "Failed to ensure accounts");
-            });
-        pubkeys
-            .iter()
-            .map(|pubkey| self.accountsdb.get_account(pubkey))
-            .collect()
     }
 
     /// Decodes, validates, and sanitizes a transaction from its string representation.
@@ -444,12 +460,19 @@ mod tests {
     use base64::{
         engine::general_purpose::STANDARD as BASE64_STANDARD, Engine,
     };
+    use magicblock_account_cloner::ChainlinkCloner;
+    use magicblock_chainlink::{
+        chainlink::config::ChainlinkConfig,
+        remote_account_provider::{Endpoint, Endpoints},
+    };
     use magicblock_config::config::ChainLinkConfig;
     use magicblock_core::{
         coordination_mode::{switch_to_primary_mode, switch_to_replica_mode},
         link::{blocks::BlockHash, link},
     };
     use solana_account::ReadableAccount;
+    use solana_commitment_config::CommitmentConfig;
+    use solana_keypair::Keypair;
     use solana_message::{
         compiled_instruction::CompiledInstruction, legacy::Message,
         MessageHeader, VersionedMessage,
@@ -484,16 +507,10 @@ mod tests {
         }
     }
 
-    fn test_dispatcher(env: &ExecutionTestEnv) -> HttpDispatcher {
-        let chainlink = Arc::new(
-            ChainlinkImpl::try_new(
-                &env.accountsdb,
-                None,
-                Pubkey::new_unique(),
-                &ChainLinkConfig::default(),
-            )
-            .expect("failed to create chainlink"),
-        );
+    fn dispatcher_from_chainlink(
+        env: &ExecutionTestEnv,
+        chainlink: Arc<ChainlinkImpl>,
+    ) -> HttpDispatcher {
         let state = SharedState::new(
             NodeContext {
                 identity: env.get_payer().pubkey,
@@ -506,6 +523,80 @@ mod tests {
             chainlink,
         );
         let (dispatch, _validator) = link();
+        HttpDispatcher {
+            context: state.context,
+            accountsdb: state.accountsdb,
+            ledger: state.ledger,
+            chainlink: state.chainlink,
+            transactions: state.transactions,
+            blocks: state.blocks,
+            transactions_scheduler: dispatch.transaction_scheduler,
+        }
+    }
+
+    fn test_dispatcher(env: &ExecutionTestEnv) -> HttpDispatcher {
+        let chainlink = Arc::new(
+            ChainlinkImpl::try_new(
+                &env.accountsdb,
+                None,
+                Pubkey::new_unique(),
+                &ChainLinkConfig::default(),
+            )
+            .expect("failed to create chainlink"),
+        );
+        dispatcher_from_chainlink(env, chainlink)
+    }
+
+    async fn primary_not_ready_dispatcher(
+        env: &ExecutionTestEnv,
+    ) -> HttpDispatcher {
+        let (dispatch, _validator) = link();
+        let cloner = Arc::new(ChainlinkCloner::new(
+            dispatch.transaction_scheduler.clone(),
+            env.ledger.latest_block().clone(),
+        ));
+        let endpoints = Endpoints::from(
+            &[
+                Endpoint::Rpc {
+                    url: "http://127.0.0.1:1".to_string(),
+                    label: "unreachable-rpc".to_string(),
+                },
+                Endpoint::WebSocket {
+                    url: "ws://127.0.0.1:1".to_string(),
+                    label: "unreachable-ws".to_string(),
+                },
+            ][..],
+        );
+        let ledger_path = std::env::temp_dir().join(format!(
+            "mb-aperture-primary-not-ready-{}",
+            Pubkey::new_unique()
+        ));
+        let chainlink = Arc::new(
+            ChainlinkImpl::try_new_from_endpoints(
+                &endpoints,
+                CommitmentConfig::confirmed(),
+                &env.accountsdb,
+                &cloner,
+                Keypair::new(),
+                ChainlinkConfig::default(),
+                &ChainLinkConfig::default(),
+                &ledger_path,
+            )
+            .await
+            .expect("failed to create endpoint-backed chainlink"),
+        );
+
+        let state = SharedState::new(
+            NodeContext {
+                identity: env.get_payer().pubkey,
+                base_fee: ExecutionTestEnv::BASE_FEE,
+                blocktime: 50,
+                ..Default::default()
+            },
+            env.accountsdb.clone(),
+            env.ledger.clone(),
+            chainlink,
+        );
         HttpDispatcher {
             context: state.context,
             accountsdb: state.accountsdb,
@@ -595,11 +686,70 @@ mod tests {
         env.fund_account(pubkey, 42);
 
         let account = dispatcher
-            .read_account_with_ensure(&pubkey)
+            .read_account_with_ensure("getAccountInfo", &pubkey)
             .await
+            .expect("replica read should not fail")
             .expect("local account should be returned in replica mode");
 
         assert_eq!(account.lamports(), 42);
+    }
+
+    #[tokio::test]
+    async fn get_account_info_in_primary_without_chainlink_readiness_returns_503(
+    ) {
+        let _lock = COORDINATION_MODE_TEST_LOCK.lock().await;
+        let env = ExecutionTestEnv::new_replica_mode(1, false);
+        switch_to_primary_mode();
+        let dispatcher = primary_not_ready_dispatcher(&env).await;
+        let pubkey = Pubkey::new_unique();
+        let mut request = request(
+            JsonRpcHttpMethod::GetAccountInfo,
+            vec![json::json!(pubkey.to_string())].into(),
+        );
+
+        let error = match dispatcher.get_account_info(&mut request).await {
+            Ok(_) => {
+                panic!("primary-not-ready getAccountInfo should be rejected")
+            }
+            Err(error) => error,
+        };
+
+        assert_eq!(error.http_status(), 503);
+        assert!(
+            error.to_string().contains(
+                "getAccountInfo requires Chainlink primary readiness"
+            ),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_multiple_accounts_in_primary_without_chainlink_readiness_returns_503(
+    ) {
+        let _lock = COORDINATION_MODE_TEST_LOCK.lock().await;
+        let env = ExecutionTestEnv::new_replica_mode(1, false);
+        switch_to_primary_mode();
+        let dispatcher = primary_not_ready_dispatcher(&env).await;
+        let pubkey = Pubkey::new_unique();
+        let mut request = request(
+            JsonRpcHttpMethod::GetMultipleAccounts,
+            vec![json::json!([pubkey.to_string()])].into(),
+        );
+
+        let error = match dispatcher.get_multiple_accounts(&mut request).await {
+            Ok(_) => panic!(
+                "primary-not-ready getMultipleAccounts should be rejected"
+            ),
+            Err(error) => error,
+        };
+
+        assert_eq!(error.http_status(), 503);
+        assert!(
+            error.to_string().contains(
+                "getMultipleAccounts requires Chainlink primary readiness"
+            ),
+            "unexpected error: {error}"
+        );
     }
 
     #[tokio::test]

--- a/magicblock-aperture/src/requests/http/mod.rs
+++ b/magicblock-aperture/src/requests/http/mod.rs
@@ -40,7 +40,6 @@ const MAX_RUNTIME_PROGRAM_ID_INDEX_EXCLUSIVE: usize =
 const SYSTEM_PROGRAM_ID: Pubkey =
     Pubkey::from_str_const("11111111111111111111111111111111");
 
-#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ApertureRoutingDecision {
     NonPrimary,
@@ -124,13 +123,12 @@ pub(crate) async fn extract_bytes(
 /// # HTTP Dispatcher Helpers
 ///
 /// This block contains common helper methods used by various RPC request handlers.
+/// Aperture routing has three states:
+/// - `NonPrimary`: local-only reads are allowed, writes/simulations are rejected.
+/// - `PrimaryReady`: Chainlink ensure paths are used.
+/// - `PrimaryNotReady`: ensure-dependent reads, writes, and simulations fail
+///   with HTTP 503 and JSON-RPC `TEMPORARILY_UNAVAILABLE`.
 impl HttpDispatcher {
-    #[allow(dead_code)]
-    fn is_primary_mode(&self) -> bool {
-        CoordinationMode::current().needs_onchain_interactions()
-    }
-
-    #[allow(dead_code)]
     async fn aperture_routing_decision(
         &self,
         method: &'static str,
@@ -202,8 +200,11 @@ impl HttpDispatcher {
             && account.owner() == &SYSTEM_PROGRAM_ID
     }
 
-    /// Fetches an account's data from the `AccountsDb` filling it in from chain
-    /// as needed.
+    /// Fetches an account's data from the `AccountsDb`.
+    ///
+    /// `NonPrimary` allows local-only reads, `PrimaryReady` fills from
+    /// Chainlink ensure paths, and `PrimaryNotReady` fails ensure-dependent
+    /// reads with HTTP 503 and JSON-RPC `TEMPORARILY_UNAVAILABLE`.
     #[instrument(skip_all)]
     async fn read_account_with_ensure(
         &self,
@@ -243,8 +244,11 @@ impl HttpDispatcher {
         }
     }
 
-    /// Fetches multiple account's data from the `AccountsDb` filling them in from chain
-    /// as needed.
+    /// Fetches multiple accounts' data from the `AccountsDb`.
+    ///
+    /// `NonPrimary` allows local-only reads, `PrimaryReady` fills from
+    /// Chainlink ensure paths, and `PrimaryNotReady` fails ensure-dependent
+    /// reads with HTTP 503 and JSON-RPC `TEMPORARILY_UNAVAILABLE`.
     #[instrument(skip(self, pubkeys), fields(pubkey_count = pubkeys.len()))]
     async fn read_accounts_with_ensure(
         &self,
@@ -347,6 +351,11 @@ impl HttpDispatcher {
     }
 
     /// Ensures all accounts required for a transaction are present in the `AccountsDb`.
+    ///
+    /// `NonPrimary` is a defensive no-op because writes/simulations are
+    /// rejected before this helper, `PrimaryReady` uses Chainlink ensure paths,
+    /// and `PrimaryNotReady` fails with HTTP 503 and JSON-RPC
+    /// `TEMPORARILY_UNAVAILABLE`.
     #[instrument(skip_all)]
     async fn ensure_transaction_accounts(
         &self,

--- a/magicblock-aperture/src/requests/http/mod.rs
+++ b/magicblock-aperture/src/requests/http/mod.rs
@@ -548,7 +548,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn simulate_transaction_in_replica_reaches_scheduler() {
+    async fn simulate_transaction_in_replica_rejects_before_scheduler() {
         let _lock = COORDINATION_MODE_TEST_LOCK.lock().await;
         let env = ExecutionTestEnv::new_replica_mode(1, false);
         let _mode = PrimaryModeGuard::switch_to_replica();
@@ -564,23 +564,15 @@ mod tests {
         );
 
         let error = match dispatcher.simulate_transaction(&mut request).await {
-            Ok(_) => panic!("simulation should reach the local scheduler"),
+            Ok(_) => panic!("replica simulateTransaction should be rejected"),
             Err(error) => error,
         };
 
         assert!(
-            error.to_string().contains("transaction simulation failed")
-                || error.to_string().contains("response channel closed")
-                || error
-                    .to_string()
-                    .contains("Transactions are currently disabled"),
-            "unexpected error: {error}"
-        );
-        assert!(
-            !error.to_string().contains(
+            error.to_string().contains(
                 "simulateTransaction is only available while validator is primary"
             ),
-            "simulateTransaction must not use the non-primary write gate"
+            "unexpected error: {error}"
         );
     }
 

--- a/magicblock-aperture/src/requests/http/mod.rs
+++ b/magicblock-aperture/src/requests/http/mod.rs
@@ -8,14 +8,13 @@ use hyper::{
     Request, Response,
 };
 use magicblock_accounts_db::traits::AccountsBank;
-use magicblock_chainlink::ChainlinkPrimaryReadiness;
+use magicblock_chainlink::PrimaryRuntimeReadiness;
 use magicblock_core::{
     coordination_mode::CoordinationMode,
     link::transactions::{SanitizeableTransaction, WithEncoded},
 };
 use magicblock_metrics::metrics::{
-    AccountFetchOrigin, ENSURE_ACCOUNTS_TIME,
-    RPC_APERTURE_ROUTING_DECISIONS_COUNT,
+    AccountFetchOrigin, APERTURE_ENSURE_ROUTING_COUNT, ENSURE_ACCOUNTS_TIME,
 };
 use prelude::JsonBody;
 use solana_account::{AccountSharedData, ReadableAccount};
@@ -41,10 +40,20 @@ const SYSTEM_PROGRAM_ID: Pubkey =
     Pubkey::from_str_const("11111111111111111111111111111111");
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ApertureRoutingDecision {
+enum EnsureRoutingDecision {
     NonPrimary,
-    PrimaryReady(ChainlinkPrimaryReadiness),
+    PrimaryReady,
     PrimaryNotReady,
+}
+
+impl EnsureRoutingDecision {
+    fn as_label(self) -> &'static str {
+        match self {
+            Self::NonPrimary => "non_primary",
+            Self::PrimaryReady => "primary_ready",
+            Self::PrimaryNotReady => "primary_not_ready",
+        }
+    }
 }
 
 /// An enum to efficiently represent a request body, avoiding allocation
@@ -123,68 +132,55 @@ pub(crate) async fn extract_bytes(
 /// # HTTP Dispatcher Helpers
 ///
 /// This block contains common helper methods used by various RPC request handlers.
-/// Aperture routing has three states:
+/// Aperture ensure routing has three states:
 /// - `NonPrimary`: local-only reads are allowed, writes/simulations are rejected.
 /// - `PrimaryReady`: Chainlink ensure paths are used.
-/// - `PrimaryNotReady`: ensure-dependent reads, writes, and simulations fail
-///   with HTTP 503 and JSON-RPC `TEMPORARILY_UNAVAILABLE`.
+/// - `PrimaryNotReady`: reads fall back to local-only data, and writes/simulations are rejected.
 impl HttpDispatcher {
-    async fn aperture_routing_decision(
+    async fn ensure_routing_decision(
         &self,
         method: &'static str,
-    ) -> ApertureRoutingDecision {
-        if !CoordinationMode::current().needs_onchain_interactions() {
-            RPC_APERTURE_ROUTING_DECISIONS_COUNT
-                .with_label_values(&[
-                    method,
-                    "non_primary_local",
-                    "not_applicable",
-                ])
-                .inc();
-            return ApertureRoutingDecision::NonPrimary;
-        }
+    ) -> EnsureRoutingDecision {
+        let decision = if !CoordinationMode::current()
+            .needs_onchain_interactions()
+        {
+            EnsureRoutingDecision::NonPrimary
+        } else {
+            match self.chainlink.primary_runtime_readiness().await {
+                PrimaryRuntimeReadiness::Ready
+                | PrimaryRuntimeReadiness::DisabledByConfig => {
+                    EnsureRoutingDecision::PrimaryReady
+                }
+                PrimaryRuntimeReadiness::NotReady => {
+                    warn!(
+                        method,
+                        "Aperture observed primary mode before Chainlink runtime readiness"
+                    );
+                    EnsureRoutingDecision::PrimaryNotReady
+                }
+            }
+        };
 
-        let readiness = self.chainlink.primary_readiness().await;
-        if readiness.allows_aperture_ensure() {
-            RPC_APERTURE_ROUTING_DECISIONS_COUNT
-                .with_label_values(&[
-                    method,
-                    "primary_ready_ensure",
-                    readiness.label(),
-                ])
-                .inc();
-            return ApertureRoutingDecision::PrimaryReady(readiness);
-        }
-
-        warn!(
-            method,
-            chainlink_readiness = readiness.label(),
-            "RPC aperture observed primary mode before Chainlink readiness"
-        );
-        RPC_APERTURE_ROUTING_DECISIONS_COUNT
-            .with_label_values(&[
-                method,
-                "primary_not_ready_reject",
-                readiness.label(),
-            ])
+        APERTURE_ENSURE_ROUTING_COUNT
+            .with_label_values(&[method, decision.as_label()])
             .inc();
-        ApertureRoutingDecision::PrimaryNotReady
+        decision
     }
 
-    async fn ensure_primary_write_ready(
+    async fn require_primary_ready_write(
         &self,
         method: &'static str,
     ) -> RpcResult<()> {
-        match self.aperture_routing_decision(method).await {
-            ApertureRoutingDecision::NonPrimary => {
+        match self.ensure_routing_decision(method).await {
+            EnsureRoutingDecision::NonPrimary => {
                 Err(RpcError::transaction_verification(format!(
                     "{method} is only available while validator is primary"
                 )))
             }
-            ApertureRoutingDecision::PrimaryReady(_) => Ok(()),
-            ApertureRoutingDecision::PrimaryNotReady => {
-                Err(RpcError::temporarily_unavailable(format!(
-                    "{method} requires Chainlink primary readiness"
+            EnsureRoutingDecision::PrimaryReady => Ok(()),
+            EnsureRoutingDecision::PrimaryNotReady => {
+                Err(RpcError::transaction_verification(format!(
+                    "{method} requires primary Chainlink runtime readiness"
                 )))
             }
         }
@@ -203,19 +199,19 @@ impl HttpDispatcher {
     /// Fetches an account's data from the `AccountsDb`.
     ///
     /// `NonPrimary` allows local-only reads, `PrimaryReady` fills from
-    /// Chainlink ensure paths, and `PrimaryNotReady` fails ensure-dependent
-    /// reads with HTTP 503 and JSON-RPC `TEMPORARILY_UNAVAILABLE`.
+    /// Chainlink ensure paths, and `PrimaryNotReady` falls back to local-only
+    /// data without calling Chainlink ensure.
     #[instrument(skip_all)]
     async fn read_account_with_ensure(
         &self,
-        method: &'static str,
+        _method: &'static str,
         pubkey: &Pubkey,
     ) -> RpcResult<Option<AccountSharedData>> {
-        match self.aperture_routing_decision(method).await {
-            ApertureRoutingDecision::NonPrimary => {
+        match self.ensure_routing_decision("read_account").await {
+            EnsureRoutingDecision::NonPrimary => {
                 Ok(self.accountsdb.get_account(pubkey))
             }
-            ApertureRoutingDecision::PrimaryReady(_) => {
+            EnsureRoutingDecision::PrimaryReady => {
                 let mark_empty_if_not_found = [*pubkey];
                 let _timer = ENSURE_ACCOUNTS_TIME
                     .with_label_values(&["account"])
@@ -236,10 +232,8 @@ impl HttpDispatcher {
                     });
                 Ok(self.accountsdb.get_account(pubkey))
             }
-            ApertureRoutingDecision::PrimaryNotReady => {
-                Err(RpcError::temporarily_unavailable(format!(
-                    "{method} requires Chainlink primary readiness"
-                )))
+            EnsureRoutingDecision::PrimaryNotReady => {
+                Ok(self.accountsdb.get_account(pubkey))
             }
         }
     }
@@ -247,20 +241,20 @@ impl HttpDispatcher {
     /// Fetches multiple accounts' data from the `AccountsDb`.
     ///
     /// `NonPrimary` allows local-only reads, `PrimaryReady` fills from
-    /// Chainlink ensure paths, and `PrimaryNotReady` fails ensure-dependent
-    /// reads with HTTP 503 and JSON-RPC `TEMPORARILY_UNAVAILABLE`.
+    /// Chainlink ensure paths, and `PrimaryNotReady` falls back to local-only
+    /// data without calling Chainlink ensure.
     #[instrument(skip(self, pubkeys), fields(pubkey_count = pubkeys.len()))]
     async fn read_accounts_with_ensure(
         &self,
-        method: &'static str,
+        _method: &'static str,
         pubkeys: &[Pubkey],
     ) -> RpcResult<Vec<Option<AccountSharedData>>> {
-        match self.aperture_routing_decision(method).await {
-            ApertureRoutingDecision::NonPrimary => Ok(pubkeys
+        match self.ensure_routing_decision("read_accounts").await {
+            EnsureRoutingDecision::NonPrimary => Ok(pubkeys
                 .iter()
                 .map(|pubkey| self.accountsdb.get_account(pubkey))
                 .collect()),
-            ApertureRoutingDecision::PrimaryReady(_) => {
+            EnsureRoutingDecision::PrimaryReady => {
                 trace!("Ensuring accounts");
                 let _timer = ENSURE_ACCOUNTS_TIME
                     .with_label_values(&["multi-account"])
@@ -284,11 +278,10 @@ impl HttpDispatcher {
                     .map(|pubkey| self.accountsdb.get_account(pubkey))
                     .collect())
             }
-            ApertureRoutingDecision::PrimaryNotReady => {
-                Err(RpcError::temporarily_unavailable(format!(
-                    "{method} requires Chainlink primary readiness"
-                )))
-            }
+            EnsureRoutingDecision::PrimaryNotReady => Ok(pubkeys
+                .iter()
+                .map(|pubkey| self.accountsdb.get_account(pubkey))
+                .collect()),
         }
     }
 
@@ -354,17 +347,16 @@ impl HttpDispatcher {
     ///
     /// `NonPrimary` is a defensive no-op because writes/simulations are
     /// rejected before this helper, `PrimaryReady` uses Chainlink ensure paths,
-    /// and `PrimaryNotReady` fails with HTTP 503 and JSON-RPC
-    /// `TEMPORARILY_UNAVAILABLE`.
+    /// and `PrimaryNotReady` rejects without calling Chainlink ensure.
     #[instrument(skip_all)]
     async fn ensure_transaction_accounts(
         &self,
-        method: &'static str,
+        _method: &'static str,
         transaction: &SanitizedTransaction,
     ) -> RpcResult<()> {
-        match self.aperture_routing_decision(method).await {
-            ApertureRoutingDecision::NonPrimary => Ok(()),
-            ApertureRoutingDecision::PrimaryReady(_) => {
+        match self.ensure_routing_decision("transaction").await {
+            EnsureRoutingDecision::NonPrimary => Ok(()),
+            EnsureRoutingDecision::PrimaryReady => {
                 let _timer = ENSURE_ACCOUNTS_TIME
                     .with_label_values(&["transaction"])
                     .start_timer();
@@ -388,10 +380,10 @@ impl HttpDispatcher {
                     }
                 }
             }
-            ApertureRoutingDecision::PrimaryNotReady => {
-                Err(RpcError::temporarily_unavailable(format!(
-                    "{method} requires Chainlink primary readiness"
-                )))
+            EnsureRoutingDecision::PrimaryNotReady => {
+                Err(RpcError::transaction_verification(
+                    "transaction requires primary Chainlink runtime readiness",
+                ))
             }
         }
     }

--- a/magicblock-aperture/src/requests/http/mod.rs
+++ b/magicblock-aperture/src/requests/http/mod.rs
@@ -8,11 +8,15 @@ use hyper::{
     Request, Response,
 };
 use magicblock_accounts_db::traits::AccountsBank;
+use magicblock_chainlink::ChainlinkPrimaryReadiness;
 use magicblock_core::{
     coordination_mode::CoordinationMode,
     link::transactions::{SanitizeableTransaction, WithEncoded},
 };
-use magicblock_metrics::metrics::{AccountFetchOrigin, ENSURE_ACCOUNTS_TIME};
+use magicblock_metrics::metrics::{
+    AccountFetchOrigin, ENSURE_ACCOUNTS_TIME,
+    RPC_APERTURE_ROUTING_DECISIONS_COUNT,
+};
 use prelude::JsonBody;
 use solana_account::{AccountSharedData, ReadableAccount};
 use solana_pubkey::Pubkey;
@@ -35,6 +39,14 @@ const MAX_RUNTIME_PROGRAM_ID_INDEX_EXCLUSIVE: usize =
     1232 / size_of::<Pubkey>();
 const SYSTEM_PROGRAM_ID: Pubkey =
     Pubkey::from_str_const("11111111111111111111111111111111");
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ApertureRoutingDecision {
+    NonPrimary,
+    PrimaryReady(ChainlinkPrimaryReadiness),
+    PrimaryNotReady,
+}
 
 /// An enum to efficiently represent a request body, avoiding allocation
 /// for single-chunk bodies (which are almost always the case)
@@ -115,6 +127,49 @@ pub(crate) async fn extract_bytes(
 impl HttpDispatcher {
     fn is_primary_mode(&self) -> bool {
         CoordinationMode::current().needs_onchain_interactions()
+    }
+
+    #[allow(dead_code)]
+    async fn aperture_routing_decision(
+        &self,
+        method: &'static str,
+    ) -> ApertureRoutingDecision {
+        if !CoordinationMode::current().needs_onchain_interactions() {
+            RPC_APERTURE_ROUTING_DECISIONS_COUNT
+                .with_label_values(&[
+                    method,
+                    "non_primary_local",
+                    "not_applicable",
+                ])
+                .inc();
+            return ApertureRoutingDecision::NonPrimary;
+        }
+
+        let readiness = self.chainlink.primary_readiness().await;
+        if readiness.allows_aperture_ensure() {
+            RPC_APERTURE_ROUTING_DECISIONS_COUNT
+                .with_label_values(&[
+                    method,
+                    "primary_ready_ensure",
+                    readiness.label(),
+                ])
+                .inc();
+            return ApertureRoutingDecision::PrimaryReady(readiness);
+        }
+
+        warn!(
+            method,
+            chainlink_readiness = readiness.label(),
+            "RPC aperture observed primary mode before Chainlink readiness"
+        );
+        RPC_APERTURE_ROUTING_DECISIONS_COUNT
+            .with_label_values(&[
+                method,
+                "primary_not_ready_reject",
+                readiness.label(),
+            ])
+            .inc();
+        ApertureRoutingDecision::PrimaryNotReady
     }
 
     fn reject_non_primary_write(&self, method: &'static str) -> RpcResult<()> {

--- a/magicblock-aperture/src/requests/http/mod.rs
+++ b/magicblock-aperture/src/requests/http/mod.rs
@@ -117,7 +117,6 @@ impl HttpDispatcher {
         CoordinationMode::current().needs_onchain_interactions()
     }
 
-    // TODO: Add integration coverage for non-primary RPC write rejection in the later test step.
     fn reject_non_primary_write(&self, method: &'static str) -> RpcResult<()> {
         if self.is_primary_mode() {
             return Ok(());
@@ -385,19 +384,205 @@ pub(crate) mod get_delegation_status;
 
 #[cfg(test)]
 mod tests {
-    use magicblock_core::link::blocks::BlockHash;
+    use std::sync::Arc;
+
+    use base64::{
+        engine::general_purpose::STANDARD as BASE64_STANDARD, Engine,
+    };
+    use magicblock_config::config::ChainLinkConfig;
+    use magicblock_core::{
+        coordination_mode::{switch_to_primary_mode, switch_to_replica_mode},
+        link::{blocks::BlockHash, link},
+    };
+    use solana_account::ReadableAccount;
     use solana_message::{
         compiled_instruction::CompiledInstruction, legacy::Message,
         MessageHeader, VersionedMessage,
     };
     use solana_signature::Signature;
+    use test_kit::{
+        guinea::{self, GuineaInstruction},
+        AccountMeta, ExecutionTestEnv, Instruction,
+    };
 
     use super::*;
+    use crate::{
+        requests::{JsonHttpRequest, JsonRpcHttpMethod},
+        state::{ChainlinkImpl, NodeContext, SharedState},
+    };
+
+    static COORDINATION_MODE_TEST_LOCK: tokio::sync::Mutex<()> =
+        tokio::sync::Mutex::const_new(());
+
+    struct PrimaryModeGuard;
+
+    impl PrimaryModeGuard {
+        fn switch_to_replica() -> Self {
+            switch_to_replica_mode();
+            Self
+        }
+    }
+
+    impl Drop for PrimaryModeGuard {
+        fn drop(&mut self) {
+            switch_to_primary_mode();
+        }
+    }
+
+    fn test_dispatcher(env: &ExecutionTestEnv) -> HttpDispatcher {
+        let chainlink = Arc::new(
+            ChainlinkImpl::try_new(
+                &env.accountsdb,
+                None,
+                Pubkey::new_unique(),
+                &ChainLinkConfig::default(),
+            )
+            .expect("failed to create chainlink"),
+        );
+        let state = SharedState::new(
+            NodeContext {
+                identity: env.get_payer().pubkey,
+                base_fee: ExecutionTestEnv::BASE_FEE,
+                blocktime: 50,
+                ..Default::default()
+            },
+            env.accountsdb.clone(),
+            env.ledger.clone(),
+            chainlink,
+        );
+        let (dispatch, _validator) = link();
+        HttpDispatcher {
+            context: state.context,
+            accountsdb: state.accountsdb,
+            ledger: state.ledger,
+            chainlink: state.chainlink,
+            transactions: state.transactions,
+            blocks: state.blocks,
+            transactions_scheduler: dispatch.transaction_scheduler,
+        }
+    }
+
+    fn encoded_transfer(env: &ExecutionTestEnv) -> (String, Signature) {
+        let from = Pubkey::new_unique();
+        let to = Pubkey::new_unique();
+        env.fund_account_with_owner(from, 10_000_000_000, guinea::ID);
+        env.fund_account_with_owner(to, 10_000_000_000, guinea::ID);
+        let ix = Instruction::new_with_bincode(
+            guinea::ID,
+            &GuineaInstruction::Transfer(1_000),
+            vec![AccountMeta::new(from, false), AccountMeta::new(to, false)],
+        );
+        let tx = env.build_transaction(&[ix]);
+        let signature = tx.signatures[0];
+        let encoded = BASE64_STANDARD.encode(
+            bincode::serialize(&tx).expect("transaction should serialize"),
+        );
+        (encoded, signature)
+    }
+
+    fn request(
+        method: JsonRpcHttpMethod,
+        params: json::Array,
+    ) -> JsonHttpRequest {
+        JsonHttpRequest {
+            id: json::json!(1),
+            method,
+            params: Some(params),
+        }
+    }
 
     const SYSTEM_PROGRAM_ID: Pubkey =
         Pubkey::from_str_const("11111111111111111111111111111111");
     const COMPUTE_BUDGET_ID: Pubkey =
         Pubkey::from_str_const("ComputeBudget111111111111111111111111111111");
+
+    #[tokio::test]
+    async fn send_transaction_in_replica_rejects_before_signature_cache_insert()
+    {
+        let _lock = COORDINATION_MODE_TEST_LOCK.lock().await;
+        let env = ExecutionTestEnv::new_replica_mode(1, false);
+        let _mode = PrimaryModeGuard::switch_to_replica();
+        let dispatcher = test_dispatcher(&env);
+        let (encoded_tx, signature) = encoded_transfer(&env);
+        let mut request = request(
+            JsonRpcHttpMethod::SendTransaction,
+            vec![
+                json::json!(encoded_tx),
+                json::json!({ "encoding": "base64", "skipPreflight": true }),
+            ]
+            .into(),
+        );
+
+        let error = match dispatcher.send_transaction(&mut request).await {
+            Ok(_) => panic!("replica sendTransaction should be rejected"),
+            Err(error) => error,
+        };
+
+        assert!(
+            error.to_string().contains(
+                "sendTransaction is only available while validator is primary"
+            ),
+            "unexpected error: {error}"
+        );
+        assert!(
+            !dispatcher.transactions.contains(&signature),
+            "rejected replica sendTransaction must not reserve signature"
+        );
+    }
+
+    #[tokio::test]
+    async fn read_account_with_ensure_in_replica_returns_local_account() {
+        let _lock = COORDINATION_MODE_TEST_LOCK.lock().await;
+        let env = ExecutionTestEnv::new_replica_mode(1, false);
+        let _mode = PrimaryModeGuard::switch_to_replica();
+        let dispatcher = test_dispatcher(&env);
+        let pubkey = Pubkey::new_unique();
+        env.fund_account(pubkey, 42);
+
+        let account = dispatcher
+            .read_account_with_ensure(&pubkey)
+            .await
+            .expect("local account should be returned in replica mode");
+
+        assert_eq!(account.lamports(), 42);
+    }
+
+    #[tokio::test]
+    async fn simulate_transaction_in_replica_reaches_scheduler() {
+        let _lock = COORDINATION_MODE_TEST_LOCK.lock().await;
+        let env = ExecutionTestEnv::new_replica_mode(1, false);
+        let _mode = PrimaryModeGuard::switch_to_replica();
+        let dispatcher = test_dispatcher(&env);
+        let (encoded_tx, _signature) = encoded_transfer(&env);
+        let mut request = request(
+            JsonRpcHttpMethod::SimulateTransaction,
+            vec![
+                json::json!(encoded_tx),
+                json::json!({ "encoding": "base64", "sigVerify": false }),
+            ]
+            .into(),
+        );
+
+        let error = match dispatcher.simulate_transaction(&mut request).await {
+            Ok(_) => panic!("simulation should reach the local scheduler"),
+            Err(error) => error,
+        };
+
+        assert!(
+            error.to_string().contains("transaction simulation failed")
+                || error.to_string().contains("response channel closed")
+                || error
+                    .to_string()
+                    .contains("Transactions are currently disabled"),
+            "unexpected error: {error}"
+        );
+        assert!(
+            !error.to_string().contains(
+                "simulateTransaction is only available while validator is primary"
+            ),
+            "simulateTransaction must not use the non-primary write gate"
+        );
+    }
 
     #[test]
     fn accepts_program_id_index_within_runtime_limit() {

--- a/magicblock-aperture/src/requests/http/mod.rs
+++ b/magicblock-aperture/src/requests/http/mod.rs
@@ -474,7 +474,7 @@ pub(crate) mod get_delegation_status;
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::{path::Path, sync::Arc};
 
     use base64::{
         engine::general_purpose::STANDARD as BASE64_STANDARD, Engine,
@@ -484,7 +484,7 @@ mod tests {
         chainlink::config::ChainlinkConfig,
         remote_account_provider::{Endpoint, Endpoints},
     };
-    use magicblock_config::config::ChainLinkConfig;
+    use magicblock_config::config::{ChainLinkConfig, LifecycleMode};
     use magicblock_core::{
         coordination_mode::{switch_to_primary_mode, switch_to_replica_mode},
         link::{blocks::BlockHash, link},
@@ -526,7 +526,7 @@ mod tests {
         }
     }
 
-    fn dispatcher_from_chainlink(
+    fn test_dispatcher_with_chainlink(
         env: &ExecutionTestEnv,
         chainlink: Arc<ChainlinkImpl>,
     ) -> HttpDispatcher {
@@ -563,12 +563,12 @@ mod tests {
             )
             .expect("failed to create chainlink"),
         );
-        dispatcher_from_chainlink(env, chainlink)
+        test_dispatcher_with_chainlink(env, chainlink)
     }
 
-    async fn primary_not_ready_dispatcher(
+    async fn not_ready_endpoint_chainlink(
         env: &ExecutionTestEnv,
-    ) -> HttpDispatcher {
+    ) -> Arc<ChainlinkImpl> {
         let (dispatch, _validator) = link();
         let cloner = Arc::new(ChainlinkCloner::new(
             dispatch.transaction_scheduler.clone(),
@@ -577,54 +577,39 @@ mod tests {
         let endpoints = Endpoints::from(
             &[
                 Endpoint::Rpc {
-                    url: "http://127.0.0.1:1".to_string(),
-                    label: "unreachable-rpc".to_string(),
+                    url: "http://127.0.0.1:8899".to_string(),
+                    label: "local-rpc".to_string(),
                 },
                 Endpoint::WebSocket {
-                    url: "ws://127.0.0.1:1".to_string(),
-                    label: "unreachable-ws".to_string(),
+                    url: "ws://127.0.0.1:8900".to_string(),
+                    label: "local-ws".to_string(),
                 },
             ][..],
         );
-        let ledger_path = std::env::temp_dir().join(format!(
-            "mb-aperture-primary-not-ready-{}",
-            Pubkey::new_unique()
-        ));
-        let chainlink = Arc::new(
+
+        Arc::new(
             ChainlinkImpl::try_new_from_endpoints(
                 &endpoints,
                 CommitmentConfig::confirmed(),
                 &env.accountsdb,
                 &cloner,
                 Keypair::new(),
-                ChainlinkConfig::default(),
+                ChainlinkConfig::default_with_lifecycle_mode(
+                    LifecycleMode::Ephemeral,
+                ),
                 &ChainLinkConfig::default(),
-                &ledger_path,
+                Path::new("."),
             )
             .await
             .expect("failed to create endpoint-backed chainlink"),
-        );
+        )
+    }
 
-        let state = SharedState::new(
-            NodeContext {
-                identity: env.get_payer().pubkey,
-                base_fee: ExecutionTestEnv::BASE_FEE,
-                blocktime: 50,
-                ..Default::default()
-            },
-            env.accountsdb.clone(),
-            env.ledger.clone(),
-            chainlink,
-        );
-        HttpDispatcher {
-            context: state.context,
-            accountsdb: state.accountsdb,
-            ledger: state.ledger,
-            chainlink: state.chainlink,
-            transactions: state.transactions,
-            blocks: state.blocks,
-            transactions_scheduler: dispatch.transaction_scheduler,
-        }
+    async fn primary_not_ready_dispatcher(
+        env: &ExecutionTestEnv,
+    ) -> HttpDispatcher {
+        let chainlink = not_ready_endpoint_chainlink(env).await;
+        test_dispatcher_with_chainlink(env, chainlink)
     }
 
     fn encoded_transfer(env: &ExecutionTestEnv) -> (String, Signature) {
@@ -654,6 +639,44 @@ mod tests {
             method,
             params: Some(params),
         }
+    }
+
+    #[tokio::test]
+    async fn ensure_routing_decision_non_primary_returns_non_primary() {
+        let _lock = COORDINATION_MODE_TEST_LOCK.lock().await;
+        let env = ExecutionTestEnv::new_replica_mode(1, false);
+        let _mode = PrimaryModeGuard::switch_to_replica();
+        let dispatcher = test_dispatcher(&env);
+
+        let decision = dispatcher.ensure_routing_decision("read_account").await;
+
+        assert_eq!(decision, EnsureRoutingDecision::NonPrimary);
+    }
+
+    #[tokio::test]
+    async fn ensure_routing_decision_primary_disabled_by_config_is_ready() {
+        let _lock = COORDINATION_MODE_TEST_LOCK.lock().await;
+        switch_to_primary_mode();
+        let env = ExecutionTestEnv::new_replica_mode(1, false);
+        let dispatcher = test_dispatcher(&env);
+
+        let decision = dispatcher.ensure_routing_decision("read_account").await;
+
+        assert_eq!(decision, EnsureRoutingDecision::PrimaryReady);
+    }
+
+    #[tokio::test]
+    async fn ensure_routing_decision_primary_endpoint_without_enable_is_not_ready(
+    ) {
+        let _lock = COORDINATION_MODE_TEST_LOCK.lock().await;
+        switch_to_primary_mode();
+        let env = ExecutionTestEnv::new_replica_mode(1, false);
+        let chainlink = not_ready_endpoint_chainlink(&env).await;
+        let dispatcher = test_dispatcher_with_chainlink(&env, chainlink);
+
+        let decision = dispatcher.ensure_routing_decision("read_account").await;
+
+        assert_eq!(decision, EnsureRoutingDecision::PrimaryNotReady);
     }
 
     const SYSTEM_PROGRAM_ID: Pubkey =
@@ -714,61 +737,23 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn get_account_info_in_primary_without_chainlink_readiness_returns_503(
-    ) {
+    async fn read_account_primary_not_ready_returns_local_account() {
         let _lock = COORDINATION_MODE_TEST_LOCK.lock().await;
         let env = ExecutionTestEnv::new_replica_mode(1, false);
         switch_to_primary_mode();
         let dispatcher = primary_not_ready_dispatcher(&env).await;
         let pubkey = Pubkey::new_unique();
-        let mut request = request(
-            JsonRpcHttpMethod::GetAccountInfo,
-            vec![json::json!(pubkey.to_string())].into(),
-        );
+        env.fund_account(pubkey, 42);
 
-        let error = match dispatcher.get_account_info(&mut request).await {
-            Ok(_) => {
-                panic!("primary-not-ready getAccountInfo should be rejected")
-            }
-            Err(error) => error,
-        };
+        let account = dispatcher
+            .read_account_with_ensure("getAccountInfo", &pubkey)
+            .await
+            .expect("primary-not-ready read should not fail")
+            .expect(
+                "local account should be returned in primary-not-ready mode",
+            );
 
-        assert_eq!(error.http_status(), 503);
-        assert!(
-            error.to_string().contains(
-                "getAccountInfo requires Chainlink primary readiness"
-            ),
-            "unexpected error: {error}"
-        );
-    }
-
-    #[tokio::test]
-    async fn get_multiple_accounts_in_primary_without_chainlink_readiness_returns_503(
-    ) {
-        let _lock = COORDINATION_MODE_TEST_LOCK.lock().await;
-        let env = ExecutionTestEnv::new_replica_mode(1, false);
-        switch_to_primary_mode();
-        let dispatcher = primary_not_ready_dispatcher(&env).await;
-        let pubkey = Pubkey::new_unique();
-        let mut request = request(
-            JsonRpcHttpMethod::GetMultipleAccounts,
-            vec![json::json!([pubkey.to_string()])].into(),
-        );
-
-        let error = match dispatcher.get_multiple_accounts(&mut request).await {
-            Ok(_) => panic!(
-                "primary-not-ready getMultipleAccounts should be rejected"
-            ),
-            Err(error) => error,
-        };
-
-        assert_eq!(error.http_status(), 503);
-        assert!(
-            error.to_string().contains(
-                "getMultipleAccounts requires Chainlink primary readiness"
-            ),
-            "unexpected error: {error}"
-        );
+        assert_eq!(account.lamports(), 42);
     }
 
     #[tokio::test]
@@ -801,7 +786,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn send_transaction_in_primary_without_chainlink_readiness_returns_503_and_does_not_cache_signature(
+    async fn send_transaction_primary_not_ready_rejects_before_signature_cache_insert(
     ) {
         let _lock = COORDINATION_MODE_TEST_LOCK.lock().await;
         let env = ExecutionTestEnv::new_replica_mode(1, false);
@@ -824,10 +809,9 @@ mod tests {
             Err(error) => error,
         };
 
-        assert_eq!(error.http_status(), 503);
         assert!(
             error.to_string().contains(
-                "sendTransaction requires Chainlink primary readiness"
+                "sendTransaction requires primary Chainlink runtime readiness"
             ),
             "unexpected error: {error}"
         );
@@ -838,8 +822,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn simulate_transaction_in_primary_without_chainlink_readiness_returns_503(
-    ) {
+    async fn simulate_transaction_primary_not_ready_rejects() {
         let _lock = COORDINATION_MODE_TEST_LOCK.lock().await;
         let env = ExecutionTestEnv::new_replica_mode(1, false);
         switch_to_primary_mode();
@@ -861,10 +844,9 @@ mod tests {
             Err(error) => error,
         };
 
-        assert_eq!(error.http_status(), 503);
         assert!(
             error.to_string().contains(
-                "simulateTransaction requires Chainlink primary readiness"
+                "simulateTransaction requires primary Chainlink runtime readiness"
             ),
             "unexpected error: {error}"
         );

--- a/magicblock-aperture/src/requests/http/mod.rs
+++ b/magicblock-aperture/src/requests/http/mod.rs
@@ -125,6 +125,7 @@ pub(crate) async fn extract_bytes(
 ///
 /// This block contains common helper methods used by various RPC request handlers.
 impl HttpDispatcher {
+    #[allow(dead_code)]
     fn is_primary_mode(&self) -> bool {
         CoordinationMode::current().needs_onchain_interactions()
     }
@@ -172,13 +173,23 @@ impl HttpDispatcher {
         ApertureRoutingDecision::PrimaryNotReady
     }
 
-    fn reject_non_primary_write(&self, method: &'static str) -> RpcResult<()> {
-        if self.is_primary_mode() {
-            return Ok(());
+    async fn ensure_primary_write_ready(
+        &self,
+        method: &'static str,
+    ) -> RpcResult<()> {
+        match self.aperture_routing_decision(method).await {
+            ApertureRoutingDecision::NonPrimary => {
+                Err(RpcError::transaction_verification(format!(
+                    "{method} is only available while validator is primary"
+                )))
+            }
+            ApertureRoutingDecision::PrimaryReady(_) => Ok(()),
+            ApertureRoutingDecision::PrimaryNotReady => {
+                Err(RpcError::temporarily_unavailable(format!(
+                    "{method} requires Chainlink primary readiness"
+                )))
+            }
         }
-        Err(RpcError::transaction_verification(format!(
-            "{method} is only available while validator is primary"
-        )))
     }
 
     // Heuristic to render synthetic empty placeholder accounts as JSON-RPC null.
@@ -339,32 +350,39 @@ impl HttpDispatcher {
     #[instrument(skip_all)]
     async fn ensure_transaction_accounts(
         &self,
+        method: &'static str,
         transaction: &SanitizedTransaction,
     ) -> RpcResult<()> {
-        if !self.is_primary_mode() {
-            return Ok(());
-        }
-
-        let _timer = ENSURE_ACCOUNTS_TIME
-            .with_label_values(&["transaction"])
-            .start_timer();
-        match self
-            .chainlink
-            .ensure_transaction_accounts(transaction)
-            .await
-        {
-            Ok(res) if res.is_ok() => Ok(()),
-            Ok(res) => {
-                debug!(%res, "Transaction account resolution encountered issues");
-                Ok(())
+        match self.aperture_routing_decision(method).await {
+            ApertureRoutingDecision::NonPrimary => Ok(()),
+            ApertureRoutingDecision::PrimaryReady(_) => {
+                let _timer = ENSURE_ACCOUNTS_TIME
+                    .with_label_values(&["transaction"])
+                    .start_timer();
+                match self
+                    .chainlink
+                    .ensure_transaction_accounts(transaction)
+                    .await
+                {
+                    Ok(res) if res.is_ok() => Ok(()),
+                    Ok(res) => {
+                        debug!(%res, "Transaction account resolution encountered issues");
+                        Ok(())
+                    }
+                    Err(err) => {
+                        // Non-OK result indicates a general failure to guarantee
+                        // all accounts, i.e. we may be disconnected, weren't able to
+                        // setup a subscription, etc.
+                        // In that case we don't even want to run the transaction.
+                        warn!(error = ?err, "Failed to ensure transaction accounts");
+                        Err(RpcError::transaction_verification(err))
+                    }
+                }
             }
-            Err(err) => {
-                // Non-OK result indicates a general failure to guarantee
-                // all accounts, i.e. we may be disconnected, weren't able to
-                // setup a subscription, etc.
-                // In that case we don't even want to run the transaction.
-                warn!(error = ?err, "Failed to ensure transaction accounts");
-                Err(RpcError::transaction_verification(err))
+            ApertureRoutingDecision::PrimaryNotReady => {
+                Err(RpcError::temporarily_unavailable(format!(
+                    "{method} requires Chainlink primary readiness"
+                )))
             }
         }
     }
@@ -776,6 +794,76 @@ mod tests {
         assert!(
             error.to_string().contains(
                 "simulateTransaction is only available while validator is primary"
+            ),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_transaction_in_primary_without_chainlink_readiness_returns_503_and_does_not_cache_signature(
+    ) {
+        let _lock = COORDINATION_MODE_TEST_LOCK.lock().await;
+        let env = ExecutionTestEnv::new_replica_mode(1, false);
+        switch_to_primary_mode();
+        let dispatcher = primary_not_ready_dispatcher(&env).await;
+        let (encoded_tx, signature) = encoded_transfer(&env);
+        let mut request = request(
+            JsonRpcHttpMethod::SendTransaction,
+            vec![
+                json::json!(encoded_tx),
+                json::json!({ "encoding": "base64", "skipPreflight": true }),
+            ]
+            .into(),
+        );
+
+        let error = match dispatcher.send_transaction(&mut request).await {
+            Ok(_) => {
+                panic!("primary-not-ready sendTransaction should be rejected")
+            }
+            Err(error) => error,
+        };
+
+        assert_eq!(error.http_status(), 503);
+        assert!(
+            error.to_string().contains(
+                "sendTransaction requires Chainlink primary readiness"
+            ),
+            "unexpected error: {error}"
+        );
+        assert!(
+            !dispatcher.transactions.contains(&signature),
+            "primary-not-ready sendTransaction must not reserve signature"
+        );
+    }
+
+    #[tokio::test]
+    async fn simulate_transaction_in_primary_without_chainlink_readiness_returns_503(
+    ) {
+        let _lock = COORDINATION_MODE_TEST_LOCK.lock().await;
+        let env = ExecutionTestEnv::new_replica_mode(1, false);
+        switch_to_primary_mode();
+        let dispatcher = primary_not_ready_dispatcher(&env).await;
+        let (encoded_tx, _signature) = encoded_transfer(&env);
+        let mut request = request(
+            JsonRpcHttpMethod::SimulateTransaction,
+            vec![
+                json::json!(encoded_tx),
+                json::json!({ "encoding": "base64", "sigVerify": false }),
+            ]
+            .into(),
+        );
+
+        let error = match dispatcher.simulate_transaction(&mut request).await {
+            Ok(_) => panic!(
+                "primary-not-ready simulateTransaction should be rejected"
+            ),
+            Err(error) => error,
+        };
+
+        assert_eq!(error.http_status(), 503);
+        assert!(
+            error.to_string().contains(
+                "simulateTransaction requires Chainlink primary readiness"
             ),
             "unexpected error: {error}"
         );

--- a/magicblock-aperture/src/requests/http/mod.rs
+++ b/magicblock-aperture/src/requests/http/mod.rs
@@ -8,8 +8,9 @@ use hyper::{
     Request, Response,
 };
 use magicblock_accounts_db::traits::AccountsBank;
-use magicblock_core::link::transactions::{
-    SanitizeableTransaction, WithEncoded,
+use magicblock_core::{
+    coordination_mode::CoordinationMode,
+    link::transactions::{SanitizeableTransaction, WithEncoded},
 };
 use magicblock_metrics::metrics::{AccountFetchOrigin, ENSURE_ACCOUNTS_TIME};
 use prelude::JsonBody;
@@ -112,6 +113,20 @@ pub(crate) async fn extract_bytes(
 ///
 /// This block contains common helper methods used by various RPC request handlers.
 impl HttpDispatcher {
+    fn is_primary_mode(&self) -> bool {
+        CoordinationMode::current().needs_onchain_interactions()
+    }
+
+    // TODO: Add integration coverage for non-primary RPC write rejection in the later test step.
+    fn reject_non_primary_write(&self, method: &'static str) -> RpcResult<()> {
+        if self.is_primary_mode() {
+            return Ok(());
+        }
+        Err(RpcError::transaction_verification(format!(
+            "{method} is only available while validator is primary"
+        )))
+    }
+
     // Heuristic to render synthetic empty placeholder accounts as JSON-RPC null.
     fn account_should_render_as_null(account: &AccountSharedData) -> bool {
         account.lamports() == 0
@@ -129,6 +144,10 @@ impl HttpDispatcher {
         &self,
         pubkey: &Pubkey,
     ) -> Option<AccountSharedData> {
+        if !self.is_primary_mode() {
+            return self.accountsdb.get_account(pubkey);
+        }
+
         let mark_empty_if_not_found = [*pubkey];
         let _timer = ENSURE_ACCOUNTS_TIME
             .with_label_values(&["account"])
@@ -157,6 +176,13 @@ impl HttpDispatcher {
         &self,
         pubkeys: &[Pubkey],
     ) -> Vec<Option<AccountSharedData>> {
+        if !self.is_primary_mode() {
+            return pubkeys
+                .iter()
+                .map(|pubkey| self.accountsdb.get_account(pubkey))
+                .collect();
+        }
+
         trace!("Ensuring accounts");
         let _timer = ENSURE_ACCOUNTS_TIME
             .with_label_values(&["multi-account"])
@@ -245,6 +271,10 @@ impl HttpDispatcher {
         &self,
         transaction: &SanitizedTransaction,
     ) -> RpcResult<()> {
+        if !self.is_primary_mode() {
+            return Ok(());
+        }
+
         let _timer = ENSURE_ACCOUNTS_TIME
             .with_label_values(&["transaction"])
             .start_timer();

--- a/magicblock-aperture/src/requests/http/send_transaction.rs
+++ b/magicblock-aperture/src/requests/http/send_transaction.rs
@@ -32,6 +32,7 @@ impl HttpDispatcher {
             .inspect_err(
                 |err| debug!(error = ?err, "Failed to prepare transaction"),
             )?;
+        self.reject_non_primary_write("sendTransaction")?;
         let signature = *transaction.txn.signature();
 
         // Perform a replay check and reserve the signature in the cache

--- a/magicblock-aperture/src/requests/http/send_transaction.rs
+++ b/magicblock-aperture/src/requests/http/send_transaction.rs
@@ -27,7 +27,7 @@ impl HttpDispatcher {
         let config = config.unwrap_or_default();
         let encoding = config.encoding.unwrap_or(UiTransactionEncoding::Base58);
 
-        self.reject_non_primary_write("sendTransaction")?;
+        self.ensure_primary_write_ready("sendTransaction").await?;
         let transaction = self
             .prepare_transaction(&transaction_str, encoding, true, false)
             .inspect_err(
@@ -42,7 +42,8 @@ impl HttpDispatcher {
             return Err(TransactionError::AlreadyProcessed.into());
         }
 
-        self.ensure_transaction_accounts(&transaction.txn).await?;
+        self.ensure_transaction_accounts("sendTransaction", &transaction.txn)
+            .await?;
 
         // Based on the preflight flag, either execute and await the result,
         // or schedule (fire-and-forget) for background processing.

--- a/magicblock-aperture/src/requests/http/send_transaction.rs
+++ b/magicblock-aperture/src/requests/http/send_transaction.rs
@@ -27,7 +27,7 @@ impl HttpDispatcher {
         let config = config.unwrap_or_default();
         let encoding = config.encoding.unwrap_or(UiTransactionEncoding::Base58);
 
-        self.ensure_primary_write_ready("sendTransaction").await?;
+        self.require_primary_ready_write("sendTransaction").await?;
         let transaction = self
             .prepare_transaction(&transaction_str, encoding, true, false)
             .inspect_err(

--- a/magicblock-aperture/src/requests/http/send_transaction.rs
+++ b/magicblock-aperture/src/requests/http/send_transaction.rs
@@ -27,12 +27,12 @@ impl HttpDispatcher {
         let config = config.unwrap_or_default();
         let encoding = config.encoding.unwrap_or(UiTransactionEncoding::Base58);
 
+        self.reject_non_primary_write("sendTransaction")?;
         let transaction = self
             .prepare_transaction(&transaction_str, encoding, true, false)
             .inspect_err(
                 |err| debug!(error = ?err, "Failed to prepare transaction"),
             )?;
-        self.reject_non_primary_write("sendTransaction")?;
         let signature = *transaction.txn.signature();
 
         // Perform a replay check and reserve the signature in the cache

--- a/magicblock-aperture/src/requests/http/simulate_transaction.rs
+++ b/magicblock-aperture/src/requests/http/simulate_transaction.rs
@@ -35,6 +35,8 @@ impl HttpDispatcher {
         let config = config.unwrap_or_default();
         let encoding = config.encoding.unwrap_or(UiTransactionEncoding::Base58);
 
+        self.reject_non_primary_write("simulateTransaction")?;
+
         // Prepare the transaction, applying simulation-specific options.
         let transaction = self
             .prepare_transaction(

--- a/magicblock-aperture/src/requests/http/simulate_transaction.rs
+++ b/magicblock-aperture/src/requests/http/simulate_transaction.rs
@@ -35,7 +35,7 @@ impl HttpDispatcher {
         let config = config.unwrap_or_default();
         let encoding = config.encoding.unwrap_or(UiTransactionEncoding::Base58);
 
-        self.ensure_primary_write_ready("simulateTransaction")
+        self.require_primary_ready_write("simulateTransaction")
             .await?;
 
         // Prepare the transaction, applying simulation-specific options.

--- a/magicblock-aperture/src/requests/http/simulate_transaction.rs
+++ b/magicblock-aperture/src/requests/http/simulate_transaction.rs
@@ -35,7 +35,8 @@ impl HttpDispatcher {
         let config = config.unwrap_or_default();
         let encoding = config.encoding.unwrap_or(UiTransactionEncoding::Base58);
 
-        self.reject_non_primary_write("simulateTransaction")?;
+        self.ensure_primary_write_ready("simulateTransaction")
+            .await?;
 
         // Prepare the transaction, applying simulation-specific options.
         let transaction = self
@@ -48,7 +49,11 @@ impl HttpDispatcher {
             .inspect_err(|err| {
                 debug!(error = ?err, "Failed to prepare transaction to simulate")
             })?;
-        self.ensure_transaction_accounts(&transaction.txn).await?;
+        self.ensure_transaction_accounts(
+            "simulateTransaction",
+            &transaction.txn,
+        )
+        .await?;
         let number_of_accounts = transaction.txn.message().account_keys().len();
 
         let replacement_blockhash = config

--- a/magicblock-aperture/src/requests/http/simulate_transaction.rs
+++ b/magicblock-aperture/src/requests/http/simulate_transaction.rs
@@ -102,8 +102,9 @@ impl HttpDispatcher {
                             .map_err(RpcError::invalid_params)
                     })
                     .collect::<Result<Vec<_>, _>>()?;
-                let current_accounts =
-                    self.read_accounts_with_ensure(&pubkeys).await;
+                let current_accounts = self
+                    .read_accounts_with_ensure("simulateTransaction", &pubkeys)
+                    .await?;
                 let post_simulation_accounts = post_simulation_accounts
                     .into_iter()
                     .collect::<HashMap<_, _>>();

--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -107,6 +107,10 @@ type ChainlinkImpl = Chainlink<
     ChainlinkCloner,
 >;
 
+fn replication_mode_can_promote(replication_mode: &ReplicationMode) -> bool {
+    matches!(replication_mode, ReplicationMode::StandBy(_))
+}
+
 async fn run_standalone_primary_start_sequence(
     validator: &MagicValidator,
     should_reset_accounts_bank: bool,
@@ -277,9 +281,8 @@ impl MagicValidator {
                     "replication channel should always exist after init",
                 );
                 // ReplicaOnly mode cannot promote to primary
-                let can_promote = matches!(
-                    config.validator.replication_mode,
-                    ReplicationMode::StandBy(_)
+                let can_promote = replication_mode_can_promote(
+                    &config.validator.replication_mode,
                 );
                 // Replication uses a reset-only cleanup handle in all modes.
                 // Only promotable StandBy contexts receive the real RPC-facing
@@ -1109,4 +1112,41 @@ fn programs_to_load(programs: &[LoadableProgram]) -> Vec<(Pubkey, PathBuf)> {
         .iter()
         .map(|program| (program.id.0, program.path.clone()))
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use magicblock_config::{
+        config::validator::ReplicationConfig, types::SerdePubkey,
+    };
+
+    fn replication_config() -> ReplicationConfig {
+        ReplicationConfig {
+            url: "nats://127.0.0.1:4222".parse().unwrap(),
+            secret: "dummy-secret".to_string(),
+        }
+    }
+
+    #[test]
+    fn standby_replication_mode_can_promote() {
+        let mode = ReplicationMode::StandBy(replication_config());
+
+        assert!(replication_mode_can_promote(&mode));
+    }
+
+    #[test]
+    fn replica_only_replication_mode_cannot_promote() {
+        let mode = ReplicationMode::ReplicaOnly {
+            config: replication_config(),
+            authority_override: SerdePubkey(Pubkey::new_unique()),
+        };
+
+        assert!(!replication_mode_can_promote(&mode));
+    }
+
+    #[test]
+    fn standalone_replication_mode_cannot_promote() {
+        assert!(!replication_mode_can_promote(&ReplicationMode::Standalone));
+    }
 }

--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -25,7 +25,7 @@ use magicblock_chainlink::{
         chain_updates_client::ChainUpdatesClient, Endpoints,
     },
     submux::SubMuxClient,
-    AccountsBankReset, Chainlink, ChainlinkPrimaryLifecycle,
+    Chainlink,
 };
 use magicblock_committor_service::{
     config::ChainConfig, BaseIntentCommittor, CommittorService,
@@ -284,25 +284,12 @@ impl MagicValidator {
                 let can_promote = replication_mode_can_promote(
                     &config.validator.replication_mode,
                 );
-                // Replication uses a reset-only cleanup handle in all modes.
-                // Only promotable StandBy contexts receive the real RPC-facing
-                // Chainlink primary lifecycle handle.
-                let accounts_bank_reset: Arc<dyn AccountsBankReset> =
-                    chainlink.clone();
-                let primary_chainlink = if can_promote {
-                    let handle: Arc<dyn ChainlinkPrimaryLifecycle> =
-                        chainlink.clone();
-                    Some(handle)
-                } else {
-                    None
-                };
                 ReplicationService::new(
                     broker,
                     mode_tx.clone(),
                     accountsdb.clone(),
                     ledger.clone(),
-                    accounts_bank_reset,
-                    primary_chainlink,
+                    chainlink.clone(),
                     dispatch.transaction_scheduler.clone(),
                     messages_rx,
                     token.clone(),

--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -25,7 +25,7 @@ use magicblock_chainlink::{
         chain_updates_client::ChainUpdatesClient, Endpoints,
     },
     submux::SubMuxClient,
-    Chainlink,
+    AccountsBankReset, Chainlink, ChainlinkPrimaryLifecycle,
 };
 use magicblock_committor_service::{
     config::ChainConfig, BaseIntentCommittor, CommittorService,
@@ -281,12 +281,25 @@ impl MagicValidator {
                     config.validator.replication_mode,
                     ReplicationMode::StandBy(_)
                 );
+                // Replication uses a reset-only cleanup handle in all modes.
+                // Only promotable StandBy contexts receive the real RPC-facing
+                // Chainlink primary lifecycle handle.
+                let accounts_bank_reset: Arc<dyn AccountsBankReset> =
+                    chainlink.clone();
+                let primary_chainlink = if can_promote {
+                    let handle: Arc<dyn ChainlinkPrimaryLifecycle> =
+                        chainlink.clone();
+                    Some(handle)
+                } else {
+                    None
+                };
                 ReplicationService::new(
                     broker,
                     mode_tx.clone(),
                     accountsdb.clone(),
                     ledger.clone(),
-                    chainlink.stub(),
+                    accounts_bank_reset,
+                    primary_chainlink,
                     dispatch.transaction_scheduler.clone(),
                     messages_rx,
                     token.clone(),

--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -876,14 +876,14 @@ impl MagicValidator {
         // Notify the scheduler that ledger replay is complete.
         // The message carries the target mode so the scheduler transitions to
         // the correct coordination mode:
-        // - Standalone validators perform primary-readiness cleanup, then
-        //   transition to Primary mode
+        // - Standalone validators perform primary-readiness cleanup and reset
+        //   the account bank before transitioning to Primary mode.
         // - StandBy/ReplicaOnly validators transition to Replica mode and
-        //   intentionally skip account-bank reset during startup
+        //   defer account-bank reset until a later promotion.
         if self.is_standalone {
             // Account-bank reset is primary-readiness cleanup: clean
-            // non-delegated accounts, including programs, only when preparing
-            // to become primary.
+            // non-delegated accounts, including programs, only when this
+            // standalone validator is preparing to become primary.
             if !self.config.accountsdb.reset {
                 let step_start = Instant::now();
                 self.chainlink.reset_accounts_bank()?;

--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -898,7 +898,7 @@ impl MagicValidator {
                         "Failed to send primary mode to scheduler: {e}"
                     ))
                 })?;
-            self.chainlink.enable_primary()?;
+            self.chainlink.enable_primary().await?;
         } else if let Some(replicator) = self.replication_service.take() {
             self.replication_handle.replace(replicator.spawn());
         }

--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -897,6 +897,7 @@ impl MagicValidator {
                         "Failed to send primary mode to scheduler: {e}"
                     ))
                 })?;
+            self.chainlink.enable_primary()?;
         } else if let Some(replicator) = self.replication_service.take() {
             self.replication_handle.replace(replicator.spawn());
         }

--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -1,5 +1,4 @@
 use std::{
-    future::Future,
     path::{Path, PathBuf},
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -108,30 +107,30 @@ type ChainlinkImpl = Chainlink<
     ChainlinkCloner,
 >;
 
-async fn run_standalone_primary_start_sequence<
-    ResetBank,
-    EnablePrimary,
-    EnablePrimaryFuture,
-    SendSchedulerPrimary,
-    SendSchedulerPrimaryFuture,
->(
+async fn run_standalone_primary_start_sequence(
+    validator: &MagicValidator,
     should_reset_accounts_bank: bool,
-    reset_bank: ResetBank,
-    enable_primary: EnablePrimary,
-    send_scheduler_primary: SendSchedulerPrimary,
-) -> ApiResult<()>
-where
-    ResetBank: FnOnce() -> ApiResult<()>,
-    EnablePrimary: FnOnce() -> EnablePrimaryFuture,
-    EnablePrimaryFuture: Future<Output = ApiResult<()>>,
-    SendSchedulerPrimary: FnOnce() -> SendSchedulerPrimaryFuture,
-    SendSchedulerPrimaryFuture: Future<Output = ApiResult<()>>,
-{
+) -> ApiResult<()> {
     if should_reset_accounts_bank {
-        reset_bank()?;
+        let step_start = Instant::now();
+        validator.chainlink.reset_accounts_bank()?;
+        log_timing("startup", "reset_accounts_bank", step_start);
     }
-    enable_primary().await?;
-    send_scheduler_primary().await?;
+
+    validator
+        .chainlink
+        .enable_primary()
+        .await
+        .map_err(ApiError::from)?;
+    validator
+        .mode_tx
+        .send(SchedulerMode::Primary)
+        .await
+        .map_err(|e| {
+            ApiError::FailedToSendModeSwitch(format!(
+                "Failed to send primary mode to scheduler: {e}"
+            ))
+        })?;
     Ok(())
 }
 
@@ -910,25 +909,8 @@ impl MagicValidator {
             // non-delegated accounts, including programs, only when this
             // standalone validator is preparing to become primary.
             run_standalone_primary_start_sequence(
+                self,
                 !self.config.accountsdb.reset,
-                || {
-                    let step_start = Instant::now();
-                    self.chainlink.reset_accounts_bank()?;
-                    log_timing("startup", "reset_accounts_bank", step_start);
-                    Ok(())
-                },
-                || async {
-                    self.chainlink.enable_primary().await.map_err(Into::into)
-                },
-                || async {
-                    self.mode_tx.send(SchedulerMode::Primary).await.map_err(
-                        |e| {
-                            ApiError::FailedToSendModeSwitch(format!(
-                                "Failed to send primary mode to scheduler: {e}"
-                            ))
-                        },
-                    )
-                },
             )
             .await?;
         } else if let Some(replicator) = self.replication_service.take() {
@@ -1111,101 +1093,4 @@ fn programs_to_load(programs: &[LoadableProgram]) -> Vec<(Pubkey, PathBuf)> {
         .iter()
         .map(|program| (program.id.0, program.path.clone()))
         .collect()
-}
-
-#[cfg(test)]
-mod tests {
-    use std::sync::{Arc, Mutex};
-
-    use super::*;
-
-    fn record(events: &Arc<Mutex<Vec<&'static str>>>, event: &'static str) {
-        events.lock().unwrap().push(event);
-    }
-
-    #[tokio::test]
-    async fn standalone_primary_start_sequence_orders_reset_chainlink_before_scheduler_primary(
-    ) {
-        let events = Arc::new(Mutex::new(Vec::new()));
-
-        run_standalone_primary_start_sequence(
-            true,
-            {
-                let events = Arc::clone(&events);
-                move || {
-                    record(&events, "reset_accounts_bank");
-                    Ok(())
-                }
-            },
-            {
-                let events = Arc::clone(&events);
-                move || async move {
-                    record(&events, "enable_primary");
-                    Ok(())
-                }
-            },
-            {
-                let events = Arc::clone(&events);
-                move || async move {
-                    record(&events, "send_scheduler_primary");
-                    Ok(())
-                }
-            },
-        )
-        .await
-        .unwrap();
-
-        assert_eq!(
-            *events.lock().unwrap(),
-            vec![
-                "reset_accounts_bank",
-                "enable_primary",
-                "send_scheduler_primary",
-            ]
-        );
-    }
-
-    #[tokio::test]
-    async fn standalone_primary_start_sequence_skips_scheduler_primary_when_chainlink_fails(
-    ) {
-        let events = Arc::new(Mutex::new(Vec::new()));
-
-        let result = run_standalone_primary_start_sequence(
-            true,
-            {
-                let events = Arc::clone(&events);
-                move || {
-                    record(&events, "reset_accounts_bank");
-                    Ok(())
-                }
-            },
-            {
-                let events = Arc::clone(&events);
-                move || async move {
-                    record(&events, "enable_primary");
-                    Err(ApiError::FailedToStartJsonRpcService(
-                        "chainlink failed".to_string(),
-                    ))
-                }
-            },
-            {
-                let events = Arc::clone(&events);
-                move || async move {
-                    record(&events, "send_scheduler_primary");
-                    Ok(())
-                }
-            },
-        )
-        .await;
-
-        assert!(matches!(
-            result,
-            Err(ApiError::FailedToStartJsonRpcService(message))
-                if message == "chainlink failed"
-        ));
-        assert_eq!(
-            *events.lock().unwrap(),
-            vec!["reset_accounts_bank", "enable_primary"]
-        );
-    }
 }

--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -122,15 +122,18 @@ async fn run_standalone_primary_start_sequence(
         .enable_primary()
         .await
         .map_err(ApiError::from)?;
-    validator
-        .mode_tx
-        .send(SchedulerMode::Primary)
-        .await
-        .map_err(|e| {
-            ApiError::FailedToSendModeSwitch(format!(
-                "Failed to send primary mode to scheduler: {e}"
-            ))
-        })?;
+    if let Err(e) = validator.mode_tx.send(SchedulerMode::Primary).await {
+        let send_error = ApiError::FailedToSendModeSwitch(format!(
+            "Failed to send primary mode to scheduler: {e}"
+        ));
+        if let Err(rollback_error) = validator.chainlink.disable().await {
+            error!(
+                %rollback_error,
+                "Failed to roll back Chainlink primary enable after scheduler primary startup failed"
+            );
+        }
+        return Err(send_error);
+    }
     Ok(())
 }
 

--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -873,13 +873,10 @@ impl MagicValidator {
 
         log_timing("startup", "maybe_process_ledger", step_start);
 
-        // Notify the scheduler that ledger replay is complete.
-        // The message carries the target mode so the scheduler transitions to
-        // the correct coordination mode:
-        // - Standalone validators perform primary-readiness cleanup and reset
-        //   the account bank before transitioning to Primary mode.
-        // - StandBy/ReplicaOnly validators transition to Replica mode and
-        //   defer account-bank reset until a later promotion.
+        // After ledger replay, standalone validators perform primary-readiness
+        // bank reset, start the Chainlink runtime, then publish global Primary
+        // mode to the scheduler. StandBy/ReplicaOnly validators transition to
+        // Replica mode and defer account-bank reset until a later promotion.
         if self.is_standalone {
             // Account-bank reset is primary-readiness cleanup: clean
             // non-delegated accounts, including programs, only when this
@@ -890,6 +887,7 @@ impl MagicValidator {
                 log_timing("startup", "reset_accounts_bank", step_start);
             }
 
+            self.chainlink.enable_primary().await?;
             self.mode_tx
                 .send(SchedulerMode::Primary)
                 .await
@@ -898,7 +896,6 @@ impl MagicValidator {
                         "Failed to send primary mode to scheduler: {e}"
                     ))
                 })?;
-            self.chainlink.enable_primary().await?;
         } else if let Some(replicator) = self.replication_service.take() {
             self.replication_handle.replace(replicator.spawn());
         }

--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -1,4 +1,5 @@
 use std::{
+    future::Future,
     path::{Path, PathBuf},
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -106,6 +107,33 @@ type ChainlinkImpl = Chainlink<
     AccountsDb,
     ChainlinkCloner,
 >;
+
+async fn run_standalone_primary_start_sequence<
+    ResetBank,
+    EnablePrimary,
+    EnablePrimaryFuture,
+    SendSchedulerPrimary,
+    SendSchedulerPrimaryFuture,
+>(
+    should_reset_accounts_bank: bool,
+    reset_bank: ResetBank,
+    enable_primary: EnablePrimary,
+    send_scheduler_primary: SendSchedulerPrimary,
+) -> ApiResult<()>
+where
+    ResetBank: FnOnce() -> ApiResult<()>,
+    EnablePrimary: FnOnce() -> EnablePrimaryFuture,
+    EnablePrimaryFuture: Future<Output = ApiResult<()>>,
+    SendSchedulerPrimary: FnOnce() -> SendSchedulerPrimaryFuture,
+    SendSchedulerPrimaryFuture: Future<Output = ApiResult<()>>,
+{
+    if should_reset_accounts_bank {
+        reset_bank()?;
+    }
+    enable_primary().await?;
+    send_scheduler_primary().await?;
+    Ok(())
+}
 
 // -----------------
 // MagicValidator
@@ -881,21 +909,28 @@ impl MagicValidator {
             // Account-bank reset is primary-readiness cleanup: clean
             // non-delegated accounts, including programs, only when this
             // standalone validator is preparing to become primary.
-            if !self.config.accountsdb.reset {
-                let step_start = Instant::now();
-                self.chainlink.reset_accounts_bank()?;
-                log_timing("startup", "reset_accounts_bank", step_start);
-            }
-
-            self.chainlink.enable_primary().await?;
-            self.mode_tx
-                .send(SchedulerMode::Primary)
-                .await
-                .map_err(|e| {
-                    ApiError::FailedToSendModeSwitch(format!(
-                        "Failed to send primary mode to scheduler: {e}"
-                    ))
-                })?;
+            run_standalone_primary_start_sequence(
+                !self.config.accountsdb.reset,
+                || {
+                    let step_start = Instant::now();
+                    self.chainlink.reset_accounts_bank()?;
+                    log_timing("startup", "reset_accounts_bank", step_start);
+                    Ok(())
+                },
+                || async {
+                    self.chainlink.enable_primary().await.map_err(Into::into)
+                },
+                || async {
+                    self.mode_tx.send(SchedulerMode::Primary).await.map_err(
+                        |e| {
+                            ApiError::FailedToSendModeSwitch(format!(
+                                "Failed to send primary mode to scheduler: {e}"
+                            ))
+                        },
+                    )
+                },
+            )
+            .await?;
         } else if let Some(replicator) = self.replication_service.take() {
             self.replication_handle.replace(replicator.spawn());
         }
@@ -1076,4 +1111,101 @@ fn programs_to_load(programs: &[LoadableProgram]) -> Vec<(Pubkey, PathBuf)> {
         .iter()
         .map(|program| (program.id.0, program.path.clone()))
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use super::*;
+
+    fn record(events: &Arc<Mutex<Vec<&'static str>>>, event: &'static str) {
+        events.lock().unwrap().push(event);
+    }
+
+    #[tokio::test]
+    async fn standalone_primary_start_sequence_orders_reset_chainlink_before_scheduler_primary(
+    ) {
+        let events = Arc::new(Mutex::new(Vec::new()));
+
+        run_standalone_primary_start_sequence(
+            true,
+            {
+                let events = Arc::clone(&events);
+                move || {
+                    record(&events, "reset_accounts_bank");
+                    Ok(())
+                }
+            },
+            {
+                let events = Arc::clone(&events);
+                move || async move {
+                    record(&events, "enable_primary");
+                    Ok(())
+                }
+            },
+            {
+                let events = Arc::clone(&events);
+                move || async move {
+                    record(&events, "send_scheduler_primary");
+                    Ok(())
+                }
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            *events.lock().unwrap(),
+            vec![
+                "reset_accounts_bank",
+                "enable_primary",
+                "send_scheduler_primary",
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn standalone_primary_start_sequence_skips_scheduler_primary_when_chainlink_fails(
+    ) {
+        let events = Arc::new(Mutex::new(Vec::new()));
+
+        let result = run_standalone_primary_start_sequence(
+            true,
+            {
+                let events = Arc::clone(&events);
+                move || {
+                    record(&events, "reset_accounts_bank");
+                    Ok(())
+                }
+            },
+            {
+                let events = Arc::clone(&events);
+                move || async move {
+                    record(&events, "enable_primary");
+                    Err(ApiError::FailedToStartJsonRpcService(
+                        "chainlink failed".to_string(),
+                    ))
+                }
+            },
+            {
+                let events = Arc::clone(&events);
+                move || async move {
+                    record(&events, "send_scheduler_primary");
+                    Ok(())
+                }
+            },
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(ApiError::FailedToStartJsonRpcService(message))
+                if message == "chainlink failed"
+        ));
+        assert_eq!(
+            *events.lock().unwrap(),
+            vec!["reset_accounts_bank", "enable_primary"]
+        );
+    }
 }

--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -872,20 +872,23 @@ impl MagicValidator {
 
         log_timing("startup", "maybe_process_ledger", step_start);
 
-        // Ledger replay has completed, we can now clean non-delegated accounts
-        // including programs from the bank
-        if !self.config.accountsdb.reset {
-            let step_start = Instant::now();
-            self.chainlink.reset_accounts_bank()?;
-            log_timing("startup", "reset_accounts_bank", step_start);
-        }
-
-        // Notify the scheduler that ledger replay and bank cleanup is complete.
+        // Notify the scheduler that ledger replay is complete.
         // The message carries the target mode so the scheduler transitions to
         // the correct coordination mode:
-        // - Standalone validators transition to Primary mode
-        // - StandBy/ReplicaOnly validators transition to Replica mode
+        // - Standalone validators perform primary-readiness cleanup, then
+        //   transition to Primary mode
+        // - StandBy/ReplicaOnly validators transition to Replica mode and
+        //   intentionally skip account-bank reset during startup
         if self.is_standalone {
+            // Account-bank reset is primary-readiness cleanup: clean
+            // non-delegated accounts, including programs, only when preparing
+            // to become primary.
+            if !self.config.accountsdb.reset {
+                let step_start = Instant::now();
+                self.chainlink.reset_accounts_bank()?;
+                log_timing("startup", "reset_accounts_bank", step_start);
+            }
+
             self.mode_tx
                 .send(SchedulerMode::Primary)
                 .await

--- a/magicblock-chainlink/Cargo.toml
+++ b/magicblock-chainlink/Cargo.toml
@@ -58,6 +58,7 @@ url = { workspace = true }
 [dev-dependencies]
 assert_matches = { workspace = true }
 magicblock-chainlink = { path = ".", features = ["dev-context"] }
+tempfile = { workspace = true }
 
 [features]
 default = []

--- a/magicblock-chainlink/src/chainlink/errors.rs
+++ b/magicblock-chainlink/src/chainlink/errors.rs
@@ -69,4 +69,7 @@ pub enum ChainlinkError {
 
     #[error("Invalid validator keypair bytes: {0}")]
     InvalidValidatorKeypair(String),
+
+    #[error("remote account provider is required by lifecycle config but was not created")]
+    MissingRemoteAccountProvider,
 }

--- a/magicblock-chainlink/src/chainlink/errors.rs
+++ b/magicblock-chainlink/src/chainlink/errors.rs
@@ -66,4 +66,7 @@ pub enum ChainlinkError {
 
     #[error("Failed to perform Range risk check: {0}")]
     RangeRisk(#[from] RiskError),
+
+    #[error("Invalid validator keypair bytes: {0}")]
+    InvalidValidatorKeypair(String),
 }

--- a/magicblock-chainlink/src/chainlink/errors.rs
+++ b/magicblock-chainlink/src/chainlink/errors.rs
@@ -72,4 +72,7 @@ pub enum ChainlinkError {
 
     #[error("remote account provider is required by lifecycle config but was not created")]
     MissingRemoteAccountProvider,
+
+    #[error("chainlink primary runtime build config is missing")]
+    MissingPrimaryRuntimeBuildConfig,
 }

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -29,10 +29,11 @@ use solana_sdk_ids::system_program;
 use solana_signature::Signature;
 use solana_signer::Signer;
 use tokio::{
-    sync::{mpsc, oneshot},
+    sync::{mpsc, oneshot, Mutex as AsyncMutex},
     task,
     task::JoinSet,
 };
+use tokio_util::sync::CancellationToken;
 use tracing::*;
 
 pub(crate) const FETCH_CLONE_OPERATION_TIMEOUT: Duration =
@@ -136,6 +137,9 @@ where
 
     pending_operation_timeout_ms: Arc<AtomicU64>,
 
+    shutdown_token: CancellationToken,
+    subscription_listener_handle: Arc<AsyncMutex<Option<task::JoinHandle<()>>>>,
+
     /// Risk checker for post-delegation action addresses.
     risk_service: Option<Arc<RiskService>>,
 }
@@ -175,6 +179,10 @@ where
             pending_clones: self.pending_clones.clone(),
             pending_operation_timeout_ms: self
                 .pending_operation_timeout_ms
+                .clone(),
+            shutdown_token: self.shutdown_token.clone(),
+            subscription_listener_handle: self
+                .subscription_listener_handle
                 .clone(),
             risk_service: self.risk_service.clone(),
         }
@@ -224,6 +232,8 @@ where
             pending_operation_timeout_ms: Arc::new(AtomicU64::new(
                 FETCH_CLONE_OPERATION_TIMEOUT.as_millis() as u64,
             )),
+            shutdown_token: CancellationToken::new(),
+            subscription_listener_handle: Arc::new(AsyncMutex::new(None)),
             risk_service,
         });
 
@@ -276,6 +286,81 @@ where
     pub fn cancel_all_pending(&self) {
         self.pending_requests
             .scan(|_pubkey, pending| pending.cancel.notify_one());
+    }
+
+    fn fail_all_pending_requests(&self) {
+        let mut pending = Vec::new();
+        self.pending_requests.scan(|pubkey, state| {
+            pending.push((*pubkey, state.generation));
+        });
+        for (pubkey, generation) in pending {
+            finish_pending(
+                &self.pending_requests,
+                pubkey,
+                generation,
+                PendingTerminal::Failed(PendingFailure::OwnerFailed(
+                    "fetch cloner shut down".to_string(),
+                )),
+            );
+        }
+    }
+
+    fn fail_all_pending_clones(&self) {
+        let pending = {
+            let mut map = self
+                .pending_clones
+                .lock()
+                .expect("pending_clones mutex poisoned");
+            std::mem::take(&mut *map)
+        };
+        for waiters in pending.into_values() {
+            for tx in waiters {
+                let _ = tx.send(CloneCompletion::Failed);
+            }
+        }
+    }
+
+    pub async fn shutdown(&self) -> ChainlinkResult<()> {
+        self.shutdown_token.cancel();
+        self.cancel_all_pending();
+        self.fail_all_pending_requests();
+        self.fail_all_pending_clones();
+
+        let listener_handle = {
+            let mut slot = self.subscription_listener_handle.lock().await;
+            slot.take()
+        };
+        if let Some(mut handle) = listener_handle {
+            if tokio::time::timeout(Duration::from_secs(2), &mut handle)
+                .await
+                .is_err()
+            {
+                handle.abort();
+                if let Err(err) = handle.await {
+                    if !err.is_cancelled() {
+                        warn!(error = ?err, "FetchCloner listener task failed after abort");
+                    }
+                }
+            }
+        }
+
+        self.remote_account_provider.shutdown().await?;
+        Ok(())
+    }
+
+    #[cfg(any(test, feature = "dev-context"))]
+    pub fn pending_request_count_for_tests(&self) -> usize {
+        let mut count = 0;
+        self.pending_requests.scan(|_, _| count += 1);
+        count
+    }
+
+    #[cfg(any(test, feature = "dev-context"))]
+    pub fn pending_clone_count_for_tests(&self) -> usize {
+        self.pending_clones
+            .lock()
+            .expect("pending_clones mutex poisoned")
+            .len()
     }
 
     /// Check if a program is allowed to be cloned.
@@ -468,10 +553,16 @@ where
         self: Arc<Self>,
         mut subscription_updates: mpsc::Receiver<ForwardedSubscriptionUpdate>,
     ) {
-        tokio::spawn(async move {
+        let listener_handle = self.subscription_listener_handle.clone();
+        let shutdown_token = self.shutdown_token.clone();
+        let handle = tokio::spawn(async move {
             let mut pending_tasks: JoinSet<()> = JoinSet::new();
 
             loop {
+                if shutdown_token.is_cancelled() {
+                    break;
+                }
+
                 match subscription_updates.try_recv() {
                     Ok(update) => {
                         let pubkey = update.pubkey;
@@ -499,6 +590,9 @@ where
                     }
                     Err(mpsc::error::TryRecvError::Empty) => {
                         tokio::select! {
+                            _ = shutdown_token.cancelled() => {
+                                break;
+                            }
                             maybe_update =
                                 subscription_updates.recv() =>
                             {
@@ -537,7 +631,23 @@ where
                     }
                 }
             }
+
+            let drain =
+                async { while pending_tasks.join_next().await.is_some() {} };
+            if tokio::time::timeout(Duration::from_secs(2), drain)
+                .await
+                .is_err()
+            {
+                pending_tasks.abort_all();
+                while pending_tasks.join_next().await.is_some() {}
+            }
         });
+        if let Ok(mut slot) = listener_handle.try_lock() {
+            *slot = Some(handle);
+        } else {
+            warn!("Failed to store FetchCloner subscription listener handle");
+            handle.abort();
+        };
     }
 
     async fn process_subscription_update(

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -4795,6 +4795,103 @@ async fn test_cancel_all_pending_on_shutdown() {
 }
 
 #[tokio::test]
+async fn test_shutdown_stops_listener_and_fails_pending_waiters() {
+    init_logger();
+    let validator_keypair = Keypair::new();
+    let account_owner = random_pubkey();
+    const CURRENT_SLOT: u64 = 100;
+
+    let account_pubkey = random_pubkey();
+    let account = Account {
+        lamports: 2_000_000,
+        data: vec![5, 6, 7, 8],
+        owner: account_owner,
+        executable: false,
+        rent_epoch: 0,
+    };
+
+    let FetcherTestCtx {
+        accounts_bank,
+        fetch_cloner,
+        ..
+    } = setup(
+        [(account_pubkey, account)],
+        CURRENT_SLOT,
+        validator_keypair.insecure_clone(),
+    )
+    .await;
+
+    let blocking_cloner = Arc::new(ClonerStub::new(accounts_bank.clone()));
+    blocking_cloner.block_clone_completion();
+
+    let (_subscription_tx, subscription_rx) = mpsc::channel(100);
+    let fetch_cloner = FetchCloner::new(
+        &fetch_cloner.remote_account_provider.clone(),
+        &accounts_bank,
+        &blocking_cloner,
+        validator_keypair.insecure_clone(),
+        subscription_rx,
+        None,
+        None,
+    );
+
+    let owner_task = {
+        let fetch_cloner = fetch_cloner.clone();
+        tokio::spawn(async move {
+            fetch_cloner
+                .fetch_and_clone_accounts_with_dedup(
+                    &[account_pubkey],
+                    None,
+                    None,
+                    AccountFetchOrigin::GetAccount,
+                    None,
+                )
+                .await
+        })
+    };
+    wait_for_pending_request(&fetch_cloner, account_pubkey).await;
+
+    let waiter_task = {
+        let fetch_cloner = fetch_cloner.clone();
+        tokio::spawn(async move {
+            fetch_cloner
+                .fetch_and_clone_accounts_with_dedup(
+                    &[account_pubkey],
+                    None,
+                    None,
+                    AccountFetchOrigin::GetAccount,
+                    None,
+                )
+                .await
+        })
+    };
+    wait_for_pending_waiter_count(&fetch_cloner, account_pubkey, 2).await;
+
+    fetch_cloner.shutdown().await.unwrap();
+
+    assert_eq!(fetch_cloner.pending_request_count_for_tests(), 0);
+    assert!(fetch_cloner
+        .subscription_listener_handle
+        .lock()
+        .await
+        .is_none());
+
+    let owner_result = tokio::time::timeout(Duration::from_secs(5), owner_task)
+        .await
+        .expect("owner should complete after shutdown")
+        .expect("owner task join should succeed");
+    let waiter_result =
+        tokio::time::timeout(Duration::from_secs(5), waiter_task)
+            .await
+            .expect("waiter should complete after shutdown")
+            .expect("waiter task join should succeed");
+    assert!(owner_result.is_err());
+    assert!(waiter_result.is_err());
+
+    blocking_cloner.allow_clone_completion();
+}
+
+#[tokio::test]
 async fn test_owned_operation_waiters_do_not_refetch_after_owner_success() {
     init_logger();
     let validator_keypair = Keypair::new();

--- a/magicblock-chainlink/src/chainlink/mod.rs
+++ b/magicblock-chainlink/src/chainlink/mod.rs
@@ -33,11 +33,14 @@ use crate::{
     fetch_cloner::FetchAndCloneResult,
     filters::is_noop_system_transfer,
     remote_account_provider::{
-        chain_pubsub_client::mock::ChainPubsubClientMock,
         chain_updates_client::ChainUpdatesClient, ChainPubsubClient,
         ChainRpcClient, ChainRpcClientImpl, Endpoints, RemoteAccountProvider,
     },
     submux::SubMuxClient,
+};
+#[cfg(any(test, feature = "dev-context"))]
+use crate::{
+    remote_account_provider::chain_pubsub_client::mock::ChainPubsubClientMock,
     testing::{cloner_stub::ClonerStub, rpc_client_mock::ChainRpcClientMock},
 };
 
@@ -50,6 +53,7 @@ pub mod fetch_cloner;
 pub use blacklisted_accounts::*;
 
 /// A type alias for chainlink with only accountsdb being real impl
+#[cfg(any(test, feature = "dev-context"))]
 pub type StubbedChainlink<V> =
     Chainlink<ChainRpcClientMock, ChainPubsubClientMock, V, ClonerStub>;
 
@@ -684,6 +688,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
     ///
     /// TODO(bmuddha):
     /// remove all accountsdb management from chainlink, after accountsdb refactoring
+    #[cfg(any(test, feature = "dev-context"))]
     pub fn stub(&self) -> StubbedChainlink<V> {
         Chainlink {
             accounts_bank: self.accounts_bank.clone(),
@@ -706,25 +711,28 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
     }
 }
 
+#[cfg(any(test, feature = "dev-context"))]
 impl<V: AccountsBank>
     Chainlink<ChainRpcClientMock, ChainPubsubClientMock, V, ClonerStub>
 {
     /// Marks the primary lifecycle boundary for stubbed chainlink remote sync.
-    pub async fn enable_primary(&self) -> ChainlinkResult<()> {
+    pub async fn enable_primary(
+        &self,
+    ) -> ChainlinkResult<ChainlinkPrimaryEnablement> {
         if self.runtime.lock().await.is_some() {
             self.lifecycle_state.store(
                 ChainlinkLifecycleState::Enabled as u8,
                 Ordering::SeqCst,
             );
+            info!("Test Chainlink primary lifecycle marked active");
+            Ok(ChainlinkPrimaryEnablement::Active)
         } else {
             self.lifecycle_state.store(
                 ChainlinkLifecycleState::Disabled as u8,
                 Ordering::SeqCst,
             );
+            Ok(ChainlinkPrimaryEnablement::DisabledByConfig)
         }
-
-        info!("Chainlink primary remote sync enabled");
-        Ok(())
     }
 }
 

--- a/magicblock-chainlink/src/chainlink/mod.rs
+++ b/magicblock-chainlink/src/chainlink/mod.rs
@@ -610,6 +610,13 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
     async fn runtime_fetch_cloner(
         &self,
     ) -> Option<Arc<FetchCloner<T, U, V, C>>> {
+        if ChainlinkLifecycleState::from_u8(
+            self.lifecycle_state.load(Ordering::SeqCst),
+        ) != ChainlinkLifecycleState::Enabled
+        {
+            return None;
+        }
+
         let runtime = self.runtime.lock().await;
         if ChainlinkLifecycleState::from_u8(
             self.lifecycle_state.load(Ordering::SeqCst),

--- a/magicblock-chainlink/src/chainlink/mod.rs
+++ b/magicblock-chainlink/src/chainlink/mod.rs
@@ -5,7 +5,6 @@ use errors::ChainlinkResult;
 use fetch_cloner::FetchCloner;
 use magicblock_accounts_db::{traits::AccountsBank, AccountsDbResult};
 use magicblock_config::config::ChainLinkConfig;
-#[cfg(not(any(test, feature = "dev-context")))]
 use magicblock_core::coordination_mode::CoordinationMode;
 use magicblock_metrics::metrics::AccountFetchOrigin;
 use solana_account::{AccountSharedData, ReadableAccount};
@@ -72,14 +71,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
     Chainlink<T, U, V, C>
 {
     fn remote_sync_enabled() -> bool {
-        #[cfg(any(test, feature = "dev-context"))]
-        {
-            true
-        }
-        #[cfg(not(any(test, feature = "dev-context")))]
-        {
-            CoordinationMode::current().needs_onchain_interactions()
-        }
+        CoordinationMode::current().needs_onchain_interactions()
     }
 
     pub fn enable_primary(&self) -> ChainlinkResult<()> {

--- a/magicblock-chainlink/src/chainlink/mod.rs
+++ b/magicblock-chainlink/src/chainlink/mod.rs
@@ -133,10 +133,42 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
     /// Marks the non-primary lifecycle boundary. Non-primary chainlink calls
     /// intentionally become no-op/local-only while bank reset remains an
     /// explicit primary-readiness operation.
-    pub fn disable(&self) {
+    pub async fn disable(&self) -> ChainlinkResult<()> {
+        self.lifecycle_state
+            .store(ChainlinkLifecycleState::Stopping as u8, Ordering::SeqCst);
+
+        let runtime = self.runtime.lock().await.take();
+        let Some(mut runtime) = runtime else {
+            self.lifecycle_state.store(
+                ChainlinkLifecycleState::Disabled as u8,
+                Ordering::SeqCst,
+            );
+            info!("Chainlink remote sync already disabled by lifecycle transition");
+            return Ok(());
+        };
+
+        if let Some(mut removed_accounts_sub) =
+            runtime.removed_accounts_sub.take()
+        {
+            removed_accounts_sub.abort();
+            if tokio::time::timeout(
+                std::time::Duration::from_secs(2),
+                &mut removed_accounts_sub,
+            )
+            .await
+            .is_err()
+            {
+                warn!("Timed out waiting for Chainlink removed-account subscription to stop");
+            }
+        }
+
+        let result = runtime.fetch_cloner.shutdown().await;
         self.lifecycle_state
             .store(ChainlinkLifecycleState::Disabled as u8, Ordering::SeqCst);
-        info!("Chainlink remote sync disabled by lifecycle transition");
+        if result.is_ok() {
+            info!("Chainlink remote sync disabled by lifecycle transition");
+        }
+        result
     }
 
     pub fn is_remote_sync_enabled(&self) -> bool {
@@ -639,11 +671,14 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
     async fn runtime_fetch_cloner(
         &self,
     ) -> Option<Arc<FetchCloner<T, U, V, C>>> {
-        self.runtime
-            .lock()
-            .await
-            .as_ref()
-            .map(|runtime| runtime.fetch_cloner.clone())
+        let runtime = self.runtime.lock().await;
+        if ChainlinkLifecycleState::from_u8(
+            self.lifecycle_state.load(Ordering::SeqCst),
+        ) != ChainlinkLifecycleState::Enabled
+        {
+            return None;
+        }
+        runtime.as_ref().map(|runtime| runtime.fetch_cloner.clone())
     }
 
     #[cfg(any(test, feature = "dev-context"))]

--- a/magicblock-chainlink/src/chainlink/mod.rs
+++ b/magicblock-chainlink/src/chainlink/mod.rs
@@ -135,20 +135,6 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
         CoordinationMode::current().needs_onchain_interactions()
     }
 
-    /// Marks the primary lifecycle boundary for chainlink remote sync.
-    /// The CoordinationMode gate remains authoritative: if this is called
-    /// before Primary mode is visible, remote work stays gated.
-    pub fn enable_primary(&self) -> ChainlinkResult<()> {
-        self.lifecycle_state
-            .store(ChainlinkLifecycleState::Enabled as u8, Ordering::SeqCst);
-        if !Self::remote_sync_enabled() {
-            trace!("Chainlink enable_primary requested before primary mode; remote sync remains gated");
-        } else {
-            info!("Chainlink primary remote sync enabled");
-        }
-        Ok(())
-    }
-
     /// Marks the non-primary lifecycle boundary. Non-primary chainlink calls
     /// intentionally become no-op/local-only while bank reset remains an
     /// explicit primary-readiness operation.
@@ -763,6 +749,148 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
             runtime_build_config: None,
             validator_id: self.validator_id,
             remove_confined_accounts: self.remove_confined_accounts,
+        }
+    }
+}
+
+impl<V: AccountsBank>
+    Chainlink<ChainRpcClientMock, ChainPubsubClientMock, V, ClonerStub>
+{
+    /// Marks the primary lifecycle boundary for stubbed chainlink remote sync.
+    pub async fn enable_primary(&self) -> ChainlinkResult<()> {
+        if self.runtime.lock().await.is_some() {
+            self.lifecycle_state.store(
+                ChainlinkLifecycleState::Enabled as u8,
+                Ordering::SeqCst,
+            );
+        } else {
+            self.lifecycle_state.store(
+                ChainlinkLifecycleState::Disabled as u8,
+                Ordering::SeqCst,
+            );
+        }
+
+        if !Self::remote_sync_enabled() {
+            trace!("Chainlink enable_primary requested before primary mode; remote sync remains gated");
+        } else {
+            info!("Chainlink primary remote sync enabled");
+        }
+        Ok(())
+    }
+}
+
+impl<V: AccountsBank, C: Cloner>
+    Chainlink<ChainRpcClientImpl, SubMuxClient<ChainUpdatesClient>, V, C>
+{
+    /// Marks the primary lifecycle boundary for chainlink remote sync and
+    /// creates the runtime from stored production configuration when needed.
+    pub async fn enable_primary(&self) -> ChainlinkResult<()> {
+        let mut runtime = self.runtime.lock().await;
+        if runtime.is_some() {
+            self.lifecycle_state.store(
+                ChainlinkLifecycleState::Enabled as u8,
+                Ordering::SeqCst,
+            );
+            Self::log_primary_enabled();
+            return Ok(());
+        }
+
+        self.lifecycle_state
+            .store(ChainlinkLifecycleState::Starting as u8, Ordering::SeqCst);
+
+        let Some(build) = self.runtime_build_config.as_ref() else {
+            self.lifecycle_state.store(
+                ChainlinkLifecycleState::Disabled as u8,
+                Ordering::SeqCst,
+            );
+            Self::log_primary_enabled();
+            return Ok(());
+        };
+
+        if !build
+            .runtime_config
+            .remote_account_provider
+            .lifecycle_mode()
+            .needs_remote_account_provider()
+        {
+            self.lifecycle_state.store(
+                ChainlinkLifecycleState::Disabled as u8,
+                Ordering::SeqCst,
+            );
+            Self::log_primary_enabled();
+            return Ok(());
+        }
+
+        match self.create_runtime_from_build_config(build).await {
+            Ok(new_runtime) => {
+                *runtime = Some(new_runtime);
+                self.lifecycle_state.store(
+                    ChainlinkLifecycleState::Enabled as u8,
+                    Ordering::SeqCst,
+                );
+                Self::log_primary_enabled();
+                Ok(())
+            }
+            Err(err) => {
+                *runtime = None;
+                self.lifecycle_state.store(
+                    ChainlinkLifecycleState::Disabled as u8,
+                    Ordering::SeqCst,
+                );
+                Err(err)
+            }
+        }
+    }
+
+    async fn create_runtime_from_build_config(
+        &self,
+        build: &ChainlinkRuntimeBuildConfig<C>,
+    ) -> ChainlinkResult<
+        ChainlinkRuntime<
+            ChainRpcClientImpl,
+            SubMuxClient<ChainUpdatesClient>,
+            V,
+            C,
+        >,
+    > {
+        let validator_keypair =
+            Self::validator_keypair_from_bytes(&build.validator_keypair_bytes)?;
+        let (tx, rx) = tokio::sync::mpsc::channel(5_000);
+        let account_provider = RemoteAccountProvider::try_from_urls_and_config(
+            &build.endpoints,
+            build.commitment,
+            tx,
+            &build.runtime_config.remote_account_provider,
+        )
+        .await?;
+
+        let Some(provider) = account_provider else {
+            return Err(ChainlinkError::MissingRemoteAccountProvider);
+        };
+
+        let provider = Arc::new(provider);
+        let risk_service = RiskService::try_from_config(
+            &build.chainlink_config.risk,
+            &build.ledger_path,
+        )?
+        .map(Arc::new);
+        let fetch_cloner = FetchCloner::new(
+            &provider,
+            &self.accounts_bank,
+            &build.cloner,
+            validator_keypair,
+            rx,
+            build.chainlink_config.allowed_programs.clone(),
+            risk_service,
+        );
+        Self::build_runtime(&self.accounts_bank, fetch_cloner)
+    }
+
+    fn log_primary_enabled() {
+        if !Self::remote_sync_enabled() {
+            trace!("Chainlink enable_primary requested before primary mode; remote sync remains gated");
+        } else {
+            info!("Chainlink primary remote sync enabled");
         }
     }
 }

--- a/magicblock-chainlink/src/chainlink/mod.rs
+++ b/magicblock-chainlink/src/chainlink/mod.rs
@@ -71,7 +71,9 @@ pub trait AccountsBankReset: Send + Sync {
 
 #[async_trait::async_trait]
 pub trait ChainlinkPrimaryLifecycle: Send + Sync {
-    async fn enable_primary(&self) -> ChainlinkResult<ChainlinkPrimaryEnablement>;
+    async fn enable_primary(
+        &self,
+    ) -> ChainlinkResult<ChainlinkPrimaryEnablement>;
 
     async fn disable(&self) -> ChainlinkResult<()>;
 }

--- a/magicblock-chainlink/src/chainlink/mod.rs
+++ b/magicblock-chainlink/src/chainlink/mod.rs
@@ -1,4 +1,11 @@
-use std::{collections::HashSet, path::Path, sync::Arc};
+use std::{
+    collections::HashSet,
+    path::Path,
+    sync::{
+        atomic::{AtomicU8, Ordering},
+        Arc,
+    },
+};
 
 use dlp_api::pda::ephemeral_balance_pda_from_payer;
 use errors::ChainlinkResult;
@@ -15,7 +22,7 @@ use solana_pubkey::Pubkey;
 use solana_sdk_ids::feature;
 use solana_signer::Signer;
 use solana_transaction::sanitized::SanitizedTransaction;
-use tokio::{sync::mpsc, task};
+use tokio::{sync::mpsc, sync::Mutex as AsyncMutex, task};
 use tracing::*;
 
 use crate::{
@@ -47,6 +54,41 @@ pub type StubbedChainlink<V> =
 // -----------------
 // Chainlink
 // -----------------
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ChainlinkLifecycleState {
+    Disabled = 0,
+    Starting = 1,
+    Enabled = 2,
+    Stopping = 3,
+}
+
+impl ChainlinkLifecycleState {
+    fn from_u8(value: u8) -> Self {
+        match value {
+            1 => Self::Starting,
+            2 => Self::Enabled,
+            3 => Self::Stopping,
+            _ => Self::Disabled,
+        }
+    }
+}
+
+struct ChainlinkRuntime<T, U, V, C>
+where
+    T: ChainRpcClient,
+    U: ChainPubsubClient,
+    V: AccountsBank,
+    C: Cloner,
+{
+    fetch_cloner: Arc<FetchCloner<T, U, V, C>>,
+    /// The subscription to events for each account that is removed from
+    /// the accounts tracked by the provider.
+    /// In that case we also remove it from the bank since it is no longer
+    /// synchronized.
+    #[allow(unused)] // needed to cleanup chainlink
+    removed_accounts_sub: Option<task::JoinHandle<()>>,
+}
+
 pub struct Chainlink<
     T: ChainRpcClient,
     U: ChainPubsubClient,
@@ -54,13 +96,8 @@ pub struct Chainlink<
     C: Cloner,
 > {
     accounts_bank: Arc<V>,
-    fetch_cloner: Option<Arc<FetchCloner<T, U, V, C>>>,
-    /// The subscription to events for each account that is removed from
-    /// the accounts tracked by the provider.
-    /// In that case we also remove it from the bank since it is no longer
-    /// synchronized.
-    #[allow(unused)] // needed to cleanup chainlink
-    removed_accounts_sub: Option<task::JoinHandle<()>>,
+    runtime: AsyncMutex<Option<ChainlinkRuntime<T, U, V, C>>>,
+    lifecycle_state: AtomicU8,
 
     validator_id: Pubkey,
 
@@ -83,6 +120,8 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
     /// The CoordinationMode gate remains authoritative: if this is called
     /// before Primary mode is visible, remote work stays gated.
     pub fn enable_primary(&self) -> ChainlinkResult<()> {
+        self.lifecycle_state
+            .store(ChainlinkLifecycleState::Enabled as u8, Ordering::SeqCst);
         if !Self::remote_sync_enabled() {
             trace!("Chainlink enable_primary requested before primary mode; remote sync remains gated");
         } else {
@@ -95,10 +134,15 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
     /// intentionally become no-op/local-only while bank reset remains an
     /// explicit primary-readiness operation.
     pub fn disable(&self) {
+        self.lifecycle_state
+            .store(ChainlinkLifecycleState::Disabled as u8, Ordering::SeqCst);
         info!("Chainlink remote sync disabled by lifecycle transition");
     }
 
     pub fn is_remote_sync_enabled(&self) -> bool {
+        let _ = ChainlinkLifecycleState::from_u8(
+            self.lifecycle_state.load(Ordering::SeqCst),
+        );
         Self::remote_sync_enabled()
     }
 
@@ -108,24 +152,39 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
         validator_pubkey: Pubkey,
         config: &ChainLinkConfig,
     ) -> ChainlinkResult<Self> {
-        let removed_accounts_sub = if let Some(fetch_cloner) = &fetch_cloner {
-            let removed_accounts_rx =
-                fetch_cloner.try_get_removed_account_rx()?;
-            let cloner = fetch_cloner.cloner();
-            Some(Self::subscribe_account_removals(
-                accounts_bank,
-                cloner,
-                removed_accounts_rx,
-            ))
+        let runtime = if let Some(fetch_cloner) = fetch_cloner {
+            Some(Self::build_runtime(accounts_bank, fetch_cloner)?)
         } else {
             None
         };
+        let lifecycle_state = if runtime.is_some() {
+            ChainlinkLifecycleState::Enabled
+        } else {
+            ChainlinkLifecycleState::Disabled
+        };
         Ok(Self {
             accounts_bank: accounts_bank.clone(),
-            fetch_cloner,
-            removed_accounts_sub,
+            runtime: AsyncMutex::new(runtime),
+            lifecycle_state: AtomicU8::new(lifecycle_state as u8),
             validator_id: validator_pubkey,
             remove_confined_accounts: config.remove_confined_accounts,
+        })
+    }
+
+    fn build_runtime(
+        accounts_bank: &Arc<V>,
+        fetch_cloner: Arc<FetchCloner<T, U, V, C>>,
+    ) -> ChainlinkResult<ChainlinkRuntime<T, U, V, C>> {
+        let removed_accounts_rx = fetch_cloner.try_get_removed_account_rx()?;
+        let cloner = fetch_cloner.cloner();
+        let removed_accounts_sub = Some(Self::subscribe_account_removals(
+            accounts_bank,
+            cloner,
+            removed_accounts_rx,
+        ));
+        Ok(ChainlinkRuntime {
+            fetch_cloner,
+            removed_accounts_sub,
         })
     }
 
@@ -413,11 +472,11 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
             return Ok(FetchAndCloneResult::default());
         }
 
-        let Some(fetch_cloner) = self.fetch_cloner() else {
+        let Some(fetch_cloner) = self.runtime_fetch_cloner().await else {
             return Ok(FetchAndCloneResult::default());
         };
         self.fetch_accounts_common(
-            fetch_cloner,
+            fetch_cloner.as_ref(),
             pubkeys,
             mark_empty_if_not_found,
             fetch_origin,
@@ -452,7 +511,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
             let count = pubkeys.len();
             trace!(count, "Fetching accounts");
         }
-        let Some(fetch_cloner) = self.fetch_cloner() else {
+        let Some(fetch_cloner) = self.runtime_fetch_cloner().await else {
             // If we're offline and not syncing accounts then we just get them from the bank
             return Ok(pubkeys
                 .iter()
@@ -461,7 +520,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
         };
         let _ = self
             .fetch_accounts_common(
-                fetch_cloner,
+                fetch_cloner.as_ref(),
                 pubkeys,
                 None,
                 fetch_origin,
@@ -537,7 +596,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
             return Ok(());
         }
 
-        let Some(fetch_cloner) = self.fetch_cloner() else {
+        let Some(fetch_cloner) = self.runtime_fetch_cloner().await else {
             return Ok(());
         };
 
@@ -551,17 +610,40 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
         Ok(())
     }
 
-    pub fn fetch_cloner(&self) -> Option<&Arc<FetchCloner<T, U, V, C>>> {
-        self.fetch_cloner.as_ref()
+    async fn runtime_fetch_cloner(
+        &self,
+    ) -> Option<Arc<FetchCloner<T, U, V, C>>> {
+        self.runtime
+            .lock()
+            .await
+            .as_ref()
+            .map(|runtime| runtime.fetch_cloner.clone())
+    }
+
+    #[cfg(any(test, feature = "dev-context"))]
+    pub async fn fetch_cloner_for_tests(
+        &self,
+    ) -> Option<Arc<FetchCloner<T, U, V, C>>> {
+        self.runtime_fetch_cloner().await
     }
 
     pub fn fetch_count(&self) -> Option<u64> {
-        self.fetch_cloner().map(|provider| provider.fetch_count())
+        self.runtime.try_lock().ok().and_then(|runtime| {
+            runtime
+                .as_ref()
+                .map(|runtime| runtime.fetch_cloner.fetch_count())
+        })
     }
 
     pub fn is_watching(&self, pubkey: &Pubkey) -> bool {
-        self.fetch_cloner()
-            .map(|provider| provider.is_watching(pubkey))
+        self.runtime
+            .try_lock()
+            .ok()
+            .and_then(|runtime| {
+                runtime
+                    .as_ref()
+                    .map(|runtime| runtime.fetch_cloner.is_watching(pubkey))
+            })
             .unwrap_or(false)
     }
 
@@ -573,8 +655,10 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
     pub fn stub(&self) -> StubbedChainlink<V> {
         Chainlink {
             accounts_bank: self.accounts_bank.clone(),
-            fetch_cloner: None,
-            removed_accounts_sub: None,
+            runtime: AsyncMutex::new(None),
+            lifecycle_state: AtomicU8::new(
+                ChainlinkLifecycleState::Disabled as u8,
+            ),
             validator_id: self.validator_id,
             remove_confined_accounts: self.remove_confined_accounts,
         }

--- a/magicblock-chainlink/src/chainlink/mod.rs
+++ b/magicblock-chainlink/src/chainlink/mod.rs
@@ -274,53 +274,25 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
     > {
         let validator_pubkey = validator_keypair.pubkey();
         let validator_keypair_bytes = validator_keypair.to_bytes();
-        // Extract accounts provider and create fetch cloner while connecting
-        // the subscription channel
-        let (tx, rx) = tokio::sync::mpsc::channel(5_000);
-        let account_provider = RemoteAccountProvider::try_from_urls_and_config(
-            endpoints,
-            commitment,
-            tx,
-            &config.remote_account_provider,
-        )
-        .await?;
-        let fetch_cloner = if let Some(provider) = account_provider {
-            let provider = Arc::new(provider);
-            let risk_service = RiskService::try_from_config(
-                &chainlink_config.risk,
-                ledger_path,
-            )?
-            .map(Arc::new);
-            let fetch_cloner = FetchCloner::new(
-                &provider,
-                accounts_bank,
-                cloner,
-                validator_keypair,
-                rx,
-                chainlink_config.allowed_programs.clone(),
-                risk_service,
-            );
-            Some(fetch_cloner)
-        } else {
-            None
-        };
 
-        let mut chainlink = Chainlink::try_new(
-            accounts_bank,
-            fetch_cloner,
-            validator_pubkey,
-            chainlink_config,
-        )?;
-        chainlink.runtime_build_config = Some(ChainlinkRuntimeBuildConfig {
-            endpoints: endpoints.clone(),
-            commitment,
-            cloner: cloner.clone(),
-            validator_keypair_bytes,
-            chainlink_config: chainlink_config.clone(),
-            runtime_config: config,
-            ledger_path: ledger_path.to_path_buf(),
-        });
-        Ok(chainlink)
+        Ok(Chainlink {
+            accounts_bank: accounts_bank.clone(),
+            runtime: AsyncMutex::new(None),
+            lifecycle_state: AtomicU8::new(
+                ChainlinkLifecycleState::Disabled as u8,
+            ),
+            runtime_build_config: Some(ChainlinkRuntimeBuildConfig {
+                endpoints: endpoints.clone(),
+                commitment,
+                cloner: cloner.clone(),
+                validator_keypair_bytes,
+                chainlink_config: chainlink_config.clone(),
+                runtime_config: config,
+                ledger_path: ledger_path.to_path_buf(),
+            }),
+            validator_id: validator_pubkey,
+            remove_confined_accounts: chainlink_config.remove_confined_accounts,
+        })
     }
 
     #[allow(dead_code)]

--- a/magicblock-chainlink/src/chainlink/mod.rs
+++ b/magicblock-chainlink/src/chainlink/mod.rs
@@ -146,6 +146,32 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
         Self::remote_sync_enabled()
     }
 
+    #[cfg(any(test, feature = "dev-context"))]
+    pub fn lifecycle_state_for_tests(&self) -> &'static str {
+        match ChainlinkLifecycleState::from_u8(
+            self.lifecycle_state.load(Ordering::SeqCst),
+        ) {
+            ChainlinkLifecycleState::Disabled => "disabled",
+            ChainlinkLifecycleState::Starting => "starting",
+            ChainlinkLifecycleState::Enabled => "enabled",
+            ChainlinkLifecycleState::Stopping => "stopping",
+        }
+    }
+
+    #[cfg(any(test, feature = "dev-context"))]
+    pub async fn is_runtime_active(&self) -> bool {
+        self.runtime.lock().await.is_some()
+    }
+
+    #[cfg(any(test, feature = "dev-context"))]
+    pub async fn active_fetch_count_for_tests(&self) -> Option<u64> {
+        self.runtime
+            .lock()
+            .await
+            .as_ref()
+            .map(|runtime| runtime.fetch_cloner.fetch_count())
+    }
+
     pub fn try_new(
         accounts_bank: &Arc<V>,
         fetch_cloner: Option<Arc<FetchCloner<T, U, V, C>>>,

--- a/magicblock-chainlink/src/chainlink/mod.rs
+++ b/magicblock-chainlink/src/chainlink/mod.rs
@@ -5,6 +5,8 @@ use errors::ChainlinkResult;
 use fetch_cloner::FetchCloner;
 use magicblock_accounts_db::{traits::AccountsBank, AccountsDbResult};
 use magicblock_config::config::ChainLinkConfig;
+#[cfg(not(any(test, feature = "dev-context")))]
+use magicblock_core::coordination_mode::CoordinationMode;
 use magicblock_metrics::metrics::AccountFetchOrigin;
 use solana_account::{AccountSharedData, ReadableAccount};
 use solana_commitment_config::CommitmentConfig;
@@ -69,6 +71,17 @@ pub struct Chainlink<
 impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
     Chainlink<T, U, V, C>
 {
+    fn remote_sync_enabled() -> bool {
+        #[cfg(any(test, feature = "dev-context"))]
+        {
+            true
+        }
+        #[cfg(not(any(test, feature = "dev-context")))]
+        {
+            CoordinationMode::current().needs_onchain_interactions()
+        }
+    }
+
     pub fn try_new(
         accounts_bank: &Arc<V>,
         fetch_cloner: Option<Arc<FetchCloner<T, U, V, C>>>,
@@ -219,6 +232,14 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
 
         task::spawn(async move {
             while let Some(pubkey) = removed_accounts_rx.recv().await {
+                if !Self::remote_sync_enabled() {
+                    trace!(
+                        pubkey = %pubkey,
+                        "Skipping account eviction while chainlink remote sync is disabled"
+                    );
+                    continue;
+                }
+
                 // Pre-flight check: skip if delegated/undelegating
                 // (the processor enforces this too, but this avoids
                 // the overhead of building and submitting a doomed tx)
@@ -294,6 +315,14 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
             return Ok(Default::default());
         }
 
+        if !Self::remote_sync_enabled() {
+            trace!(
+                tx_sig = %tx.signature(),
+                "Skipping transaction account ensure while chainlink remote sync is disabled"
+            );
+            return Ok(Default::default());
+        }
+
         let mut pubkeys = tx
             .message()
             .account_keys()
@@ -348,6 +377,14 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
         fetch_origin: AccountFetchOrigin,
         program_ids: Option<&[Pubkey]>,
     ) -> ChainlinkResult<FetchAndCloneResult> {
+        if !Self::remote_sync_enabled() {
+            trace!(
+                count = pubkeys.len(),
+                "Skipping account ensure while chainlink remote sync is disabled"
+            );
+            return Ok(FetchAndCloneResult::default());
+        }
+
         let Some(fetch_cloner) = self.fetch_cloner() else {
             return Ok(FetchAndCloneResult::default());
         };
@@ -372,6 +409,17 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
         fetch_origin: AccountFetchOrigin,
         program_ids: Option<&[Pubkey]>,
     ) -> ChainlinkResult<Vec<Option<AccountSharedData>>> {
+        if !Self::remote_sync_enabled() {
+            trace!(
+                count = pubkeys.len(),
+                "Reading local accounts while chainlink remote sync is disabled"
+            );
+            return Ok(pubkeys
+                .iter()
+                .map(|pubkey| self.accounts_bank.get_account(pubkey))
+                .collect());
+        }
+
         if tracing::enabled!(tracing::Level::TRACE) {
             let count = pubkeys.len();
             trace!(count, "Fetching accounts");
@@ -452,6 +500,14 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
         debug!(pubkey = %pubkey, "Undelegation requested");
 
         magicblock_metrics::metrics::inc_undelegation_requested();
+
+        if !Self::remote_sync_enabled() {
+            debug!(
+                pubkey = %pubkey,
+                "Skipping undelegation subscription while chainlink remote sync is disabled"
+            );
+            return Ok(());
+        }
 
         let Some(fetch_cloner) = self.fetch_cloner() else {
             return Ok(());

--- a/magicblock-chainlink/src/chainlink/mod.rs
+++ b/magicblock-chainlink/src/chainlink/mod.rs
@@ -58,16 +58,19 @@ pub type StubbedChainlink<V> =
     Chainlink<ChainRpcClientMock, ChainPubsubClientMock, V, ClonerStub>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ChainlinkPrimaryEnablement {
-    Active,
+pub enum PrimaryEnableOutcome {
+    RuntimeActive,
     DisabledByConfig,
 }
 
-impl ChainlinkPrimaryEnablement {
+impl PrimaryEnableOutcome {
     pub fn is_active(self) -> bool {
-        matches!(self, Self::Active)
+        matches!(self, Self::RuntimeActive)
     }
 }
+
+#[deprecated(note = "use PrimaryEnableOutcome")]
+pub type ChainlinkPrimaryEnablement = PrimaryEnableOutcome;
 
 pub trait AccountsBankReset: Send + Sync {
     fn reset_accounts_bank(&self) -> AccountsDbResult<()>;
@@ -75,9 +78,7 @@ pub trait AccountsBankReset: Send + Sync {
 
 #[async_trait::async_trait]
 pub trait ChainlinkPrimaryLifecycle: Send + Sync {
-    async fn enable_primary(
-        &self,
-    ) -> ChainlinkResult<ChainlinkPrimaryEnablement>;
+    async fn enable_primary(&self) -> ChainlinkResult<PrimaryEnableOutcome>;
 
     async fn disable(&self) -> ChainlinkResult<()>;
 }
@@ -109,6 +110,19 @@ impl ChainlinkPrimaryReadiness {
             Self::ReadyWithoutRemoteProvider => "ready_without_remote_provider",
             Self::NotReady => "not_ready",
         }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PrimaryRuntimeReadiness {
+    Ready,
+    DisabledByConfig,
+    NotReady,
+}
+
+impl PrimaryRuntimeReadiness {
+    pub fn allows_primary_ensure(self) -> bool {
+        matches!(self, Self::Ready | Self::DisabledByConfig)
     }
 }
 
@@ -182,6 +196,26 @@ pub struct Chainlink<
 impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
     Chainlink<T, U, V, C>
 {
+    pub async fn primary_runtime_readiness(&self) -> PrimaryRuntimeReadiness {
+        if self.runtime.lock().await.is_some() {
+            return PrimaryRuntimeReadiness::Ready;
+        }
+
+        let Some(build) = self.runtime_build_config.as_ref() else {
+            return PrimaryRuntimeReadiness::DisabledByConfig;
+        };
+        if !build
+            .runtime_config
+            .remote_account_provider
+            .lifecycle_mode()
+            .needs_remote_account_provider()
+        {
+            PrimaryRuntimeReadiness::DisabledByConfig
+        } else {
+            PrimaryRuntimeReadiness::NotReady
+        }
+    }
+
     pub async fn primary_readiness(&self) -> ChainlinkPrimaryReadiness {
         match ChainlinkLifecycleState::from_u8(
             self.lifecycle_state.load(Ordering::SeqCst),
@@ -778,20 +812,20 @@ impl<V: AccountsBank>
     /// Marks the primary lifecycle boundary for stubbed chainlink remote sync.
     pub async fn enable_primary(
         &self,
-    ) -> ChainlinkResult<ChainlinkPrimaryEnablement> {
+    ) -> ChainlinkResult<PrimaryEnableOutcome> {
         if self.runtime.lock().await.is_some() {
             self.lifecycle_state.store(
                 ChainlinkLifecycleState::Enabled as u8,
                 Ordering::SeqCst,
             );
             info!("Test Chainlink primary lifecycle marked active");
-            Ok(ChainlinkPrimaryEnablement::Active)
+            Ok(PrimaryEnableOutcome::RuntimeActive)
         } else {
             self.lifecycle_state.store(
                 ChainlinkLifecycleState::Disabled as u8,
                 Ordering::SeqCst,
             );
-            Ok(ChainlinkPrimaryEnablement::DisabledByConfig)
+            Ok(PrimaryEnableOutcome::DisabledByConfig)
         }
     }
 }
@@ -803,15 +837,15 @@ impl<V: AccountsBank, C: Cloner>
     /// creates the runtime from stored production configuration when needed.
     pub async fn enable_primary(
         &self,
-    ) -> ChainlinkResult<ChainlinkPrimaryEnablement> {
+    ) -> ChainlinkResult<PrimaryEnableOutcome> {
         let mut runtime = self.runtime.lock().await;
         if runtime.is_some() {
             self.lifecycle_state.store(
                 ChainlinkLifecycleState::Enabled as u8,
                 Ordering::SeqCst,
             );
-            Self::log_primary_enabled();
-            return Ok(ChainlinkPrimaryEnablement::Active);
+            Self::log_primary_runtime_active();
+            return Ok(PrimaryEnableOutcome::RuntimeActive);
         }
 
         self.lifecycle_state
@@ -822,7 +856,8 @@ impl<V: AccountsBank, C: Cloner>
                 ChainlinkLifecycleState::Disabled as u8,
                 Ordering::SeqCst,
             );
-            return Err(ChainlinkError::MissingPrimaryRuntimeBuildConfig);
+            Self::log_primary_disabled_by_config();
+            return Ok(PrimaryEnableOutcome::DisabledByConfig);
         };
 
         if !build
@@ -835,8 +870,8 @@ impl<V: AccountsBank, C: Cloner>
                 ChainlinkLifecycleState::Disabled as u8,
                 Ordering::SeqCst,
             );
-            info!("Chainlink primary remote sync disabled by config");
-            return Ok(ChainlinkPrimaryEnablement::DisabledByConfig);
+            Self::log_primary_disabled_by_config();
+            return Ok(PrimaryEnableOutcome::DisabledByConfig);
         }
 
         match self.create_runtime_from_build_config(build).await {
@@ -846,8 +881,8 @@ impl<V: AccountsBank, C: Cloner>
                     ChainlinkLifecycleState::Enabled as u8,
                     Ordering::SeqCst,
                 );
-                Self::log_primary_enabled();
-                Ok(ChainlinkPrimaryEnablement::Active)
+                Self::log_primary_runtime_active();
+                Ok(PrimaryEnableOutcome::RuntimeActive)
             }
             Err(err) => {
                 *runtime = None;
@@ -904,8 +939,12 @@ impl<V: AccountsBank, C: Cloner>
         Self::build_runtime(&self.accounts_bank, fetch_cloner)
     }
 
-    fn log_primary_enabled() {
+    fn log_primary_runtime_active() {
         info!("Chainlink primary remote sync enabled");
+    }
+
+    fn log_primary_disabled_by_config() {
+        info!("Chainlink primary remote sync disabled by config");
     }
 }
 
@@ -913,9 +952,7 @@ impl<V: AccountsBank, C: Cloner>
 impl<V: AccountsBank, C: Cloner> ChainlinkPrimaryLifecycle
     for Chainlink<ChainRpcClientImpl, SubMuxClient<ChainUpdatesClient>, V, C>
 {
-    async fn enable_primary(
-        &self,
-    ) -> ChainlinkResult<ChainlinkPrimaryEnablement> {
+    async fn enable_primary(&self) -> ChainlinkResult<PrimaryEnableOutcome> {
         <Chainlink<ChainRpcClientImpl, SubMuxClient<ChainUpdatesClient>, V, C>>::enable_primary(self).await
     }
 

--- a/magicblock-chainlink/src/chainlink/mod.rs
+++ b/magicblock-chainlink/src/chainlink/mod.rs
@@ -71,10 +71,17 @@ pub struct Chainlink<
 impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
     Chainlink<T, U, V, C>
 {
+    // Remote sync is allowed only while the validator is in Primary mode.
+    // Non-primary ensure/fetch/subscription/eviction calls are intentionally
+    // no-op or local-only; explicit bank reset remains separate
+    // primary-readiness cleanup and is not controlled by these generic gates.
     fn remote_sync_enabled() -> bool {
         CoordinationMode::current().needs_onchain_interactions()
     }
 
+    /// Marks the primary lifecycle boundary for chainlink remote sync.
+    /// The CoordinationMode gate remains authoritative: if this is called
+    /// before Primary mode is visible, remote work stays gated.
     pub fn enable_primary(&self) -> ChainlinkResult<()> {
         if !Self::remote_sync_enabled() {
             trace!("Chainlink enable_primary requested before primary mode; remote sync remains gated");
@@ -84,6 +91,9 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
         Ok(())
     }
 
+    /// Marks the non-primary lifecycle boundary. Non-primary chainlink calls
+    /// intentionally become no-op/local-only while bank reset remains an
+    /// explicit primary-readiness operation.
     pub fn disable(&self) {
         info!("Chainlink remote sync disabled by lifecycle transition");
     }
@@ -179,10 +189,11 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
         )
     }
 
-    /// Removes all accounts that aren't delegated to us and not blacklisted from the bank
-    /// This should only be called _before_ the validator starts up, i.e.
-    /// when resuming an existing ledger to guarantee that we don't hold
-    /// accounts that might be stale.
+    /// Removes all accounts that aren't delegated to us and not blacklisted from the bank.
+    /// This is explicit primary-readiness cleanup: standalone validators run it
+    /// before entering Primary mode, and replicated validators run it during
+    /// promotion. It is intentionally not controlled by the generic remote sync
+    /// gates used by ensure/fetch calls.
     pub fn reset_accounts_bank(&self) -> AccountsDbResult<()> {
         let blacklisted_accounts = blacklisted_accounts(&self.validator_id);
 

--- a/magicblock-chainlink/src/chainlink/mod.rs
+++ b/magicblock-chainlink/src/chainlink/mod.rs
@@ -87,8 +87,14 @@ pub trait ChainlinkPrimaryLifecycle: Send + Sync {
 // -----------------
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ChainlinkPrimaryReadiness {
+    /// Runtime is enabled and available for primary Chainlink ensure paths.
     Ready,
+    /// Local-only readiness: Chainlink is disabled because this instance has
+    /// no remote provider configured or remote-account-provider lifecycle is
+    /// disabled by config, so aperture ensure gates may proceed without a
+    /// runtime.
     ReadyWithoutRemoteProvider,
+    /// Primary Chainlink ensure paths must not run yet.
     NotReady,
 }
 

--- a/magicblock-chainlink/src/chainlink/mod.rs
+++ b/magicblock-chainlink/src/chainlink/mod.rs
@@ -100,9 +100,7 @@ impl ChainlinkPrimaryReadiness {
     pub fn label(self) -> &'static str {
         match self {
             Self::Ready => "ready",
-            Self::ReadyWithoutRemoteProvider => {
-                "ready_without_remote_provider"
-            }
+            Self::ReadyWithoutRemoteProvider => "ready_without_remote_provider",
             Self::NotReady => "not_ready",
         }
     }
@@ -944,9 +942,7 @@ mod readiness_tests {
     use magicblock_config::config::ChainLinkConfig;
     use solana_pubkey::Pubkey;
 
-    use super::{
-        ChainlinkPrimaryReadiness, StubbedChainlink,
-    };
+    use super::{ChainlinkPrimaryReadiness, StubbedChainlink};
 
     #[tokio::test]
     async fn try_new_without_fetch_cloner_is_ready_without_remote_provider(

--- a/magicblock-chainlink/src/chainlink/mod.rs
+++ b/magicblock-chainlink/src/chainlink/mod.rs
@@ -38,11 +38,6 @@ use crate::{
     },
     submux::SubMuxClient,
 };
-#[cfg(any(test, feature = "dev-context"))]
-use crate::{
-    remote_account_provider::chain_pubsub_client::mock::ChainPubsubClientMock,
-    testing::{cloner_stub::ClonerStub, rpc_client_mock::ChainRpcClientMock},
-};
 
 mod account_still_undelegating_on_chain;
 mod blacklisted_accounts;
@@ -51,11 +46,6 @@ pub mod errors;
 pub mod fetch_cloner;
 
 pub use blacklisted_accounts::*;
-
-/// A type alias for chainlink with only accountsdb being real impl
-#[cfg(any(test, feature = "dev-context"))]
-pub type StubbedChainlink<V> =
-    Chainlink<ChainRpcClientMock, ChainPubsubClientMock, V, ClonerStub>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PrimaryEnableOutcome {
@@ -72,15 +62,12 @@ impl PrimaryEnableOutcome {
 #[deprecated(note = "use PrimaryEnableOutcome")]
 pub type ChainlinkPrimaryEnablement = PrimaryEnableOutcome;
 
-pub trait AccountsBankReset: Send + Sync {
-    fn reset_accounts_bank(&self) -> AccountsDbResult<()>;
-}
-
 #[async_trait::async_trait]
-pub trait ChainlinkPrimaryLifecycle: Send + Sync {
+pub trait PrimaryChainlink: Send + Sync {
+    fn reset_accounts_bank(&self) -> AccountsDbResult<()>;
     async fn enable_primary(&self) -> ChainlinkResult<PrimaryEnableOutcome>;
-
     async fn disable(&self) -> ChainlinkResult<()>;
+    async fn primary_runtime_readiness(&self) -> PrimaryRuntimeReadiness;
 }
 
 // -----------------
@@ -776,58 +763,6 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
             })
             .unwrap_or(false)
     }
-
-    /// A temporary hacky method to clone chainlink with accountsdb only,
-    /// for it's used by the replication service to clean up accountsdb
-    ///
-    /// TODO(bmuddha):
-    /// remove all accountsdb management from chainlink, after accountsdb refactoring
-    #[cfg(any(test, feature = "dev-context"))]
-    pub fn stub(&self) -> StubbedChainlink<V> {
-        Chainlink {
-            accounts_bank: self.accounts_bank.clone(),
-            runtime: AsyncMutex::new(None),
-            lifecycle_state: AtomicU8::new(
-                ChainlinkLifecycleState::Disabled as u8,
-            ),
-            runtime_build_config: None,
-            validator_id: self.validator_id,
-            remove_confined_accounts: self.remove_confined_accounts,
-        }
-    }
-}
-
-impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
-    AccountsBankReset for Chainlink<T, U, V, C>
-{
-    fn reset_accounts_bank(&self) -> AccountsDbResult<()> {
-        Chainlink::reset_accounts_bank(self)
-    }
-}
-
-#[cfg(any(test, feature = "dev-context"))]
-impl<V: AccountsBank>
-    Chainlink<ChainRpcClientMock, ChainPubsubClientMock, V, ClonerStub>
-{
-    /// Marks the primary lifecycle boundary for stubbed chainlink remote sync.
-    pub async fn enable_primary(
-        &self,
-    ) -> ChainlinkResult<PrimaryEnableOutcome> {
-        if self.runtime.lock().await.is_some() {
-            self.lifecycle_state.store(
-                ChainlinkLifecycleState::Enabled as u8,
-                Ordering::SeqCst,
-            );
-            info!("Test Chainlink primary lifecycle marked active");
-            Ok(PrimaryEnableOutcome::RuntimeActive)
-        } else {
-            self.lifecycle_state.store(
-                ChainlinkLifecycleState::Disabled as u8,
-                Ordering::SeqCst,
-            );
-            Ok(PrimaryEnableOutcome::DisabledByConfig)
-        }
-    }
 }
 
 impl<V: AccountsBank, C: Cloner>
@@ -949,15 +884,26 @@ impl<V: AccountsBank, C: Cloner>
 }
 
 #[async_trait::async_trait]
-impl<V: AccountsBank, C: Cloner> ChainlinkPrimaryLifecycle
+impl<V, C> PrimaryChainlink
     for Chainlink<ChainRpcClientImpl, SubMuxClient<ChainUpdatesClient>, V, C>
+where
+    V: AccountsBank + Send + Sync + 'static,
+    C: Cloner + Send + Sync + 'static,
 {
+    fn reset_accounts_bank(&self) -> AccountsDbResult<()> {
+        Chainlink::reset_accounts_bank(self)
+    }
+
     async fn enable_primary(&self) -> ChainlinkResult<PrimaryEnableOutcome> {
-        <Chainlink<ChainRpcClientImpl, SubMuxClient<ChainUpdatesClient>, V, C>>::enable_primary(self).await
+        Chainlink::enable_primary(self).await
     }
 
     async fn disable(&self) -> ChainlinkResult<()> {
         Chainlink::disable(self).await
+    }
+
+    async fn primary_runtime_readiness(&self) -> PrimaryRuntimeReadiness {
+        Chainlink::primary_runtime_readiness(self).await
     }
 }
 
@@ -985,14 +931,26 @@ mod readiness_tests {
     use magicblock_config::config::ChainLinkConfig;
     use solana_pubkey::Pubkey;
 
-    use super::{ChainlinkPrimaryReadiness, StubbedChainlink};
+    use crate::{
+        remote_account_provider::chain_pubsub_client::mock::ChainPubsubClientMock,
+        testing::{
+            cloner_stub::ClonerStub, rpc_client_mock::ChainRpcClientMock,
+        },
+    };
+
+    use super::{Chainlink, ChainlinkPrimaryReadiness};
 
     #[tokio::test]
     async fn try_new_without_fetch_cloner_is_ready_without_remote_provider(
     ) -> Result<(), Box<dyn std::error::Error>> {
         let tempdir = tempfile::tempdir()?;
         let accounts_db = Arc::new(AccountsDb::open(tempdir.path())?);
-        let chainlink = StubbedChainlink::try_new(
+        let chainlink = Chainlink::<
+            ChainRpcClientMock,
+            ChainPubsubClientMock,
+            AccountsDb,
+            ClonerStub,
+        >::try_new(
             &accounts_db,
             None,
             Pubkey::new_unique(),

--- a/magicblock-chainlink/src/chainlink/mod.rs
+++ b/magicblock-chainlink/src/chainlink/mod.rs
@@ -82,6 +82,23 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
         }
     }
 
+    pub fn enable_primary(&self) -> ChainlinkResult<()> {
+        if !Self::remote_sync_enabled() {
+            trace!("Chainlink enable_primary requested before primary mode; remote sync remains gated");
+        } else {
+            info!("Chainlink primary remote sync enabled");
+        }
+        Ok(())
+    }
+
+    pub fn disable(&self) {
+        info!("Chainlink remote sync disabled by lifecycle transition");
+    }
+
+    pub fn is_remote_sync_enabled(&self) -> bool {
+        Self::remote_sync_enabled()
+    }
+
     pub fn try_new(
         accounts_bank: &Arc<V>,
         fetch_cloner: Option<Arc<FetchCloner<T, U, V, C>>>,

--- a/magicblock-chainlink/src/chainlink/mod.rs
+++ b/magicblock-chainlink/src/chainlink/mod.rs
@@ -13,7 +13,6 @@ use fetch_cloner::FetchCloner;
 use magicblock_accounts_db::{traits::AccountsBank, AccountsDbResult};
 use magicblock_aml::RiskService;
 use magicblock_config::config::ChainLinkConfig;
-use magicblock_core::coordination_mode::CoordinationMode;
 use magicblock_metrics::metrics::AccountFetchOrigin;
 use solana_account::{AccountSharedData, ReadableAccount};
 use solana_commitment_config::CommitmentConfig;
@@ -127,14 +126,6 @@ pub struct Chainlink<
 impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
     Chainlink<T, U, V, C>
 {
-    // Remote sync is allowed only while the validator is in Primary mode.
-    // Non-primary ensure/fetch/subscription/eviction calls are intentionally
-    // no-op or local-only; explicit bank reset remains separate
-    // primary-readiness cleanup and is not controlled by these generic gates.
-    fn remote_sync_enabled() -> bool {
-        CoordinationMode::current().needs_onchain_interactions()
-    }
-
     /// Marks the non-primary lifecycle boundary. Non-primary chainlink calls
     /// intentionally become no-op/local-only while bank reset remains an
     /// explicit primary-readiness operation.
@@ -174,13 +165,6 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
             info!("Chainlink remote sync disabled by lifecycle transition");
         }
         result
-    }
-
-    pub fn is_remote_sync_enabled(&self) -> bool {
-        let _ = ChainlinkLifecycleState::from_u8(
-            self.lifecycle_state.load(Ordering::SeqCst),
-        );
-        Self::remote_sync_enabled()
     }
 
     #[cfg(any(test, feature = "dev-context"))]
@@ -375,14 +359,6 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
 
         task::spawn(async move {
             while let Some(pubkey) = removed_accounts_rx.recv().await {
-                if !Self::remote_sync_enabled() {
-                    trace!(
-                        pubkey = %pubkey,
-                        "Skipping account eviction while chainlink remote sync is disabled"
-                    );
-                    continue;
-                }
-
                 // Pre-flight check: skip if delegated/undelegating
                 // (the processor enforces this too, but this avoids
                 // the overhead of building and submitting a doomed tx)
@@ -458,14 +434,6 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
             return Ok(Default::default());
         }
 
-        if !Self::remote_sync_enabled() {
-            trace!(
-                tx_sig = %tx.signature(),
-                "Skipping transaction account ensure while chainlink remote sync is disabled"
-            );
-            return Ok(Default::default());
-        }
-
         let mut pubkeys = tx
             .message()
             .account_keys()
@@ -520,14 +488,6 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
         fetch_origin: AccountFetchOrigin,
         program_ids: Option<&[Pubkey]>,
     ) -> ChainlinkResult<FetchAndCloneResult> {
-        if !Self::remote_sync_enabled() {
-            trace!(
-                count = pubkeys.len(),
-                "Skipping account ensure while chainlink remote sync is disabled"
-            );
-            return Ok(FetchAndCloneResult::default());
-        }
-
         let Some(fetch_cloner) = self.runtime_fetch_cloner().await else {
             return Ok(FetchAndCloneResult::default());
         };
@@ -552,17 +512,6 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
         fetch_origin: AccountFetchOrigin,
         program_ids: Option<&[Pubkey]>,
     ) -> ChainlinkResult<Vec<Option<AccountSharedData>>> {
-        if !Self::remote_sync_enabled() {
-            trace!(
-                count = pubkeys.len(),
-                "Reading local accounts while chainlink remote sync is disabled"
-            );
-            return Ok(pubkeys
-                .iter()
-                .map(|pubkey| self.accounts_bank.get_account(pubkey))
-                .collect());
-        }
-
         if tracing::enabled!(tracing::Level::TRACE) {
             let count = pubkeys.len();
             trace!(count, "Fetching accounts");
@@ -643,14 +592,6 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
         debug!(pubkey = %pubkey, "Undelegation requested");
 
         magicblock_metrics::metrics::inc_undelegation_requested();
-
-        if !Self::remote_sync_enabled() {
-            debug!(
-                pubkey = %pubkey,
-                "Skipping undelegation subscription while chainlink remote sync is disabled"
-            );
-            return Ok(());
-        }
 
         let Some(fetch_cloner) = self.runtime_fetch_cloner().await else {
             return Ok(());
@@ -742,11 +683,7 @@ impl<V: AccountsBank>
             );
         }
 
-        if !Self::remote_sync_enabled() {
-            trace!("Chainlink enable_primary requested before primary mode; remote sync remains gated");
-        } else {
-            info!("Chainlink primary remote sync enabled");
-        }
+        info!("Chainlink primary remote sync enabled");
         Ok(())
     }
 }
@@ -859,11 +796,7 @@ impl<V: AccountsBank, C: Cloner>
     }
 
     fn log_primary_enabled() {
-        if !Self::remote_sync_enabled() {
-            trace!("Chainlink enable_primary requested before primary mode; remote sync remains gated");
-        } else {
-            info!("Chainlink primary remote sync enabled");
-        }
+        info!("Chainlink primary remote sync enabled");
     }
 }
 

--- a/magicblock-chainlink/src/chainlink/mod.rs
+++ b/magicblock-chainlink/src/chainlink/mod.rs
@@ -53,6 +53,29 @@ pub use blacklisted_accounts::*;
 pub type StubbedChainlink<V> =
     Chainlink<ChainRpcClientMock, ChainPubsubClientMock, V, ClonerStub>;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChainlinkPrimaryEnablement {
+    Active,
+    DisabledByConfig,
+}
+
+impl ChainlinkPrimaryEnablement {
+    pub fn is_active(self) -> bool {
+        matches!(self, Self::Active)
+    }
+}
+
+pub trait AccountsBankReset: Send + Sync {
+    fn reset_accounts_bank(&self) -> AccountsDbResult<()>;
+}
+
+#[async_trait::async_trait]
+pub trait ChainlinkPrimaryLifecycle: Send + Sync {
+    async fn enable_primary(&self) -> ChainlinkResult<ChainlinkPrimaryEnablement>;
+
+    async fn disable(&self) -> ChainlinkResult<()>;
+}
+
 // -----------------
 // Chainlink
 // -----------------
@@ -673,6 +696,14 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
     }
 }
 
+impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
+    AccountsBankReset for Chainlink<T, U, V, C>
+{
+    fn reset_accounts_bank(&self) -> AccountsDbResult<()> {
+        Chainlink::reset_accounts_bank(self)
+    }
+}
+
 impl<V: AccountsBank>
     Chainlink<ChainRpcClientMock, ChainPubsubClientMock, V, ClonerStub>
 {
@@ -700,7 +731,9 @@ impl<V: AccountsBank, C: Cloner>
 {
     /// Marks the primary lifecycle boundary for chainlink remote sync and
     /// creates the runtime from stored production configuration when needed.
-    pub async fn enable_primary(&self) -> ChainlinkResult<()> {
+    pub async fn enable_primary(
+        &self,
+    ) -> ChainlinkResult<ChainlinkPrimaryEnablement> {
         let mut runtime = self.runtime.lock().await;
         if runtime.is_some() {
             self.lifecycle_state.store(
@@ -708,7 +741,7 @@ impl<V: AccountsBank, C: Cloner>
                 Ordering::SeqCst,
             );
             Self::log_primary_enabled();
-            return Ok(());
+            return Ok(ChainlinkPrimaryEnablement::Active);
         }
 
         self.lifecycle_state
@@ -719,8 +752,7 @@ impl<V: AccountsBank, C: Cloner>
                 ChainlinkLifecycleState::Disabled as u8,
                 Ordering::SeqCst,
             );
-            Self::log_primary_enabled();
-            return Ok(());
+            return Err(ChainlinkError::MissingPrimaryRuntimeBuildConfig);
         };
 
         if !build
@@ -733,8 +765,8 @@ impl<V: AccountsBank, C: Cloner>
                 ChainlinkLifecycleState::Disabled as u8,
                 Ordering::SeqCst,
             );
-            Self::log_primary_enabled();
-            return Ok(());
+            info!("Chainlink primary remote sync disabled by config");
+            return Ok(ChainlinkPrimaryEnablement::DisabledByConfig);
         }
 
         match self.create_runtime_from_build_config(build).await {
@@ -745,7 +777,7 @@ impl<V: AccountsBank, C: Cloner>
                     Ordering::SeqCst,
                 );
                 Self::log_primary_enabled();
-                Ok(())
+                Ok(ChainlinkPrimaryEnablement::Active)
             }
             Err(err) => {
                 *runtime = None;
@@ -804,6 +836,21 @@ impl<V: AccountsBank, C: Cloner>
 
     fn log_primary_enabled() {
         info!("Chainlink primary remote sync enabled");
+    }
+}
+
+#[async_trait::async_trait]
+impl<V: AccountsBank, C: Cloner> ChainlinkPrimaryLifecycle
+    for Chainlink<ChainRpcClientImpl, SubMuxClient<ChainUpdatesClient>, V, C>
+{
+    async fn enable_primary(
+        &self,
+    ) -> ChainlinkResult<ChainlinkPrimaryEnablement> {
+        <Chainlink<ChainRpcClientImpl, SubMuxClient<ChainUpdatesClient>, V, C>>::enable_primary(self).await
+    }
+
+    async fn disable(&self) -> ChainlinkResult<()> {
+        Chainlink::disable(self).await
     }
 }
 

--- a/magicblock-chainlink/src/chainlink/mod.rs
+++ b/magicblock-chainlink/src/chainlink/mod.rs
@@ -86,6 +86,29 @@ pub trait ChainlinkPrimaryLifecycle: Send + Sync {
 // Chainlink
 // -----------------
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChainlinkPrimaryReadiness {
+    Ready,
+    ReadyWithoutRemoteProvider,
+    NotReady,
+}
+
+impl ChainlinkPrimaryReadiness {
+    pub fn allows_aperture_ensure(self) -> bool {
+        matches!(self, Self::Ready | Self::ReadyWithoutRemoteProvider)
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Ready => "ready",
+            Self::ReadyWithoutRemoteProvider => {
+                "ready_without_remote_provider"
+            }
+            Self::NotReady => "not_ready",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ChainlinkLifecycleState {
     Disabled = 0,
     Starting = 1,
@@ -155,6 +178,39 @@ pub struct Chainlink<
 impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
     Chainlink<T, U, V, C>
 {
+    pub async fn primary_readiness(&self) -> ChainlinkPrimaryReadiness {
+        match ChainlinkLifecycleState::from_u8(
+            self.lifecycle_state.load(Ordering::SeqCst),
+        ) {
+            ChainlinkLifecycleState::Enabled => {
+                if self.runtime.lock().await.is_some() {
+                    ChainlinkPrimaryReadiness::Ready
+                } else {
+                    ChainlinkPrimaryReadiness::NotReady
+                }
+            }
+            ChainlinkLifecycleState::Starting
+            | ChainlinkLifecycleState::Stopping => {
+                ChainlinkPrimaryReadiness::NotReady
+            }
+            ChainlinkLifecycleState::Disabled => {
+                let Some(build) = self.runtime_build_config.as_ref() else {
+                    return ChainlinkPrimaryReadiness::ReadyWithoutRemoteProvider;
+                };
+                if !build
+                    .runtime_config
+                    .remote_account_provider
+                    .lifecycle_mode()
+                    .needs_remote_account_provider()
+                {
+                    ChainlinkPrimaryReadiness::ReadyWithoutRemoteProvider
+                } else {
+                    ChainlinkPrimaryReadiness::NotReady
+                }
+            }
+        }
+    }
+
     /// Marks the non-primary lifecycle boundary. Non-primary chainlink calls
     /// intentionally become no-op/local-only while bank reset remains an
     /// explicit primary-readiness operation.
@@ -878,4 +934,54 @@ fn extract_program_ids_from_transaction(
         .map(|(program_id, _)| *program_id)
         .collect::<HashSet<_>>();
     program_ids.into_iter().collect()
+}
+
+#[cfg(test)]
+mod readiness_tests {
+    use std::sync::Arc;
+
+    use magicblock_accounts_db::AccountsDb;
+    use magicblock_config::config::ChainLinkConfig;
+    use solana_pubkey::Pubkey;
+
+    use super::{
+        ChainlinkPrimaryReadiness, StubbedChainlink,
+    };
+
+    #[tokio::test]
+    async fn try_new_without_fetch_cloner_is_ready_without_remote_provider(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let tempdir = tempfile::tempdir()?;
+        let accounts_db = Arc::new(AccountsDb::open(tempdir.path())?);
+        let chainlink = StubbedChainlink::try_new(
+            &accounts_db,
+            None,
+            Pubkey::new_unique(),
+            &ChainLinkConfig::default(),
+        )?;
+
+        assert_eq!(
+            chainlink.primary_readiness().await,
+            ChainlinkPrimaryReadiness::ReadyWithoutRemoteProvider
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn label_matches_expected_metric_values() {
+        assert_eq!(ChainlinkPrimaryReadiness::Ready.label(), "ready");
+        assert_eq!(
+            ChainlinkPrimaryReadiness::ReadyWithoutRemoteProvider.label(),
+            "ready_without_remote_provider"
+        );
+        assert_eq!(ChainlinkPrimaryReadiness::NotReady.label(), "not_ready");
+    }
+
+    #[test]
+    fn allows_aperture_ensure_only_for_ready_variants() {
+        assert!(ChainlinkPrimaryReadiness::Ready.allows_aperture_ensure());
+        assert!(ChainlinkPrimaryReadiness::ReadyWithoutRemoteProvider
+            .allows_aperture_ensure());
+        assert!(!ChainlinkPrimaryReadiness::NotReady.allows_aperture_ensure());
+    }
 }

--- a/magicblock-chainlink/src/chainlink/mod.rs
+++ b/magicblock-chainlink/src/chainlink/mod.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::HashSet,
-    path::Path,
+    path::{Path, PathBuf},
     sync::{
         atomic::{AtomicU8, Ordering},
         Arc,
@@ -8,7 +8,7 @@ use std::{
 };
 
 use dlp_api::pda::ephemeral_balance_pda_from_payer;
-use errors::ChainlinkResult;
+use errors::{ChainlinkError, ChainlinkResult};
 use fetch_cloner::FetchCloner;
 use magicblock_accounts_db::{traits::AccountsBank, AccountsDbResult};
 use magicblock_aml::RiskService;
@@ -22,7 +22,10 @@ use solana_pubkey::Pubkey;
 use solana_sdk_ids::feature;
 use solana_signer::Signer;
 use solana_transaction::sanitized::SanitizedTransaction;
-use tokio::{sync::mpsc, sync::Mutex as AsyncMutex, task};
+use tokio::{
+    sync::{mpsc, Mutex as AsyncMutex},
+    task,
+};
 use tracing::*;
 
 use crate::{
@@ -89,6 +92,20 @@ where
     removed_accounts_sub: Option<task::JoinHandle<()>>,
 }
 
+#[allow(dead_code)]
+struct ChainlinkRuntimeBuildConfig<C>
+where
+    C: Cloner,
+{
+    endpoints: Endpoints,
+    commitment: CommitmentConfig,
+    cloner: Arc<C>,
+    validator_keypair_bytes: [u8; 64],
+    chainlink_config: ChainLinkConfig,
+    runtime_config: ChainlinkConfig,
+    ledger_path: PathBuf,
+}
+
 pub struct Chainlink<
     T: ChainRpcClient,
     U: ChainPubsubClient,
@@ -98,6 +115,8 @@ pub struct Chainlink<
     accounts_bank: Arc<V>,
     runtime: AsyncMutex<Option<ChainlinkRuntime<T, U, V, C>>>,
     lifecycle_state: AtomicU8,
+    #[allow(dead_code)]
+    runtime_build_config: Option<ChainlinkRuntimeBuildConfig<C>>,
 
     validator_id: Pubkey,
 
@@ -224,6 +243,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
             accounts_bank: accounts_bank.clone(),
             runtime: AsyncMutex::new(runtime),
             lifecycle_state: AtomicU8::new(lifecycle_state as u8),
+            runtime_build_config: None,
             validator_id: validator_pubkey,
             remove_confined_accounts: config.remove_confined_accounts,
         })
@@ -267,6 +287,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
         Chainlink<ChainRpcClientImpl, SubMuxClient<ChainUpdatesClient>, V, C>,
     > {
         let validator_pubkey = validator_keypair.pubkey();
+        let validator_keypair_bytes = validator_keypair.to_bytes();
         // Extract accounts provider and create fetch cloner while connecting
         // the subscription channel
         let (tx, rx) = tokio::sync::mpsc::channel(5_000);
@@ -298,12 +319,31 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
             None
         };
 
-        Chainlink::try_new(
+        let mut chainlink = Chainlink::try_new(
             accounts_bank,
             fetch_cloner,
             validator_pubkey,
             chainlink_config,
-        )
+        )?;
+        chainlink.runtime_build_config = Some(ChainlinkRuntimeBuildConfig {
+            endpoints: endpoints.clone(),
+            commitment,
+            cloner: cloner.clone(),
+            validator_keypair_bytes,
+            chainlink_config: chainlink_config.clone(),
+            runtime_config: config,
+            ledger_path: ledger_path.to_path_buf(),
+        });
+        Ok(chainlink)
+    }
+
+    #[allow(dead_code)]
+    fn validator_keypair_from_bytes(
+        bytes: &[u8; 64],
+    ) -> ChainlinkResult<Keypair> {
+        Keypair::try_from(&bytes[..]).map_err(|err| {
+            ChainlinkError::InvalidValidatorKeypair(err.to_string())
+        })
     }
 
     /// Removes all accounts that aren't delegated to us and not blacklisted from the bank.
@@ -720,6 +760,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
             lifecycle_state: AtomicU8::new(
                 ChainlinkLifecycleState::Disabled as u8,
             ),
+            runtime_build_config: None,
             validator_id: self.validator_id,
             remove_confined_accounts: self.remove_confined_accounts,
         }

--- a/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/actor.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/actor.rs
@@ -355,7 +355,7 @@ impl<H: StreamHandle, S: StreamFactory<H>> ChainLaserActor<H, S> {
             }
             Shutdown { response } => {
                 info!(client_id = self.client_id, "Received Shutdown message");
-                Self::clear_subscriptions(&mut self.stream_manager);
+                self.stream_manager.shutdown();
                 let _ = response.send(Ok(())).inspect_err(|_| {
                     warn!(
                         client_id = self.client_id,
@@ -607,8 +607,7 @@ impl<H: StreamHandle, S: StreamFactory<H>> ChainLaserActor<H, S> {
     }
 
     fn clear_subscriptions(stream_manager: &mut StreamManager<H, S>) {
-        stream_manager.clear_account_subscriptions();
-        stream_manager.clear_program_subscriptions();
+        stream_manager.shutdown();
     }
 
     /// Signals a connection issue by clearing all subscriptions

--- a/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/stream_manager.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/stream_manager.rs
@@ -387,6 +387,17 @@ impl<S: StreamHandle, SF: StreamFactory<S>> StreamManager<S, SF> {
         !self.stream_map.is_empty()
     }
 
+    /// Clears all account, program, slot-filter, and stream state.
+    pub fn shutdown(&mut self) {
+        self.clear_account_subscriptions();
+        self.clear_program_subscriptions();
+    }
+
+    #[cfg(any(test, feature = "dev-context"))]
+    pub fn active_stream_count_for_tests(&self) -> usize {
+        self.stream_map.len()
+    }
+
     /// Returns `true` if there are unoptimized old streams.
     pub fn has_unoptimized_streams(&self) -> bool {
         !self.unoptimized_old_handles.is_empty()

--- a/magicblock-chainlink/src/remote_account_provider/chain_pubsub_actor.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_pubsub_actor.rs
@@ -383,6 +383,16 @@ impl ChainPubsubActor {
                 .await;
             }
             ChainPubsubActorMessage::Reconnect { response } => {
+                if shutdown_token.is_cancelled() {
+                    let _ = response.send(Err(
+                        RemoteAccountProviderError::AccountSubscriptionsTaskFailed(
+                            format!(
+                                "Client {client_id} is shutting down; reconnect skipped"
+                            ),
+                        ),
+                    ));
+                    return;
+                }
                 let result = Self::try_reconnect(
                     pubsub_connection,
                     pubsub_client_config,

--- a/magicblock-chainlink/src/remote_account_provider/chain_pubsub_client.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_pubsub_client.rs
@@ -318,6 +318,7 @@ pub mod mock {
         subscribe_blocked: Arc<Mutex<bool>>,
         subscribe_attempts: Arc<AtomicU64>,
         subscribe_notify: Arc<Notify>,
+        shutdown_attempts: Arc<AtomicU64>,
     }
 
     impl ChainPubsubClientMock {
@@ -337,6 +338,7 @@ pub mod mock {
                 subscribe_blocked: Arc::new(Mutex::new(false)),
                 subscribe_attempts: Arc::new(AtomicU64::new(0)),
                 subscribe_notify: Arc::new(Notify::new()),
+                shutdown_attempts: Arc::new(AtomicU64::new(0)),
             }
         }
 
@@ -434,6 +436,10 @@ pub mod mock {
             self.subscribed_programs.lock().clone()
         }
 
+        pub fn shutdown_attempts(&self) -> u64 {
+            self.shutdown_attempts.load(AtomicOrdering::SeqCst)
+        }
+
         /// Directly insert a subscription without going through subscribe().
         /// Useful for testing reconciliation scenarios.
         pub fn insert_subscription(&self, pubkey: Pubkey) {
@@ -513,6 +519,7 @@ pub mod mock {
         }
 
         async fn shutdown(&self) -> RemoteAccountProviderResult<()> {
+            self.shutdown_attempts.fetch_add(1, AtomicOrdering::SeqCst);
             Ok(())
         }
 

--- a/magicblock-chainlink/src/remote_account_provider/chain_pubsub_client.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_pubsub_client.rs
@@ -520,6 +520,8 @@ pub mod mock {
 
         async fn shutdown(&self) -> RemoteAccountProviderResult<()> {
             self.shutdown_attempts.fetch_add(1, AtomicOrdering::SeqCst);
+            self.subscribed_pubkeys.lock().clear();
+            self.subscribed_programs.lock().clear();
             Ok(())
         }
 

--- a/magicblock-chainlink/src/remote_account_provider/chain_updates_client.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_updates_client.rs
@@ -92,6 +92,14 @@ impl ChainUpdatesClient {
             }
         }
     }
+
+    pub async fn shutdown(&self) -> RemoteAccountProviderResult<()> {
+        use ChainUpdatesClient::*;
+        match self {
+            WebSocket(client) => client.shutdown().await,
+            Laser(client) => client.shutdown().await,
+        }
+    }
 }
 
 #[async_trait]
@@ -131,11 +139,7 @@ impl ChainPubsubClient for ChainUpdatesClient {
     }
 
     async fn shutdown(&self) -> RemoteAccountProviderResult<()> {
-        use ChainUpdatesClient::*;
-        match self {
-            WebSocket(client) => client.shutdown().await,
-            Laser(client) => client.shutdown().await,
-        }
+        ChainUpdatesClient::shutdown(self).await
     }
 
     fn take_updates(&self) -> mpsc::Receiver<SubscriptionUpdate> {

--- a/magicblock-chainlink/src/remote_account_provider/endpoint.rs
+++ b/magicblock-chainlink/src/remote_account_provider/endpoint.rs
@@ -111,7 +111,7 @@ impl TryFrom<&Remote> for Endpoint {
 /// Previously this was enforced at construction time but now we rely on
 /// the config validation to ensure this.
 /// However in order to allow for future extensions we keep this type.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Endpoints(Vec<Endpoint>);
 
 impl Deref for Endpoints {

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -144,7 +144,8 @@ fn spawn_deferred_pubsub_clients(
     submux: SubMuxClient<ChainUpdatesClient>,
     subscribed_accounts: Arc<AccountsLruCache>,
     subscription_transition_lock: Arc<AsyncMutex<()>>,
-) {
+    shutdown_token: CancellationToken,
+) -> task::JoinHandle<()> {
     tokio::spawn(async move {
         let mut pubsub_futs = endpoints
             .into_iter()
@@ -159,7 +160,14 @@ fn spawn_deferred_pubsub_clients(
                 )
             })
             .collect::<FuturesUnordered<_>>();
-        while let Some((label, result)) = pubsub_futs.next().await {
+        loop {
+            let next = tokio::select! {
+                _ = shutdown_token.cancelled() => break,
+                next = pubsub_futs.next() => next,
+            };
+            let Some((label, result)) = next else {
+                break;
+            };
             let (client, abort_rx) = match result {
                 Ok(client) => client,
                 Err(err) => {
@@ -172,13 +180,26 @@ fn spawn_deferred_pubsub_clients(
                 }
             };
 
-            let add_result = {
-                let _transition_guard =
-                    subscription_transition_lock.lock().await;
-                submux
-                    .add_client(client, abort_rx, subscribed_accounts.clone())
-                    .await
+            if shutdown_token.is_cancelled() {
+                break;
+            }
+
+            let add_result = tokio::select! {
+                _ = shutdown_token.cancelled() => break,
+                add_result = async {
+                    let _transition_guard =
+                        subscription_transition_lock.lock().await;
+                    if shutdown_token.is_cancelled() {
+                        return Ok(());
+                    }
+                    submux
+                        .add_client(client, abort_rx, subscribed_accounts.clone())
+                        .await
+                } => add_result,
             };
+            if shutdown_token.is_cancelled() {
+                break;
+            }
             if let Err(err) = add_result {
                 warn!(
                     endpoint = %label,
@@ -189,7 +210,7 @@ fn spawn_deferred_pubsub_clients(
             }
             debug!(endpoint = %label, "Attached deferred pubsub client");
         }
-    });
+    })
 }
 
 // Maps pubkey -> (fetch_start_slot, requests_waiting)
@@ -413,6 +434,7 @@ pub struct RemoteAccountProvider<T: ChainRpcClient, U: ChainPubsubClient> {
 
     shutdown_token: CancellationToken,
     account_updates_task_handle: AsyncMutex<Option<task::JoinHandle<()>>>,
+    deferred_pubsub_task_handle: AsyncMutex<Option<task::JoinHandle<()>>>,
     /// Task that periodically updates the active subscriptions gauge
     active_subscriptions_task_handle: AsyncMutex<Option<task::JoinHandle<()>>>,
 }
@@ -586,6 +608,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
             removed_account_rx: Mutex::new(Some(removed_account_rx)),
             shutdown_token,
             account_updates_task_handle: AsyncMutex::new(None),
+            deferred_pubsub_task_handle: AsyncMutex::new(None),
             active_subscriptions_task_handle: AsyncMutex::new(
                 active_subscriptions_updater,
             ),
@@ -668,7 +691,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
         {
             Ok((provider, deferred_pubsubs)) => {
                 if !deferred_pubsubs.is_empty() {
-                    spawn_deferred_pubsub_clients(
+                    let handle = spawn_deferred_pubsub_clients(
                         deferred_pubsubs,
                         commitment,
                         rpc_client,
@@ -678,7 +701,10 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                         provider.pubsub_client.clone(),
                         provider.lrucache_subscribed_accounts.clone(),
                         provider.subscription_transition_lock.clone(),
+                        provider.shutdown_token.child_token(),
                     );
+                    *provider.deferred_pubsub_task_handle.lock().await =
+                        Some(handle);
                 }
                 Ok(provider)
             }
@@ -831,6 +857,24 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                 Err(err)
             }
         };
+
+        if let Some(mut handle) =
+            self.deferred_pubsub_task_handle.lock().await.take()
+        {
+            match time::timeout(Duration::from_secs(2), &mut handle).await {
+                Ok(Ok(())) => {}
+                Ok(Err(err)) => {
+                    warn!(error = %err, "Deferred pubsub task failed during shutdown");
+                }
+                Err(_) => {
+                    warn!(
+                        "Deferred pubsub task did not stop in time; aborting"
+                    );
+                    handle.abort();
+                    let _ = handle.await;
+                }
+            }
+        }
 
         if let Some(mut handle) =
             self.account_updates_task_handle.lock().await.take()

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -40,6 +40,7 @@ use tokio::{
     sync::{mpsc, oneshot, Mutex as AsyncMutex},
     task, time,
 };
+use tokio_util::sync::CancellationToken;
 use tracing::*;
 
 pub mod chain_slot;
@@ -410,8 +411,10 @@ pub struct RemoteAccountProvider<T: ChainRpcClient, U: ChainPubsubClient> {
 
     subscription_forwarder: Arc<mpsc::Sender<ForwardedSubscriptionUpdate>>,
 
+    shutdown_token: CancellationToken,
+    account_updates_task_handle: AsyncMutex<Option<task::JoinHandle<()>>>,
     /// Task that periodically updates the active subscriptions gauge
-    _active_subscriptions_task_handle: Option<task::JoinHandle<()>>,
+    active_subscriptions_task_handle: AsyncMutex<Option<task::JoinHandle<()>>>,
 }
 
 // -----------------
@@ -507,6 +510,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
         subscribed_accounts: Arc<AccountsLruCache>,
         pubsub_client: Arc<PubsubClient>,
         removed_account_tx: mpsc::Sender<Pubkey>,
+        shutdown_token: CancellationToken,
     ) -> task::JoinHandle<()> {
         task::spawn(async move {
             let mut interval = time::interval(Duration::from_millis(
@@ -515,18 +519,25 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
             let never_evicted = subscribed_accounts.never_evicted_accounts();
 
             loop {
-                interval.tick().await;
-                let pubsub_total =
-                    subscription_reconciler::reconcile_subscriptions(
-                        &subscribed_accounts,
-                        pubsub_client.as_ref(),
-                        &never_evicted,
-                        &removed_account_tx,
-                    )
-                    .await;
+                tokio::select! {
+                    _ = interval.tick() => {
+                        let pubsub_total =
+                            subscription_reconciler::reconcile_subscriptions(
+                                &subscribed_accounts,
+                                pubsub_client.as_ref(),
+                                &never_evicted,
+                                &removed_account_tx,
+                            )
+                            .await;
 
-                debug!(count = pubsub_total, "Updating active subscriptions");
-                set_monitored_accounts_count(pubsub_total);
+                        debug!(count = pubsub_total, "Updating active subscriptions");
+                        set_monitored_accounts_count(pubsub_total);
+                    }
+                    _ = shutdown_token.cancelled() => {
+                        debug!("Stopping active subscriptions updater");
+                        break;
+                    }
+                }
             }
         })
     }
@@ -544,6 +555,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
     ) -> RemoteAccountProviderResult<Self> {
         let (removed_account_tx, removed_account_rx) =
             tokio::sync::mpsc::channel(100);
+        let shutdown_token = CancellationToken::new();
 
         let active_subscriptions_updater =
             if config.enable_subscription_metrics() {
@@ -551,6 +563,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                     lrucache_subscribed_accounts.clone(),
                     Arc::new(pubsub_client.clone()),
                     removed_account_tx.clone(),
+                    shutdown_token.child_token(),
                 ))
             } else {
                 None
@@ -571,11 +584,15 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
             subscription_forwarder: Arc::new(subscription_forwarder),
             removed_account_tx,
             removed_account_rx: Mutex::new(Some(removed_account_rx)),
-            _active_subscriptions_task_handle: active_subscriptions_updater,
+            shutdown_token,
+            account_updates_task_handle: AsyncMutex::new(None),
+            active_subscriptions_task_handle: AsyncMutex::new(
+                active_subscriptions_updater,
+            ),
         };
 
         let updates = me.pubsub_client.take_updates();
-        me.listen_for_account_updates(updates)?;
+        me.listen_for_account_updates(updates).await?;
         let clock_remote_account = me
             .try_get(clock::ID, AccountFetchOrigin::GetAccount)
             .await?;
@@ -804,7 +821,85 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
         self.received_updates_count.load(Ordering::Relaxed)
     }
 
-    fn listen_for_account_updates(
+    pub async fn shutdown(&self) -> RemoteAccountProviderResult<()> {
+        self.shutdown_token.cancel();
+
+        let shutdown_result = match self.pubsub_client.shutdown().await {
+            Ok(()) => Ok(()),
+            Err(err) => {
+                warn!(error = %err, "Remote account pubsub shutdown failed");
+                Err(err)
+            }
+        };
+
+        if let Some(mut handle) =
+            self.account_updates_task_handle.lock().await.take()
+        {
+            match time::timeout(Duration::from_secs(2), &mut handle).await {
+                Ok(Ok(())) => {}
+                Ok(Err(err)) => {
+                    warn!(error = %err, "Account updates task failed during shutdown");
+                }
+                Err(_) => {
+                    warn!(
+                        "Account updates task did not stop in time; aborting"
+                    );
+                    handle.abort();
+                    let _ = handle.await;
+                }
+            }
+        }
+
+        if let Some(mut handle) =
+            self.active_subscriptions_task_handle.lock().await.take()
+        {
+            match time::timeout(Duration::from_secs(2), &mut handle).await {
+                Ok(Ok(())) => {}
+                Ok(Err(err)) => {
+                    warn!(error = %err, "Active subscriptions task failed during shutdown");
+                }
+                Err(_) => {
+                    warn!(
+                        "Active subscriptions task did not stop in time; aborting"
+                    );
+                    handle.abort();
+                    let _ = handle.await;
+                }
+            }
+        }
+
+        if let Some(mut removed_account_rx) = self
+            .removed_account_rx
+            .lock()
+            .expect("removed_account_rx lock poisoned")
+            .take()
+        {
+            while removed_account_rx.try_recv().is_ok() {}
+        }
+
+        {
+            let mut fetching = self
+                .fetching_accounts
+                .lock()
+                .expect("fetching_accounts lock poisoned");
+            for (_, state) in fetching.drain() {
+                for waiter in state.waiters {
+                    let _ = waiter.send(Err(
+                        RemoteAccountProviderError::AccountSubscriptionsTaskFailed(
+                            "remote account provider shut down".to_string(),
+                        ),
+                    ));
+                }
+            }
+        }
+
+        self.subscription_ownership.lock().await.clear();
+        self.subscription_key_locks.lock().await.clear();
+
+        shutdown_result
+    }
+
+    async fn listen_for_account_updates(
         &self,
         mut updates: mpsc::Receiver<SubscriptionUpdate>,
     ) -> RemoteAccountProviderResult<()> {
@@ -813,8 +908,16 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
         let received_updates_count = self.received_updates_count.clone();
         let last_update_slot = self.last_update_slot.clone();
         let subscription_forwarder = self.subscription_forwarder.clone();
-        task::spawn(async move {
-            while let Some(update) = updates.recv().await {
+        let shutdown_token = self.shutdown_token.child_token();
+        let handle = task::spawn(async move {
+            loop {
+                let update = tokio::select! {
+                    update = updates.recv() => match update {
+                        Some(update) => update,
+                        None => break,
+                    },
+                    _ = shutdown_token.cancelled() => break,
+                };
                 let slot = update.slot;
 
                 received_updates_count.fetch_add(1, Ordering::Relaxed);
@@ -906,6 +1009,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                 }
             }
         });
+        *self.account_updates_task_handle.lock().await = Some(handle);
         Ok(())
     }
 

--- a/magicblock-chainlink/src/remote_account_provider/tests.rs
+++ b/magicblock-chainlink/src/remote_account_provider/tests.rs
@@ -6,7 +6,7 @@ use std::{
 
 use solana_account::Account;
 use solana_system_interface::program as system_program;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 
 use super::*;
 use crate::{
@@ -81,6 +81,67 @@ struct TestSlotConfig {
     current_slot: u64,
     account1_slot: u64,
     account2_slot: u64,
+}
+
+#[tokio::test]
+async fn test_shutdown_clears_subscriptions_and_fails_pending_waiters() {
+    init_logger();
+
+    let account_pubkey = solana_pubkey::Pubkey::new_unique();
+    let program_id = solana_pubkey::Pubkey::new_unique();
+    let account = Account {
+        lamports: 1_000_000,
+        data: vec![1, 2, 3, 4],
+        owner: system_program::id(),
+        executable: false,
+        rent_epoch: 0,
+    };
+
+    let ProviderTestCtx {
+        provider,
+        _pubsub_client,
+        ..
+    } = setup_provider(account_pubkey, account).await;
+
+    provider
+        .acquire_subscription(
+            &account_pubkey,
+            SubscriptionReason::DirectAccount,
+        )
+        .await
+        .unwrap();
+    provider.subscribe_program(program_id).await.unwrap();
+
+    let (waiter_tx, waiter_rx) = oneshot::channel();
+    provider
+        .fetching_accounts
+        .lock()
+        .expect("fetching_accounts lock poisoned")
+        .insert(
+            account_pubkey,
+            FetchingAccountState {
+                generation: 1,
+                fetch_start_slot: 100,
+                waiters: vec![waiter_tx],
+            },
+        );
+
+    provider.shutdown().await.unwrap();
+
+    assert_eq!(_pubsub_client.shutdown_attempts(), 1);
+    assert!(provider.subscription_ownership.lock().await.is_empty());
+    assert!(provider
+        .fetching_accounts
+        .lock()
+        .expect("fetching_accounts lock poisoned")
+        .is_empty());
+    assert!(provider.subscription_key_locks.lock().await.is_empty());
+
+    let waiter_result = waiter_rx
+        .await
+        .expect("shutdown should resolve pending waiter");
+    let err = waiter_result.expect_err("pending waiter should fail");
+    assert!(err.to_string().contains("shut down"));
 }
 
 async fn setup_matching_slots(

--- a/magicblock-chainlink/src/remote_account_provider/tests.rs
+++ b/magicblock-chainlink/src/remote_account_provider/tests.rs
@@ -144,6 +144,42 @@ async fn test_shutdown_clears_subscriptions_and_fails_pending_waiters() {
     assert!(err.to_string().contains("shut down"));
 }
 
+#[tokio::test]
+async fn test_shutdown_stops_deferred_pubsub_task() {
+    init_logger();
+
+    let account_pubkey = solana_pubkey::Pubkey::new_unique();
+    let account = Account {
+        lamports: 1_000_000,
+        data: vec![1, 2, 3, 4],
+        owner: system_program::id(),
+        executable: false,
+        rent_epoch: 0,
+    };
+
+    let ProviderTestCtx {
+        provider,
+        _pubsub_client,
+        ..
+    } = setup_provider(account_pubkey, account).await;
+
+    let task_shutdown_token = provider.shutdown_token.child_token();
+    let (started_tx, started_rx) = oneshot::channel();
+    let handle = tokio::spawn(async move {
+        let _ = started_tx.send(());
+        task_shutdown_token.cancelled().await;
+    });
+
+    *provider.deferred_pubsub_task_handle.lock().await = Some(handle);
+    started_rx.await.expect("deferred pubsub task should start");
+
+    provider.shutdown().await.unwrap();
+
+    assert_eq!(_pubsub_client.shutdown_attempts(), 1);
+    assert!(provider.shutdown_token.is_cancelled());
+    assert!(provider.deferred_pubsub_task_handle.lock().await.is_none());
+}
+
 async fn setup_matching_slots(
     config: TestSlotConfig,
     pubkey1: Pubkey,

--- a/magicblock-chainlink/src/submux/mod.rs
+++ b/magicblock-chainlink/src/submux/mod.rs
@@ -251,15 +251,16 @@ where
             .map(|(client, _)| client.clone())
             .collect::<Vec<_>>();
 
+        let shutdown_token = CancellationToken::new();
         Self::spawn_reconnectors(
             clients,
             subscribed_accounts_tracker,
             program_subs.clone(),
             connected_clients.clone(),
             connected_clients_subscribing_immediately.clone(),
+            shutdown_token.child_token(),
         );
 
-        let shutdown_token = CancellationToken::new();
         let me = Self {
             clients: Arc::new(Mutex::new(clients_only)),
             out_tx,
@@ -293,6 +294,7 @@ where
         program_subs: Arc<Mutex<HashSet<Pubkey>>>,
         connected_clients: Arc<AtomicU16>,
         connected_clients_subscribing_immediately: Arc<AtomicU16>,
+        shutdown_token: CancellationToken,
     ) {
         for (client, mut abort_rx) in clients.into_iter() {
             let subscribed_accounts_tracker =
@@ -301,8 +303,20 @@ where
             let connected_clients = connected_clients.clone();
             let connected_clients_subscribing_immediately =
                 connected_clients_subscribing_immediately.clone();
+            let shutdown_token = shutdown_token.child_token();
             tokio::spawn(async move {
-                while (abort_rx.recv().await).is_some() {
+                loop {
+                    tokio::select! {
+                        abort = abort_rx.recv() => {
+                            if abort.is_none() {
+                                break;
+                            }
+                        }
+                        _ = shutdown_token.cancelled() => break,
+                    }
+                    if shutdown_token.is_cancelled() {
+                        break;
+                    }
                     // Drain any duplicate abort signals to coalesce reconnect attempts
                     while abort_rx.try_recv().is_ok() {}
 
@@ -336,6 +350,7 @@ where
                         program_subs.clone(),
                         connected_clients.clone(),
                         connected_clients_subscribing_immediately.clone(),
+                        shutdown_token.child_token(),
                     )
                     .await;
                 }
@@ -417,6 +432,7 @@ where
             self.program_subs.clone(),
             self.connected_clients.clone(),
             self.connected_clients_subscribing_immediately.clone(),
+            self.shutdown_token.child_token(),
         );
         Ok(())
     }
@@ -441,7 +457,8 @@ where
             accounts_tracker,
             program_subs,
             connected_clients,
-            connected_clients_subscribing_immediately
+            connected_clients_subscribing_immediately,
+            shutdown_token
         ),
         fields(client_id = %client.id())
     )]
@@ -451,6 +468,7 @@ where
         program_subs: Arc<Mutex<HashSet<Pubkey>>>,
         connected_clients: Arc<AtomicU16>,
         connected_clients_subscribing_immediately: Arc<AtomicU16>,
+        shutdown_token: CancellationToken,
     ) {
         fn fib_with_max_secs(n: u64) -> u64 {
             let (mut a, mut b) = (0u64, 1u64);
@@ -464,6 +482,9 @@ where
         const WARN_EVERY_ATTEMPTS: u64 = 10;
         let mut attempt = 0;
         loop {
+            if shutdown_token.is_cancelled() {
+                break;
+            }
             attempt += 1;
             // Track the current resubscription delay for this client
             if let Some(delay_ms) = client.current_resub_delay_ms() {
@@ -520,7 +541,10 @@ where
                         "Failed to reconnect client, will retry after backoff"
                     );
                 }
-                tokio::time::sleep(wait_duration).await;
+                tokio::select! {
+                    _ = tokio::time::sleep(wait_duration) => {}
+                    _ = shutdown_token.cancelled() => break,
+                }
                 debug!(
                     client_id = %client.id(),
                     attempt,
@@ -888,6 +912,39 @@ where
             / self.debounce_interval.as_millis()) as usize
     }
 
+    #[cfg(any(test, feature = "dev-context"))]
+    pub fn connected_client_count_for_tests(&self) -> u16 {
+        self.connected_clients.load(Ordering::SeqCst)
+    }
+
+    #[cfg(any(test, feature = "dev-context"))]
+    pub fn program_subscription_count_for_tests(&self) -> usize {
+        self.program_subs
+            .lock()
+            .expect("program_subs lock poisoned")
+            .len()
+    }
+
+    pub async fn shutdown(&self) -> RemoteAccountProviderResult<()> {
+        self.shutdown_token.cancel();
+        let result = AccountSubscriptionTask::Shutdown
+            .process(self.clients_snapshot())
+            .await;
+        self.program_subs
+            .lock()
+            .expect("program_subs lock poisoned")
+            .clear();
+        self.dedup_cache
+            .lock()
+            .expect("dedup_cache lock poisoned")
+            .clear();
+        self.debounce_states
+            .lock()
+            .expect("debounce_states lock poisoned")
+            .clear();
+        result
+    }
+
     #[cfg(test)]
     fn get_debounce_state(&self, pubkey: Pubkey) -> Option<DebounceState> {
         let states = self
@@ -988,9 +1045,7 @@ where
     }
 
     async fn shutdown(&self) -> RemoteAccountProviderResult<()> {
-        AccountSubscriptionTask::Shutdown
-            .process(self.clients_snapshot())
-            .await
+        SubMuxClient::shutdown(self).await
     }
 
     fn take_updates(&self) -> mpsc::Receiver<SubscriptionUpdate> {

--- a/magicblock-chainlink/src/submux/mod.rs
+++ b/magicblock-chainlink/src/submux/mod.rs
@@ -404,6 +404,7 @@ where
                 self.debounce_interval,
                 self.debounce_detection_window,
                 self.allowed_in_debounce_window_count(),
+                self.shutdown_token.child_token(),
             );
         }
 
@@ -708,6 +709,7 @@ where
                 debounce_interval,
                 detection_window,
                 allowed_count,
+                self.shutdown_token.child_token(),
             );
         }
     }
@@ -719,6 +721,7 @@ where
         debounce_interval: Duration,
         detection_window: Duration,
         allowed_count: usize,
+        shutdown_token: CancellationToken,
     ) {
         let mut inner_rx = client.take_updates();
         let params = ForwarderParams {
@@ -732,7 +735,13 @@ where
         };
         let never_debounce = self.never_debounce.clone();
         tokio::spawn(async move {
-            Self::forwarder_loop(&mut inner_rx, params, never_debounce).await;
+            Self::forwarder_loop(
+                &mut inner_rx,
+                params,
+                never_debounce,
+                shutdown_token,
+            )
+            .await;
         });
     }
 
@@ -740,8 +749,19 @@ where
         inner_rx: &mut mpsc::Receiver<SubscriptionUpdate>,
         params: ForwarderParams,
         never_debounce: HashSet<Pubkey>,
+        shutdown_token: CancellationToken,
     ) {
-        while let Some(update) = inner_rx.recv().await {
+        loop {
+            let update = tokio::select! {
+                update = inner_rx.recv() => match update {
+                    Some(update) => update,
+                    None => break,
+                },
+                _ = shutdown_token.cancelled() => break,
+            };
+            if shutdown_token.is_cancelled() {
+                break;
+            }
             let now = Instant::now();
             let key = (update.pubkey, update.slot);
             if !Self::should_forward_dedup(
@@ -1251,6 +1271,52 @@ mod tests {
         assert_eq!(lams, vec![10, 20]);
 
         mux.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_submux_shutdown_stops_clients_and_forwarders() {
+        init_logger();
+
+        let (tx1, rx1) = mpsc::channel(10_000);
+        let (tx2, rx2) = mpsc::channel(10_000);
+        let client1 = Arc::new(ChainPubsubClientMock::new(tx1, rx1));
+        let client2 = Arc::new(ChainPubsubClientMock::new(tx2, rx2));
+        let mux: SubMuxClient<ChainPubsubClientMock> =
+            new_submux_client(vec![client1.clone(), client2.clone()], None);
+        let mut mux_rx = mux.take_updates();
+
+        let pk = Pubkey::new_unique();
+        mux.subscribe(pk, None).await.unwrap();
+        client1
+            .send_account_update(pk, 1, &account_with_lamports(10))
+            .await;
+        tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            mux_rx.recv(),
+        )
+        .await
+        .expect("pre-shutdown update expected")
+        .expect("stream open");
+
+        mux.shutdown().await.unwrap();
+        assert_eq!(client1.shutdown_attempts(), 1);
+        assert_eq!(client2.shutdown_attempts(), 1);
+
+        client1
+            .send_account_update(pk, 2, &account_with_lamports(20))
+            .await;
+        client2
+            .send_account_update(pk, 3, &account_with_lamports(30))
+            .await;
+        let post_shutdown_update = tokio::time::timeout(
+            std::time::Duration::from_millis(50),
+            mux_rx.recv(),
+        )
+        .await;
+        assert!(
+            post_shutdown_update.is_err(),
+            "no update should be forwarded after shutdown"
+        );
     }
 
     #[tokio::test]

--- a/magicblock-chainlink/tests/09_waiter_reconciliation_race.rs
+++ b/magicblock-chainlink/tests/09_waiter_reconciliation_race.rs
@@ -24,7 +24,8 @@ async fn wait_for_registered_waiters(
     expected_waiters: usize,
 ) {
     let fetch_cloner = chainlink
-        .fetch_cloner()
+        .fetch_cloner_for_tests()
+        .await
         .expect("fetch cloner should be configured");
     let waiter_registration_start = tokio::time::Instant::now();
     let waiter_registration_timeout = tokio::time::Duration::from_secs(2);

--- a/magicblock-chainlink/tests/10_non_primary_gating.rs
+++ b/magicblock-chainlink/tests/10_non_primary_gating.rs
@@ -13,6 +13,7 @@ use magicblock_chainlink::{
     AccountFetchOrigin, Chainlink,
 };
 use magicblock_config::config::{ChainLinkConfig, LifecycleMode};
+use magicblock_core::coordination_mode::switch_to_replica_mode;
 use solana_account::Account;
 use solana_program::clock::Slot;
 use solana_pubkey::Pubkey;
@@ -34,9 +35,19 @@ async fn setup(slot: Slot) -> TestContext {
     TestContext::init(slot).await
 }
 
-async fn new_endpoint_chainlink() -> (EndpointChainlink, Arc<AccountsBankStub>)
-{
+fn lifecycle_mode_for_startup_mode(mode: &str) -> LifecycleMode {
+    match mode {
+        "Replica" | "ReplicaOnly" | "StandBy" => LifecycleMode::Replica,
+        _ => panic!("unexpected non-primary startup mode: {mode}"),
+    }
+}
+
+async fn new_endpoint_chainlink(
+    startup_mode: &str,
+) -> (EndpointChainlink, Arc<AccountsBankStub>) {
     init_logger();
+    switch_to_replica_mode();
+    let lifecycle_mode = lifecycle_mode_for_startup_mode(startup_mode);
     let bank = Arc::<AccountsBankStub>::default();
     let cloner = Arc::new(ClonerStub::new(bank.clone()));
     let endpoints = Endpoints::from(
@@ -63,7 +74,7 @@ async fn new_endpoint_chainlink() -> (EndpointChainlink, Arc<AccountsBankStub>)
         &bank,
         &cloner,
         solana_keypair::Keypair::new(),
-        ChainlinkConfig::default_with_lifecycle_mode(LifecycleMode::Ephemeral),
+        ChainlinkConfig::default_with_lifecycle_mode(lifecycle_mode),
         &ChainLinkConfig::default(),
         Path::new("."),
     )
@@ -129,7 +140,7 @@ async fn assert_public_calls_do_not_start_runtime(
 
 #[tokio::test]
 async fn new_endpoint_chainlink_starts_without_active_runtime() {
-    let (chainlink, _) = new_endpoint_chainlink().await;
+    let (chainlink, _) = new_endpoint_chainlink("Replica").await;
 
     assert_no_runtime_or_remote_work(&chainlink).await;
 }
@@ -137,16 +148,16 @@ async fn new_endpoint_chainlink_starts_without_active_runtime() {
 #[tokio::test]
 async fn non_primary_startup_modes_keep_chainlink_runtime_disabled() {
     // Chainlink is constructed before replicated validators publish Primary
-    // mode. The existing chainlink test utilities model Replica,
-    // ReplicaOnly, and StandBy startup with the same deferred endpoint
-    // construction path: no runtime, no subscriptions, and no streams/tasks
-    // are created until an explicit primary enablement succeeds.
+    // mode. Replica, ReplicaOnly, and StandBy startup all enter Replica
+    // coordination and defer endpoint runtime creation: no runtime, no
+    // subscriptions, and no streams/tasks are created until an explicit
+    // primary enablement succeeds.
     for mode in ["Replica", "ReplicaOnly", "StandBy"] {
-        let (chainlink, bank) = new_endpoint_chainlink().await;
+        let (chainlink, bank) = new_endpoint_chainlink(mode).await;
         assert_no_runtime_or_remote_work(&chainlink).await;
         assert_public_calls_do_not_start_runtime(&chainlink, &bank).await;
         assert_no_runtime_or_remote_work(&chainlink).await;
-        drop((mode, chainlink));
+        drop(chainlink);
     }
 }
 

--- a/magicblock-chainlink/tests/10_non_primary_gating.rs
+++ b/magicblock-chainlink/tests/10_non_primary_gating.rs
@@ -1,4 +1,17 @@
-use magicblock_chainlink::{testing::init_logger, AccountFetchOrigin};
+use std::{path::Path, sync::Arc};
+
+use magicblock_chainlink::{
+    accounts_bank::mock::AccountsBankStub,
+    chainlink::config::ChainlinkConfig,
+    remote_account_provider::{
+        chain_rpc_client::ChainRpcClientImpl,
+        chain_updates_client::ChainUpdatesClient, Endpoint, Endpoints,
+    },
+    submux::SubMuxClient,
+    testing::{cloner_stub::ClonerStub, init_logger},
+    AccountFetchOrigin, Chainlink,
+};
+use magicblock_config::config::{ChainLinkConfig, LifecycleMode};
 use magicblock_core::coordination_mode::{
     switch_to_primary_mode, switch_to_replica_mode,
 };
@@ -29,6 +42,51 @@ impl Drop for PrimaryModeGuard {
 async fn setup(slot: Slot) -> TestContext {
     init_logger();
     TestContext::init(slot).await
+}
+
+#[tokio::test]
+async fn new_endpoint_chainlink_starts_without_active_runtime() {
+    init_logger();
+    let bank = Arc::<AccountsBankStub>::default();
+    let cloner = Arc::new(ClonerStub::new(bank.clone()));
+    let endpoints = Endpoints::from(
+        [
+            Endpoint::Rpc {
+                url: "http://127.0.0.1:8899".to_string(),
+                label: "local-rpc".to_string(),
+            },
+            Endpoint::WebSocket {
+                url: "ws://127.0.0.1:8900".to_string(),
+                label: "local-ws".to_string(),
+            },
+        ]
+        .as_slice(),
+    );
+    let chainlink: Chainlink<
+        ChainRpcClientImpl,
+        SubMuxClient<ChainUpdatesClient>,
+        AccountsBankStub,
+        ClonerStub,
+    > = Chainlink::<
+        ChainRpcClientImpl,
+        SubMuxClient<ChainUpdatesClient>,
+        AccountsBankStub,
+        ClonerStub,
+    >::try_new_from_endpoints(
+        &endpoints,
+        Default::default(),
+        &bank,
+        &cloner,
+        solana_keypair::Keypair::new(),
+        ChainlinkConfig::default_with_lifecycle_mode(LifecycleMode::Ephemeral),
+        &ChainLinkConfig::default(),
+        Path::new("."),
+    )
+    .await
+    .unwrap();
+
+    assert!(!chainlink.is_runtime_active().await);
+    assert_eq!(chainlink.lifecycle_state_for_tests(), "disabled");
 }
 
 #[tokio::test]

--- a/magicblock-chainlink/tests/10_non_primary_gating.rs
+++ b/magicblock-chainlink/tests/10_non_primary_gating.rs
@@ -1,0 +1,121 @@
+use magicblock_chainlink::{testing::init_logger, AccountFetchOrigin};
+use magicblock_core::coordination_mode::{
+    switch_to_primary_mode, switch_to_replica_mode,
+};
+use solana_account::Account;
+use solana_program::clock::Slot;
+use solana_pubkey::Pubkey;
+use utils::{
+    accounts::account_shared_with_owner_and_slot, test_context::TestContext,
+};
+
+mod utils;
+
+struct PrimaryModeGuard;
+
+impl PrimaryModeGuard {
+    fn enter_replica() -> Self {
+        switch_to_replica_mode();
+        Self
+    }
+}
+
+impl Drop for PrimaryModeGuard {
+    fn drop(&mut self) {
+        switch_to_primary_mode();
+    }
+}
+
+async fn setup(slot: Slot) -> TestContext {
+    init_logger();
+    TestContext::init(slot).await
+}
+
+#[tokio::test]
+async fn replica_mode_chainlink_apis_are_noop_or_local_only() {
+    let slot = 11;
+    let ctx = setup(slot).await;
+    let chainlink = ctx.chainlink.clone();
+
+    let _primary_mode_guard = PrimaryModeGuard::enter_replica();
+
+    let ensure_pubkey = Pubkey::new_unique();
+    let ensure_owner = Pubkey::new_unique();
+    let ensure_account = account_shared_with_owner_and_slot(
+        &Account {
+            lamports: 1_000,
+            ..Default::default()
+        },
+        ensure_owner,
+        slot,
+    );
+    ctx.rpc_client
+        .add_account(ensure_pubkey, ensure_account.into());
+
+    let before_ensure_fetch_count = chainlink.fetch_count().unwrap_or(0);
+    let ensure_result = chainlink
+        .ensure_accounts(
+            &[ensure_pubkey],
+            None,
+            AccountFetchOrigin::GetMultipleAccounts,
+            None,
+        )
+        .await
+        .unwrap();
+    assert!(ensure_result.is_ok());
+    assert!(ensure_result.not_found_on_chain.is_empty());
+    assert!(ensure_result.missing_delegation_record.is_empty());
+    assert_eq!(
+        chainlink.fetch_count().unwrap_or(0),
+        before_ensure_fetch_count
+    );
+
+    let local_pubkey = Pubkey::new_unique();
+    let local_owner = Pubkey::new_unique();
+    let local_account = account_shared_with_owner_and_slot(
+        &Account {
+            lamports: 2_000,
+            ..Default::default()
+        },
+        local_owner,
+        slot,
+    );
+    ctx.bank.insert(local_pubkey, local_account.clone());
+
+    let remote_account = account_shared_with_owner_and_slot(
+        &Account {
+            lamports: 3_000,
+            ..Default::default()
+        },
+        Pubkey::new_unique(),
+        slot + 1,
+    );
+    ctx.rpc_client
+        .add_account(local_pubkey, remote_account.into());
+
+    let before_fetch_count = chainlink.fetch_count().unwrap_or(0);
+    let fetched_accounts = chainlink
+        .fetch_accounts(
+            &[local_pubkey],
+            AccountFetchOrigin::GetMultipleAccounts,
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(fetched_accounts, vec![Some(local_account)]);
+    assert_eq!(chainlink.fetch_count().unwrap_or(0), before_fetch_count);
+
+    let undelegation_pubkey = Pubkey::new_unique();
+    assert!(!chainlink.is_watching(&undelegation_pubkey));
+    chainlink
+        .undelegation_requested(undelegation_pubkey)
+        .await
+        .unwrap();
+    assert!(!chainlink.is_watching(&undelegation_pubkey));
+
+    // TODO(chainlink): `subscribe_account_removals` is fed by an internal
+    // removed-account channel that the current `TestContext` does not expose.
+    // The replica-mode eviction path is gated by the same `remote_sync_enabled`
+    // check exercised above; add a direct eviction submission assertion if the
+    // test utilities grow a narrow removed-account notification hook.
+}

--- a/magicblock-chainlink/tests/10_non_primary_gating.rs
+++ b/magicblock-chainlink/tests/10_non_primary_gating.rs
@@ -10,7 +10,8 @@ use magicblock_chainlink::{
     },
     submux::SubMuxClient,
     testing::{cloner_stub::ClonerStub, init_logger},
-    AccountFetchOrigin, Chainlink, ChainlinkPrimaryEnablement,
+    AccountFetchOrigin, Chainlink, PrimaryEnableOutcome,
+    PrimaryRuntimeReadiness,
 };
 use magicblock_config::config::{ChainLinkConfig, LifecycleMode};
 use magicblock_core::coordination_mode::switch_to_replica_mode;
@@ -94,7 +95,10 @@ async fn new_endpoint_chainlink_with_lifecycle_mode(
 
 async fn assert_no_runtime_or_remote_work(chainlink: &EndpointChainlink) {
     assert!(!chainlink.is_runtime_active().await);
-    assert_eq!(chainlink.lifecycle_state_for_tests(), "disabled");
+    assert_eq!(
+        chainlink.primary_runtime_readiness().await,
+        PrimaryRuntimeReadiness::NotReady
+    );
     assert_eq!(chainlink.active_fetch_count_for_tests().await, None);
 }
 
@@ -175,7 +179,7 @@ async fn repeated_enable_disable_leaves_no_runtime_or_mock_subscriptions() {
 
     assert_eq!(
         ctx.chainlink.enable_primary().await.unwrap(),
-        ChainlinkPrimaryEnablement::Active
+        PrimaryEnableOutcome::RuntimeActive
     );
     assert!(ctx.chainlink.is_runtime_active().await);
 
@@ -184,12 +188,15 @@ async fn repeated_enable_disable_leaves_no_runtime_or_mock_subscriptions() {
 
     assert_eq!(
         ctx.chainlink.enable_primary().await.unwrap(),
-        ChainlinkPrimaryEnablement::DisabledByConfig
+        PrimaryEnableOutcome::DisabledByConfig
     );
     ctx.chainlink.disable().await.unwrap();
 
     assert!(!ctx.chainlink.is_runtime_active().await);
-    assert_eq!(ctx.chainlink.lifecycle_state_for_tests(), "disabled");
+    assert_eq!(
+        ctx.chainlink.primary_runtime_readiness().await,
+        PrimaryRuntimeReadiness::DisabledByConfig
+    );
     assert_eq!(ctx.chainlink.active_fetch_count_for_tests().await, None);
     assert!(ctx.pubsub_client.subscriptions_union().is_empty());
     assert!(ctx.pubsub_client.subscribed_program_ids().is_empty());
@@ -203,10 +210,13 @@ async fn offline_primary_enable_reports_disabled_by_config() {
 
     assert_eq!(
         chainlink.enable_primary().await.unwrap(),
-        ChainlinkPrimaryEnablement::DisabledByConfig
+        PrimaryEnableOutcome::DisabledByConfig
     );
     assert!(!chainlink.is_runtime_active().await);
-    assert_eq!(chainlink.lifecycle_state_for_tests(), "disabled");
+    assert_eq!(
+        chainlink.primary_runtime_readiness().await,
+        PrimaryRuntimeReadiness::DisabledByConfig
+    );
 }
 
 #[tokio::test]

--- a/magicblock-chainlink/tests/10_non_primary_gating.rs
+++ b/magicblock-chainlink/tests/10_non_primary_gating.rs
@@ -10,7 +10,7 @@ use magicblock_chainlink::{
     },
     submux::SubMuxClient,
     testing::{cloner_stub::ClonerStub, init_logger},
-    AccountFetchOrigin, Chainlink,
+    AccountFetchOrigin, Chainlink, ChainlinkPrimaryEnablement,
 };
 use magicblock_config::config::{ChainLinkConfig, LifecycleMode};
 use magicblock_core::coordination_mode::switch_to_replica_mode;
@@ -45,9 +45,17 @@ fn lifecycle_mode_for_startup_mode(mode: &str) -> LifecycleMode {
 async fn new_endpoint_chainlink(
     startup_mode: &str,
 ) -> (EndpointChainlink, Arc<AccountsBankStub>) {
+    new_endpoint_chainlink_with_lifecycle_mode(lifecycle_mode_for_startup_mode(
+        startup_mode,
+    ))
+    .await
+}
+
+async fn new_endpoint_chainlink_with_lifecycle_mode(
+    lifecycle_mode: LifecycleMode,
+) -> (EndpointChainlink, Arc<AccountsBankStub>) {
     init_logger();
     switch_to_replica_mode();
-    let lifecycle_mode = lifecycle_mode_for_startup_mode(startup_mode);
     let bank = Arc::<AccountsBankStub>::default();
     let cloner = Arc::new(ClonerStub::new(bank.clone()));
     let endpoints = Endpoints::from(
@@ -165,13 +173,19 @@ async fn non_primary_startup_modes_keep_chainlink_runtime_disabled() {
 async fn repeated_enable_disable_leaves_no_runtime_or_mock_subscriptions() {
     let ctx = setup(21).await;
 
-    ctx.chainlink.enable_primary().await.unwrap();
+    assert_eq!(
+        ctx.chainlink.enable_primary().await.unwrap(),
+        ChainlinkPrimaryEnablement::Active
+    );
     assert!(ctx.chainlink.is_runtime_active().await);
 
     ctx.chainlink.disable().await.unwrap();
     assert!(!ctx.chainlink.is_runtime_active().await);
 
-    ctx.chainlink.enable_primary().await.unwrap();
+    assert_eq!(
+        ctx.chainlink.enable_primary().await.unwrap(),
+        ChainlinkPrimaryEnablement::DisabledByConfig
+    );
     ctx.chainlink.disable().await.unwrap();
 
     assert!(!ctx.chainlink.is_runtime_active().await);
@@ -179,6 +193,20 @@ async fn repeated_enable_disable_leaves_no_runtime_or_mock_subscriptions() {
     assert_eq!(ctx.chainlink.active_fetch_count_for_tests().await, None);
     assert!(ctx.pubsub_client.subscriptions_union().is_empty());
     assert!(ctx.pubsub_client.subscribed_program_ids().is_empty());
+}
+
+#[tokio::test]
+async fn offline_primary_enable_reports_disabled_by_config() {
+    let (chainlink, _) =
+        new_endpoint_chainlink_with_lifecycle_mode(LifecycleMode::Offline)
+            .await;
+
+    assert_eq!(
+        chainlink.enable_primary().await.unwrap(),
+        ChainlinkPrimaryEnablement::DisabledByConfig
+    );
+    assert!(!chainlink.is_runtime_active().await);
+    assert_eq!(chainlink.lifecycle_state_for_tests(), "disabled");
 }
 
 #[tokio::test]

--- a/magicblock-chainlink/tests/10_non_primary_gating.rs
+++ b/magicblock-chainlink/tests/10_non_primary_gating.rs
@@ -13,9 +13,6 @@ use magicblock_chainlink::{
     AccountFetchOrigin, Chainlink,
 };
 use magicblock_config::config::{ChainLinkConfig, LifecycleMode};
-use magicblock_core::coordination_mode::{
-    switch_to_primary_mode, switch_to_replica_mode,
-};
 use solana_account::Account;
 use solana_program::clock::Slot;
 use solana_pubkey::Pubkey;
@@ -31,21 +28,6 @@ type EndpointChainlink = Chainlink<
     AccountsBankStub,
     ClonerStub,
 >;
-
-struct PrimaryModeGuard;
-
-impl PrimaryModeGuard {
-    fn enter_replica() -> Self {
-        switch_to_replica_mode();
-        Self
-    }
-}
-
-impl Drop for PrimaryModeGuard {
-    fn drop(&mut self) {
-        switch_to_primary_mode();
-    }
-}
 
 async fn setup(slot: Slot) -> TestContext {
     init_logger();
@@ -252,95 +234,4 @@ async fn public_calls_after_disable_do_not_recreate_runtime_or_subscriptions() {
     assert!(!ctx.chainlink.is_runtime_active().await);
     assert!(ctx.pubsub_client.subscriptions_union().is_empty());
     assert!(ctx.pubsub_client.subscribed_program_ids().is_empty());
-}
-
-#[tokio::test]
-async fn replica_mode_chainlink_apis_are_noop_or_local_only() {
-    let slot = 11;
-    let ctx = setup(slot).await;
-    let chainlink = ctx.chainlink.clone();
-
-    let _primary_mode_guard = PrimaryModeGuard::enter_replica();
-
-    let ensure_pubkey = Pubkey::new_unique();
-    let ensure_owner = Pubkey::new_unique();
-    let ensure_account = account_shared_with_owner_and_slot(
-        &Account {
-            lamports: 1_000,
-            ..Default::default()
-        },
-        ensure_owner,
-        slot,
-    );
-    ctx.rpc_client
-        .add_account(ensure_pubkey, ensure_account.into());
-
-    let before_ensure_fetch_count = chainlink.fetch_count().unwrap_or(0);
-    let ensure_result = chainlink
-        .ensure_accounts(
-            &[ensure_pubkey],
-            None,
-            AccountFetchOrigin::GetMultipleAccounts,
-            None,
-        )
-        .await
-        .unwrap();
-    assert!(ensure_result.is_ok());
-    assert!(ensure_result.not_found_on_chain.is_empty());
-    assert!(ensure_result.missing_delegation_record.is_empty());
-    assert_eq!(
-        chainlink.fetch_count().unwrap_or(0),
-        before_ensure_fetch_count
-    );
-
-    let local_pubkey = Pubkey::new_unique();
-    let local_owner = Pubkey::new_unique();
-    let local_account = account_shared_with_owner_and_slot(
-        &Account {
-            lamports: 2_000,
-            ..Default::default()
-        },
-        local_owner,
-        slot,
-    );
-    ctx.bank.insert(local_pubkey, local_account.clone());
-
-    let remote_account = account_shared_with_owner_and_slot(
-        &Account {
-            lamports: 3_000,
-            ..Default::default()
-        },
-        Pubkey::new_unique(),
-        slot + 1,
-    );
-    ctx.rpc_client
-        .add_account(local_pubkey, remote_account.into());
-
-    let before_fetch_count = chainlink.fetch_count().unwrap_or(0);
-    let fetched_accounts = chainlink
-        .fetch_accounts(
-            &[local_pubkey],
-            AccountFetchOrigin::GetMultipleAccounts,
-            None,
-        )
-        .await
-        .unwrap();
-    assert_eq!(fetched_accounts, vec![Some(local_account)]);
-    assert_eq!(chainlink.fetch_count().unwrap_or(0), before_fetch_count);
-
-    let undelegation_pubkey = Pubkey::new_unique();
-    assert!(!chainlink.is_watching(&undelegation_pubkey));
-    chainlink
-        .undelegation_requested(undelegation_pubkey)
-        .await
-        .unwrap();
-    assert!(!chainlink.is_watching(&undelegation_pubkey));
-
-    // Transitional defensive non-primary gate coverage: Step 17 will delete or
-    // rewrite this once Step 16 removes the internal CoordinationMode gates.
-    // `subscribe_account_removals` is fed by an internal removed-account channel
-    // that the current `TestContext` does not expose. The replica-mode eviction
-    // path is gated by the same `remote_sync_enabled` check exercised above; add
-    // a direct eviction submission assertion if the test utilities grow a narrow
-    // removed-account notification hook.
 }

--- a/magicblock-chainlink/tests/10_non_primary_gating.rs
+++ b/magicblock-chainlink/tests/10_non_primary_gating.rs
@@ -174,22 +174,14 @@ async fn non_primary_startup_modes_keep_chainlink_runtime_disabled() {
 }
 
 #[tokio::test]
-async fn repeated_enable_disable_leaves_no_runtime_or_mock_subscriptions() {
+async fn repeated_disable_leaves_no_runtime_or_mock_subscriptions() {
     let ctx = setup(21).await;
 
-    assert_eq!(
-        ctx.chainlink.enable_primary().await.unwrap(),
-        PrimaryEnableOutcome::RuntimeActive
-    );
     assert!(ctx.chainlink.is_runtime_active().await);
 
     ctx.chainlink.disable().await.unwrap();
     assert!(!ctx.chainlink.is_runtime_active().await);
 
-    assert_eq!(
-        ctx.chainlink.enable_primary().await.unwrap(),
-        PrimaryEnableOutcome::DisabledByConfig
-    );
     ctx.chainlink.disable().await.unwrap();
 
     assert!(!ctx.chainlink.is_runtime_active().await);

--- a/magicblock-chainlink/tests/10_non_primary_gating.rs
+++ b/magicblock-chainlink/tests/10_non_primary_gating.rs
@@ -4,6 +4,7 @@ use magicblock_chainlink::{
     accounts_bank::mock::AccountsBankStub,
     chainlink::config::ChainlinkConfig,
     remote_account_provider::{
+        chain_pubsub_client::ChainPubsubClient,
         chain_rpc_client::ChainRpcClientImpl,
         chain_updates_client::ChainUpdatesClient, Endpoint, Endpoints,
     },
@@ -23,6 +24,13 @@ use utils::{
 };
 
 mod utils;
+
+type EndpointChainlink = Chainlink<
+    ChainRpcClientImpl,
+    SubMuxClient<ChainUpdatesClient>,
+    AccountsBankStub,
+    ClonerStub,
+>;
 
 struct PrimaryModeGuard;
 
@@ -44,8 +52,8 @@ async fn setup(slot: Slot) -> TestContext {
     TestContext::init(slot).await
 }
 
-#[tokio::test]
-async fn new_endpoint_chainlink_starts_without_active_runtime() {
+async fn new_endpoint_chainlink() -> (EndpointChainlink, Arc<AccountsBankStub>)
+{
     init_logger();
     let bank = Arc::<AccountsBankStub>::default();
     let cloner = Arc::new(ClonerStub::new(bank.clone()));
@@ -62,12 +70,7 @@ async fn new_endpoint_chainlink_starts_without_active_runtime() {
         ]
         .as_slice(),
     );
-    let chainlink: Chainlink<
-        ChainRpcClientImpl,
-        SubMuxClient<ChainUpdatesClient>,
-        AccountsBankStub,
-        ClonerStub,
-    > = Chainlink::<
+    let chainlink = Chainlink::<
         ChainRpcClientImpl,
         SubMuxClient<ChainUpdatesClient>,
         AccountsBankStub,
@@ -85,8 +88,170 @@ async fn new_endpoint_chainlink_starts_without_active_runtime() {
     .await
     .unwrap();
 
+    (chainlink, bank)
+}
+
+async fn assert_no_runtime_or_remote_work(chainlink: &EndpointChainlink) {
     assert!(!chainlink.is_runtime_active().await);
     assert_eq!(chainlink.lifecycle_state_for_tests(), "disabled");
+    assert_eq!(chainlink.active_fetch_count_for_tests().await, None);
+}
+
+async fn assert_public_calls_do_not_start_runtime(
+    chainlink: &EndpointChainlink,
+    bank: &AccountsBankStub,
+) {
+    let local_pubkey = Pubkey::new_unique();
+    let local_account = account_shared_with_owner_and_slot(
+        &Account {
+            lamports: 2_000,
+            ..Default::default()
+        },
+        Pubkey::new_unique(),
+        1,
+    );
+    bank.insert(local_pubkey, local_account.clone());
+
+    let ensure_pubkey = Pubkey::new_unique();
+    let ensure_result = chainlink
+        .ensure_accounts(
+            &[ensure_pubkey],
+            None,
+            AccountFetchOrigin::GetMultipleAccounts,
+            None,
+        )
+        .await
+        .unwrap();
+    assert!(ensure_result.not_found_on_chain.is_empty());
+    assert!(ensure_result.missing_delegation_record.is_empty());
+    assert_no_runtime_or_remote_work(chainlink).await;
+
+    let fetched_accounts = chainlink
+        .fetch_accounts(
+            &[local_pubkey],
+            AccountFetchOrigin::GetMultipleAccounts,
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(fetched_accounts, vec![Some(local_account)]);
+    assert_no_runtime_or_remote_work(chainlink).await;
+
+    let undelegation_pubkey = Pubkey::new_unique();
+    chainlink
+        .undelegation_requested(undelegation_pubkey)
+        .await
+        .unwrap();
+    assert_no_runtime_or_remote_work(chainlink).await;
+}
+
+#[tokio::test]
+async fn new_endpoint_chainlink_starts_without_active_runtime() {
+    let (chainlink, _) = new_endpoint_chainlink().await;
+
+    assert_no_runtime_or_remote_work(&chainlink).await;
+}
+
+#[tokio::test]
+async fn non_primary_startup_modes_keep_chainlink_runtime_disabled() {
+    // Chainlink is constructed before replicated validators publish Primary
+    // mode. The existing chainlink test utilities model Replica,
+    // ReplicaOnly, and StandBy startup with the same deferred endpoint
+    // construction path: no runtime, no subscriptions, and no streams/tasks
+    // are created until an explicit primary enablement succeeds.
+    for mode in ["Replica", "ReplicaOnly", "StandBy"] {
+        let (chainlink, bank) = new_endpoint_chainlink().await;
+        assert_no_runtime_or_remote_work(&chainlink).await;
+        assert_public_calls_do_not_start_runtime(&chainlink, &bank).await;
+        assert_no_runtime_or_remote_work(&chainlink).await;
+        drop((mode, chainlink));
+    }
+}
+
+#[tokio::test]
+async fn repeated_enable_disable_leaves_no_runtime_or_mock_subscriptions() {
+    let ctx = setup(21).await;
+
+    ctx.chainlink.enable_primary().await.unwrap();
+    assert!(ctx.chainlink.is_runtime_active().await);
+
+    ctx.chainlink.disable().await.unwrap();
+    assert!(!ctx.chainlink.is_runtime_active().await);
+
+    ctx.chainlink.enable_primary().await.unwrap();
+    ctx.chainlink.disable().await.unwrap();
+
+    assert!(!ctx.chainlink.is_runtime_active().await);
+    assert_eq!(ctx.chainlink.lifecycle_state_for_tests(), "disabled");
+    assert_eq!(ctx.chainlink.active_fetch_count_for_tests().await, None);
+    assert!(ctx.pubsub_client.subscriptions_union().is_empty());
+    assert!(ctx.pubsub_client.subscribed_program_ids().is_empty());
+}
+
+#[tokio::test]
+async fn public_calls_after_disable_do_not_recreate_runtime_or_subscriptions() {
+    let slot = 22;
+    let ctx = setup(slot).await;
+    ctx.chainlink.disable().await.unwrap();
+
+    let ensure_pubkey = Pubkey::new_unique();
+    let ensure_owner = Pubkey::new_unique();
+    let ensure_account = account_shared_with_owner_and_slot(
+        &Account {
+            lamports: 1_000,
+            ..Default::default()
+        },
+        ensure_owner,
+        slot,
+    );
+    ctx.rpc_client
+        .add_account(ensure_pubkey, ensure_account.into());
+
+    let ensure_result = ctx
+        .chainlink
+        .ensure_accounts(
+            &[ensure_pubkey],
+            None,
+            AccountFetchOrigin::GetMultipleAccounts,
+            None,
+        )
+        .await
+        .unwrap();
+    assert!(ensure_result.not_found_on_chain.is_empty());
+    assert!(ensure_result.missing_delegation_record.is_empty());
+    assert!(!ctx.chainlink.is_runtime_active().await);
+    assert!(ctx.pubsub_client.subscriptions_union().is_empty());
+
+    let local_pubkey = Pubkey::new_unique();
+    let local_account = account_shared_with_owner_and_slot(
+        &Account {
+            lamports: 2_000,
+            ..Default::default()
+        },
+        Pubkey::new_unique(),
+        slot,
+    );
+    ctx.bank.insert(local_pubkey, local_account.clone());
+    let fetched_accounts = ctx
+        .chainlink
+        .fetch_accounts(
+            &[local_pubkey],
+            AccountFetchOrigin::GetMultipleAccounts,
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(fetched_accounts, vec![Some(local_account)]);
+    assert!(!ctx.chainlink.is_runtime_active().await);
+    assert!(ctx.pubsub_client.subscriptions_union().is_empty());
+
+    ctx.chainlink
+        .undelegation_requested(Pubkey::new_unique())
+        .await
+        .unwrap();
+    assert!(!ctx.chainlink.is_runtime_active().await);
+    assert!(ctx.pubsub_client.subscriptions_union().is_empty());
+    assert!(ctx.pubsub_client.subscribed_program_ids().is_empty());
 }
 
 #[tokio::test]
@@ -171,9 +336,11 @@ async fn replica_mode_chainlink_apis_are_noop_or_local_only() {
         .unwrap();
     assert!(!chainlink.is_watching(&undelegation_pubkey));
 
-    // TODO(chainlink): `subscribe_account_removals` is fed by an internal
-    // removed-account channel that the current `TestContext` does not expose.
-    // The replica-mode eviction path is gated by the same `remote_sync_enabled`
-    // check exercised above; add a direct eviction submission assertion if the
-    // test utilities grow a narrow removed-account notification hook.
+    // Transitional defensive non-primary gate coverage: Step 17 will delete or
+    // rewrite this once Step 16 removes the internal CoordinationMode gates.
+    // `subscribe_account_removals` is fed by an internal removed-account channel
+    // that the current `TestContext` does not expose. The replica-mode eviction
+    // path is gated by the same `remote_sync_enabled` check exercised above; add
+    // a direct eviction submission assertion if the test utilities grow a narrow
+    // removed-account notification hook.
 }

--- a/magicblock-chainlink/tests/11_lifecycle_shutdown.rs
+++ b/magicblock-chainlink/tests/11_lifecycle_shutdown.rs
@@ -1,0 +1,215 @@
+use magicblock_accounts_db::traits::AccountsBank;
+use magicblock_chainlink::{
+    testing::{deleg::add_delegation_record_for, init_logger},
+    AccountFetchOrigin,
+};
+use solana_account::{Account, ReadableAccount};
+use solana_pubkey::Pubkey;
+use tokio::time::{sleep, Duration};
+use utils::{
+    accounts::account_shared_with_owner_and_slot, test_context::TestContext,
+};
+
+mod utils;
+
+async fn setup(slot: u64) -> TestContext {
+    init_logger();
+    TestContext::init(slot).await
+}
+
+fn account_with_lamports(lamports: u64, owner: Pubkey, slot: u64) -> Account {
+    account_shared_with_owner_and_slot(
+        &Account {
+            lamports,
+            ..Default::default()
+        },
+        owner,
+        slot,
+    )
+    .into()
+}
+
+#[tokio::test]
+async fn chainlink_runtime_is_active_after_primary_enable() {
+    let ctx = setup(1).await;
+
+    assert!(ctx.chainlink.is_runtime_active().await);
+    assert_eq!(ctx.chainlink.lifecycle_state_for_tests(), "enabled");
+    ctx.chainlink.enable_primary().await.unwrap();
+    assert!(ctx.chainlink.is_runtime_active().await);
+}
+
+#[tokio::test]
+async fn disable_after_enable_stops_runtime_and_is_idempotent() {
+    let ctx = setup(2).await;
+    assert!(ctx.chainlink.is_runtime_active().await);
+
+    ctx.chainlink.disable().await.unwrap();
+    assert!(!ctx.chainlink.is_runtime_active().await);
+    assert_eq!(ctx.chainlink.lifecycle_state_for_tests(), "disabled");
+
+    ctx.chainlink.disable().await.unwrap();
+    assert!(!ctx.chainlink.is_runtime_active().await);
+}
+
+#[tokio::test]
+async fn active_runtime_fetches_before_shutdown_and_not_after() {
+    let slot = 3;
+    let ctx = setup(slot).await;
+    let pubkey = Pubkey::new_unique();
+    let owner = Pubkey::new_unique();
+
+    ctx.rpc_client
+        .add_account(pubkey, account_with_lamports(1_000, owner, slot));
+    let before_fetch_count = ctx.chainlink.active_fetch_count_for_tests().await;
+    ctx.chainlink
+        .ensure_accounts(
+            &[pubkey],
+            None,
+            AccountFetchOrigin::GetMultipleAccounts,
+            None,
+        )
+        .await
+        .unwrap();
+    assert!(
+        ctx.chainlink.active_fetch_count_for_tests().await > before_fetch_count
+    );
+    assert!(ctx.chainlink.is_watching(&pubkey));
+
+    ctx.chainlink.disable().await.unwrap();
+    assert!(!ctx.chainlink.is_runtime_active().await);
+
+    let after_disable_fetch_count =
+        ctx.chainlink.active_fetch_count_for_tests().await;
+    ctx.chainlink
+        .ensure_accounts(
+            &[Pubkey::new_unique()],
+            None,
+            AccountFetchOrigin::GetMultipleAccounts,
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        ctx.chainlink.active_fetch_count_for_tests().await,
+        after_disable_fetch_count
+    );
+}
+
+#[tokio::test]
+async fn provider_account_updates_do_not_clone_after_disable() {
+    let slot = 4;
+    let ctx = setup(slot).await;
+    let pubkey = Pubkey::new_unique();
+    let owner = Pubkey::new_unique();
+
+    ctx.rpc_client
+        .add_account(pubkey, account_with_lamports(1_000, owner, slot));
+    ctx.ensure_account(&pubkey).await.unwrap();
+    assert!(ctx.chainlink.is_watching(&pubkey));
+
+    ctx.rpc_client.set_slot(slot + 1);
+    assert!(
+        ctx.send_and_receive_account_update(
+            pubkey,
+            Account {
+                lamports: 2_000,
+                ..Default::default()
+            },
+            Some(400),
+        )
+        .await
+    );
+    assert_eq!(ctx.cloner.get_account(&pubkey).unwrap().lamports(), 2_000);
+    let clone_requests_before_disable = ctx.cloner.clone_request_count();
+
+    ctx.chainlink.disable().await.unwrap();
+    ctx.rpc_client.set_slot(slot + 2);
+    ctx.send_account_update(
+        pubkey,
+        &Account {
+            lamports: 3_000,
+            ..Default::default()
+        },
+    )
+    .await;
+    sleep(Duration::from_millis(50)).await;
+
+    assert_eq!(
+        ctx.cloner.clone_request_count(),
+        clone_requests_before_disable
+    );
+    assert_eq!(ctx.cloner.get_account(&pubkey).unwrap().lamports(), 2_000);
+}
+
+#[tokio::test]
+async fn removed_account_notifications_do_not_evict_after_disable() {
+    let slot = 5;
+    let ctx = TestContext::init_with_lru_capacity(slot, Some(1)).await;
+    let first_pubkey = Pubkey::new_unique();
+    let second_pubkey = Pubkey::new_unique();
+    let third_pubkey = Pubkey::new_unique();
+    let owner = Pubkey::new_unique();
+
+    ctx.rpc_client
+        .add_account(first_pubkey, account_with_lamports(1_000, owner, slot));
+    ctx.ensure_account(&first_pubkey).await.unwrap();
+    assert!(ctx.bank.get_account(&first_pubkey).is_some());
+
+    ctx.rpc_client.add_account(
+        second_pubkey,
+        account_with_lamports(2_000, owner, slot + 1),
+    );
+    ctx.ensure_account(&second_pubkey).await.unwrap();
+    sleep(Duration::from_millis(50)).await;
+    assert!(
+        ctx.bank.get_account(&first_pubkey).is_none(),
+        "first LRU eviction should remove the account before shutdown"
+    );
+
+    ctx.rpc_client
+        .add_account(third_pubkey, account_with_lamports(3_000, owner, slot));
+    ctx.ensure_account(&third_pubkey).await.unwrap();
+    assert!(ctx.bank.get_account(&third_pubkey).is_some());
+
+    ctx.chainlink.disable().await.unwrap();
+    sleep(Duration::from_millis(50)).await;
+    assert!(
+        ctx.bank.get_account(&third_pubkey).is_some(),
+        "shutdown should stop removed-account eviction handling"
+    );
+}
+
+#[tokio::test]
+async fn delegated_account_can_be_fetched_through_fresh_runtime_after_shutdown()
+{
+    let slot = 6;
+    let ctx = setup(slot).await;
+    let pubkey = Pubkey::new_unique();
+    let owner = Pubkey::new_unique();
+    ctx.rpc_client
+        .add_account(pubkey, account_with_lamports(1_000, dlp_api::id(), slot));
+    add_delegation_record_for(
+        &ctx.rpc_client,
+        pubkey,
+        ctx.validator_pubkey,
+        owner,
+    );
+
+    ctx.chainlink.disable().await.unwrap();
+    assert!(!ctx.chainlink.is_runtime_active().await);
+
+    let fresh_ctx = setup(slot).await;
+    fresh_ctx
+        .rpc_client
+        .add_account(pubkey, account_with_lamports(1_000, dlp_api::id(), slot));
+    add_delegation_record_for(
+        &fresh_ctx.rpc_client,
+        pubkey,
+        fresh_ctx.validator_pubkey,
+        owner,
+    );
+    fresh_ctx.ensure_account(&pubkey).await.unwrap();
+    assert!(fresh_ctx.chainlink.is_runtime_active().await);
+    assert!(fresh_ctx.cloner.get_account(&pubkey).is_some());
+}

--- a/magicblock-chainlink/tests/11_lifecycle_shutdown.rs
+++ b/magicblock-chainlink/tests/11_lifecycle_shutdown.rs
@@ -1,7 +1,7 @@
 use magicblock_accounts_db::traits::AccountsBank;
 use magicblock_chainlink::{
     testing::{deleg::add_delegation_record_for, init_logger},
-    AccountFetchOrigin, PrimaryEnableOutcome, PrimaryRuntimeReadiness,
+    AccountFetchOrigin, PrimaryRuntimeReadiness,
 };
 use solana_account::{Account, ReadableAccount};
 use solana_pubkey::Pubkey;
@@ -30,7 +30,7 @@ fn account_with_lamports(lamports: u64, owner: Pubkey, slot: u64) -> Account {
 }
 
 #[tokio::test]
-async fn chainlink_runtime_is_active_after_primary_enable() {
+async fn chainlink_runtime_is_active_after_startup() {
     let ctx = setup(1).await;
 
     assert!(ctx.chainlink.is_runtime_active().await);
@@ -38,11 +38,6 @@ async fn chainlink_runtime_is_active_after_primary_enable() {
         ctx.chainlink.primary_runtime_readiness().await,
         PrimaryRuntimeReadiness::Ready
     );
-    assert_eq!(
-        ctx.chainlink.enable_primary().await.unwrap(),
-        PrimaryEnableOutcome::RuntimeActive
-    );
-    assert!(ctx.chainlink.is_runtime_active().await);
 }
 
 #[tokio::test]

--- a/magicblock-chainlink/tests/11_lifecycle_shutdown.rs
+++ b/magicblock-chainlink/tests/11_lifecycle_shutdown.rs
@@ -1,7 +1,7 @@
 use magicblock_accounts_db::traits::AccountsBank;
 use magicblock_chainlink::{
     testing::{deleg::add_delegation_record_for, init_logger},
-    AccountFetchOrigin, ChainlinkPrimaryEnablement,
+    AccountFetchOrigin, PrimaryEnableOutcome, PrimaryRuntimeReadiness,
 };
 use solana_account::{Account, ReadableAccount};
 use solana_pubkey::Pubkey;
@@ -34,10 +34,13 @@ async fn chainlink_runtime_is_active_after_primary_enable() {
     let ctx = setup(1).await;
 
     assert!(ctx.chainlink.is_runtime_active().await);
-    assert_eq!(ctx.chainlink.lifecycle_state_for_tests(), "enabled");
+    assert_eq!(
+        ctx.chainlink.primary_runtime_readiness().await,
+        PrimaryRuntimeReadiness::Ready
+    );
     assert_eq!(
         ctx.chainlink.enable_primary().await.unwrap(),
-        ChainlinkPrimaryEnablement::Active
+        PrimaryEnableOutcome::RuntimeActive
     );
     assert!(ctx.chainlink.is_runtime_active().await);
 }
@@ -49,7 +52,10 @@ async fn disable_after_enable_stops_runtime_and_is_idempotent() {
 
     ctx.chainlink.disable().await.unwrap();
     assert!(!ctx.chainlink.is_runtime_active().await);
-    assert_eq!(ctx.chainlink.lifecycle_state_for_tests(), "disabled");
+    assert_eq!(
+        ctx.chainlink.primary_runtime_readiness().await,
+        PrimaryRuntimeReadiness::DisabledByConfig
+    );
 
     ctx.chainlink.disable().await.unwrap();
     assert!(!ctx.chainlink.is_runtime_active().await);

--- a/magicblock-chainlink/tests/11_lifecycle_shutdown.rs
+++ b/magicblock-chainlink/tests/11_lifecycle_shutdown.rs
@@ -1,7 +1,7 @@
 use magicblock_accounts_db::traits::AccountsBank;
 use magicblock_chainlink::{
     testing::{deleg::add_delegation_record_for, init_logger},
-    AccountFetchOrigin,
+    AccountFetchOrigin, ChainlinkPrimaryEnablement,
 };
 use solana_account::{Account, ReadableAccount};
 use solana_pubkey::Pubkey;
@@ -35,7 +35,10 @@ async fn chainlink_runtime_is_active_after_primary_enable() {
 
     assert!(ctx.chainlink.is_runtime_active().await);
     assert_eq!(ctx.chainlink.lifecycle_state_for_tests(), "enabled");
-    ctx.chainlink.enable_primary().await.unwrap();
+    assert_eq!(
+        ctx.chainlink.enable_primary().await.unwrap(),
+        ChainlinkPrimaryEnablement::Active
+    );
     assert!(ctx.chainlink.is_runtime_active().await);
 }
 

--- a/magicblock-chainlink/tests/utils/test_context.rs
+++ b/magicblock-chainlink/tests/utils/test_context.rs
@@ -143,7 +143,9 @@ impl TestContext {
         let timeout = timeout_millis
             .map(Duration::from_millis)
             .unwrap_or_else(|| Duration::from_secs(1));
-        if let Some(fetch_cloner) = self.chainlink.fetch_cloner() {
+        if let Some(fetch_cloner) =
+            self.chainlink.fetch_cloner_for_tests().await
+        {
             let target_count = fetch_cloner.received_updates_count() + count;
             trace!(
                 "Waiting for {} account updates, current count: {}",

--- a/magicblock-chainlink/tests/utils/test_context.rs
+++ b/magicblock-chainlink/tests/utils/test_context.rs
@@ -24,6 +24,7 @@ use magicblock_chainlink::{
     AccountFetchOrigin, Chainlink,
 };
 use magicblock_config::config::{ChainLinkConfig, LifecycleMode};
+use magicblock_core::coordination_mode::switch_to_primary_mode;
 use solana_account::{Account, AccountSharedData};
 use solana_keypair::Keypair;
 use solana_program::{clock::Slot, sysvar::clock};
@@ -55,6 +56,8 @@ pub struct TestContext {
 
 impl TestContext {
     pub async fn init(slot: Slot) -> Self {
+        switch_to_primary_mode();
+
         let (rpc_client, pubsub_client) = {
             let rpc_client =
                 ChainRpcClientMockBuilder::new().slot(slot).build();

--- a/magicblock-chainlink/tests/utils/test_context.rs
+++ b/magicblock-chainlink/tests/utils/test_context.rs
@@ -56,6 +56,13 @@ pub struct TestContext {
 
 impl TestContext {
     pub async fn init(slot: Slot) -> Self {
+        Self::init_with_lru_capacity(slot, None).await
+    }
+
+    pub async fn init_with_lru_capacity(
+        slot: Slot,
+        subscribed_accounts_lru_capacity: Option<usize>,
+    ) -> Self {
         switch_to_primary_mode();
 
         let (rpc_client, pubsub_client) = {
@@ -75,10 +82,15 @@ impl TestContext {
         let faucet_pubkey = Pubkey::new_unique();
         let (fetch_cloner, remote_account_provider) = {
             let (tx, rx) = tokio::sync::mpsc::channel(100);
-            let config =
+            let mut config =
                 RemoteAccountProviderConfig::default_with_lifecycle_mode(
                     lifecycle_mode,
                 );
+            if let Some(capacity) = subscribed_accounts_lru_capacity {
+                config = config
+                    .with_subscribed_accounts_lru_capacity(capacity)
+                    .expect("test LRU capacity should be valid");
+            }
             let subscribed_accounts =
                 create_test_lru_cache_with_config(&config);
 

--- a/magicblock-metrics/src/metrics/mod.rs
+++ b/magicblock-metrics/src/metrics/mod.rs
@@ -246,6 +246,15 @@ lazy_static::lazy_static! {
         &["name"],
     ).unwrap();
 
+    pub static ref RPC_APERTURE_ROUTING_DECISIONS_COUNT: IntCounterVec = IntCounterVec::new(
+        Opts::new(
+            "rpc_aperture_routing_decisions_count",
+            "Count of RPC aperture routing decisions by method, decision, and Chainlink readiness",
+        ),
+        &["method", "decision", "chainlink_readiness"],
+    )
+    .unwrap();
+
     pub static ref RPC_WS_SUBSCRIPTIONS_COUNT: IntGaugeVec = IntGaugeVec::new(
         Opts::new("rpc_ws_subscriptions_count", "Count of active rpc websocket subscriptions"),
         &["name"],
@@ -602,6 +611,7 @@ pub(crate) fn register() {
         register!(TRANSACTION_PROCESSING_TIME);
         register!(TRANSACTION_SKIP_PREFLIGHT);
         register!(RPC_REQUESTS_COUNT);
+        register!(RPC_APERTURE_ROUTING_DECISIONS_COUNT);
         register!(RPC_WS_SUBSCRIPTIONS_COUNT);
         register!(ACCOUNT_FETCHES_SUCCESS_COUNT);
         register!(ACCOUNT_FETCHES_FAILED_COUNT);

--- a/magicblock-metrics/src/metrics/mod.rs
+++ b/magicblock-metrics/src/metrics/mod.rs
@@ -213,6 +213,14 @@ lazy_static::lazy_static! {
         &["kind"]
     ).unwrap();
 
+    pub static ref APERTURE_ENSURE_ROUTING_COUNT: IntCounterVec = IntCounterVec::new(
+        Opts::new(
+            "aperture_ensure_routing_count",
+            "Number of aperture ensure-routing decisions by method and decision",
+        ),
+        &["method", "decision"],
+    ).unwrap();
+
     pub static ref TRANSACTION_PROCESSING_TIME: Histogram = Histogram::with_opts(
         HistogramOpts::new("transaction_processing_time", "Total time spent in transaction processing")
             .buckets(
@@ -607,6 +615,7 @@ pub(crate) fn register() {
         register!(COMMITTOR_INTENT_ALT_PREPARATION_TIME);
         register!(COMMITTOR_FETCH_COMMIT_NONCES_WAIT_TIME);
         register!(ENSURE_ACCOUNTS_TIME);
+        register!(APERTURE_ENSURE_ROUTING_COUNT);
         register!(RPC_REQUEST_HANDLING_TIME);
         register!(TRANSACTION_PROCESSING_TIME);
         register!(TRANSACTION_SKIP_PREFLIGHT);

--- a/magicblock-replicator/Cargo.toml
+++ b/magicblock-replicator/Cargo.toml
@@ -36,4 +36,5 @@ tracing = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]
+async-trait = { workspace = true }
 tempfile = { workspace = true }

--- a/magicblock-replicator/src/error.rs
+++ b/magicblock-replicator/src/error.rs
@@ -3,6 +3,7 @@
 use std::fmt::{Debug, Display};
 
 use magicblock_accounts_db::error::AccountsDbError;
+use magicblock_chainlink::errors::ChainlinkError;
 use magicblock_ledger::errors::LedgerError;
 use solana_transaction_error::TransactionError;
 
@@ -28,6 +29,10 @@ pub enum Error {
     /// Ledger access error.
     #[error("ledger access error: {0}")]
     Ledger(#[from] LedgerError),
+
+    /// Chainlink lifecycle error.
+    #[error("chainlink error: {0}")]
+    Chainlink(#[from] ChainlinkError),
 
     /// Transaction execution error.
     #[error("transaction execution error: {0}")]

--- a/magicblock-replicator/src/service/context.rs
+++ b/magicblock-replicator/src/service/context.rs
@@ -1,6 +1,6 @@
 //! Shared context for primary and standby roles.
 
-use std::sync::Arc;
+use std::{future::Future, sync::Arc};
 
 use machineid_rs::IdBuilder;
 use magicblock_accounts_db::AccountsDb;
@@ -238,21 +238,47 @@ impl ReplicationContext {
 async fn run_primary_readiness_sequence(
     ctx: &ReplicationContext,
 ) -> Result<()> {
-    let _guard = ctx.scheduler.wait_for_idle().await;
-    ctx.accounts_bank_reset
+    run_primary_readiness_sequence_with_hooks(
+        || ctx.scheduler.wait_for_idle(),
+        ctx.accounts_bank_reset.as_ref(),
+        ctx.primary_chainlink.as_deref(),
+        || ctx.enter_primary_mode(),
+    )
+    .await
+}
+
+async fn run_primary_readiness_sequence_with_hooks<
+    WaitForIdle,
+    WaitFut,
+    IdleGuard,
+    EnterPrimary,
+    EnterPrimaryFut,
+>(
+    wait_for_idle: WaitForIdle,
+    accounts_bank_reset: &dyn AccountsBankReset,
+    primary_chainlink: Option<&dyn ChainlinkPrimaryLifecycle>,
+    enter_primary: EnterPrimary,
+) -> Result<()>
+where
+    WaitForIdle: FnOnce() -> WaitFut,
+    WaitFut: Future<Output = IdleGuard>,
+    EnterPrimary: FnOnce() -> EnterPrimaryFut,
+    EnterPrimaryFut: Future<Output = Result<()>>,
+{
+    let _guard = wait_for_idle().await;
+    accounts_bank_reset
         .reset_accounts_bank()
         .map_err(Error::from)?;
-    let primary_chainlink =
-        ctx.primary_chainlink.as_ref().ok_or_else(|| {
-            Error::Internal(
-                "primary Chainlink lifecycle handle is unavailable".to_string(),
-            )
-        })?;
+    let primary_chainlink = primary_chainlink.ok_or_else(|| {
+        Error::Internal(
+            "primary Chainlink lifecycle handle is unavailable".to_string(),
+        )
+    })?;
     primary_chainlink
         .enable_primary()
         .await
         .map_err(Error::from)?;
-    if let Err(scheduler_mode_error) = ctx.enter_primary_mode().await {
+    if let Err(scheduler_mode_error) = enter_primary().await {
         if let Err(rollback_error) = primary_chainlink.disable().await {
             error!(
                 %rollback_error,
@@ -269,9 +295,267 @@ async fn run_standby_start_sequence(
     ctx: &ReplicationContext,
     reset: bool,
 ) -> Result<Option<Consumer>> {
-    ctx.enter_replica_mode().await?;
-    if let Some(primary_chainlink) = &ctx.primary_chainlink {
+    run_standby_lifecycle_sequence_with_hooks(
+        ctx.primary_chainlink.as_deref(),
+        || ctx.enter_replica_mode(),
+    )
+    .await?;
+    Ok(ctx.create_consumer(reset).await)
+}
+
+async fn run_standby_lifecycle_sequence_with_hooks<
+    EnterReplica,
+    EnterReplicaFut,
+>(
+    primary_chainlink: Option<&dyn ChainlinkPrimaryLifecycle>,
+    enter_replica: EnterReplica,
+) -> Result<()>
+where
+    EnterReplica: FnOnce() -> EnterReplicaFut,
+    EnterReplicaFut: Future<Output = Result<()>>,
+{
+    enter_replica().await?;
+    if let Some(primary_chainlink) = primary_chainlink {
         primary_chainlink.disable().await.map_err(Error::from)?;
     }
-    Ok(ctx.create_consumer(reset).await)
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use magicblock_accounts_db::AccountsDbResult;
+    use magicblock_chainlink::{
+        errors::{ChainlinkError, ChainlinkResult},
+        ChainlinkPrimaryEnablement,
+    };
+
+    use super::*;
+
+    #[derive(Clone)]
+    struct RecordingReset {
+        events: Arc<Mutex<Vec<&'static str>>>,
+    }
+
+    impl AccountsBankReset for RecordingReset {
+        fn reset_accounts_bank(&self) -> AccountsDbResult<()> {
+            self.events.lock().unwrap().push("reset");
+            Ok(())
+        }
+    }
+
+    struct RecordingPrimaryChainlink {
+        events: Arc<Mutex<Vec<&'static str>>>,
+        enable_error: bool,
+    }
+
+    #[async_trait::async_trait]
+    impl ChainlinkPrimaryLifecycle for RecordingPrimaryChainlink {
+        async fn enable_primary(
+            &self,
+        ) -> ChainlinkResult<ChainlinkPrimaryEnablement> {
+            self.events.lock().unwrap().push("enable");
+            if self.enable_error {
+                Err(ChainlinkError::MissingPrimaryRuntimeBuildConfig)
+            } else {
+                Ok(ChainlinkPrimaryEnablement::Active)
+            }
+        }
+
+        async fn disable(&self) -> ChainlinkResult<()> {
+            self.events.lock().unwrap().push("disable");
+            Ok(())
+        }
+    }
+
+    fn events() -> Arc<Mutex<Vec<&'static str>>> {
+        Arc::new(Mutex::new(Vec::new()))
+    }
+
+    fn reset(events: Arc<Mutex<Vec<&'static str>>>) -> RecordingReset {
+        RecordingReset { events }
+    }
+
+    fn chainlink(
+        events: Arc<Mutex<Vec<&'static str>>>,
+    ) -> RecordingPrimaryChainlink {
+        RecordingPrimaryChainlink {
+            events,
+            enable_error: false,
+        }
+    }
+
+    fn failing_chainlink(
+        events: Arc<Mutex<Vec<&'static str>>>,
+    ) -> RecordingPrimaryChainlink {
+        RecordingPrimaryChainlink {
+            events,
+            enable_error: true,
+        }
+    }
+
+    fn recorded_events(
+        events: &Arc<Mutex<Vec<&'static str>>>,
+    ) -> Vec<&'static str> {
+        events.lock().unwrap().clone()
+    }
+
+    #[tokio::test]
+    async fn primary_readiness_waits_resets_enables_then_publishes_primary() {
+        let events = events();
+        let reset = reset(events.clone());
+        let chainlink = chainlink(events.clone());
+
+        run_primary_readiness_sequence_with_hooks(
+            || {
+                let events = events.clone();
+                async move {
+                    events.lock().unwrap().push("idle");
+                }
+            },
+            &reset,
+            Some(&chainlink),
+            || {
+                let events = events.clone();
+                async move {
+                    events.lock().unwrap().push("primary");
+                    Ok(())
+                }
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            recorded_events(&events),
+            vec!["idle", "reset", "enable", "primary"]
+        );
+    }
+
+    #[tokio::test]
+    async fn primary_readiness_enable_failure_does_not_publish_primary() {
+        let events = events();
+        let reset = reset(events.clone());
+        let chainlink = failing_chainlink(events.clone());
+
+        let result = run_primary_readiness_sequence_with_hooks(
+            || {
+                let events = events.clone();
+                async move {
+                    events.lock().unwrap().push("idle");
+                }
+            },
+            &reset,
+            Some(&chainlink),
+            || {
+                let events = events.clone();
+                async move {
+                    events.lock().unwrap().push("primary");
+                    Ok(())
+                }
+            },
+        )
+        .await;
+
+        assert!(matches!(result, Err(Error::Chainlink(_))));
+        assert_eq!(recorded_events(&events), vec!["idle", "reset", "enable"]);
+    }
+
+    #[tokio::test]
+    async fn primary_readiness_missing_lifecycle_handle_does_not_publish_primary(
+    ) {
+        let events = events();
+        let reset = reset(events.clone());
+
+        let result = run_primary_readiness_sequence_with_hooks(
+            || {
+                let events = events.clone();
+                async move {
+                    events.lock().unwrap().push("idle");
+                }
+            },
+            &reset,
+            None,
+            || {
+                let events = events.clone();
+                async move {
+                    events.lock().unwrap().push("primary");
+                    Ok(())
+                }
+            },
+        )
+        .await;
+
+        assert!(matches!(result, Err(Error::Internal(_))));
+        assert_eq!(recorded_events(&events), vec!["idle", "reset"]);
+    }
+
+    #[tokio::test]
+    async fn primary_readiness_rolls_back_chainlink_when_primary_publish_fails()
+    {
+        let events = events();
+        let reset = reset(events.clone());
+        let chainlink = chainlink(events.clone());
+
+        let result = run_primary_readiness_sequence_with_hooks(
+            || {
+                let events = events.clone();
+                async move {
+                    events.lock().unwrap().push("idle");
+                }
+            },
+            &reset,
+            Some(&chainlink),
+            || {
+                let events = events.clone();
+                async move {
+                    events.lock().unwrap().push("primary");
+                    Err(Error::Internal("publish failed".to_string()))
+                }
+            },
+        )
+        .await;
+
+        assert!(matches!(result, Err(Error::Internal(_))));
+        assert_eq!(
+            recorded_events(&events),
+            vec!["idle", "reset", "enable", "primary", "disable"]
+        );
+    }
+
+    #[tokio::test]
+    async fn standby_lifecycle_enters_replica_before_disabling_chainlink() {
+        let events = events();
+        let chainlink = chainlink(events.clone());
+
+        run_standby_lifecycle_sequence_with_hooks(Some(&chainlink), || {
+            let events = events.clone();
+            async move {
+                events.lock().unwrap().push("replica");
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(recorded_events(&events), vec!["replica", "disable"]);
+    }
+
+    #[tokio::test]
+    async fn standby_lifecycle_replica_only_skips_real_chainlink_disable() {
+        let events = events();
+
+        run_standby_lifecycle_sequence_with_hooks(None, || {
+            let events = events.clone();
+            async move {
+                events.lock().unwrap().push("replica");
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(recorded_events(&events), vec!["replica"]);
+    }
 }

--- a/magicblock-replicator/src/service/context.rs
+++ b/magicblock-replicator/src/service/context.rs
@@ -1,9 +1,10 @@
 //! Shared context for primary and standby roles.
 
-use std::{future::Future, pin::Pin, sync::Arc};
+use std::sync::Arc;
 
 use machineid_rs::IdBuilder;
 use magicblock_accounts_db::AccountsDb;
+use magicblock_chainlink::PrimaryChainlink;
 use magicblock_core::{
     link::{
         replication::{Block, Message, SuperBlock},
@@ -25,78 +26,6 @@ use crate::{
     watcher::SnapshotWatcher,
     Error, Result,
 };
-
-/// Narrow Chainlink lifecycle surface needed by replication.
-pub trait PrimaryChainlink: Send + Sync {
-    fn reset_accounts_bank(
-        &self,
-    ) -> magicblock_accounts_db::AccountsDbResult<()>;
-
-    fn enable_primary<'a>(
-        &'a self,
-    ) -> Pin<
-        Box<
-            dyn Future<
-                    Output = magicblock_chainlink::errors::ChainlinkResult<()>,
-                > + Send
-                + 'a,
-        >,
-    >;
-
-    fn disable<'a>(
-        &'a self,
-    ) -> Pin<
-        Box<
-            dyn Future<
-                    Output = magicblock_chainlink::errors::ChainlinkResult<()>,
-                > + Send
-                + 'a,
-        >,
-    >;
-}
-
-impl<C> PrimaryChainlink
-    for magicblock_chainlink::Chainlink<
-        magicblock_chainlink::remote_account_provider::chain_rpc_client::ChainRpcClientImpl,
-        magicblock_chainlink::submux::SubMuxClient<
-            magicblock_chainlink::remote_account_provider::chain_updates_client::ChainUpdatesClient,
-        >,
-        AccountsDb,
-        C,
-    >
-where
-    C: magicblock_chainlink::cloner::Cloner + Send + Sync + 'static,
-{
-    fn reset_accounts_bank(&self) -> magicblock_accounts_db::AccountsDbResult<()> {
-        self.reset_accounts_bank()
-    }
-
-    fn enable_primary<'a>(
-        &'a self,
-    ) -> Pin<
-        Box<
-            dyn Future<Output = magicblock_chainlink::errors::ChainlinkResult<()>>
-                + Send
-                + 'a,
-        >,
-    > {
-        Box::pin(async move {
-            self.enable_primary().await.map(|_| ())
-        })
-    }
-
-    fn disable<'a>(
-        &'a self,
-    ) -> Pin<
-        Box<
-            dyn Future<Output = magicblock_chainlink::errors::ChainlinkResult<()>>
-                + Send
-                + 'a,
-        >,
-    > {
-        Box::pin(self.disable())
-    }
-}
 
 /// Shared state for both primary and standby roles.
 pub struct ReplicationContext {
@@ -314,7 +243,13 @@ async fn run_primary_readiness_sequence_with(
 ) -> Result<()> {
     let _guard = scheduler.wait_for_idle().await;
     chainlink.reset_accounts_bank().map_err(Error::from)?;
-    chainlink.enable_primary().await.map_err(Error::from)?;
+    let outcome = chainlink.enable_primary().await.map_err(Error::from)?;
+    let readiness = chainlink.primary_runtime_readiness().await;
+    if !readiness.allows_primary_ensure() {
+        return Err(Error::Internal(format!(
+            "chainlink primary runtime not ready after enable: outcome={outcome:?}, readiness={readiness:?}"
+        )));
+    }
     mode_tx.send(SchedulerMode::Primary).await.map_err(|e| {
         Error::Internal(format!("failed to enter primary mode: {e}"))
     })
@@ -344,26 +279,44 @@ async fn run_standby_start_sequence_with(
 mod tests {
     use std::sync::{Arc, Mutex};
 
-    use magicblock_chainlink::errors::{ChainlinkError, ChainlinkResult};
+    use magicblock_chainlink::{
+        errors::ChainlinkResult, PrimaryChainlink, PrimaryEnableOutcome,
+        PrimaryRuntimeReadiness,
+    };
     use magicblock_core::link::{link, transactions::SchedulerMode};
     use tokio::sync::mpsc;
 
     use super::{
         run_primary_readiness_sequence_with, run_standby_start_sequence_with,
-        PrimaryChainlink,
     };
 
-    #[derive(Default)]
     struct RecordingPrimaryChainlink {
         calls: Arc<Mutex<Vec<&'static str>>>,
-        enable_primary_result: Mutex<Option<ChainlinkResult<()>>>,
+        enable_primary_result:
+            Mutex<Option<ChainlinkResult<PrimaryEnableOutcome>>>,
+        readiness: Mutex<PrimaryRuntimeReadiness>,
+    }
+
+    impl Default for RecordingPrimaryChainlink {
+        fn default() -> Self {
+            Self {
+                calls: Arc::default(),
+                enable_primary_result: Mutex::new(Some(Ok(
+                    PrimaryEnableOutcome::RuntimeActive,
+                ))),
+                readiness: Mutex::new(PrimaryRuntimeReadiness::Ready),
+            }
+        }
     }
 
     impl RecordingPrimaryChainlink {
-        fn with_enable_primary_result(result: ChainlinkResult<()>) -> Self {
+        fn with_readiness(readiness: PrimaryRuntimeReadiness) -> Self {
             Self {
                 calls: Arc::default(),
-                enable_primary_result: Mutex::new(Some(result)),
+                enable_primary_result: Mutex::new(Some(Ok(
+                    PrimaryEnableOutcome::RuntimeActive,
+                ))),
+                readiness: Mutex::new(readiness),
             }
         }
 
@@ -372,6 +325,7 @@ mod tests {
         }
     }
 
+    #[async_trait::async_trait]
     impl PrimaryChainlink for RecordingPrimaryChainlink {
         fn reset_accounts_bank(
             &self,
@@ -383,53 +337,51 @@ mod tests {
             Ok(())
         }
 
-        fn enable_primary<'a>(
-            &'a self,
-        ) -> std::pin::Pin<
-            Box<
-                dyn std::future::Future<Output = ChainlinkResult<()>>
-                    + Send
-                    + 'a,
-            >,
-        > {
-            Box::pin(async move {
-                self.calls
-                    .lock()
-                    .expect("calls lock poisoned")
-                    .push("enable_primary");
-                self.enable_primary_result
-                    .lock()
-                    .expect("enable_primary_result lock poisoned")
-                    .take()
-                    .unwrap_or(Ok(()))
-            })
+        async fn enable_primary(
+            &self,
+        ) -> ChainlinkResult<PrimaryEnableOutcome> {
+            self.calls
+                .lock()
+                .expect("calls lock poisoned")
+                .push("enable_primary");
+            self.enable_primary_result
+                .lock()
+                .expect("enable_primary_result lock poisoned")
+                .take()
+                .unwrap_or(Ok(PrimaryEnableOutcome::RuntimeActive))
         }
 
-        fn disable<'a>(
-            &'a self,
-        ) -> std::pin::Pin<
-            Box<
-                dyn std::future::Future<Output = ChainlinkResult<()>>
-                    + Send
-                    + 'a,
-            >,
-        > {
-            Box::pin(async move {
-                self.calls
-                    .lock()
-                    .expect("calls lock poisoned")
-                    .push("disable");
-                Ok(())
-            })
+        async fn disable(&self) -> ChainlinkResult<()> {
+            self.calls
+                .lock()
+                .expect("calls lock poisoned")
+                .push("disable");
+            Ok(())
+        }
+
+        async fn primary_runtime_readiness(&self) -> PrimaryRuntimeReadiness {
+            self.calls
+                .lock()
+                .expect("calls lock poisoned")
+                .push("primary_runtime_readiness");
+            *self.readiness.lock().expect("readiness lock poisoned")
         }
     }
 
     #[tokio::test]
-    async fn run_primary_readiness_sequence_enables_chainlink_before_primary_mode(
-    ) {
+    async fn primary_readiness_sequence_resets_and_enables_before_primary_mode()
+    {
         let (dispatch, _validator) = link();
         let (mode_tx, mut mode_rx) = mpsc::channel(1);
         let chainlink = RecordingPrimaryChainlink::default();
+        let calls = chainlink.calls.clone();
+        let mode_recorder = tokio::spawn(async move {
+            assert_eq!(mode_rx.recv().await, Some(SchedulerMode::Primary));
+            calls
+                .lock()
+                .expect("calls lock poisoned")
+                .push("primary_mode");
+        });
 
         run_primary_readiness_sequence_with(
             &chainlink,
@@ -439,16 +391,21 @@ mod tests {
         .await
         .expect("primary readiness sequence should succeed");
 
+        mode_recorder.await.expect("mode recorder should finish");
+
         assert_eq!(
             chainlink.recorded_calls(),
-            vec!["reset_accounts_bank", "enable_primary"]
+            vec![
+                "reset_accounts_bank",
+                "enable_primary",
+                "primary_runtime_readiness",
+                "primary_mode"
+            ]
         );
-        assert_eq!(mode_rx.try_recv(), Ok(SchedulerMode::Primary));
     }
 
     #[tokio::test]
-    async fn run_standby_start_sequence_disables_chainlink_after_replica_mode()
-    {
+    async fn standby_start_sequence_enters_replica_then_disables_chainlink() {
         let (mode_tx, mut mode_rx) = mpsc::channel(1);
         let chainlink = RecordingPrimaryChainlink::default();
 
@@ -461,12 +418,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn run_primary_readiness_sequence_does_not_publish_primary_when_chainlink_enable_fails(
+    async fn primary_readiness_sequence_does_not_publish_primary_when_chainlink_not_ready(
     ) {
         let (dispatch, _validator) = link();
         let (mode_tx, mut mode_rx) = mpsc::channel(1);
-        let chainlink = RecordingPrimaryChainlink::with_enable_primary_result(
-            Err(ChainlinkError::MissingPrimaryRuntimeBuildConfig),
+        let chainlink = RecordingPrimaryChainlink::with_readiness(
+            PrimaryRuntimeReadiness::NotReady,
         );
 
         let err = run_primary_readiness_sequence_with(
@@ -477,10 +434,14 @@ mod tests {
         .await
         .expect_err("primary readiness sequence should fail");
 
-        assert!(matches!(err, crate::Error::Chainlink(_)));
+        assert!(matches!(err, crate::Error::Internal(_)));
         assert_eq!(
             chainlink.recorded_calls(),
-            vec!["reset_accounts_bank", "enable_primary"]
+            vec![
+                "reset_accounts_bank",
+                "enable_primary",
+                "primary_runtime_readiness"
+            ]
         );
         assert!(mode_rx.try_recv().is_err());
     }

--- a/magicblock-replicator/src/service/context.rs
+++ b/magicblock-replicator/src/service/context.rs
@@ -292,6 +292,8 @@ where
 mod tests {
     use std::sync::{Arc, Mutex};
 
+    use tokio::sync::oneshot;
+
     use super::*;
 
     fn record(events: &Arc<Mutex<Vec<&'static str>>>, event: &'static str) {
@@ -348,6 +350,56 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn primary_readiness_sequence_skips_primary_mode_when_chainlink_fails(
+    ) {
+        let events = Arc::new(Mutex::new(Vec::new()));
+
+        let result = run_primary_readiness_sequence(
+            {
+                let events = Arc::clone(&events);
+                move || async move {
+                    record(&events, "wait_for_idle_started");
+                    record(&events, "wait_for_idle_completed");
+                }
+            },
+            {
+                let events = Arc::clone(&events);
+                move || {
+                    record(&events, "reset_accounts_bank");
+                    Ok(())
+                }
+            },
+            {
+                let events = Arc::clone(&events);
+                move || async move {
+                    record(&events, "enable_primary");
+                    Err(Error::Internal("chainlink failed".to_string()))
+                }
+            },
+            {
+                let events = Arc::clone(&events);
+                move || async move {
+                    record(&events, "enter_primary_mode");
+                }
+            },
+        )
+        .await;
+
+        assert!(
+            matches!(result, Err(Error::Internal(message)) if message == "chainlink failed")
+        );
+        assert_eq!(
+            *events.lock().unwrap(),
+            vec![
+                "wait_for_idle_started",
+                "wait_for_idle_completed",
+                "reset_accounts_bank",
+                "enable_primary",
+            ]
+        );
+    }
+
+    #[tokio::test]
     async fn standby_start_sequence_disables_chainlink_before_consumer_creation(
     ) {
         let events = Arc::new(Mutex::new(Vec::new()));
@@ -383,6 +435,65 @@ mod tests {
             vec![
                 "enter_replica_mode",
                 "disable_chainlink",
+                "create_consumer_started",
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn standby_start_sequence_waits_for_chainlink_disable_to_complete() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let (disable_started_tx, disable_started_rx) = oneshot::channel();
+        let (finish_disable_tx, finish_disable_rx) = oneshot::channel();
+
+        let sequence = tokio::spawn({
+            let events = Arc::clone(&events);
+            async move {
+                run_standby_start_sequence(
+                    {
+                        let events = Arc::clone(&events);
+                        move || async move {
+                            record(&events, "enter_replica_mode");
+                        }
+                    },
+                    {
+                        let events = Arc::clone(&events);
+                        move || async move {
+                            record(&events, "disable_chainlink_started");
+                            disable_started_tx.send(()).unwrap();
+                            finish_disable_rx.await.unwrap();
+                            record(&events, "disable_chainlink_completed");
+                            Ok(())
+                        }
+                    },
+                    {
+                        let events = Arc::clone(&events);
+                        move || async move {
+                            record(&events, "create_consumer_started");
+                            Some(())
+                        }
+                    },
+                )
+                .await
+            }
+        });
+
+        disable_started_rx.await.unwrap();
+        assert_eq!(
+            *events.lock().unwrap(),
+            vec!["enter_replica_mode", "disable_chainlink_started"]
+        );
+
+        finish_disable_tx.send(()).unwrap();
+        let consumer = sequence.await.unwrap().unwrap();
+
+        assert_eq!(consumer, Some(()));
+        assert_eq!(
+            *events.lock().unwrap(),
+            vec![
+                "enter_replica_mode",
+                "disable_chainlink_started",
+                "disable_chainlink_completed",
                 "create_consumer_started",
             ]
         );

--- a/magicblock-replicator/src/service/context.rs
+++ b/magicblock-replicator/src/service/context.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use machineid_rs::IdBuilder;
 use magicblock_accounts_db::AccountsDb;
-use magicblock_chainlink::StubbedChainlink;
+use magicblock_chainlink::{AccountsBankReset, ChainlinkPrimaryLifecycle};
 use magicblock_core::{
     link::{
         replication::{Block, Message, SuperBlock},
@@ -18,7 +18,7 @@ use tokio::{
     sync::mpsc::{Receiver, Sender},
 };
 use tokio_util::sync::CancellationToken;
-use tracing::info;
+use tracing::{error, info};
 
 use super::{Primary, Standby, CONSUMER_RETRY_DELAY};
 use crate::{
@@ -39,10 +39,10 @@ pub struct ReplicationContext {
     pub mode_tx: Sender<SchedulerMode>,
     /// Accounts database.
     pub accountsdb: Arc<AccountsDb>,
-    /// Mocked chainlink to reset accountsdb
-    /// TODO(bmuddha): this is a temporary hack, which will be removed
-    /// once the accounts management is moved to the accountsdb
-    pub chainlink: StubbedChainlink<AccountsDb>,
+    /// Reset-only Chainlink cleanup handle for accounts bank readiness.
+    pub accounts_bank_reset: Arc<dyn AccountsBankReset>,
+    /// Real Chainlink primary lifecycle handle for promotable contexts.
+    pub primary_chainlink: Option<Arc<dyn ChainlinkPrimaryLifecycle>>,
     /// Transaction ledger.
     pub ledger: Arc<Ledger>,
     /// Transaction scheduler.
@@ -63,7 +63,8 @@ impl ReplicationContext {
         mode_tx: Sender<SchedulerMode>,
         accountsdb: Arc<AccountsDb>,
         ledger: Arc<Ledger>,
-        chainlink: StubbedChainlink<AccountsDb>,
+        accounts_bank_reset: Arc<dyn AccountsBankReset>,
+        primary_chainlink: Option<Arc<dyn ChainlinkPrimaryLifecycle>>,
         scheduler: TransactionSchedulerHandle,
         cancel: CancellationToken,
         can_promote: bool,
@@ -72,6 +73,12 @@ impl ReplicationContext {
             .add_component(machineid_rs::HWIDComponent::SystemID)
             .build("magicblock")
             .map_err(|e| Error::Internal(e.to_string()))?;
+
+        if can_promote && primary_chainlink.is_none() {
+            return Err(Error::Internal(
+                "promotable replication context requires a primary Chainlink lifecycle handle".to_string(),
+            ));
+        }
 
         let slot = accountsdb.slot();
         let index = ledger
@@ -85,7 +92,8 @@ impl ReplicationContext {
             cancel,
             mode_tx,
             accountsdb,
-            chainlink,
+            accounts_bank_reset,
+            primary_chainlink,
             ledger,
             scheduler,
             slot,
@@ -231,9 +239,29 @@ async fn run_primary_readiness_sequence(
     ctx: &ReplicationContext,
 ) -> Result<()> {
     let _guard = ctx.scheduler.wait_for_idle().await;
-    ctx.chainlink.reset_accounts_bank().map_err(Error::from)?;
-    ctx.chainlink.enable_primary().await.map_err(Error::from)?;
-    ctx.enter_primary_mode().await
+    ctx.accounts_bank_reset
+        .reset_accounts_bank()
+        .map_err(Error::from)?;
+    let primary_chainlink =
+        ctx.primary_chainlink.as_ref().ok_or_else(|| {
+            Error::Internal(
+                "primary Chainlink lifecycle handle is unavailable".to_string(),
+            )
+        })?;
+    primary_chainlink
+        .enable_primary()
+        .await
+        .map_err(Error::from)?;
+    if let Err(scheduler_mode_error) = ctx.enter_primary_mode().await {
+        if let Err(rollback_error) = primary_chainlink.disable().await {
+            error!(
+                %rollback_error,
+                "Failed to roll back Chainlink primary enable after scheduler primary mode failed"
+            );
+        }
+        return Err(scheduler_mode_error);
+    }
+    Ok(())
 }
 
 /// Runs the standby start sequence.
@@ -242,6 +270,8 @@ async fn run_standby_start_sequence(
     reset: bool,
 ) -> Result<Option<Consumer>> {
     ctx.enter_replica_mode().await?;
-    ctx.chainlink.disable().await.map_err(Error::from)?;
+    if let Some(primary_chainlink) = &ctx.primary_chainlink {
+        primary_chainlink.disable().await.map_err(Error::from)?;
+    }
     Ok(ctx.create_consumer(reset).await)
 }

--- a/magicblock-replicator/src/service/context.rs
+++ b/magicblock-replicator/src/service/context.rs
@@ -1,6 +1,6 @@
 //! Shared context for primary and standby roles.
 
-use std::{future::Future, sync::Arc};
+use std::sync::Arc;
 
 use machineid_rs::IdBuilder;
 use magicblock_accounts_db::AccountsDb;
@@ -26,63 +26,6 @@ use crate::{
     watcher::SnapshotWatcher,
     Error, Result,
 };
-
-async fn run_primary_readiness_sequence<
-    Guard,
-    WaitForIdle,
-    WaitForIdleFuture,
-    ResetBank,
-    EnterPrimary,
-    EnterPrimaryFuture,
-    EnablePrimary,
->(
-    wait_for_idle: WaitForIdle,
-    reset_bank: ResetBank,
-    enter_primary: EnterPrimary,
-    enable_primary: EnablePrimary,
-) -> Result<()>
-where
-    WaitForIdle: FnOnce() -> WaitForIdleFuture,
-    WaitForIdleFuture: Future<Output = Guard>,
-    ResetBank: FnOnce() -> Result<()>,
-    EnterPrimary: FnOnce() -> EnterPrimaryFuture,
-    EnterPrimaryFuture: Future<Output = ()>,
-    EnablePrimary: FnOnce() -> Result<()>,
-{
-    // Primary readiness order is intentional: first wait for the scheduler to
-    // become idle, then reset the account bank, then expose Primary mode, and
-    // finally enable the chainlink lifecycle. Reset is primary-readiness cleanup
-    // and is intentionally skipped during standby/replica startup.
-    let _guard = wait_for_idle().await;
-    reset_bank()?;
-    enter_primary().await;
-    enable_primary()?;
-    Ok(())
-}
-
-async fn run_standby_start_sequence<
-    Consumer,
-    EnterReplica,
-    EnterReplicaFuture,
-    DisableChainlink,
-    CreateConsumer,
-    CreateConsumerFuture,
->(
-    enter_replica: EnterReplica,
-    disable_chainlink: DisableChainlink,
-    create_consumer: CreateConsumer,
-) -> Option<Consumer>
-where
-    EnterReplica: FnOnce() -> EnterReplicaFuture,
-    EnterReplicaFuture: Future<Output = ()>,
-    DisableChainlink: FnOnce(),
-    CreateConsumer: FnOnce() -> CreateConsumerFuture,
-    CreateConsumerFuture: Future<Output = Option<Consumer>>,
-{
-    enter_replica().await;
-    disable_chainlink();
-    create_consumer().await
-}
 
 /// Shared state for both primary and standby roles.
 pub struct ReplicationContext {
@@ -232,6 +175,25 @@ impl ReplicationContext {
         }
     }
 
+    /// Runs the primary readiness sequence.
+    /// Ordering: wait for scheduler idle, reset bank, switch to Primary mode,
+    /// then enable the chainlink lifecycle. Reset is primary-readiness cleanup
+    /// and is intentionally skipped during standby/replica startup.
+    async fn run_primary_readiness_sequence(&self) -> Result<()> {
+        let _guard = self.scheduler.wait_for_idle().await;
+        self.chainlink.reset_accounts_bank()?;
+        self.enter_primary_mode().await;
+        self.chainlink.enable_primary()?;
+        Ok(())
+    }
+
+    /// Runs the standby start sequence.
+    async fn run_standby_start_sequence(&self, reset: bool) -> Option<Consumer> {
+        self.enter_replica_mode().await;
+        self.chainlink.disable();
+        self.create_consumer(reset).await
+    }
+
     /// Transitions to primary role with the given producer.
     /// Ordering: wait for scheduler idle, reset bank, switch to Primary mode,
     /// then enable the chainlink lifecycle.
@@ -241,13 +203,7 @@ impl ReplicationContext {
         messages: Receiver<Message>,
     ) -> Result<Primary> {
         let snapshots = self.create_snapshot_watcher()?;
-        run_primary_readiness_sequence(
-            || self.scheduler.wait_for_idle(),
-            || self.chainlink.reset_accounts_bank().map_err(Into::into),
-            || self.enter_primary_mode(),
-            || self.chainlink.enable_primary().map_err(Into::into),
-        )
-        .await?;
+        self.run_primary_readiness_sequence().await?;
         Ok(Primary::new(self, producer, messages, snapshots))
     }
 
@@ -261,13 +217,7 @@ impl ReplicationContext {
         messages: Receiver<Message>,
         reset: bool,
     ) -> Result<Option<Standby>> {
-        let Some(consumer) = run_standby_start_sequence(
-            || self.enter_replica_mode(),
-            || self.chainlink.disable(),
-            || self.create_consumer(reset),
-        )
-        .await
-        else {
+        let Some(consumer) = self.run_standby_start_sequence(reset).await else {
             return Ok(None);
         };
         let Some(watcher) = LockWatcher::new(&self.broker, &self.cancel).await
@@ -280,133 +230,5 @@ impl ReplicationContext {
             messages,
             watcher,
         )))
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::sync::{Arc, Mutex};
-
-    use tokio::sync::oneshot;
-
-    use super::*;
-
-    struct TestGuard;
-
-    fn push(events: &Arc<Mutex<Vec<&'static str>>>, event: &'static str) {
-        events.lock().unwrap().push(event);
-    }
-
-    #[tokio::test]
-    async fn primary_readiness_waits_for_idle_before_reset_and_mode_entry() {
-        let events = Arc::new(Mutex::new(Vec::new()));
-        let (release_idle_tx, release_idle_rx) = oneshot::channel::<()>();
-
-        let sequence = {
-            let wait_events = events.clone();
-            let reset_events = events.clone();
-            let enter_events = events.clone();
-            let enable_events = events.clone();
-            run_primary_readiness_sequence(
-                move || async move {
-                    push(&wait_events, "wait_for_idle_started");
-                    release_idle_rx.await.unwrap();
-                    push(&wait_events, "wait_for_idle_completed");
-                    TestGuard
-                },
-                move || {
-                    push(&reset_events, "reset_accounts_bank");
-                    Ok(())
-                },
-                move || async move {
-                    push(&enter_events, "enter_primary_mode");
-                },
-                move || {
-                    push(&enable_events, "enable_primary");
-                    Ok(())
-                },
-            )
-        };
-
-        tokio::pin!(sequence);
-        tokio::select! {
-            _ = &mut sequence => panic!("primary readiness must wait for idle"),
-            _ = tokio::time::sleep(std::time::Duration::from_millis(10)) => {}
-        }
-        assert_eq!(&*events.lock().unwrap(), &["wait_for_idle_started"]);
-
-        release_idle_tx.send(()).unwrap();
-        sequence.await.unwrap();
-        assert_eq!(
-            &*events.lock().unwrap(),
-            &[
-                "wait_for_idle_started",
-                "wait_for_idle_completed",
-                "reset_accounts_bank",
-                "enter_primary_mode",
-                "enable_primary",
-            ]
-        );
-    }
-
-    #[tokio::test]
-    async fn standby_start_enters_replica_before_consumer_creation_can_block() {
-        let events = Arc::new(Mutex::new(Vec::new()));
-        let (consumer_started_tx, consumer_started_rx) =
-            oneshot::channel::<()>();
-        let (release_consumer_tx, release_consumer_rx) =
-            oneshot::channel::<()>();
-
-        let sequence = {
-            let events = events.clone();
-            run_standby_start_sequence(
-                {
-                    let events = events.clone();
-                    move || async move {
-                        push(&events, "enter_replica_mode");
-                    }
-                },
-                {
-                    let events = events.clone();
-                    move || push(&events, "disable_chainlink")
-                },
-                {
-                    let events = events.clone();
-                    move || async move {
-                        push(&events, "create_consumer_started");
-                        consumer_started_tx.send(()).unwrap();
-                        release_consumer_rx.await.unwrap();
-                        push(&events, "create_consumer_completed");
-                        Some(())
-                    }
-                },
-            )
-        };
-
-        tokio::pin!(sequence);
-        tokio::select! {
-            _ = &mut sequence => panic!("consumer creation should still be blocked"),
-            _ = consumer_started_rx => {}
-        }
-        assert_eq!(
-            &*events.lock().unwrap(),
-            &[
-                "enter_replica_mode",
-                "disable_chainlink",
-                "create_consumer_started",
-            ]
-        );
-
-        release_consumer_tx.send(()).unwrap();
-        assert_eq!(sequence.await, Some(()));
-        assert_eq!(
-            &*events.lock().unwrap(),
-            &[
-                "enter_replica_mode",
-                "disable_chainlink",
-                "create_consumer_started",
-                "create_consumer_completed",
-            ]
-        );
     }
 }

--- a/magicblock-replicator/src/service/context.rs
+++ b/magicblock-replicator/src/service/context.rs
@@ -182,8 +182,10 @@ impl ReplicationContext {
         messages: Receiver<Message>,
     ) -> Result<Primary> {
         let snapshots = self.create_snapshot_watcher()?;
-        // TODO(bmuddha): remove dependency on the chainlink
         let _guard = self.scheduler.wait_for_idle().await;
+        // Account-bank reset is primary-readiness cleanup and is intentionally
+        // skipped during standby/replica startup. Run it only after primary
+        // work is idle and before exposing primary mode.
         self.chainlink.reset_accounts_bank()?;
         self.enter_primary_mode().await;
         Ok(Primary::new(self, producer, messages, snapshots))

--- a/magicblock-replicator/src/service/context.rs
+++ b/magicblock-replicator/src/service/context.rs
@@ -188,10 +188,13 @@ impl ReplicationContext {
     }
 
     /// Runs the standby start sequence.
-    async fn run_standby_start_sequence(&self, reset: bool) -> Option<Consumer> {
+    async fn run_standby_start_sequence(
+        &self,
+        reset: bool,
+    ) -> Result<Option<Consumer>> {
         self.enter_replica_mode().await;
-        self.chainlink.disable();
-        self.create_consumer(reset).await
+        self.chainlink.disable().await?;
+        Ok(self.create_consumer(reset).await)
     }
 
     /// Transitions to primary role with the given producer.
@@ -217,7 +220,8 @@ impl ReplicationContext {
         messages: Receiver<Message>,
         reset: bool,
     ) -> Result<Option<Standby>> {
-        let Some(consumer) = self.run_standby_start_sequence(reset).await else {
+        let Some(consumer) = self.run_standby_start_sequence(reset).await?
+        else {
             return Ok(None);
         };
         let Some(watcher) = LockWatcher::new(&self.broker, &self.cancel).await

--- a/magicblock-replicator/src/service/context.rs
+++ b/magicblock-replicator/src/service/context.rs
@@ -49,10 +49,11 @@ where
     EnterPrimaryFuture: Future<Output = ()>,
     EnablePrimary: FnOnce() -> Result<()>,
 {
+    // Primary readiness order is intentional: first wait for the scheduler to
+    // become idle, then reset the account bank, then expose Primary mode, and
+    // finally enable the chainlink lifecycle. Reset is primary-readiness cleanup
+    // and is intentionally skipped during standby/replica startup.
     let _guard = wait_for_idle().await;
-    // Account-bank reset is primary-readiness cleanup and is intentionally
-    // skipped during standby/replica startup. Run it only after primary work is
-    // idle and before exposing primary mode or enabling the chainlink lifecycle.
     reset_bank()?;
     enter_primary().await;
     enable_primary()?;
@@ -232,6 +233,8 @@ impl ReplicationContext {
     }
 
     /// Transitions to primary role with the given producer.
+    /// Ordering: wait for scheduler idle, reset bank, switch to Primary mode,
+    /// then enable the chainlink lifecycle.
     pub async fn into_primary(
         self,
         producer: Producer,

--- a/magicblock-replicator/src/service/context.rs
+++ b/magicblock-replicator/src/service/context.rs
@@ -188,6 +188,7 @@ impl ReplicationContext {
         // work is idle and before exposing primary mode.
         self.chainlink.reset_accounts_bank()?;
         self.enter_primary_mode().await;
+        self.chainlink.enable_primary()?;
         Ok(Primary::new(self, producer, messages, snapshots))
     }
 
@@ -202,6 +203,7 @@ impl ReplicationContext {
         reset: bool,
     ) -> Result<Option<Standby>> {
         self.enter_replica_mode().await;
+        self.chainlink.disable();
         let Some(consumer) = self.create_consumer(reset).await else {
             return Ok(None);
         };

--- a/magicblock-replicator/src/service/context.rs
+++ b/magicblock-replicator/src/service/context.rs
@@ -299,10 +299,25 @@ impl ReplicationContext {
 async fn run_primary_readiness_sequence(
     ctx: &ReplicationContext,
 ) -> Result<()> {
-    let _guard = ctx.scheduler.wait_for_idle().await;
-    ctx.chainlink.reset_accounts_bank().map_err(Error::from)?;
-    ctx.chainlink.enable_primary().await.map_err(Error::from)?;
-    ctx.enter_primary_mode().await
+    run_primary_readiness_sequence_with(
+        ctx.chainlink.as_ref(),
+        &ctx.scheduler,
+        &ctx.mode_tx,
+    )
+    .await
+}
+
+async fn run_primary_readiness_sequence_with(
+    chainlink: &dyn PrimaryChainlink,
+    scheduler: &TransactionSchedulerHandle,
+    mode_tx: &Sender<SchedulerMode>,
+) -> Result<()> {
+    let _guard = scheduler.wait_for_idle().await;
+    chainlink.reset_accounts_bank().map_err(Error::from)?;
+    chainlink.enable_primary().await.map_err(Error::from)?;
+    mode_tx.send(SchedulerMode::Primary).await.map_err(|e| {
+        Error::Internal(format!("failed to enter primary mode: {e}"))
+    })
 }
 
 /// Runs the standby start sequence.
@@ -310,7 +325,163 @@ async fn run_standby_start_sequence(
     ctx: &ReplicationContext,
     reset: bool,
 ) -> Result<Option<Consumer>> {
-    ctx.enter_replica_mode().await?;
-    ctx.chainlink.disable().await.map_err(Error::from)?;
+    run_standby_start_sequence_with(ctx.chainlink.as_ref(), &ctx.mode_tx)
+        .await?;
     Ok(ctx.create_consumer(reset).await)
+}
+
+async fn run_standby_start_sequence_with(
+    chainlink: &dyn PrimaryChainlink,
+    mode_tx: &Sender<SchedulerMode>,
+) -> Result<()> {
+    mode_tx.send(SchedulerMode::Replica).await.map_err(|e| {
+        Error::Internal(format!("failed to enter replica mode: {e}"))
+    })?;
+    chainlink.disable().await.map_err(Error::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use magicblock_chainlink::errors::{ChainlinkError, ChainlinkResult};
+    use magicblock_core::link::{link, transactions::SchedulerMode};
+    use tokio::sync::mpsc;
+
+    use super::{
+        run_primary_readiness_sequence_with, run_standby_start_sequence_with,
+        PrimaryChainlink,
+    };
+
+    #[derive(Default)]
+    struct RecordingPrimaryChainlink {
+        calls: Arc<Mutex<Vec<&'static str>>>,
+        enable_primary_result: Mutex<Option<ChainlinkResult<()>>>,
+    }
+
+    impl RecordingPrimaryChainlink {
+        fn with_enable_primary_result(result: ChainlinkResult<()>) -> Self {
+            Self {
+                calls: Arc::default(),
+                enable_primary_result: Mutex::new(Some(result)),
+            }
+        }
+
+        fn recorded_calls(&self) -> Vec<&'static str> {
+            self.calls.lock().expect("calls lock poisoned").clone()
+        }
+    }
+
+    impl PrimaryChainlink for RecordingPrimaryChainlink {
+        fn reset_accounts_bank(
+            &self,
+        ) -> magicblock_accounts_db::AccountsDbResult<()> {
+            self.calls
+                .lock()
+                .expect("calls lock poisoned")
+                .push("reset_accounts_bank");
+            Ok(())
+        }
+
+        fn enable_primary<'a>(
+            &'a self,
+        ) -> std::pin::Pin<
+            Box<
+                dyn std::future::Future<Output = ChainlinkResult<()>>
+                    + Send
+                    + 'a,
+            >,
+        > {
+            Box::pin(async move {
+                self.calls
+                    .lock()
+                    .expect("calls lock poisoned")
+                    .push("enable_primary");
+                self.enable_primary_result
+                    .lock()
+                    .expect("enable_primary_result lock poisoned")
+                    .take()
+                    .unwrap_or(Ok(()))
+            })
+        }
+
+        fn disable<'a>(
+            &'a self,
+        ) -> std::pin::Pin<
+            Box<
+                dyn std::future::Future<Output = ChainlinkResult<()>>
+                    + Send
+                    + 'a,
+            >,
+        > {
+            Box::pin(async move {
+                self.calls
+                    .lock()
+                    .expect("calls lock poisoned")
+                    .push("disable");
+                Ok(())
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn run_primary_readiness_sequence_enables_chainlink_before_primary_mode(
+    ) {
+        let (dispatch, _validator) = link();
+        let (mode_tx, mut mode_rx) = mpsc::channel(1);
+        let chainlink = RecordingPrimaryChainlink::default();
+
+        run_primary_readiness_sequence_with(
+            &chainlink,
+            &dispatch.transaction_scheduler,
+            &mode_tx,
+        )
+        .await
+        .expect("primary readiness sequence should succeed");
+
+        assert_eq!(
+            chainlink.recorded_calls(),
+            vec!["reset_accounts_bank", "enable_primary"]
+        );
+        assert_eq!(mode_rx.try_recv(), Ok(SchedulerMode::Primary));
+    }
+
+    #[tokio::test]
+    async fn run_standby_start_sequence_disables_chainlink_after_replica_mode()
+    {
+        let (mode_tx, mut mode_rx) = mpsc::channel(1);
+        let chainlink = RecordingPrimaryChainlink::default();
+
+        run_standby_start_sequence_with(&chainlink, &mode_tx)
+            .await
+            .expect("standby start sequence should succeed");
+
+        assert_eq!(mode_rx.try_recv(), Ok(SchedulerMode::Replica));
+        assert_eq!(chainlink.recorded_calls(), vec!["disable"]);
+    }
+
+    #[tokio::test]
+    async fn run_primary_readiness_sequence_does_not_publish_primary_when_chainlink_enable_fails(
+    ) {
+        let (dispatch, _validator) = link();
+        let (mode_tx, mut mode_rx) = mpsc::channel(1);
+        let chainlink = RecordingPrimaryChainlink::with_enable_primary_result(
+            Err(ChainlinkError::MissingPrimaryRuntimeBuildConfig),
+        );
+
+        let err = run_primary_readiness_sequence_with(
+            &chainlink,
+            &dispatch.transaction_scheduler,
+            &mode_tx,
+        )
+        .await
+        .expect_err("primary readiness sequence should fail");
+
+        assert!(matches!(err, crate::Error::Chainlink(_)));
+        assert_eq!(
+            chainlink.recorded_calls(),
+            vec!["reset_accounts_bank", "enable_primary"]
+        );
+        assert!(mode_rx.try_recv().is_err());
+    }
 }

--- a/magicblock-replicator/src/service/context.rs
+++ b/magicblock-replicator/src/service/context.rs
@@ -1,6 +1,6 @@
 //! Shared context for primary and standby roles.
 
-use std::sync::Arc;
+use std::{future::Future, sync::Arc};
 
 use machineid_rs::IdBuilder;
 use magicblock_accounts_db::AccountsDb;
@@ -175,38 +175,25 @@ impl ReplicationContext {
         }
     }
 
-    /// Runs the primary readiness sequence.
-    /// Ordering: wait for scheduler idle, reset bank, switch to Primary mode,
-    /// then enable the chainlink lifecycle. Reset is primary-readiness cleanup
-    /// and is intentionally skipped during standby/replica startup.
-    async fn run_primary_readiness_sequence(&self) -> Result<()> {
-        let _guard = self.scheduler.wait_for_idle().await;
-        self.chainlink.reset_accounts_bank()?;
-        self.enter_primary_mode().await;
-        self.chainlink.enable_primary().await?;
-        Ok(())
-    }
-
-    /// Runs the standby start sequence.
-    async fn run_standby_start_sequence(
-        &self,
-        reset: bool,
-    ) -> Result<Option<Consumer>> {
-        self.enter_replica_mode().await;
-        self.chainlink.disable().await?;
-        Ok(self.create_consumer(reset).await)
-    }
-
     /// Transitions to primary role with the given producer.
-    /// Ordering: wait for scheduler idle, reset bank, switch to Primary mode,
-    /// then enable the chainlink lifecycle.
+    /// Ordering: wait for scheduler idle, reset bank, enable the chainlink
+    /// lifecycle, then switch to Primary mode. Reset is primary-readiness
+    /// cleanup and is intentionally skipped during standby/replica startup.
     pub async fn into_primary(
         self,
         producer: Producer,
         messages: Receiver<Message>,
     ) -> Result<Primary> {
         let snapshots = self.create_snapshot_watcher()?;
-        self.run_primary_readiness_sequence().await?;
+        run_primary_readiness_sequence(
+            || self.scheduler.wait_for_idle(),
+            || self.chainlink.reset_accounts_bank().map_err(Into::into),
+            || async {
+                self.chainlink.enable_primary().await.map_err(Into::into)
+            },
+            || self.enter_primary_mode(),
+        )
+        .await?;
         Ok(Primary::new(self, producer, messages, snapshots))
     }
 
@@ -220,7 +207,12 @@ impl ReplicationContext {
         messages: Receiver<Message>,
         reset: bool,
     ) -> Result<Option<Standby>> {
-        let Some(consumer) = self.run_standby_start_sequence(reset).await?
+        let Some(consumer) = run_standby_start_sequence(
+            || self.enter_replica_mode(),
+            || async { self.chainlink.disable().await.map_err(Into::into) },
+            || self.create_consumer(reset),
+        )
+        .await?
         else {
             return Ok(None);
         };
@@ -234,5 +226,165 @@ impl ReplicationContext {
             messages,
             watcher,
         )))
+    }
+}
+
+/// Runs the primary readiness sequence.
+async fn run_primary_readiness_sequence<
+    WaitForIdle,
+    WaitForIdleFuture,
+    IdleGuard,
+    ResetBank,
+    EnablePrimary,
+    EnablePrimaryFuture,
+    EnterPrimary,
+    EnterPrimaryFuture,
+>(
+    wait_for_idle: WaitForIdle,
+    reset_bank: ResetBank,
+    enable_primary: EnablePrimary,
+    enter_primary: EnterPrimary,
+) -> Result<()>
+where
+    WaitForIdle: FnOnce() -> WaitForIdleFuture,
+    WaitForIdleFuture: Future<Output = IdleGuard>,
+    ResetBank: FnOnce() -> Result<()>,
+    EnablePrimary: FnOnce() -> EnablePrimaryFuture,
+    EnablePrimaryFuture: Future<Output = Result<()>>,
+    EnterPrimary: FnOnce() -> EnterPrimaryFuture,
+    EnterPrimaryFuture: Future<Output = ()>,
+{
+    let _guard = wait_for_idle().await;
+    reset_bank()?;
+    enable_primary().await?;
+    enter_primary().await;
+    Ok(())
+}
+
+/// Runs the standby start sequence.
+async fn run_standby_start_sequence<
+    Consumer,
+    EnterReplica,
+    EnterReplicaFuture,
+    DisableChainlink,
+    DisableChainlinkFuture,
+    CreateConsumer,
+    CreateConsumerFuture,
+>(
+    enter_replica: EnterReplica,
+    disable_chainlink: DisableChainlink,
+    create_consumer: CreateConsumer,
+) -> Result<Option<Consumer>>
+where
+    EnterReplica: FnOnce() -> EnterReplicaFuture,
+    EnterReplicaFuture: Future<Output = ()>,
+    DisableChainlink: FnOnce() -> DisableChainlinkFuture,
+    DisableChainlinkFuture: Future<Output = Result<()>>,
+    CreateConsumer: FnOnce() -> CreateConsumerFuture,
+    CreateConsumerFuture: Future<Output = Option<Consumer>>,
+{
+    enter_replica().await;
+    disable_chainlink().await?;
+    Ok(create_consumer().await)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use super::*;
+
+    fn record(events: &Arc<Mutex<Vec<&'static str>>>, event: &'static str) {
+        events.lock().unwrap().push(event);
+    }
+
+    #[tokio::test]
+    async fn primary_readiness_sequence_orders_async_chainlink_before_primary_mode(
+    ) {
+        let events = Arc::new(Mutex::new(Vec::new()));
+
+        run_primary_readiness_sequence(
+            {
+                let events = Arc::clone(&events);
+                move || async move {
+                    record(&events, "wait_for_idle_started");
+                    record(&events, "wait_for_idle_completed");
+                }
+            },
+            {
+                let events = Arc::clone(&events);
+                move || {
+                    record(&events, "reset_accounts_bank");
+                    Ok(())
+                }
+            },
+            {
+                let events = Arc::clone(&events);
+                move || async move {
+                    record(&events, "enable_primary");
+                    Ok(())
+                }
+            },
+            {
+                let events = Arc::clone(&events);
+                move || async move {
+                    record(&events, "enter_primary_mode");
+                }
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            *events.lock().unwrap(),
+            vec![
+                "wait_for_idle_started",
+                "wait_for_idle_completed",
+                "reset_accounts_bank",
+                "enable_primary",
+                "enter_primary_mode",
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn standby_start_sequence_disables_chainlink_before_consumer_creation(
+    ) {
+        let events = Arc::new(Mutex::new(Vec::new()));
+
+        let consumer = run_standby_start_sequence(
+            {
+                let events = Arc::clone(&events);
+                move || async move {
+                    record(&events, "enter_replica_mode");
+                }
+            },
+            {
+                let events = Arc::clone(&events);
+                move || async move {
+                    record(&events, "disable_chainlink");
+                    Ok(())
+                }
+            },
+            {
+                let events = Arc::clone(&events);
+                move || async move {
+                    record(&events, "create_consumer_started");
+                    Some(())
+                }
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(consumer, Some(()));
+        assert_eq!(
+            *events.lock().unwrap(),
+            vec![
+                "enter_replica_mode",
+                "disable_chainlink",
+                "create_consumer_started",
+            ]
+        );
     }
 }

--- a/magicblock-replicator/src/service/context.rs
+++ b/magicblock-replicator/src/service/context.rs
@@ -201,6 +201,7 @@ impl ReplicationContext {
         messages: Receiver<Message>,
         reset: bool,
     ) -> Result<Option<Standby>> {
+        self.enter_replica_mode().await;
         let Some(consumer) = self.create_consumer(reset).await else {
             return Ok(None);
         };
@@ -208,7 +209,6 @@ impl ReplicationContext {
         else {
             return Ok(None);
         };
-        self.enter_replica_mode().await;
         Ok(Some(Standby::new(
             self,
             Box::new(consumer),

--- a/magicblock-replicator/src/service/context.rs
+++ b/magicblock-replicator/src/service/context.rs
@@ -183,7 +183,7 @@ impl ReplicationContext {
         let _guard = self.scheduler.wait_for_idle().await;
         self.chainlink.reset_accounts_bank()?;
         self.enter_primary_mode().await;
-        self.chainlink.enable_primary()?;
+        self.chainlink.enable_primary().await?;
         Ok(())
     }
 

--- a/magicblock-replicator/src/service/context.rs
+++ b/magicblock-replicator/src/service/context.rs
@@ -139,13 +139,23 @@ impl ReplicationContext {
     }
 
     /// Switches to replica mode.
-    pub async fn enter_replica_mode(&self) {
-        let _ = self.mode_tx.send(SchedulerMode::Replica).await;
+    pub async fn enter_replica_mode(&self) -> Result<()> {
+        self.mode_tx
+            .send(SchedulerMode::Replica)
+            .await
+            .map_err(|e| {
+                Error::Internal(format!("failed to enter replica mode: {e}"))
+            })
     }
 
     /// Switches to primary mode.
-    pub async fn enter_primary_mode(&self) {
-        let _ = self.mode_tx.send(SchedulerMode::Primary).await;
+    pub async fn enter_primary_mode(&self) -> Result<()> {
+        self.mode_tx
+            .send(SchedulerMode::Primary)
+            .await
+            .map_err(|e| {
+                Error::Internal(format!("failed to enter primary mode: {e}"))
+            })
     }
 
     /// Uploads snapshot.
@@ -252,13 +262,12 @@ where
     EnablePrimary: FnOnce() -> EnablePrimaryFuture,
     EnablePrimaryFuture: Future<Output = Result<()>>,
     EnterPrimary: FnOnce() -> EnterPrimaryFuture,
-    EnterPrimaryFuture: Future<Output = ()>,
+    EnterPrimaryFuture: Future<Output = Result<()>>,
 {
     let _guard = wait_for_idle().await;
     reset_bank()?;
     enable_primary().await?;
-    enter_primary().await;
-    Ok(())
+    enter_primary().await
 }
 
 /// Runs the standby start sequence.
@@ -277,13 +286,13 @@ async fn run_standby_start_sequence<
 ) -> Result<Option<Consumer>>
 where
     EnterReplica: FnOnce() -> EnterReplicaFuture,
-    EnterReplicaFuture: Future<Output = ()>,
+    EnterReplicaFuture: Future<Output = Result<()>>,
     DisableChainlink: FnOnce() -> DisableChainlinkFuture,
     DisableChainlinkFuture: Future<Output = Result<()>>,
     CreateConsumer: FnOnce() -> CreateConsumerFuture,
     CreateConsumerFuture: Future<Output = Option<Consumer>>,
 {
-    enter_replica().await;
+    enter_replica().await?;
     disable_chainlink().await?;
     Ok(create_consumer().await)
 }
@@ -331,6 +340,7 @@ mod tests {
                 let events = Arc::clone(&events);
                 move || async move {
                     record(&events, "enter_primary_mode");
+                    Ok(())
                 }
             },
         )
@@ -380,6 +390,7 @@ mod tests {
                 let events = Arc::clone(&events);
                 move || async move {
                     record(&events, "enter_primary_mode");
+                    Ok(())
                 }
             },
         )
@@ -400,6 +411,44 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn primary_readiness_sequence_propagates_primary_mode_failure() {
+        let result = run_primary_readiness_sequence(
+            || async {},
+            || Ok(()),
+            || async { Ok(()) },
+            || async { Err(Error::Internal("mode send failed".to_string())) },
+        )
+        .await;
+
+        assert!(
+            matches!(result, Err(Error::Internal(message)) if message == "mode send failed")
+        );
+    }
+
+    #[tokio::test]
+    async fn standby_start_sequence_propagates_replica_mode_failure() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+
+        let result = run_standby_start_sequence(
+            || async { Err(Error::Internal("mode send failed".to_string())) },
+            {
+                let events = Arc::clone(&events);
+                move || async move {
+                    record(&events, "disable_chainlink");
+                    Ok(())
+                }
+            },
+            || async { Some(()) },
+        )
+        .await;
+
+        assert!(
+            matches!(result, Err(Error::Internal(message)) if message == "mode send failed")
+        );
+        assert!(events.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
     async fn standby_start_sequence_disables_chainlink_before_consumer_creation(
     ) {
         let events = Arc::new(Mutex::new(Vec::new()));
@@ -409,6 +458,7 @@ mod tests {
                 let events = Arc::clone(&events);
                 move || async move {
                     record(&events, "enter_replica_mode");
+                    Ok(())
                 }
             },
             {
@@ -454,6 +504,7 @@ mod tests {
                         let events = Arc::clone(&events);
                         move || async move {
                             record(&events, "enter_replica_mode");
+                            Ok(())
                         }
                     },
                     {

--- a/magicblock-replicator/src/service/context.rs
+++ b/magicblock-replicator/src/service/context.rs
@@ -1,10 +1,9 @@
 //! Shared context for primary and standby roles.
 
-use std::{future::Future, sync::Arc};
+use std::{future::Future, pin::Pin, sync::Arc};
 
 use machineid_rs::IdBuilder;
 use magicblock_accounts_db::AccountsDb;
-use magicblock_chainlink::{AccountsBankReset, ChainlinkPrimaryLifecycle};
 use magicblock_core::{
     link::{
         replication::{Block, Message, SuperBlock},
@@ -18,7 +17,7 @@ use tokio::{
     sync::mpsc::{Receiver, Sender},
 };
 use tokio_util::sync::CancellationToken;
-use tracing::{error, info};
+use tracing::info;
 
 use super::{Primary, Standby, CONSUMER_RETRY_DELAY};
 use crate::{
@@ -26,6 +25,78 @@ use crate::{
     watcher::SnapshotWatcher,
     Error, Result,
 };
+
+/// Narrow Chainlink lifecycle surface needed by replication.
+pub trait PrimaryChainlink: Send + Sync {
+    fn reset_accounts_bank(
+        &self,
+    ) -> magicblock_accounts_db::AccountsDbResult<()>;
+
+    fn enable_primary<'a>(
+        &'a self,
+    ) -> Pin<
+        Box<
+            dyn Future<
+                    Output = magicblock_chainlink::errors::ChainlinkResult<()>,
+                > + Send
+                + 'a,
+        >,
+    >;
+
+    fn disable<'a>(
+        &'a self,
+    ) -> Pin<
+        Box<
+            dyn Future<
+                    Output = magicblock_chainlink::errors::ChainlinkResult<()>,
+                > + Send
+                + 'a,
+        >,
+    >;
+}
+
+impl<C> PrimaryChainlink
+    for magicblock_chainlink::Chainlink<
+        magicblock_chainlink::remote_account_provider::chain_rpc_client::ChainRpcClientImpl,
+        magicblock_chainlink::submux::SubMuxClient<
+            magicblock_chainlink::remote_account_provider::chain_updates_client::ChainUpdatesClient,
+        >,
+        AccountsDb,
+        C,
+    >
+where
+    C: magicblock_chainlink::cloner::Cloner + Send + Sync + 'static,
+{
+    fn reset_accounts_bank(&self) -> magicblock_accounts_db::AccountsDbResult<()> {
+        self.reset_accounts_bank()
+    }
+
+    fn enable_primary<'a>(
+        &'a self,
+    ) -> Pin<
+        Box<
+            dyn Future<Output = magicblock_chainlink::errors::ChainlinkResult<()>>
+                + Send
+                + 'a,
+        >,
+    > {
+        Box::pin(async move {
+            self.enable_primary().await.map(|_| ())
+        })
+    }
+
+    fn disable<'a>(
+        &'a self,
+    ) -> Pin<
+        Box<
+            dyn Future<Output = magicblock_chainlink::errors::ChainlinkResult<()>>
+                + Send
+                + 'a,
+        >,
+    > {
+        Box::pin(self.disable())
+    }
+}
 
 /// Shared state for both primary and standby roles.
 pub struct ReplicationContext {
@@ -39,10 +110,8 @@ pub struct ReplicationContext {
     pub mode_tx: Sender<SchedulerMode>,
     /// Accounts database.
     pub accountsdb: Arc<AccountsDb>,
-    /// Reset-only Chainlink cleanup handle for accounts bank readiness.
-    pub accounts_bank_reset: Arc<dyn AccountsBankReset>,
-    /// Real Chainlink primary lifecycle handle for promotable contexts.
-    pub primary_chainlink: Option<Arc<dyn ChainlinkPrimaryLifecycle>>,
+    /// Real RPC-facing Chainlink primary-readiness handle.
+    pub chainlink: Arc<dyn PrimaryChainlink>,
     /// Transaction ledger.
     pub ledger: Arc<Ledger>,
     /// Transaction scheduler.
@@ -63,8 +132,7 @@ impl ReplicationContext {
         mode_tx: Sender<SchedulerMode>,
         accountsdb: Arc<AccountsDb>,
         ledger: Arc<Ledger>,
-        accounts_bank_reset: Arc<dyn AccountsBankReset>,
-        primary_chainlink: Option<Arc<dyn ChainlinkPrimaryLifecycle>>,
+        chainlink: Arc<dyn PrimaryChainlink>,
         scheduler: TransactionSchedulerHandle,
         cancel: CancellationToken,
         can_promote: bool,
@@ -73,12 +141,6 @@ impl ReplicationContext {
             .add_component(machineid_rs::HWIDComponent::SystemID)
             .build("magicblock")
             .map_err(|e| Error::Internal(e.to_string()))?;
-
-        if can_promote && primary_chainlink.is_none() {
-            return Err(Error::Internal(
-                "promotable replication context requires a primary Chainlink lifecycle handle".to_string(),
-            ));
-        }
 
         let slot = accountsdb.slot();
         let index = ledger
@@ -92,8 +154,7 @@ impl ReplicationContext {
             cancel,
             mode_tx,
             accountsdb,
-            accounts_bank_reset,
-            primary_chainlink,
+            chainlink,
             ledger,
             scheduler,
             slot,
@@ -238,56 +299,10 @@ impl ReplicationContext {
 async fn run_primary_readiness_sequence(
     ctx: &ReplicationContext,
 ) -> Result<()> {
-    run_primary_readiness_sequence_with_hooks(
-        || ctx.scheduler.wait_for_idle(),
-        ctx.accounts_bank_reset.as_ref(),
-        ctx.primary_chainlink.as_deref(),
-        || ctx.enter_primary_mode(),
-    )
-    .await
-}
-
-async fn run_primary_readiness_sequence_with_hooks<
-    WaitForIdle,
-    WaitFut,
-    IdleGuard,
-    EnterPrimary,
-    EnterPrimaryFut,
->(
-    wait_for_idle: WaitForIdle,
-    accounts_bank_reset: &dyn AccountsBankReset,
-    primary_chainlink: Option<&dyn ChainlinkPrimaryLifecycle>,
-    enter_primary: EnterPrimary,
-) -> Result<()>
-where
-    WaitForIdle: FnOnce() -> WaitFut,
-    WaitFut: Future<Output = IdleGuard>,
-    EnterPrimary: FnOnce() -> EnterPrimaryFut,
-    EnterPrimaryFut: Future<Output = Result<()>>,
-{
-    let _guard = wait_for_idle().await;
-    accounts_bank_reset
-        .reset_accounts_bank()
-        .map_err(Error::from)?;
-    let primary_chainlink = primary_chainlink.ok_or_else(|| {
-        Error::Internal(
-            "primary Chainlink lifecycle handle is unavailable".to_string(),
-        )
-    })?;
-    primary_chainlink
-        .enable_primary()
-        .await
-        .map_err(Error::from)?;
-    if let Err(scheduler_mode_error) = enter_primary().await {
-        if let Err(rollback_error) = primary_chainlink.disable().await {
-            error!(
-                %rollback_error,
-                "Failed to roll back Chainlink primary enable after scheduler primary mode failed"
-            );
-        }
-        return Err(scheduler_mode_error);
-    }
-    Ok(())
+    let _guard = ctx.scheduler.wait_for_idle().await;
+    ctx.chainlink.reset_accounts_bank().map_err(Error::from)?;
+    ctx.chainlink.enable_primary().await.map_err(Error::from)?;
+    ctx.enter_primary_mode().await
 }
 
 /// Runs the standby start sequence.
@@ -295,267 +310,7 @@ async fn run_standby_start_sequence(
     ctx: &ReplicationContext,
     reset: bool,
 ) -> Result<Option<Consumer>> {
-    run_standby_lifecycle_sequence_with_hooks(
-        ctx.primary_chainlink.as_deref(),
-        || ctx.enter_replica_mode(),
-    )
-    .await?;
+    ctx.enter_replica_mode().await?;
+    ctx.chainlink.disable().await.map_err(Error::from)?;
     Ok(ctx.create_consumer(reset).await)
-}
-
-async fn run_standby_lifecycle_sequence_with_hooks<
-    EnterReplica,
-    EnterReplicaFut,
->(
-    primary_chainlink: Option<&dyn ChainlinkPrimaryLifecycle>,
-    enter_replica: EnterReplica,
-) -> Result<()>
-where
-    EnterReplica: FnOnce() -> EnterReplicaFut,
-    EnterReplicaFut: Future<Output = Result<()>>,
-{
-    enter_replica().await?;
-    if let Some(primary_chainlink) = primary_chainlink {
-        primary_chainlink.disable().await.map_err(Error::from)?;
-    }
-    Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use std::sync::{Arc, Mutex};
-
-    use magicblock_accounts_db::AccountsDbResult;
-    use magicblock_chainlink::{
-        errors::{ChainlinkError, ChainlinkResult},
-        ChainlinkPrimaryEnablement,
-    };
-
-    use super::*;
-
-    #[derive(Clone)]
-    struct RecordingReset {
-        events: Arc<Mutex<Vec<&'static str>>>,
-    }
-
-    impl AccountsBankReset for RecordingReset {
-        fn reset_accounts_bank(&self) -> AccountsDbResult<()> {
-            self.events.lock().unwrap().push("reset");
-            Ok(())
-        }
-    }
-
-    struct RecordingPrimaryChainlink {
-        events: Arc<Mutex<Vec<&'static str>>>,
-        enable_error: bool,
-    }
-
-    #[async_trait::async_trait]
-    impl ChainlinkPrimaryLifecycle for RecordingPrimaryChainlink {
-        async fn enable_primary(
-            &self,
-        ) -> ChainlinkResult<ChainlinkPrimaryEnablement> {
-            self.events.lock().unwrap().push("enable");
-            if self.enable_error {
-                Err(ChainlinkError::MissingPrimaryRuntimeBuildConfig)
-            } else {
-                Ok(ChainlinkPrimaryEnablement::Active)
-            }
-        }
-
-        async fn disable(&self) -> ChainlinkResult<()> {
-            self.events.lock().unwrap().push("disable");
-            Ok(())
-        }
-    }
-
-    fn events() -> Arc<Mutex<Vec<&'static str>>> {
-        Arc::new(Mutex::new(Vec::new()))
-    }
-
-    fn reset(events: Arc<Mutex<Vec<&'static str>>>) -> RecordingReset {
-        RecordingReset { events }
-    }
-
-    fn chainlink(
-        events: Arc<Mutex<Vec<&'static str>>>,
-    ) -> RecordingPrimaryChainlink {
-        RecordingPrimaryChainlink {
-            events,
-            enable_error: false,
-        }
-    }
-
-    fn failing_chainlink(
-        events: Arc<Mutex<Vec<&'static str>>>,
-    ) -> RecordingPrimaryChainlink {
-        RecordingPrimaryChainlink {
-            events,
-            enable_error: true,
-        }
-    }
-
-    fn recorded_events(
-        events: &Arc<Mutex<Vec<&'static str>>>,
-    ) -> Vec<&'static str> {
-        events.lock().unwrap().clone()
-    }
-
-    #[tokio::test]
-    async fn primary_readiness_waits_resets_enables_then_publishes_primary() {
-        let events = events();
-        let reset = reset(events.clone());
-        let chainlink = chainlink(events.clone());
-
-        run_primary_readiness_sequence_with_hooks(
-            || {
-                let events = events.clone();
-                async move {
-                    events.lock().unwrap().push("idle");
-                }
-            },
-            &reset,
-            Some(&chainlink),
-            || {
-                let events = events.clone();
-                async move {
-                    events.lock().unwrap().push("primary");
-                    Ok(())
-                }
-            },
-        )
-        .await
-        .unwrap();
-
-        assert_eq!(
-            recorded_events(&events),
-            vec!["idle", "reset", "enable", "primary"]
-        );
-    }
-
-    #[tokio::test]
-    async fn primary_readiness_enable_failure_does_not_publish_primary() {
-        let events = events();
-        let reset = reset(events.clone());
-        let chainlink = failing_chainlink(events.clone());
-
-        let result = run_primary_readiness_sequence_with_hooks(
-            || {
-                let events = events.clone();
-                async move {
-                    events.lock().unwrap().push("idle");
-                }
-            },
-            &reset,
-            Some(&chainlink),
-            || {
-                let events = events.clone();
-                async move {
-                    events.lock().unwrap().push("primary");
-                    Ok(())
-                }
-            },
-        )
-        .await;
-
-        assert!(matches!(result, Err(Error::Chainlink(_))));
-        assert_eq!(recorded_events(&events), vec!["idle", "reset", "enable"]);
-    }
-
-    #[tokio::test]
-    async fn primary_readiness_missing_lifecycle_handle_does_not_publish_primary(
-    ) {
-        let events = events();
-        let reset = reset(events.clone());
-
-        let result = run_primary_readiness_sequence_with_hooks(
-            || {
-                let events = events.clone();
-                async move {
-                    events.lock().unwrap().push("idle");
-                }
-            },
-            &reset,
-            None,
-            || {
-                let events = events.clone();
-                async move {
-                    events.lock().unwrap().push("primary");
-                    Ok(())
-                }
-            },
-        )
-        .await;
-
-        assert!(matches!(result, Err(Error::Internal(_))));
-        assert_eq!(recorded_events(&events), vec!["idle", "reset"]);
-    }
-
-    #[tokio::test]
-    async fn primary_readiness_rolls_back_chainlink_when_primary_publish_fails()
-    {
-        let events = events();
-        let reset = reset(events.clone());
-        let chainlink = chainlink(events.clone());
-
-        let result = run_primary_readiness_sequence_with_hooks(
-            || {
-                let events = events.clone();
-                async move {
-                    events.lock().unwrap().push("idle");
-                }
-            },
-            &reset,
-            Some(&chainlink),
-            || {
-                let events = events.clone();
-                async move {
-                    events.lock().unwrap().push("primary");
-                    Err(Error::Internal("publish failed".to_string()))
-                }
-            },
-        )
-        .await;
-
-        assert!(matches!(result, Err(Error::Internal(_))));
-        assert_eq!(
-            recorded_events(&events),
-            vec!["idle", "reset", "enable", "primary", "disable"]
-        );
-    }
-
-    #[tokio::test]
-    async fn standby_lifecycle_enters_replica_before_disabling_chainlink() {
-        let events = events();
-        let chainlink = chainlink(events.clone());
-
-        run_standby_lifecycle_sequence_with_hooks(Some(&chainlink), || {
-            let events = events.clone();
-            async move {
-                events.lock().unwrap().push("replica");
-                Ok(())
-            }
-        })
-        .await
-        .unwrap();
-
-        assert_eq!(recorded_events(&events), vec!["replica", "disable"]);
-    }
-
-    #[tokio::test]
-    async fn standby_lifecycle_replica_only_skips_real_chainlink_disable() {
-        let events = events();
-
-        run_standby_lifecycle_sequence_with_hooks(None, || {
-            let events = events.clone();
-            async move {
-                events.lock().unwrap().push("replica");
-                Ok(())
-            }
-        })
-        .await
-        .unwrap();
-
-        assert_eq!(recorded_events(&events), vec!["replica"]);
-    }
 }

--- a/magicblock-replicator/src/service/context.rs
+++ b/magicblock-replicator/src/service/context.rs
@@ -1,6 +1,6 @@
 //! Shared context for primary and standby roles.
 
-use std::{future::Future, sync::Arc};
+use std::sync::Arc;
 
 use machineid_rs::IdBuilder;
 use magicblock_accounts_db::AccountsDb;
@@ -195,15 +195,7 @@ impl ReplicationContext {
         messages: Receiver<Message>,
     ) -> Result<Primary> {
         let snapshots = self.create_snapshot_watcher()?;
-        run_primary_readiness_sequence(
-            || self.scheduler.wait_for_idle(),
-            || self.chainlink.reset_accounts_bank().map_err(Into::into),
-            || async {
-                self.chainlink.enable_primary().await.map_err(Into::into)
-            },
-            || self.enter_primary_mode(),
-        )
-        .await?;
+        run_primary_readiness_sequence(&self).await?;
         Ok(Primary::new(self, producer, messages, snapshots))
     }
 
@@ -217,12 +209,7 @@ impl ReplicationContext {
         messages: Receiver<Message>,
         reset: bool,
     ) -> Result<Option<Standby>> {
-        let Some(consumer) = run_standby_start_sequence(
-            || self.enter_replica_mode(),
-            || async { self.chainlink.disable().await.map_err(Into::into) },
-            || self.create_consumer(reset),
-        )
-        .await?
+        let Some(consumer) = run_standby_start_sequence(&self, reset).await?
         else {
             return Ok(None);
         };
@@ -240,313 +227,21 @@ impl ReplicationContext {
 }
 
 /// Runs the primary readiness sequence.
-async fn run_primary_readiness_sequence<
-    WaitForIdle,
-    WaitForIdleFuture,
-    IdleGuard,
-    ResetBank,
-    EnablePrimary,
-    EnablePrimaryFuture,
-    EnterPrimary,
-    EnterPrimaryFuture,
->(
-    wait_for_idle: WaitForIdle,
-    reset_bank: ResetBank,
-    enable_primary: EnablePrimary,
-    enter_primary: EnterPrimary,
-) -> Result<()>
-where
-    WaitForIdle: FnOnce() -> WaitForIdleFuture,
-    WaitForIdleFuture: Future<Output = IdleGuard>,
-    ResetBank: FnOnce() -> Result<()>,
-    EnablePrimary: FnOnce() -> EnablePrimaryFuture,
-    EnablePrimaryFuture: Future<Output = Result<()>>,
-    EnterPrimary: FnOnce() -> EnterPrimaryFuture,
-    EnterPrimaryFuture: Future<Output = Result<()>>,
-{
-    let _guard = wait_for_idle().await;
-    reset_bank()?;
-    enable_primary().await?;
-    enter_primary().await
+async fn run_primary_readiness_sequence(
+    ctx: &ReplicationContext,
+) -> Result<()> {
+    let _guard = ctx.scheduler.wait_for_idle().await;
+    ctx.chainlink.reset_accounts_bank().map_err(Error::from)?;
+    ctx.chainlink.enable_primary().await.map_err(Error::from)?;
+    ctx.enter_primary_mode().await
 }
 
 /// Runs the standby start sequence.
-async fn run_standby_start_sequence<
-    Consumer,
-    EnterReplica,
-    EnterReplicaFuture,
-    DisableChainlink,
-    DisableChainlinkFuture,
-    CreateConsumer,
-    CreateConsumerFuture,
->(
-    enter_replica: EnterReplica,
-    disable_chainlink: DisableChainlink,
-    create_consumer: CreateConsumer,
-) -> Result<Option<Consumer>>
-where
-    EnterReplica: FnOnce() -> EnterReplicaFuture,
-    EnterReplicaFuture: Future<Output = Result<()>>,
-    DisableChainlink: FnOnce() -> DisableChainlinkFuture,
-    DisableChainlinkFuture: Future<Output = Result<()>>,
-    CreateConsumer: FnOnce() -> CreateConsumerFuture,
-    CreateConsumerFuture: Future<Output = Option<Consumer>>,
-{
-    enter_replica().await?;
-    disable_chainlink().await?;
-    Ok(create_consumer().await)
-}
-
-#[cfg(test)]
-mod tests {
-    use std::sync::{Arc, Mutex};
-
-    use tokio::sync::oneshot;
-
-    use super::*;
-
-    fn record(events: &Arc<Mutex<Vec<&'static str>>>, event: &'static str) {
-        events.lock().unwrap().push(event);
-    }
-
-    #[tokio::test]
-    async fn primary_readiness_sequence_orders_async_chainlink_before_primary_mode(
-    ) {
-        let events = Arc::new(Mutex::new(Vec::new()));
-
-        run_primary_readiness_sequence(
-            {
-                let events = Arc::clone(&events);
-                move || async move {
-                    record(&events, "wait_for_idle_started");
-                    record(&events, "wait_for_idle_completed");
-                }
-            },
-            {
-                let events = Arc::clone(&events);
-                move || {
-                    record(&events, "reset_accounts_bank");
-                    Ok(())
-                }
-            },
-            {
-                let events = Arc::clone(&events);
-                move || async move {
-                    record(&events, "enable_primary");
-                    Ok(())
-                }
-            },
-            {
-                let events = Arc::clone(&events);
-                move || async move {
-                    record(&events, "enter_primary_mode");
-                    Ok(())
-                }
-            },
-        )
-        .await
-        .unwrap();
-
-        assert_eq!(
-            *events.lock().unwrap(),
-            vec![
-                "wait_for_idle_started",
-                "wait_for_idle_completed",
-                "reset_accounts_bank",
-                "enable_primary",
-                "enter_primary_mode",
-            ]
-        );
-    }
-
-    #[tokio::test]
-    async fn primary_readiness_sequence_skips_primary_mode_when_chainlink_fails(
-    ) {
-        let events = Arc::new(Mutex::new(Vec::new()));
-
-        let result = run_primary_readiness_sequence(
-            {
-                let events = Arc::clone(&events);
-                move || async move {
-                    record(&events, "wait_for_idle_started");
-                    record(&events, "wait_for_idle_completed");
-                }
-            },
-            {
-                let events = Arc::clone(&events);
-                move || {
-                    record(&events, "reset_accounts_bank");
-                    Ok(())
-                }
-            },
-            {
-                let events = Arc::clone(&events);
-                move || async move {
-                    record(&events, "enable_primary");
-                    Err(Error::Internal("chainlink failed".to_string()))
-                }
-            },
-            {
-                let events = Arc::clone(&events);
-                move || async move {
-                    record(&events, "enter_primary_mode");
-                    Ok(())
-                }
-            },
-        )
-        .await;
-
-        assert!(
-            matches!(result, Err(Error::Internal(message)) if message == "chainlink failed")
-        );
-        assert_eq!(
-            *events.lock().unwrap(),
-            vec![
-                "wait_for_idle_started",
-                "wait_for_idle_completed",
-                "reset_accounts_bank",
-                "enable_primary",
-            ]
-        );
-    }
-
-    #[tokio::test]
-    async fn primary_readiness_sequence_propagates_primary_mode_failure() {
-        let result = run_primary_readiness_sequence(
-            || async {},
-            || Ok(()),
-            || async { Ok(()) },
-            || async { Err(Error::Internal("mode send failed".to_string())) },
-        )
-        .await;
-
-        assert!(
-            matches!(result, Err(Error::Internal(message)) if message == "mode send failed")
-        );
-    }
-
-    #[tokio::test]
-    async fn standby_start_sequence_propagates_replica_mode_failure() {
-        let events = Arc::new(Mutex::new(Vec::new()));
-
-        let result = run_standby_start_sequence(
-            || async { Err(Error::Internal("mode send failed".to_string())) },
-            {
-                let events = Arc::clone(&events);
-                move || async move {
-                    record(&events, "disable_chainlink");
-                    Ok(())
-                }
-            },
-            || async { Some(()) },
-        )
-        .await;
-
-        assert!(
-            matches!(result, Err(Error::Internal(message)) if message == "mode send failed")
-        );
-        assert!(events.lock().unwrap().is_empty());
-    }
-
-    #[tokio::test]
-    async fn standby_start_sequence_disables_chainlink_before_consumer_creation(
-    ) {
-        let events = Arc::new(Mutex::new(Vec::new()));
-
-        let consumer = run_standby_start_sequence(
-            {
-                let events = Arc::clone(&events);
-                move || async move {
-                    record(&events, "enter_replica_mode");
-                    Ok(())
-                }
-            },
-            {
-                let events = Arc::clone(&events);
-                move || async move {
-                    record(&events, "disable_chainlink");
-                    Ok(())
-                }
-            },
-            {
-                let events = Arc::clone(&events);
-                move || async move {
-                    record(&events, "create_consumer_started");
-                    Some(())
-                }
-            },
-        )
-        .await
-        .unwrap();
-
-        assert_eq!(consumer, Some(()));
-        assert_eq!(
-            *events.lock().unwrap(),
-            vec![
-                "enter_replica_mode",
-                "disable_chainlink",
-                "create_consumer_started",
-            ]
-        );
-    }
-
-    #[tokio::test]
-    async fn standby_start_sequence_waits_for_chainlink_disable_to_complete() {
-        let events = Arc::new(Mutex::new(Vec::new()));
-        let (disable_started_tx, disable_started_rx) = oneshot::channel();
-        let (finish_disable_tx, finish_disable_rx) = oneshot::channel();
-
-        let sequence = tokio::spawn({
-            let events = Arc::clone(&events);
-            async move {
-                run_standby_start_sequence(
-                    {
-                        let events = Arc::clone(&events);
-                        move || async move {
-                            record(&events, "enter_replica_mode");
-                            Ok(())
-                        }
-                    },
-                    {
-                        let events = Arc::clone(&events);
-                        move || async move {
-                            record(&events, "disable_chainlink_started");
-                            disable_started_tx.send(()).unwrap();
-                            finish_disable_rx.await.unwrap();
-                            record(&events, "disable_chainlink_completed");
-                            Ok(())
-                        }
-                    },
-                    {
-                        let events = Arc::clone(&events);
-                        move || async move {
-                            record(&events, "create_consumer_started");
-                            Some(())
-                        }
-                    },
-                )
-                .await
-            }
-        });
-
-        disable_started_rx.await.unwrap();
-        assert_eq!(
-            *events.lock().unwrap(),
-            vec!["enter_replica_mode", "disable_chainlink_started"]
-        );
-
-        finish_disable_tx.send(()).unwrap();
-        let consumer = sequence.await.unwrap().unwrap();
-
-        assert_eq!(consumer, Some(()));
-        assert_eq!(
-            *events.lock().unwrap(),
-            vec![
-                "enter_replica_mode",
-                "disable_chainlink_started",
-                "disable_chainlink_completed",
-                "create_consumer_started",
-            ]
-        );
-    }
+async fn run_standby_start_sequence(
+    ctx: &ReplicationContext,
+    reset: bool,
+) -> Result<Option<Consumer>> {
+    ctx.enter_replica_mode().await?;
+    ctx.chainlink.disable().await.map_err(Error::from)?;
+    Ok(ctx.create_consumer(reset).await)
 }

--- a/magicblock-replicator/src/service/context.rs
+++ b/magicblock-replicator/src/service/context.rs
@@ -1,6 +1,6 @@
 //! Shared context for primary and standby roles.
 
-use std::sync::Arc;
+use std::{future::Future, sync::Arc};
 
 use machineid_rs::IdBuilder;
 use magicblock_accounts_db::AccountsDb;
@@ -26,6 +26,62 @@ use crate::{
     watcher::SnapshotWatcher,
     Error, Result,
 };
+
+async fn run_primary_readiness_sequence<
+    Guard,
+    WaitForIdle,
+    WaitForIdleFuture,
+    ResetBank,
+    EnterPrimary,
+    EnterPrimaryFuture,
+    EnablePrimary,
+>(
+    wait_for_idle: WaitForIdle,
+    reset_bank: ResetBank,
+    enter_primary: EnterPrimary,
+    enable_primary: EnablePrimary,
+) -> Result<()>
+where
+    WaitForIdle: FnOnce() -> WaitForIdleFuture,
+    WaitForIdleFuture: Future<Output = Guard>,
+    ResetBank: FnOnce() -> Result<()>,
+    EnterPrimary: FnOnce() -> EnterPrimaryFuture,
+    EnterPrimaryFuture: Future<Output = ()>,
+    EnablePrimary: FnOnce() -> Result<()>,
+{
+    let _guard = wait_for_idle().await;
+    // Account-bank reset is primary-readiness cleanup and is intentionally
+    // skipped during standby/replica startup. Run it only after primary work is
+    // idle and before exposing primary mode or enabling the chainlink lifecycle.
+    reset_bank()?;
+    enter_primary().await;
+    enable_primary()?;
+    Ok(())
+}
+
+async fn run_standby_start_sequence<
+    Consumer,
+    EnterReplica,
+    EnterReplicaFuture,
+    DisableChainlink,
+    CreateConsumer,
+    CreateConsumerFuture,
+>(
+    enter_replica: EnterReplica,
+    disable_chainlink: DisableChainlink,
+    create_consumer: CreateConsumer,
+) -> Option<Consumer>
+where
+    EnterReplica: FnOnce() -> EnterReplicaFuture,
+    EnterReplicaFuture: Future<Output = ()>,
+    DisableChainlink: FnOnce(),
+    CreateConsumer: FnOnce() -> CreateConsumerFuture,
+    CreateConsumerFuture: Future<Output = Option<Consumer>>,
+{
+    enter_replica().await;
+    disable_chainlink();
+    create_consumer().await
+}
 
 /// Shared state for both primary and standby roles.
 pub struct ReplicationContext {
@@ -182,13 +238,13 @@ impl ReplicationContext {
         messages: Receiver<Message>,
     ) -> Result<Primary> {
         let snapshots = self.create_snapshot_watcher()?;
-        let _guard = self.scheduler.wait_for_idle().await;
-        // Account-bank reset is primary-readiness cleanup and is intentionally
-        // skipped during standby/replica startup. Run it only after primary
-        // work is idle and before exposing primary mode.
-        self.chainlink.reset_accounts_bank()?;
-        self.enter_primary_mode().await;
-        self.chainlink.enable_primary()?;
+        run_primary_readiness_sequence(
+            || self.scheduler.wait_for_idle(),
+            || self.chainlink.reset_accounts_bank().map_err(Into::into),
+            || self.enter_primary_mode(),
+            || self.chainlink.enable_primary().map_err(Into::into),
+        )
+        .await?;
         Ok(Primary::new(self, producer, messages, snapshots))
     }
 
@@ -202,9 +258,13 @@ impl ReplicationContext {
         messages: Receiver<Message>,
         reset: bool,
     ) -> Result<Option<Standby>> {
-        self.enter_replica_mode().await;
-        self.chainlink.disable();
-        let Some(consumer) = self.create_consumer(reset).await else {
+        let Some(consumer) = run_standby_start_sequence(
+            || self.enter_replica_mode(),
+            || self.chainlink.disable(),
+            || self.create_consumer(reset),
+        )
+        .await
+        else {
             return Ok(None);
         };
         let Some(watcher) = LockWatcher::new(&self.broker, &self.cancel).await
@@ -217,5 +277,133 @@ impl ReplicationContext {
             messages,
             watcher,
         )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use tokio::sync::oneshot;
+
+    use super::*;
+
+    struct TestGuard;
+
+    fn push(events: &Arc<Mutex<Vec<&'static str>>>, event: &'static str) {
+        events.lock().unwrap().push(event);
+    }
+
+    #[tokio::test]
+    async fn primary_readiness_waits_for_idle_before_reset_and_mode_entry() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let (release_idle_tx, release_idle_rx) = oneshot::channel::<()>();
+
+        let sequence = {
+            let wait_events = events.clone();
+            let reset_events = events.clone();
+            let enter_events = events.clone();
+            let enable_events = events.clone();
+            run_primary_readiness_sequence(
+                move || async move {
+                    push(&wait_events, "wait_for_idle_started");
+                    release_idle_rx.await.unwrap();
+                    push(&wait_events, "wait_for_idle_completed");
+                    TestGuard
+                },
+                move || {
+                    push(&reset_events, "reset_accounts_bank");
+                    Ok(())
+                },
+                move || async move {
+                    push(&enter_events, "enter_primary_mode");
+                },
+                move || {
+                    push(&enable_events, "enable_primary");
+                    Ok(())
+                },
+            )
+        };
+
+        tokio::pin!(sequence);
+        tokio::select! {
+            _ = &mut sequence => panic!("primary readiness must wait for idle"),
+            _ = tokio::time::sleep(std::time::Duration::from_millis(10)) => {}
+        }
+        assert_eq!(&*events.lock().unwrap(), &["wait_for_idle_started"]);
+
+        release_idle_tx.send(()).unwrap();
+        sequence.await.unwrap();
+        assert_eq!(
+            &*events.lock().unwrap(),
+            &[
+                "wait_for_idle_started",
+                "wait_for_idle_completed",
+                "reset_accounts_bank",
+                "enter_primary_mode",
+                "enable_primary",
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn standby_start_enters_replica_before_consumer_creation_can_block() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let (consumer_started_tx, consumer_started_rx) =
+            oneshot::channel::<()>();
+        let (release_consumer_tx, release_consumer_rx) =
+            oneshot::channel::<()>();
+
+        let sequence = {
+            let events = events.clone();
+            run_standby_start_sequence(
+                {
+                    let events = events.clone();
+                    move || async move {
+                        push(&events, "enter_replica_mode");
+                    }
+                },
+                {
+                    let events = events.clone();
+                    move || push(&events, "disable_chainlink")
+                },
+                {
+                    let events = events.clone();
+                    move || async move {
+                        push(&events, "create_consumer_started");
+                        consumer_started_tx.send(()).unwrap();
+                        release_consumer_rx.await.unwrap();
+                        push(&events, "create_consumer_completed");
+                        Some(())
+                    }
+                },
+            )
+        };
+
+        tokio::pin!(sequence);
+        tokio::select! {
+            _ = &mut sequence => panic!("consumer creation should still be blocked"),
+            _ = consumer_started_rx => {}
+        }
+        assert_eq!(
+            &*events.lock().unwrap(),
+            &[
+                "enter_replica_mode",
+                "disable_chainlink",
+                "create_consumer_started",
+            ]
+        );
+
+        release_consumer_tx.send(()).unwrap();
+        assert_eq!(sequence.await, Some(()));
+        assert_eq!(
+            &*events.lock().unwrap(),
+            &[
+                "enter_replica_mode",
+                "disable_chainlink",
+                "create_consumer_started",
+                "create_consumer_completed",
+            ]
+        );
     }
 }

--- a/magicblock-replicator/src/service/mod.rs
+++ b/magicblock-replicator/src/service/mod.rs
@@ -27,7 +27,7 @@ use std::{sync::Arc, thread::JoinHandle, time::Duration};
 
 pub use context::ReplicationContext;
 use magicblock_accounts_db::AccountsDb;
-use magicblock_chainlink::StubbedChainlink;
+use magicblock_chainlink::{AccountsBankReset, ChainlinkPrimaryLifecycle};
 use magicblock_core::link::{
     replication::Message,
     transactions::{SchedulerMode, TransactionSchedulerHandle},
@@ -78,15 +78,18 @@ fn initial_role_path(can_promote: bool) -> InitialRolePath {
 impl Service {
     /// Creates service, attempting primary role first if allowed.
     ///
-    /// When `can_promote` is false (ReplicaOnly mode), skips lock acquisition
-    /// and goes directly to standby mode.
+    /// Accounts bank reset cleanup is provided separately from the real
+    /// Chainlink primary lifecycle handle. When `can_promote` is false
+    /// (ReplicaOnly mode), skips lock acquisition, receives no primary
+    /// lifecycle handle, and goes directly to standby mode.
     #[allow(clippy::too_many_arguments)]
     pub async fn new(
         broker: Broker,
         mode_tx: Sender<SchedulerMode>,
         accountsdb: Arc<AccountsDb>,
         ledger: Arc<Ledger>,
-        chainlink: StubbedChainlink<AccountsDb>,
+        accounts_bank_reset: Arc<dyn AccountsBankReset>,
+        primary_chainlink: Option<Arc<dyn ChainlinkPrimaryLifecycle>>,
         scheduler: TransactionSchedulerHandle,
         messages: Receiver<Message>,
         cancel: CancellationToken,
@@ -98,7 +101,8 @@ impl Service {
             mode_tx,
             accountsdb,
             ledger,
-            chainlink,
+            accounts_bank_reset,
+            primary_chainlink,
             scheduler,
             cancel,
             can_promote,

--- a/magicblock-replicator/src/service/mod.rs
+++ b/magicblock-replicator/src/service/mod.rs
@@ -61,6 +61,20 @@ pub enum Service {
     Standby(Standby),
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum InitialRolePath {
+    TryPrimary,
+    StandbyOnly,
+}
+
+fn initial_role_path(can_promote: bool) -> InitialRolePath {
+    if can_promote {
+        InitialRolePath::TryPrimary
+    } else {
+        InitialRolePath::StandbyOnly
+    }
+}
+
 impl Service {
     /// Creates service, attempting primary role first if allowed.
     ///
@@ -92,7 +106,7 @@ impl Service {
         .await?;
 
         // Try to become primary only if promotion is allowed.
-        if can_promote {
+        if initial_role_path(can_promote) == InitialRolePath::TryPrimary {
             match ctx.try_acquire_producer().await? {
                 Some(producer) => Ok(Some(Self::Primary(
                     ctx.into_primary(producer, messages).await?,
@@ -146,5 +160,20 @@ impl Service {
 
             runtime.block_on(tokio::task::unconstrained(self.run()))
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn replica_only_initial_role_never_attempts_primary() {
+        assert_eq!(initial_role_path(false), InitialRolePath::StandbyOnly);
+    }
+
+    #[test]
+    fn promotable_initial_role_attempts_primary_first() {
+        assert_eq!(initial_role_path(true), InitialRolePath::TryPrimary);
     }
 }

--- a/magicblock-replicator/src/service/mod.rs
+++ b/magicblock-replicator/src/service/mod.rs
@@ -25,9 +25,8 @@ mod standby;
 
 use std::{sync::Arc, thread::JoinHandle, time::Duration};
 
-pub use context::ReplicationContext;
+pub use context::{PrimaryChainlink, ReplicationContext};
 use magicblock_accounts_db::AccountsDb;
-use magicblock_chainlink::{AccountsBankReset, ChainlinkPrimaryLifecycle};
 use magicblock_core::link::{
     replication::Message,
     transactions::{SchedulerMode, TransactionSchedulerHandle},
@@ -78,18 +77,16 @@ fn initial_role_path(can_promote: bool) -> InitialRolePath {
 impl Service {
     /// Creates service, attempting primary role first if allowed.
     ///
-    /// Accounts bank reset cleanup is provided separately from the real
-    /// Chainlink primary lifecycle handle. When `can_promote` is false
-    /// (ReplicaOnly mode), skips lock acquisition, receives no primary
-    /// lifecycle handle, and goes directly to standby mode.
+    /// Replication uses the real RPC-facing Chainlink primary-readiness
+    /// handle. When `can_promote` is false (ReplicaOnly mode), skips lock
+    /// acquisition and goes directly to standby mode.
     #[allow(clippy::too_many_arguments)]
     pub async fn new(
         broker: Broker,
         mode_tx: Sender<SchedulerMode>,
         accountsdb: Arc<AccountsDb>,
         ledger: Arc<Ledger>,
-        accounts_bank_reset: Arc<dyn AccountsBankReset>,
-        primary_chainlink: Option<Arc<dyn ChainlinkPrimaryLifecycle>>,
+        chainlink: Arc<dyn PrimaryChainlink>,
         scheduler: TransactionSchedulerHandle,
         messages: Receiver<Message>,
         cancel: CancellationToken,
@@ -101,8 +98,7 @@ impl Service {
             mode_tx,
             accountsdb,
             ledger,
-            accounts_bank_reset,
-            primary_chainlink,
+            chainlink,
             scheduler,
             cancel,
             can_promote,

--- a/magicblock-replicator/src/service/mod.rs
+++ b/magicblock-replicator/src/service/mod.rs
@@ -25,8 +25,9 @@ mod standby;
 
 use std::{sync::Arc, thread::JoinHandle, time::Duration};
 
-pub use context::{PrimaryChainlink, ReplicationContext};
+pub use context::ReplicationContext;
 use magicblock_accounts_db::AccountsDb;
+use magicblock_chainlink::PrimaryChainlink;
 use magicblock_core::link::{
     replication::Message,
     transactions::{SchedulerMode, TransactionSchedulerHandle},
@@ -58,20 +59,6 @@ const CONSUMER_RETRY_DELAY: Duration = Duration::from_secs(1);
 pub enum Service {
     Primary(Primary),
     Standby(Standby),
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum InitialRolePath {
-    TryPrimary,
-    StandbyOnly,
-}
-
-fn initial_role_path(can_promote: bool) -> InitialRolePath {
-    if can_promote {
-        InitialRolePath::TryPrimary
-    } else {
-        InitialRolePath::StandbyOnly
-    }
 }
 
 impl Service {
@@ -106,7 +93,7 @@ impl Service {
         .await?;
 
         // Try to become primary only if promotion is allowed.
-        if initial_role_path(can_promote) == InitialRolePath::TryPrimary {
+        if can_promote {
             match ctx.try_acquire_producer().await? {
                 Some(producer) => Ok(Some(Self::Primary(
                     ctx.into_primary(producer, messages).await?,
@@ -160,20 +147,5 @@ impl Service {
 
             runtime.block_on(tokio::task::unconstrained(self.run()))
         })
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn replica_only_initial_role_never_attempts_primary() {
-        assert_eq!(initial_role_path(false), InitialRolePath::StandbyOnly);
-    }
-
-    #[test]
-    fn promotable_initial_role_attempts_primary_first() {
-        assert_eq!(initial_role_path(true), InitialRolePath::TryPrimary);
     }
 }

--- a/test-integration/test-chainlink/src/test_context.rs
+++ b/test-integration/test-chainlink/src/test_context.rs
@@ -141,7 +141,9 @@ impl TestContext {
         let timeout = timeout_millis
             .map(Duration::from_millis)
             .unwrap_or_else(|| Duration::from_secs(1));
-        if let Some(fetch_cloner) = self.chainlink.fetch_cloner() {
+        if let Some(fetch_cloner) =
+            self.chainlink.fetch_cloner_for_tests().await
+        {
             let target_count = fetch_cloner.received_updates_count() + count;
             trace!(
                 "Waiting for {} account updates, current count: {}",


### PR DESCRIPTION
## Summary

Make Chainlink and RPC behavior coordination-mode aware so replica/standby validators stay local-only until they become primary, and fully tie Chainlink remote runtime startup/shutdown to primary lifecycle transitions.

- Reject non-primary transaction RPCs before transaction preparation, signature-cache mutation, account ensuring, or scheduler simulation.
- Keep account reads available in replica mode without triggering remote Chainlink work.
- Defer Chainlink remote runtime construction until primary enablement instead of constructing providers during validator startup.
- Shut down Chainlink remote runtime state when leaving primary mode, including fetch cloning, pubsub/submux work, remote provider subscriptions, pending waiters, and removed-account eviction handling.
- Move account-bank reset and Chainlink enablement to primary-readiness transitions.
- Switch out of primary mode before standby setup during demotion, and roll back Chainlink enablement if publishing primary mode to the scheduler fails.
- Add coverage for RPC side-effect prevention, Chainlink inactive startup behavior, runtime shutdown/restart, lower-layer pubsub/provider teardown, and replication lifecycle ordering.

ADDRESSES: #1203

## Details

This PR tightens the boundary between primary and non-primary validator behavior. Transaction RPCs are rejected while a validator is non-primary, account read RPCs remain local-only, and Chainlink remote work now exists only while the validator is explicitly enabled as primary.

## Steps when Switching Modes

### Switching to Primary Mode

For standalone startup, the validator performs account-bank cleanup before enabling Chainlink and publishing primary scheduler mode. For replicated validators, the same cleanup runs during promotion after replica replay work is idle.

1. During validator initialization, Chainlink stores the configuration needed to build its remote runtime, but does not start the remote account provider, pubsub clients, FetchCloner listener, removed-account subscription, or subscription bookkeeping.
2. During promotion, wait for the scheduler to become idle so no replica/standby work is still being processed.
3. Reset the account bank as primary-readiness cleanup. This removes non-delegated, non-blacklisted accounts from the local bank while preserving delegated, undelegating, ephemeral, and protected accounts.
4. Call `chainlink.enable_primary()`. This builds and installs the active Chainlink runtime: remote account provider, WebSocket/gRPC/Laserstream pubsub clients, FetchCloner, removed-account subscription handling, and subscription management.
5. Publish `Primary` mode to the scheduler/global coordination state. At this point primary traffic can be accepted and Chainlink remote paths are active.
6. If publishing primary mode fails after Chainlink was enabled, disable Chainlink again so remote runtime state is not left active while the scheduler remains non-primary.
7. Once primary mode is visible, Chainlink remote paths can fetch/clone missing state, subscribe to monitored accounts, set up program subscriptions, process clock/account updates, reconcile active account subscriptions, and submit eviction/undelegation-related work when those paths are requested.

### Switching from Primary Mode

When a primary demotes into standby/replica behavior, the order is intentionally reversed around externally visible behavior: stop being primary first, then perform Chainlink shutdown and standby setup.

1. Switch the scheduler/global coordination state to `Replica` immediately at the start of standby transition.
2. Call `chainlink.disable()` to take and stop the active Chainlink runtime.
3. Disablement aborts the removed-account subscription task, shuts down the FetchCloner, cancels its subscription listener, clears/fails pending fetch waiters, stops remote account provider/submux/pubsub work, and leaves Chainlink in the disabled lifecycle state.
4. From that point, Chainlink public entry points are inactive: account ensure returns no-op results, fetches read local `AccountsDb`, undelegation subscription setup is skipped, removed-account eviction notifications cannot submit eviction transactions, and public calls do not recreate remote subscriptions.
5. Transaction RPCs (`sendTransaction` and `simulateTransaction`) reject while non-primary, so they cannot trigger transaction preparation, account ensure, signature-cache mutation, or scheduler simulation.
6. Account read RPCs remain local-only and do not invoke remote Chainlink ensure.
7. Standby setup then creates the replica consumer and lock watcher. If that setup blocks or retries, the validator is already non-primary and Chainlink remote runtime state has been disabled.
8. Promotion after shutdown creates a fresh Chainlink runtime, so delegated accounts can be fetched again after becoming primary.

### magicblock-aperture

RPC dispatch checks the current coordination mode. `sendTransaction` is rejected while non-primary before it can affect the transaction cache, and `simulateTransaction` is rejected before transaction preparation, account ensuring, or scheduler simulation. Account reads remain usable against local state. Tests cover non-primary transaction RPC rejection and local account reads.

### magicblock-chainlink

Chainlink now owns an explicit lifecycle state (`Disabled`, `Starting`, `Enabled`, `Stopping`) and an optional active runtime. Runtime construction is deferred until `enable_primary()`, while `disable()` tears down the active runtime asynchronously. The previous broad defensive remote-sync gates inside lower-level Chainlink paths were removed in favor of this active/inactive runtime boundary.

The shutdown path covers FetchCloner cancellation, pending waiter failure, remote account provider shutdown, deterministic pubsub/submux cleanup, deferred pubsub task shutdown, and removed-account subscription task cancellation. Tests cover inactive startup modes, repeated enable/disable cycles, public calls after disable, provider account updates after disable, removed-account notifications after disable, and fresh runtime startup after shutdown.

### magicblock-api

Standalone validators now reset the account bank only as part of primary readiness, then enable Chainlink before publishing primary scheduler mode. If sending primary mode to the scheduler fails, Chainlink enablement is rolled back. Replicated validators skip startup reset and defer cleanup until promotion.

### magicblock-replicator

Promotion ordering is documented and covered: wait for scheduler idle, reset account bank, enable Chainlink runtime, then enter primary mode. Demotion switches to replica mode before disabling Chainlink and before standby setup can block or retry, preventing stale primary behavior from continuing during transition. Tests cover promotion failure ordering, Chainlink enable/disable ordering, and replica-only behavior that must not reach the primary path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Write-like RPCs (send/simulate transactions) are rejected when the node cannot act as primary; replica-mode reads return local account data without remote gating.

* **Refactor**
  * Startup and role-transition ordering tightened to enforce primary readiness before promotion and consumer creation.

* **New Features**
  * Added graceful shutdown and lifecycle controls for remote-sync, subscriptions, and background tasks; new routing/availability signals for RPC handling.

* **Tests**
  * Expanded integration/unit tests for non-primary gating, lifecycle enable/disable, and shutdown behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/magicblock-labs/magicblock-validator/pull/1227?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->