### PR TITLE
fix(replicator): disable automatic failover

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4239,6 +4239,7 @@ dependencies = [
  "machineid-rs",
  "magicblock-accounts-db",
  "magicblock-chainlink",
+ "magicblock-config",
  "magicblock-core",
  "magicblock-ledger",
  "notify",

--- a/config.example.toml
+++ b/config.example.toml
@@ -125,17 +125,14 @@ keypair = "9Vo7TbA5YfC5a33JhAi9Fb41usA6JwecHNRw3f9MzzHAM8hFnXTzL5DcEHwsAFjuUZ8vN
 # Default: "standalone"
 # Options:
 # - "standalone": disable replication
+# - "primary": replicate the state transitions
+# - "replica": replay the state transitions from primary
 # 
-# - "stand-by": replicate and allow takeover
-# 
-# [validator.replication-mode.stand-by]
+# [validator.replication-mode.primary]
 # url = "nats://0.0.0.0:4222"
 # secret = "SUAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 # 
-# - "replica-only": replicate without takeover
-#   Requires the primary validator pubkey we are replicating from.
-# 
-# [validator.replication-mode.replica-only]
+# [validator.replication-mode.replica]
 # url = "nats://0.0.0.0:4222"
 # secret = "SUAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 # authority-override = "L12m1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo"

--- a/magicblock-aperture/tests/accounts.rs
+++ b/magicblock-aperture/tests/accounts.rs
@@ -46,8 +46,19 @@ async fn test_get_account_info() {
         .get_account_with_commitment(&missing_pubkey, Default::default())
         .await
         .expect("second rpc request for non-existent account failed");
-    assert_eq!(first_miss.context.slot, env.latest_slot());
-    assert_eq!(second_miss.context.slot, env.latest_slot());
+    let latest_slot = env.latest_slot();
+    assert!(
+        first_miss.context.slot <= latest_slot,
+        "first lookup context slot should not be ahead of the ledger: context={}, latest={latest_slot}",
+        first_miss.context.slot
+    );
+    assert!(
+        second_miss.context.slot >= first_miss.context.slot
+            && second_miss.context.slot <= latest_slot,
+        "second lookup context slot should be monotonic and not ahead of the ledger: first={}, second={}, latest={latest_slot}",
+        first_miss.context.slot,
+        second_miss.context.slot
+    );
     assert_eq!(first_miss.value, None, "first lookup should return null");
     assert_eq!(
         second_miss.value, None,

--- a/magicblock-api/src/errors.rs
+++ b/magicblock-api/src/errors.rs
@@ -44,15 +44,6 @@ pub enum ApiError {
     #[error("Failed to load programs into bank: {0}")]
     FailedToLoadProgramsIntoBank(String),
 
-    #[error(
-        "StandBy node keypair '{configured}' does not match primary's \
-         keypair '{expected}'. StandBy nodes must use the primary's keypair."
-    )]
-    StandByKeypairMismatch {
-        configured: Pubkey,
-        expected: Pubkey,
-    },
-
     #[error("Failed to send mode switch to scheduler: {0}")]
     FailedToSendModeSwitch(String),
 

--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -129,7 +129,8 @@ pub struct MagicValidator {
     claim_fees_task: ClaimFeesTask,
     task_scheduler: Option<TaskSchedulerService>,
     transaction_execution: thread::JoinHandle<()>,
-    replication_handle: Option<thread::JoinHandle<()>>,
+    replication_handle:
+        Option<thread::JoinHandle<magicblock_replicator::Result<()>>>,
     mode_tx: Sender<SchedulerMode>,
     is_standalone: bool,
 }
@@ -1025,10 +1026,20 @@ impl MagicValidator {
         log_timing("shutdown", "ledger_truncator_join", step_start);
         let step_start = Instant::now();
         let _ = self.transaction_execution.join();
-        if let Some(handle) = self.replication_handle {
-            let _ = handle.join();
-        }
         log_timing("shutdown", "transaction_execution_join", step_start);
+        let step_start = Instant::now();
+        if let Some(handle) = self.replication_handle {
+            match handle.join() {
+                Ok(Ok(())) => {}
+                Ok(Err(err)) => {
+                    error!(error = ?err, "Replication service exited with error");
+                }
+                Err(err) => {
+                    error!(panic = ?err, "Replication service thread panicked");
+                }
+            }
+        }
+        log_timing("shutdown", "replication_service_join", step_start);
 
         log_timing("shutdown", "stop_total", stop_start);
         info!("MagicValidator shutdown");

--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -129,8 +129,7 @@ pub struct MagicValidator {
     claim_fees_task: ClaimFeesTask,
     task_scheduler: Option<TaskSchedulerService>,
     transaction_execution: thread::JoinHandle<()>,
-    replication_handle:
-        Option<thread::JoinHandle<magicblock_replicator::Result<()>>>,
+    replication_handle: Option<thread::JoinHandle<()>>,
     mode_tx: Sender<SchedulerMode>,
     is_standalone: bool,
 }
@@ -246,11 +245,6 @@ impl MagicValidator {
                 let messages_rx = dispatch.replication_messages.take().expect(
                     "replication channel should always exist after init",
                 );
-                // ReplicaOnly mode cannot promote to primary
-                let can_promote = matches!(
-                    config.validator.replication_mode,
-                    ReplicationMode::StandBy(_)
-                );
                 ReplicationService::new(
                     broker,
                     mode_tx.clone(),
@@ -261,7 +255,7 @@ impl MagicValidator {
                     messages_rx,
                     token.clone(),
                     is_fresh_start,
-                    can_promote,
+                    &config.validator.replication_mode,
                 )
                 .await?
             } else {
@@ -882,10 +876,6 @@ impl MagicValidator {
         }
 
         // Notify the scheduler that ledger replay and bank cleanup is complete.
-        // The message carries the target mode so the scheduler transitions to
-        // the correct coordination mode:
-        // - Standalone validators transition to Primary mode
-        // - StandBy/ReplicaOnly validators transition to Replica mode
         if self.is_standalone {
             self.mode_tx
                 .send(SchedulerMode::Primary)
@@ -1036,9 +1026,7 @@ impl MagicValidator {
         let step_start = Instant::now();
         let _ = self.transaction_execution.join();
         if let Some(handle) = self.replication_handle {
-            if let Ok(Err(error)) = handle.join() {
-                error!(%error, "replication service experienced catastrophic failure");
-            }
+            let _ = handle.join();
         }
         log_timing("shutdown", "transaction_execution_join", step_start);
 

--- a/magicblock-config/src/config/validator.rs
+++ b/magicblock-config/src/config/validator.rs
@@ -30,10 +30,10 @@ pub struct ValidatorConfig {
 pub enum ReplicationMode {
     // Validator which doesn't participate in replication
     Standalone,
-    /// Validator which participates in replication: acting as either a primary or replicator
-    StandBy(ReplicationConfig),
-    /// Validator which participates in replication only as replicator (no takeover)
-    ReplicaOnly {
+    /// Validator which participates in replication: acting as a primary source of events
+    Primary(ReplicationConfig),
+    /// Validator which participates in replication as consumer of state transitions
+    Replica {
         #[serde(flatten)]
         config: ReplicationConfig,
         #[serde(rename = "authority-override")]
@@ -95,13 +95,13 @@ impl ReplicationMode {
     pub fn config(&self) -> Option<ReplicationConfig> {
         match self {
             Self::Standalone => None,
-            Self::StandBy(c) => Some(c.clone()),
-            Self::ReplicaOnly { config, .. } => Some(config.clone()),
+            Self::Primary(c) => Some(c.clone()),
+            Self::Replica { config, .. } => Some(config.clone()),
         }
     }
 
     pub fn authority_override(&self) -> Option<Pubkey> {
-        if let Self::ReplicaOnly {
+        if let Self::Replica {
             authority_override, ..
         } = self
         {

--- a/magicblock-core/src/coordination_mode.rs
+++ b/magicblock-core/src/coordination_mode.rs
@@ -7,9 +7,7 @@ use std::sync::atomic::{AtomicU8, Ordering};
 ///
 /// Valid Transitions:
 ///   StartingUp (0) → Primary (1)   [Standalone validators]
-///   StartingUp (0) → Replica (2)   [StandBy/ReplicaOnly validators]
-///   Primary (1) → Replica (2)      [Failover: primary to replica]
-///   Replica (2) → Primary (1)      [Failover: replica takeover becomes primary]
+///   StartingUp (0) → Replica (2)   [Replica validators]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum CoordinationMode {

--- a/magicblock-replicator/Cargo.toml
+++ b/magicblock-replicator/Cargo.toml
@@ -1,37 +1,31 @@
 [package]
-name = "magicblock-replicator"
-version.workspace = true
 authors.workspace = true
-repository.workspace = true
+edition.workspace = true
 homepage.workspace = true
 license.workspace = true
-edition.workspace = true
+name = "magicblock-replicator"
+repository.workspace = true
+version.workspace = true
 
 [dependencies]
 async-nats = { workspace = true }
 bincode = { workspace = true }
 bytes = { workspace = true }
 futures = { workspace = true }
+machineid-rs = { workspace = true }
 magicblock-accounts-db = { workspace = true }
 magicblock-chainlink = { workspace = true }
+magicblock-config = { workspace = true }
 magicblock-core = { workspace = true }
 magicblock-ledger = { workspace = true }
-machineid-rs = { workspace = true }
 notify = { version = "8.0", features = ["macos_kqueue"] }
-thiserror = { workspace = true }
-tokio = { workspace = true, features = [
-  "net",
-  "rt",
-  "macros",
-  "sync",
-  "io-util",
-  "fs",
-] }
-tokio-util = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 solana-hash = { workspace = true, features = ["serde"] }
 solana-transaction = { workspace = true, features = ["serde"] }
 solana-transaction-error = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["fs", "io-util", "macros", "net", "rt", "sync"] }
+tokio-util = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
 

--- a/magicblock-replicator/README.md
+++ b/magicblock-replicator/README.md
@@ -1,6 +1,6 @@
 # magicblock-replicator
 
-State replication protocol for streaming validator events via NATS JetStream. Enables primary-standby failover with automatic role transitions.
+State replication protocol for streaming validator events via NATS JetStream. 
 
 ## Architecture
 
@@ -11,7 +11,7 @@ State replication protocol for streaming validator events via NATS JetStream. En
         ┌────────────┴────────────┐
         ▼                         ▼
    ┌─────────┐               ┌─────────┐
-   │ Primary │ ← ─ ─ ─ ─ ─ → │ Standby │
+   │ Primary │               │ Replica │
    └────┬────┘               └────┬────┘
         │                         │
     ┌───┴───┐                 ┌───┴───┐
@@ -21,86 +21,5 @@ State replication protocol for streaming validator events via NATS JetStream. En
     └───────┘                 └───────┘
 ```
 
-The replicator implements a leader-follower pattern where exactly one node acts as **Primary** (publishes events) while others act as **Standby** (consume and replay events). Automatic failover occurs when the primary loses its lock or becomes unresponsive.
+The replicator implements a leader-follower pattern where exactly one node acts as **Primary** (publishes events) while others act as **Replica** (consume and replay events).
 
-## Core Components
-
-### Service
-
-Entry point that manages role transitions. On startup, attempts to acquire the leader lock:
-- **Success**: Becomes Primary, starts publishing
-- **Failure**: Becomes Standby, starts consuming
-
-The service automatically transitions between roles:
-- Primary → Standby: When lock refresh fails or publish errors occur
-- Standby → Primary: When leader lock expires and takeover succeeds
-
-### Primary Node
-
-- Holds a distributed leader lock (5-second TTL, refreshed every second)
-- Publishes three event types to NATS JetStream:
-  - **Transactions**: Individual transaction executions
-  - **Blocks**: Slot boundary markers
-  - **SuperBlocks**: Periodic state checksums for divergence detection
-- Uploads AccountsDb snapshots when new archive files appear in the database directory
-
-### Standby Node
-
-- Consumes events from the stream and replys them locally
-- Watches the leader lock for expiration (enables fast takeover)
-- Monitors activity timeout (10 seconds of silence triggers takeover attempt)
-- Verifies SuperBlock checksums against local AccountsDb state
-- Can operate in **ReplicaOnly mode** where takeover is disabled
-
-## NATS JetStream Resources
-
-| Resource | Name | Purpose |
-|----------|------|---------|
-| Stream | `EVENTS` | Event log (256 GB max, 24h TTL, S2 compression) |
-| Object Store | `SNAPSHOTS` | AccountsDb archives (512 GB max) |
-| KV Bucket | `PRODUCER` | Leader election lock |
-
-### Event Subjects
-
-- `event.transaction` — Transaction executions
-- `event.block` — Block boundaries
-- `event.superblock` — State checksums
-
-## Wire Format
-
-Messages are serialized with bincode. Each message includes slot and index for positioning, enabling consumers to track progress and detect gaps.
-
-## Snapshots
-
-Primary nodes watch the AccountsDb directory for new `snapshot-{slot:0>12}.tar.gz` files and upload them to the object store. Snapshots include metadata:
-- **Slot**: When the snapshot was taken
-- **Sequence**: JetStream sequence number for replay positioning
-
-Standbys can download snapshots for fast recovery instead of full replay.
-
-## Failover Nuances
-
-### Lock Expiration vs Activity Timeout
-
-Two mechanisms trigger standby takeover:
-
-1. **Lock Watcher** (fast): Detects when the leader lock KV entry is deleted/purged
-2. **Activity Timeout** (fallback): Triggers after 10 seconds of no messages
-
-The lock watcher provides faster failover, but activity timeout handles cases where the primary crashes without cleanly releasing the lock.
-
-### Pending Message Check
-
-Before attempting takeover on lock expiry, standbys check for pending messages in their consumer. This prevents premature takeover when messages are simply delayed.
-
-### ReplicaOnly Mode
-
-Nodes configured with `can_promote: false` never attempt takeover. They remain in standby mode indefinitely, useful for read-only replicas or debugging.
-
-## Checksum Verification
-
-SuperBlocks carry an AccountsDb checksum. Standbys verify this against their local state after processing. Mismatch indicates state divergence and is logged as an error.
-
-## Threading Model
-
-The service spawns in a dedicated OS thread with a single-threaded Tokio runtime named `replication-service`. This isolation prevents replication work from interfering with the main validator runtime.

--- a/magicblock-replicator/src/lib.rs
+++ b/magicblock-replicator/src/lib.rs
@@ -2,11 +2,11 @@
 //!
 //! # Architecture
 //!
-//! The replicator enables primary-standby state replication using NATS JetStream:
+//! The replicator enables primary-replica state replication using NATS JetStream:
 //!
 //! - **Producer**: Primary node publishes transactions, blocks, and superblocks
-//! - **Consumer**: Standby nodes consume events to maintain synchronized state
-//! - **Snapshots**: Periodic AccountsDb snapshots enable fast standby recovery
+//! - **Consumer**: replica nodes consume events to maintain synchronized state
+//! - **Snapshots**: Periodic AccountsDb snapshots enable fast replica recovery
 //!
 //! # Wire Format
 //!

--- a/magicblock-replicator/src/nats/broker.rs
+++ b/magicblock-replicator/src/nats/broker.rs
@@ -150,7 +150,7 @@ impl Broker {
     /// Uploads a snapshot in the background.
     ///
     /// The snapshot is tagged with the current stream sequence number,
-    /// allowing standbys to resume replay from the correct position.
+    /// allowing replica to resume replay from the correct position.
     #[instrument(skip(self, file))]
     pub async fn put_snapshot(&self, slot: Slot, mut file: File) -> Result<()> {
         let store = self.ctx.get_object_store(cfg::SNAPSHOTS).await?;

--- a/magicblock-replicator/src/nats/consumer.rs
+++ b/magicblock-replicator/src/nats/consumer.rs
@@ -83,25 +83,4 @@ impl Consumer {
             }
         }
     }
-
-    pub(crate) async fn pending(
-        &self,
-        cancel: &CancellationToken,
-    ) -> Option<u64> {
-        loop {
-            tokio::select! {
-                result = self.inner.get_info() => {
-                    match result {
-                        Ok(i) => break Some(i.num_pending),
-                        Err(error) => {
-                            warn!(%error, "failed to query consumer info")
-                        }
-                    }
-                }
-                _ = cancel.cancelled() => {
-                    break None;
-                }
-            }
-        }
-    }
 }

--- a/magicblock-replicator/src/nats/lock_watcher.rs
+++ b/magicblock-replicator/src/nats/lock_watcher.rs
@@ -10,7 +10,7 @@ use crate::nats::Broker;
 
 /// Watches the leader lock for expiration/deletion.
 ///
-/// Used by standby nodes to detect when the primary's lock expires,
+/// Used by replica nodes to detect when the primary's lock expires,
 /// enabling faster takeover than waiting for the activity timeout.
 pub struct LockWatcher {
     watch: Box<Watch>,
@@ -18,6 +18,7 @@ pub struct LockWatcher {
 
 impl LockWatcher {
     /// Creates a new lock watcher.
+    #[allow(unused)]
     pub(crate) async fn new(
         broker: &Broker,
         cancel: &CancellationToken,

--- a/magicblock-replicator/src/nats/lock_watcher.rs
+++ b/magicblock-replicator/src/nats/lock_watcher.rs
@@ -1,4 +1,4 @@
-//! Lock watcher for detecting leader expiration.
+//! Lock watcher for observing producer lock expiration.
 
 use async_nats::jetstream::kv::{Operation, Watch};
 use futures::StreamExt;
@@ -8,10 +8,10 @@ use tracing::warn;
 use super::cfg;
 use crate::nats::Broker;
 
-/// Watches the leader lock for expiration/deletion.
+/// Watches the producer lock for expiration or deletion.
 ///
-/// Used by replica nodes to detect when the primary's lock expires,
-/// enabling faster takeover than waiting for the activity timeout.
+/// This is useful for observability or operator-driven workflows that need to
+/// notice lock loss. It does not trigger runtime failover on its own.
 pub struct LockWatcher {
     watch: Box<Watch>,
 }
@@ -49,7 +49,6 @@ impl LockWatcher {
     /// Waits for the lock to be deleted or expire.
     ///
     /// Returns when the lock key is deleted or purged (TTL expiry).
-    /// This signals that a takeover attempt should be made.
     pub async fn wait_for_expiry(&mut self) {
         while let Some(result) = self.watch.next().await {
             let operation = match result {

--- a/magicblock-replicator/src/nats/mod.rs
+++ b/magicblock-replicator/src/nats/mod.rs
@@ -39,9 +39,9 @@ mod cfg {
     pub const META_SLOT: &str = "slot";
     pub const META_SEQUENCE: &str = "sequence";
 
-    // Size limits (256 GB stream, 1 GB snapshots)
+    // Size limits (256 GB stream, 5 GB snapshots)
     pub const STREAM_BYTES: i64 = 256 * 1024 * 1024 * 1024;
-    pub const SNAPSHOT_BYTES: i64 = 1024 * 1024 * 1024;
+    pub const SNAPSHOT_BYTES: i64 = 5 * 1024 * 1024 * 1024;
 
     // Timeouts
     pub const TTL_STREAM: Duration = Duration::from_secs(24 * 60 * 60);

--- a/magicblock-replicator/src/nats/mod.rs
+++ b/magicblock-replicator/src/nats/mod.rs
@@ -4,7 +4,7 @@
 //!
 //! - [`Broker`]: Connection manager with stream/bucket initialization
 //! - [`Producer`]: Event publisher with distributed leader lock
-//! - [`Consumer`]: Event subscriber for standby replay
+//! - [`Consumer`]: Event subscriber for replay
 //! - [`Snapshot`]: AccountsDb snapshot with positioning metadata
 //! - [`LockWatcher`]: Watcher for leader lock expiration
 

--- a/magicblock-replicator/src/nats/mod.rs
+++ b/magicblock-replicator/src/nats/mod.rs
@@ -6,7 +6,7 @@
 //! - [`Producer`]: Event publisher with distributed leader lock
 //! - [`Consumer`]: Event subscriber for replay
 //! - [`Snapshot`]: AccountsDb snapshot with positioning metadata
-//! - [`LockWatcher`]: Watcher for leader lock expiration
+//! - [`LockWatcher`]: Watcher for producer lock state changes
 
 mod broker;
 mod consumer;

--- a/magicblock-replicator/src/service/context.rs
+++ b/magicblock-replicator/src/service/context.rs
@@ -1,4 +1,4 @@
-//! Shared context for primary and standby roles.
+//! Shared context for primary and replica roles.
 
 use std::sync::Arc;
 
@@ -20,14 +20,14 @@ use tokio::{
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 
-use super::{Primary, Standby, CONSUMER_RETRY_DELAY};
+use super::{Primary, Replica, CONSUMER_RETRY_DELAY};
 use crate::{
-    nats::{Broker, Consumer, LockWatcher, Producer},
+    nats::{Broker, Consumer, Producer},
     watcher::SnapshotWatcher,
     Error, Result,
 };
 
-/// Shared state for both primary and standby roles.
+/// Shared state for both primary and replica roles.
 pub struct ReplicationContext {
     /// Node identifier for leader election.
     pub id: String,
@@ -51,8 +51,6 @@ pub struct ReplicationContext {
     pub slot: Slot,
     /// Position of the last transaction within slot
     pub index: TransactionIndex,
-    /// Whether this node can promote from standby to primary.
-    pub can_promote: bool,
 }
 
 impl ReplicationContext {
@@ -66,7 +64,6 @@ impl ReplicationContext {
         chainlink: StubbedChainlink<AccountsDb>,
         scheduler: TransactionSchedulerHandle,
         cancel: CancellationToken,
-        can_promote: bool,
     ) -> Result<Self> {
         let id = IdBuilder::new(machineid_rs::Encryption::SHA256)
             .add_component(machineid_rs::HWIDComponent::SystemID)
@@ -78,7 +75,7 @@ impl ReplicationContext {
             .get_highest_transaction_index_for_slot(slot)?
             .unwrap_or_default();
 
-        info!(%id, slot, can_promote, "context initialized");
+        info!(%id, slot, "context initialized");
         Ok(Self {
             id,
             broker,
@@ -90,7 +87,6 @@ impl ReplicationContext {
             scheduler,
             slot,
             index,
-            can_promote,
         })
     }
 
@@ -189,29 +185,16 @@ impl ReplicationContext {
         Ok(Primary::new(self, producer, messages, snapshots))
     }
 
-    /// Transitions to standby role.
+    /// Transitions to replica role.
     /// Returns `None` if shutdown is triggered during consumer creation.
     /// reset parameter controls where in the stream the consumption starts:
     /// true - the last known position that we know
     /// false - the last known position that message broker tracks for us
-    pub async fn into_standby(
-        self,
-        messages: Receiver<Message>,
-        reset: bool,
-    ) -> Result<Option<Standby>> {
+    pub async fn into_replica(self, reset: bool) -> Result<Option<Replica>> {
         let Some(consumer) = self.create_consumer(reset).await else {
             return Ok(None);
         };
-        let Some(watcher) = LockWatcher::new(&self.broker, &self.cancel).await
-        else {
-            return Ok(None);
-        };
         self.enter_replica_mode().await;
-        Ok(Some(Standby::new(
-            self,
-            Box::new(consumer),
-            messages,
-            watcher,
-        )))
+        Ok(Some(Replica::new(self, Box::new(consumer))))
     }
 }

--- a/magicblock-replicator/src/service/mod.rs
+++ b/magicblock-replicator/src/service/mod.rs
@@ -42,7 +42,7 @@ use tokio::{
 };
 use tokio_util::sync::CancellationToken;
 
-use crate::{nats::Broker, Error};
+use crate::{nats::Broker, Error, Result};
 
 // =============================================================================
 // Constants
@@ -56,7 +56,7 @@ const CONSUMER_RETRY_DELAY: Duration = Duration::from_secs(1);
 // Service
 // =============================================================================
 
-/// Replication service with automatic role transitions.
+/// Replication service for the selected replication role.
 pub enum Service {
     Primary(Primary),
     Replica(Replica),
@@ -105,7 +105,7 @@ impl Service {
         }
     }
 
-    /// Runs service with automatic role transitions.
+    /// Runs the configured replication role until it exits.
     pub async fn run(self) {
         match self {
             Service::Primary(p) => p.run().await,
@@ -115,16 +115,17 @@ impl Service {
 
     /// Spawns the service in a dedicated OS thread with a single-threaded runtime.
     ///
-    /// Returns a `JoinHandle` that can be used to wait for the service to complete.
-    pub fn spawn(self) -> JoinHandle<()> {
+    /// Returns a `JoinHandle` that yields startup/runtime errors from the
+    /// service thread.
+    pub fn spawn(self) -> JoinHandle<Result<()>> {
         std::thread::spawn(move || {
             let runtime = Builder::new_current_thread()
                 .enable_all()
                 .thread_name("replication-service")
-                .build()
-                .expect("Failed to build replication service runtime");
+                .build()?;
 
-            runtime.block_on(tokio::task::unconstrained(self.run()))
+            runtime.block_on(tokio::task::unconstrained(self.run()));
+            Ok(())
         })
     }
 }

--- a/magicblock-replicator/src/service/mod.rs
+++ b/magicblock-replicator/src/service/mod.rs
@@ -1,4 +1,4 @@
-//! Primary-standby state synchronization via NATS JetStream.
+//! Primary-Replica state synchronization via NATS JetStream.
 //!
 //! # Architecture
 //!
@@ -9,7 +9,7 @@
 //!       ┌─────────┴─────────┐
 //!       ▼                   ▼
 //!  ┌─────────┐       ┌─────────┐
-//!  │ Primary │ ←────→│ Standby │
+//!  │ Primary │       │ Replica │
 //!  └────┬────┘       └────┬────┘
 //!       │                 │
 //!   ┌───┴───┐         ┌───┴───┐
@@ -21,27 +21,28 @@
 
 mod context;
 mod primary;
-mod standby;
+mod replica;
 
 use std::{sync::Arc, thread::JoinHandle, time::Duration};
 
 pub use context::ReplicationContext;
 use magicblock_accounts_db::AccountsDb;
 use magicblock_chainlink::StubbedChainlink;
+use magicblock_config::config::validator::ReplicationMode;
 use magicblock_core::link::{
     replication::Message,
     transactions::{SchedulerMode, TransactionSchedulerHandle},
 };
 use magicblock_ledger::Ledger;
 pub use primary::Primary;
-pub use standby::Standby;
+pub use replica::Replica;
 use tokio::{
     runtime::Builder,
     sync::mpsc::{Receiver, Sender},
 };
 use tokio_util::sync::CancellationToken;
 
-use crate::{nats::Broker, Result};
+use crate::{nats::Broker, Error};
 
 // =============================================================================
 // Constants
@@ -58,14 +59,14 @@ const CONSUMER_RETRY_DELAY: Duration = Duration::from_secs(1);
 /// Replication service with automatic role transitions.
 pub enum Service {
     Primary(Primary),
-    Standby(Standby),
+    Replica(Replica),
 }
 
 impl Service {
     /// Creates service, attempting primary role first if allowed.
     ///
     /// When `can_promote` is false (ReplicaOnly mode), skips lock acquisition
-    /// and goes directly to standby mode.
+    /// and goes directly to Replica mode.
     #[allow(clippy::too_many_arguments)]
     pub async fn new(
         broker: Broker,
@@ -77,66 +78,45 @@ impl Service {
         messages: Receiver<Message>,
         cancel: CancellationToken,
         reset: bool,
-        can_promote: bool,
+        mode: &ReplicationMode,
     ) -> crate::Result<Option<Self>> {
         let ctx = ReplicationContext::new(
-            broker,
-            mode_tx,
-            accountsdb,
-            ledger,
-            chainlink,
-            scheduler,
-            cancel,
-            can_promote,
+            broker, mode_tx, accountsdb, ledger, chainlink, scheduler, cancel,
         )
         .await?;
 
-        // Try to become primary only if promotion is allowed.
-        if can_promote {
+        if let ReplicationMode::Primary(_) = mode {
+            // Try to become primary
             match ctx.try_acquire_producer().await? {
                 Some(producer) => Ok(Some(Self::Primary(
                     ctx.into_primary(producer, messages).await?,
                 ))),
-                None => {
-                    let Some(standby) =
-                        ctx.into_standby(messages, reset).await?
-                    else {
-                        // Shutdown during consumer creation
-                        return Ok(None);
-                    };
-                    Ok(Some(Self::Standby(standby)))
-                }
+                None => Err(Error::Internal(
+                    "Failed to acquire producer lock".into(),
+                )),
             }
         } else {
-            // ReplicaOnly mode: skip lock acquisition, go directly to standby
-            let Some(standby) = ctx.into_standby(messages, reset).await? else {
+            // Replica mode: skip lock acquisition, go directly to Replica
+            let Some(replica) = ctx.into_replica(reset).await? else {
                 // Shutdown during consumer creation
                 return Ok(None);
             };
-            Ok(Some(Self::Standby(standby)))
+            Ok(Some(Self::Replica(replica)))
         }
     }
 
     /// Runs service with automatic role transitions.
-    pub async fn run(mut self) -> Result<()> {
-        loop {
-            self = match self {
-                Service::Primary(p) => match p.run().await? {
-                    Some(s) => Service::Standby(s),
-                    None => return Ok(()),
-                },
-                Service::Standby(s) => match s.run().await? {
-                    Some(p) => Service::Primary(p),
-                    None => return Ok(()),
-                },
-            };
+    pub async fn run(self) {
+        match self {
+            Service::Primary(p) => p.run().await,
+            Service::Replica(s) => s.run().await,
         }
     }
 
     /// Spawns the service in a dedicated OS thread with a single-threaded runtime.
     ///
     /// Returns a `JoinHandle` that can be used to wait for the service to complete.
-    pub fn spawn(self) -> JoinHandle<Result<()>> {
+    pub fn spawn(self) -> JoinHandle<()> {
         std::thread::spawn(move || {
             let runtime = Builder::new_current_thread()
                 .enable_all()

--- a/magicblock-replicator/src/service/primary.rs
+++ b/magicblock-replicator/src/service/primary.rs
@@ -7,7 +7,6 @@ use tracing::{error, info, instrument, warn};
 use super::{ReplicationContext, LOCK_REFRESH_INTERVAL};
 use crate::{
     nats::{Producer, Subjects},
-    service::Standby,
     watcher::SnapshotWatcher,
     Result,
 };
@@ -36,35 +35,42 @@ impl Primary {
         }
     }
 
-    /// Runs until leadership lost or shutdown.
-    /// Returns `Some(Standby)` on demotion, `None` on shutdown.
+    /// Runs the state replication until shutdown.
     #[instrument(skip(self))]
-    pub async fn run(mut self) -> Result<Option<Standby>> {
+    pub async fn run(mut self) {
         info!("entering primary replication mode");
         let mut lock_tick = tokio::time::interval(LOCK_REFRESH_INTERVAL);
 
         loop {
             tokio::select! {
                 biased;
+                _ = self.ctx.cancel.cancelled() => {
+                    info!("shutdown received, terminating primary mode");
+                    if let Err(error) = self.producer.release().await {
+                        warn!(%error, "failed to release the lock");
+                    }
+                    return;
+                }
                 _ = lock_tick.tick() => {
-                    let held = match self.producer.refresh().await {
-                        Ok(h) => h,
-                        Err(e) => {
-                            warn!(%e, "lock refresh failed");
-                            false
+                    loop {
+                        match self.producer.refresh().await {
+                            Ok(locked) if locked => {
+                                break;
+                            },
+                            Ok(_) => {
+                                warn!("lock lost, should never happen, trying to renew");
+                            }
+                            Err(e) => {
+                                warn!(%e, "lock refresh failed");
+                            }
                         }
-                    };
-                    if !held {
-                        info!("lost leadership, demoting");
-                        return self.ctx.into_standby(self.messages, true).await;
                     }
                 }
                 Some(msg) = self.messages.recv() => {
-                    if let Err(error) = self.publish(msg).await {
+                    while let Err(error) = self.publish(&msg).await {
                         // publish should not easily fail, if that happens, it means
                         // the message broker has become unrecoverably unreacheable
                         warn!(%error, "failed to publish the message");
-                        return self.ctx.into_standby(self.messages, true).await;
                     }
                 }
                 Some((file, slot)) = self.snapshots.recv() => {
@@ -72,23 +78,19 @@ impl Primary {
                         warn!(%e, "snapshot upload failed");
                     }
                 }
-                _ = self.ctx.cancel.cancelled() => {
-                    info!("shutdown received, terminating primary mode");
-                    return Ok(None);
-                }
             }
         }
     }
 
-    async fn publish(&mut self, msg: Message) -> Result<()> {
-        let payload = match bincode::serialize(&msg) {
+    async fn publish(&mut self, msg: &Message) -> Result<()> {
+        let payload = match bincode::serialize(msg) {
             Ok(p) => p,
             Err(error) => {
                 error!(%error, "serialization failed, should never happen");
                 return Ok(());
             }
         };
-        let subject = Subjects::from_message(&msg);
+        let subject = Subjects::from_message(msg);
         let (slot, index) = msg.slot_and_index();
         let ack = matches!(msg, Message::SuperBlock(_));
 

--- a/magicblock-replicator/src/service/primary.rs
+++ b/magicblock-replicator/src/service/primary.rs
@@ -40,16 +40,14 @@ impl Primary {
     pub async fn run(mut self) {
         info!("entering primary replication mode");
         let mut lock_tick = tokio::time::interval(LOCK_REFRESH_INTERVAL);
+        let mut draining = self.ctx.cancel.is_cancelled();
 
         loop {
             tokio::select! {
                 biased;
-                _ = self.ctx.cancel.cancelled() => {
-                    info!("shutdown received, terminating primary mode");
-                    if let Err(error) = self.producer.release().await {
-                        warn!(%error, "failed to release the lock");
-                    }
-                    return;
+                _ = self.ctx.cancel.cancelled(), if !draining => {
+                    draining = true;
+                    info!("shutdown received, draining replication messages");
                 }
                 _ = lock_tick.tick() => {
                     loop {
@@ -58,7 +56,7 @@ impl Primary {
                                 break;
                             },
                             Ok(_) => {
-                                warn!("lock lost, should never happen, trying to renew");
+                                warn!("primary lock lost, should never happen, trying to renew");
                             }
                             Err(e) => {
                                 warn!(%e, "lock refresh failed");
@@ -66,16 +64,24 @@ impl Primary {
                         }
                     }
                 }
-                Some(msg) = self.messages.recv() => {
+                msg = self.messages.recv() => {
+                    let Some(msg) = msg else {
+                        if let Err(error) = self.producer.release().await {
+                            warn!(%error, "failed to release the lock");
+                        }
+                        return;
+                    };
                     while let Err(error) = self.publish(&msg).await {
                         // publish should not easily fail, if that happens, it means
                         // the message broker has become unrecoverably unreacheable
                         warn!(%error, "failed to publish the message");
                     }
                 }
-                Some((file, slot)) = self.snapshots.recv() => {
-                    if let Err(e) = self.ctx.upload_snapshot(file, slot).await {
-                        warn!(%e, "snapshot upload failed");
+                snapshot = self.snapshots.recv(), if !draining => {
+                    if let Some((file, slot)) = snapshot {
+                        if let Err(e) = self.ctx.upload_snapshot(file, slot).await {
+                            warn!(%e, "snapshot upload failed");
+                        }
                     }
                 }
             }

--- a/magicblock-replicator/src/service/replica.rs
+++ b/magicblock-replicator/src/service/replica.rs
@@ -1,4 +1,4 @@
-//! Standby node: consumes events and watches for leader failure.
+//! Replica node: consumes events and watches for leader failure.
 
 use std::time::{Duration, Instant};
 
@@ -9,75 +9,44 @@ use magicblock_core::link::{
     transactions::{ReplayPosition, WithEncoded},
 };
 use solana_transaction::versioned::VersionedTransaction;
-use tokio::sync::mpsc::Receiver;
 use tracing::{error, info, warn};
 
 use super::{ReplicationContext, LEADER_TIMEOUT};
-use crate::{
-    nats::{Consumer, LockWatcher},
-    service::Primary,
-    Result,
-};
+use crate::{nats::Consumer, Result};
 
-/// Standby node: consumes events and watches for leader failure.
-pub struct Standby {
+/// replica node: consumes events and watches for leader failure.
+pub struct Replica {
     pub(crate) ctx: ReplicationContext,
     consumer: Box<Consumer>,
-    messages: Receiver<Message>,
-    watcher: LockWatcher,
     last_activity: Instant,
-    can_promote: bool,
 }
 
-impl Standby {
-    /// Creates a new standby instance.
-    pub fn new(
-        ctx: ReplicationContext,
-        consumer: Box<Consumer>,
-        messages: Receiver<Message>,
-        watcher: LockWatcher,
-    ) -> Self {
-        let can_promote = ctx.can_promote;
+impl Replica {
+    /// Creates a new replica instance.
+    pub fn new(ctx: ReplicationContext, consumer: Box<Consumer>) -> Self {
         Self {
             ctx,
             consumer,
-            messages,
-            watcher,
             last_activity: Instant::now(),
-            can_promote,
         }
     }
 
     /// Runs until leadership acquired or shutdown.
     /// Returns `Some(Primary)` on promotion, `None` on shutdown.
-    pub async fn run(mut self) -> Result<Option<Primary>> {
-        info!("entering standby replication mode");
+    pub async fn run(mut self) {
+        info!("entering replica replication mode");
         let mut timeout_check = tokio::time::interval(Duration::from_secs(1));
         let Some(mut stream) = self.consumer.messages(&self.ctx.cancel).await
         else {
-            return Ok(None);
+            return;
         };
 
         loop {
             tokio::select! {
                 biased;
                 _ = self.ctx.cancel.cancelled() => {
-                    info!("shutdown received, terminating standby mode");
-                    return Ok(None);
-                }
-                _ = self.watcher.wait_for_expiry() => {
-                    if self.has_pending().await {
-                        continue;
-                    }
-                    if !self.can_promote {
-                        warn!("leader lock expired, but takeover disabled (ReplicaOnly mode)");
-                        continue
-                    }
-                    info!("leader lock expired, attempting takeover");
-                    if let Ok(Some(producer)) = self.ctx.try_acquire_producer().await {
-                        info!("acquired leadership, promoting");
-                        return self.ctx.into_primary(producer, self.messages).await.map(Some);
-                    }
+                    info!("shutdown received, terminating replica mode");
+                    return;
                 }
                 result = stream.next() => {
                     let Some(result) = result else {
@@ -85,7 +54,7 @@ impl Standby {
                             stream = s;
                             continue;
                         } else {
-                            return Ok(None);
+                            return;
                         };
                     };
                     match result {
@@ -97,17 +66,11 @@ impl Standby {
                     }
                 }
                 _ = timeout_check.tick() => {
-                     if self.last_activity.elapsed() < LEADER_TIMEOUT {
-                         continue;
-                     }
-                     if !self.can_promote {
-                        warn!("leader timeout reached, but takeover disabled (ReplicaOnly mode)");
+                    if self.last_activity.elapsed() < LEADER_TIMEOUT {
                         continue;
                     }
-                    if let Ok(Some(producer)) = self.ctx.try_acquire_producer().await {
-                        info!("acquired leadership via timeout, promoting");
-                        return self.ctx.into_primary(producer, self.messages).await.map(Some);
-                    }
+                    self.last_activity = Instant::now();
+                    warn!("no leader activity for too long");
                 }
             }
         }
@@ -155,15 +118,6 @@ impl Standby {
             return;
         }
         self.ctx.update_position(slot, index);
-    }
-
-    /// Check whether consumer has any undelivered messages in the stream
-    async fn has_pending(&mut self) -> bool {
-        self.consumer
-            .pending(&self.ctx.cancel)
-            .await
-            .map(|pending| pending != 0)
-            .unwrap_or_default()
     }
 
     async fn replay_tx(&self, msg: Transaction) -> Result<()> {

--- a/magicblock-replicator/src/service/replica.rs
+++ b/magicblock-replicator/src/service/replica.rs
@@ -1,4 +1,4 @@
-//! Replica node: consumes events and watches for leader failure.
+//! Replica node: consumes and applies replicated events.
 
 use std::time::{Duration, Instant};
 
@@ -14,7 +14,7 @@ use tracing::{error, info, warn};
 use super::{ReplicationContext, LEADER_TIMEOUT};
 use crate::{nats::Consumer, Result};
 
-/// replica node: consumes events and watches for leader failure.
+/// Replica node: consumes and applies replicated events.
 pub struct Replica {
     pub(crate) ctx: ReplicationContext,
     consumer: Box<Consumer>,
@@ -31,8 +31,7 @@ impl Replica {
         }
     }
 
-    /// Runs until leadership acquired or shutdown.
-    /// Returns `Some(Primary)` on promotion, `None` on shutdown.
+    /// Runs the replica loop until shutdown or the message stream exits.
     pub async fn run(mut self) {
         info!("entering replica replication mode");
         let mut timeout_check = tokio::time::interval(Duration::from_secs(1));

--- a/test-integration/Cargo.lock
+++ b/test-integration/Cargo.lock
@@ -4778,6 +4778,7 @@ dependencies = [
  "machineid-rs",
  "magicblock-accounts-db",
  "magicblock-chainlink",
+ "magicblock-config",
  "magicblock-core",
  "magicblock-ledger",
  "notify",


### PR DESCRIPTION
This PR disable automatic failover. As a result, node should be pre-configured to start in one the three available modes: Standalone, Primary, Replica. The mode transition during runtime is impossible and any transition should be explicit and requires a restart. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration**
  * Validator replication template updated: "standby"/"replica-only" replaced by "primary"/"replica" placeholders.

* **Documentation**
  * Replaced "standby" with "replica" across docs and README; removed mention of automatic failover.

* **Refactor**
  * Replication model renamed to primary/replica; primaries retain leadership and retry publishes, replicas focus on replay without automatic promotion.

* **Tests**
  * Account test updated to assert monotonic, bounded slot behavior for missing-account lookups.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/magicblock-labs/magicblock-validator/pull/1228?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->