### PR TITLE
fix(ledger): base replay slot has to be next slot after last persisted one

### DIFF
--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -601,10 +601,13 @@ impl MagicValidator {
         // we have this number for our max blockhash age in slots, which correspond to 60 seconds
         let max_block_age =
             SOLANA_VALID_BLOCKHASH_AGE / self.config.ledger.block_time_ms();
+        // replay has to start 1 slot after accountsdb_slot
+        let full_process_starting_slot = accountsdb_slot + 1;
+
         let step_start = Instant::now();
         let process_ledger_result = process_ledger(
             &self.ledger,
-            accountsdb_slot,
+            full_process_starting_slot,
             self.transaction_scheduler.clone(),
             max_block_age,
         )


### PR DESCRIPTION
<!--
PR title must match: type(scope): summary
Types: feat|fix|docs|chore|refactor|test|perf|ci|build
Examples:
  fix: avoid panic on empty slot
  feat(rpc): add getFoo endpoint
-->

## Summary
<!-- One sentence. Link to issue if applicable. -->
Base replay slot has to be next slot after last persisted one

## Breaking Changes
- [ ] None
- [ ] Yes — migration path described below


## Test Plan
<!-- How you verified this works. e.g., "unit tests", "ran locally against testnet", "existing tests pass" -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Adjusted ledger synchronization behavior to correct the processing start position when the database falls behind, ensuring proper consistency during ledger replay operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/magicblock-labs/magicblock-validator/pull/1229?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->