### PR TITLE
chore: return 503 on cluster maintainance error

### DIFF
--- a/magicblock-aperture/src/error.rs
+++ b/magicblock-aperture/src/error.rs
@@ -116,6 +116,27 @@ impl RpcError {
         }
     }
 
+    /// Maps a scheduler simulation error to an `RpcError`, preserving the
+    /// `TRANSACTION_SIMULATION` JSON-RPC code while surfacing the transient
+    /// shutdown case (`ClusterMaintenance`) as HTTP 503 so upstream retry
+    /// proxies can absorb the validator restart gap. Mirrors the behavior of
+    /// `From<TransactionError> for RpcError`, which routes scheduler errors
+    /// from `send_transaction` / `execute` through HTTP 503 the same way.
+    pub(crate) fn transaction_simulation_from_scheduler(
+        error: TransactionError,
+    ) -> Self {
+        let http_status =
+            if matches!(error, TransactionError::ClusterMaintenance) {
+                503
+            } else {
+                200
+            };
+        Self {
+            http_status,
+            ..Self::transaction_simulation(error)
+        }
+    }
+
     pub(crate) fn transaction_verification<E: Display>(error: E) -> Self {
         Self {
             code: TRANSACTION_VERIFICATION,

--- a/magicblock-aperture/src/error.rs
+++ b/magicblock-aperture/src/error.rs
@@ -24,6 +24,12 @@ pub enum ApertureError {
 pub struct RpcError {
     code: i16,
     message: String,
+    // HTTP status to use when rendering this error. Defaults to 200 (the
+    // JSON-RPC convention). Set to 503 for transient unavailability so that
+    // upstream retry-aware proxies can absorb the failure instead of
+    // forwarding a JSON-RPC error body to the client.
+    #[serde(skip)]
+    http_status: u16,
 }
 
 impl Display for RpcError {
@@ -46,7 +52,19 @@ impl From<json::Error> for RpcError {
 
 impl From<TransactionError> for RpcError {
     fn from(value: TransactionError) -> Self {
-        Self::transaction_verification(value)
+        // ClusterMaintenance is returned when the scheduler channels are
+        // closed during shutdown. Surface it as HTTP 503 so the upstream
+        // retry buffer can absorb the brief restart gap.
+        let http_status =
+            if matches!(value, TransactionError::ClusterMaintenance) {
+                503
+            } else {
+                200
+            };
+        Self {
+            http_status,
+            ..Self::transaction_verification(value)
+        }
     }
 }
 
@@ -78,10 +96,15 @@ macro_rules! some_or_err {
 }
 
 impl RpcError {
+    pub(crate) fn http_status(&self) -> u16 {
+        self.http_status
+    }
+
     pub(crate) fn invalid_params<E: Display>(error: E) -> Self {
         Self {
             code: INVALID_PARAMS,
             message: format!("invalid request params: {error}"),
+            http_status: 200,
         }
     }
 
@@ -89,6 +112,7 @@ impl RpcError {
         Self {
             code: TRANSACTION_SIMULATION,
             message: error.to_string(),
+            http_status: 200,
         }
     }
 
@@ -96,6 +120,7 @@ impl RpcError {
         Self {
             code: TRANSACTION_VERIFICATION,
             message: format!("transaction verification error: {error}"),
+            http_status: 200,
         }
     }
 
@@ -103,6 +128,7 @@ impl RpcError {
         Self {
             code: INVALID_REQUEST,
             message: format!("invalid request: {error}"),
+            http_status: 200,
         }
     }
 
@@ -110,6 +136,7 @@ impl RpcError {
         Self {
             code: PARSE_ERROR,
             message: format!("error parsing request body: {error}"),
+            http_status: 200,
         }
     }
 
@@ -117,6 +144,7 @@ impl RpcError {
         Self {
             code: INTERNAL_ERROR,
             message: format!("internal server error: {error}"),
+            http_status: 200,
         }
     }
 
@@ -124,6 +152,7 @@ impl RpcError {
         Self {
             code,
             message: error.to_string(),
+            http_status: 200,
         }
     }
 }

--- a/magicblock-aperture/src/requests/http/simulate_transaction.rs
+++ b/magicblock-aperture/src/requests/http/simulate_transaction.rs
@@ -60,7 +60,7 @@ impl HttpDispatcher {
             .transactions_scheduler
             .simulate(transaction.txn)
             .await
-            .map_err(RpcError::transaction_simulation)?;
+            .map_err(RpcError::transaction_simulation_from_scheduler)?;
         let TransactionSimulationResult {
             result,
             logs,

--- a/magicblock-aperture/src/requests/payload.rs
+++ b/magicblock-aperture/src/requests/payload.rs
@@ -1,4 +1,4 @@
-use hyper::{body::Bytes, header::CONTENT_TYPE, Response};
+use hyper::{body::Bytes, header::CONTENT_TYPE, Response, StatusCode};
 use json::{Serialize, Value};
 use magicblock_core::Slot;
 
@@ -106,12 +106,19 @@ impl<'id> ResponseErrorPayload<'id> {
         id: Option<&'id Value>,
         error: RpcError,
     ) -> Response<JsonBody> {
+        let http_status = error.http_status();
         let payload = Self {
             jsonrpc: "2.0",
             error,
             id,
         };
-        build_json_response(payload)
+        let mut response = build_json_response(payload);
+        if http_status != 200 {
+            if let Ok(status) = StatusCode::from_u16(http_status) {
+                *response.status_mut() = status;
+            }
+        }
+        response
     }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved HTTP status code handling in API error responses. The API now returns appropriate status codes based on error type (e.g., 503 for cluster maintenance), enabling more precise error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/magicblock-labs/magicblock-validator/pull/1230?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->