### PR TITLE
Fix eATA projection min-context refetch

### DIFF
--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -3091,6 +3091,112 @@ async fn test_delegated_eata_subscription_update_clones_raw_eata_and_projects_at
 }
 
 #[tokio::test]
+async fn test_ata_subscription_update_projects_eata_when_chain_slot_lags() {
+    init_logger();
+    let validator_keypair = Keypair::new();
+    let validator_pubkey = validator_keypair.pubkey();
+    let wallet_owner = random_pubkey();
+    let mint = random_pubkey();
+    const EATA_SLOT: u64 = 100;
+    const ATA_SLOT: u64 = EATA_SLOT + 3;
+    const EATA_AMOUNT: u64 = 777;
+    const BASE_ATA_AMOUNT: u64 = 999;
+
+    let eata_pubkey = derive_eata(&wallet_owner, &mint);
+    let ata_pubkey = derive_ata(&wallet_owner, &mint);
+    let eata_account =
+        create_eata_account(&wallet_owner, &mint, EATA_AMOUNT, true);
+    let mut ata_account = create_ata_account(&wallet_owner, &mint);
+    ata_account.data[64..72].copy_from_slice(&BASE_ATA_AMOUNT.to_le_bytes());
+
+    let FetcherTestCtx {
+        accounts_bank,
+        rpc_client,
+        subscription_tx,
+        ..
+    } = setup(
+        [(eata_pubkey, eata_account)],
+        EATA_SLOT,
+        validator_keypair.insecure_clone(),
+    )
+    .await;
+
+    add_delegation_record_with_slot_for(
+        &rpc_client,
+        eata_pubkey,
+        validator_pubkey,
+        EATA_PROGRAM_ID,
+        EATA_SLOT,
+    );
+
+    let rpc_to_advance = rpc_client.clone();
+    let advance_handle = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(800)).await;
+        rpc_to_advance.set_slot(ATA_SLOT);
+    });
+
+    use crate::remote_account_provider::{
+        RemoteAccount, RemoteAccountUpdateSource,
+    };
+
+    subscription_tx
+        .send(ForwardedSubscriptionUpdate {
+            pubkey: ata_pubkey,
+            account: RemoteAccount::from_fresh_account(
+                ata_account,
+                ATA_SLOT,
+                RemoteAccountUpdateSource::Subscription,
+            ),
+        })
+        .await
+        .unwrap();
+
+    const POLL_INTERVAL: std::time::Duration = Duration::from_millis(10);
+    const TIMEOUT: std::time::Duration = Duration::from_secs(3);
+    tokio::time::timeout(TIMEOUT, async {
+        loop {
+            if let Some(account) = accounts_bank.get_account(&ata_pubkey) {
+                let amount = u64::from_le_bytes(
+                    account.data()[64..72].try_into().unwrap(),
+                );
+                assert_ne!(
+                    amount, BASE_ATA_AMOUNT,
+                    "ATA was cloned from base account before eATA projection"
+                );
+                if amount == EATA_AMOUNT {
+                    break;
+                }
+            }
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+    })
+    .await
+    .expect("timed out waiting for projected ATA from lagging eATA refetch");
+    advance_handle.await.unwrap();
+
+    let projected_ata = accounts_bank
+        .get_account(&ata_pubkey)
+        .expect("ATA should be projected from delegated eATA");
+    assert!(projected_ata.delegated());
+    assert_eq!(projected_ata.remote_slot(), ATA_SLOT);
+
+    let ata_data = projected_ata.data();
+    assert!(
+        ata_data.len() >= 72,
+        "Projected ATA data must contain mint/owner/amount"
+    );
+    let projected_mint =
+        Pubkey::new_from_array(ata_data[0..32].try_into().unwrap());
+    let projected_owner =
+        Pubkey::new_from_array(ata_data[32..64].try_into().unwrap());
+    let projected_amount =
+        u64::from_le_bytes(ata_data[64..72].try_into().unwrap());
+    assert_eq!(projected_mint, mint);
+    assert_eq!(projected_owner, wallet_owner);
+    assert_eq!(projected_amount, EATA_AMOUNT);
+}
+
+#[tokio::test]
 async fn test_delegated_eata_subscription_update_clones_action_dependencies() {
     init_logger();
     let validator_keypair = Keypair::new();

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -946,6 +946,14 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
         }
 
         let config = config.unwrap_or_default();
+        // Capture the fetch start slot once and reuse it across retries. When a
+        // caller provides a stricter min_context_slot, the forced refetch must
+        // start from that slot rather than the provider's possibly lagging
+        // chain slot.
+        let fetch_start_slot = self
+            .chain_slot
+            .load()
+            .max(config.min_context_slot.unwrap_or_default());
         // 2. Force a re-fetch unless all the accounts are already pending which
         //    means someone else already requested a re-fetch for all of them
         let refetch = {
@@ -957,14 +965,14 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                 trace!(
                     "Triggering re-fetch for accounts [{}] at slot {}",
                     pubkeys_str(pubkeys),
-                    self.chain_slot()
+                    fetch_start_slot
                 );
             }
             self.fetch(
                 pubkeys.to_vec(),
                 HashMap::new(),
                 None,
-                self.chain_slot(),
+                fetch_start_slot,
                 fetch_origin,
                 None,
             );
@@ -972,10 +980,6 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
 
         // 3. Wait for the slots to match
         const MAX_TOTAL_TIME: Duration = Duration::from_secs(10);
-        // NOTE: we capture the fetch start slot here and reuse it across retries as otherwise
-        // we never get a valid result if the RPC node we fetch from is just slightly behind and
-        // cannot serve us any data with the absolute latest min context slot
-        let fetch_start_slot = self.chain_slot.load();
         let start = std::time::Instant::now();
         let mut retries = 0;
         loop {
@@ -1715,6 +1719,15 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                                      return;
                                  }
                             }
+                        }
+                        ErrorKind::Custom(message)
+                            if message
+                                .to_ascii_lowercase()
+                                .contains("minimum context slot") =>
+                        {
+                            retry!(
+                                "Minimum context slot {min_context_slot} not reached for {commitment:?}: {message}"
+                            );
                         }
                         _ => {
                             let err_msg = format!(

--- a/magicblock-chainlink/src/remote_account_provider/tests.rs
+++ b/magicblock-chainlink/src/remote_account_provider/tests.rs
@@ -920,7 +920,7 @@ async fn test_get_accounts_until_slots_match_not_finding_matching_slot() {
 }
 
 #[tokio::test]
-async fn test_get_accounts_until_slots_match_finding_matching_slot_but_chain_slot_smaller_than_min_context_slot(
+async fn test_get_accounts_until_slots_match_waits_when_chain_slot_smaller_than_min_context_slot(
 ) {
     const CURRENT_SLOT: u64 = 42;
     let pubkey1 = random_pubkey();
@@ -936,7 +936,13 @@ async fn test_get_accounts_until_slots_match_finding_matching_slot_but_chain_slo
     )
     .await;
 
-    let res = remote_account_provider
+    let rpc_to_advance = remote_account_provider.rpc_client.clone();
+    let advance_handle = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(800)).await;
+        rpc_to_advance.set_slot(CURRENT_SLOT + 1);
+    });
+
+    let remote_accounts = remote_account_provider
         .try_get_multi_until_slots_match(
             &[pubkey1, pubkey2],
             Some(MatchSlotsConfig {
@@ -946,20 +952,16 @@ async fn test_get_accounts_until_slots_match_finding_matching_slot_but_chain_slo
             }),
             AccountFetchOrigin::GetAccount,
         )
-        .await;
+        .await
+        .unwrap();
 
-    debug!(result = ?res, "Result");
+    advance_handle.await.unwrap();
 
-    assert!(res.is_err());
-    assert!(matches!(
-        res.unwrap_err(),
-        RemoteAccountProviderError::MatchingSlotsNotSatisfyingMinContextSlot(
-            _pubkeys,
-            _slots,
-            slot,
-            _
-        ) if slot == CURRENT_SLOT + 1
-    ));
+    assert_eq!(remote_accounts.len(), 2);
+    assert!(remote_accounts[0].is_found());
+    assert!(remote_accounts[1].is_found());
+    assert_eq!(remote_accounts[0].slot(), CURRENT_SLOT + 1);
+    assert_eq!(remote_accounts[1].slot(), CURRENT_SLOT + 1);
 }
 
 #[tokio::test]

--- a/magicblock-chainlink/src/testing/rpc_client_mock.rs
+++ b/magicblock-chainlink/src/testing/rpc_client_mock.rs
@@ -365,8 +365,7 @@ impl ChainRpcClient for ChainRpcClientMock {
         for pubkey in pubkeys {
             let val = self
                 .get_account_with_config(pubkey, config.clone())
-                .await
-                .unwrap()
+                .await?
                 .value;
             accounts.push(val);
         }


### PR DESCRIPTION
## Summary
- Honor an explicit `min_context_slot` when refetching accounts for slot-matching, so projection refetches do not start from a lagging provider chain slot.
- Retry custom minimum-context-slot RPC errors instead of treating them as terminal fetch failures.
- Add regression coverage for an ATA subscription update that arrives ahead of provider chain slot and must still project from the delegated eATA.

## Root Cause
The ATA projection path requested the derived eATA with `min_context_slot` from the ATA subscription update, but the provider refetch path still used the current provider `chain_slot`. When that slot lagged behind the update, the eATA fetch could fail before RPC caught up, causing the base ATA to be cloned instead of the projected delegated ATA.

## Validation
- `cargo test -p magicblock-chainlink test_ata_subscription_update_projects_eata_when_chain_slot_lags -- --nocapture`
- `cargo test -p magicblock-chainlink test_get_accounts_until_slots_match -- --nocapture`
- `cargo test -p magicblock-chainlink --lib`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of RPC errors related to minimum context slot synchronization requirements
  * Enhanced retry logic for account fetches to respect stricter context slot requirements

* **Tests**
  * Added test coverage for ATA subscription updates when chain slots lag behind expectations
  * Improved error handling in mock client for multi-account fetch operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/magicblock-labs/magicblock-validator/pull/1240?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->