### PR TITLE
fix: reset owner to default when closing buffer accounts

### DIFF
--- a/programs/magicblock/src/clone_account/common.rs
+++ b/programs/magicblock/src/clone_account/common.rs
@@ -173,6 +173,7 @@ pub fn adjust_authority_lamports(
 /// The account will be removed from accountsdb due to the ephemeral flag.
 pub fn close_buffer_account(mut acc: AccountRefMut<'_>) {
     acc.set_lamports(0);
+    acc.set_owner(Pubkey::default());
     acc.resize(0, 0);
     // Setting ephemeral flag on empty account, forces
     // accountsdb to remove it, thus reclaiming space


### PR DESCRIPTION
This fixes zombie accounts leaks in accounts when large accounts are cloned via multiple transactions and buffer is not properly closed when the transaction sequence fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account closure process to ensure proper cleanup of temporary account state, enhancing data integrity and security during cleanup operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/magicblock-labs/magicblock-validator/pull/1241?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->