### PR TITLE
Fix same-slot account refetch

### DIFF
--- a/magicblock-chainlink/src/remote_account_provider/errors.rs
+++ b/magicblock-chainlink/src/remote_account_provider/errors.rs
@@ -59,13 +59,13 @@ pub enum RemoteAccountProviderError {
     #[error("Failed to resolve account ({0}) to track slots")]
     ClockAccountCouldNotBeResolved(String),
 
-    #[error("Failed to resolve accounts to same slot ({0}) to track slots hit limit: {2}")]
+    #[error("Failed to resolve accounts to same slot ({0}) with slots {1:?} to track slots hit limit: {2}")]
     SlotsDidNotMatch(String, Vec<u64>, String),
 
     #[error("The message {0} is not supported by this actor")]
     UnsupportedActorMessage(String),
 
-    #[error("Accounts matched same slot ({0}), but it's less than min required context slot {2} hit limit: {3}")]
+    #[error("Accounts matched same slot ({0}) with slots {1:?}, but it's less than min required context slot {2} hit limit: {3}")]
     MatchingSlotsNotSatisfyingMinContextSlot(String, Vec<u64>, u64, String),
 
     #[error("LRU capacity must be greater than 0")]

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -455,8 +455,17 @@ fn next_match_slots_retry(
     Ok(match_slots_retry_delay(config))
 }
 
+fn next_match_slots_rpc_error_retry(
+    retries: &mut u64,
+    start: std::time::Instant,
+    config: &MatchSlotsConfig,
+) -> Result<Duration, String> {
+    next_match_slots_retry(retries, start, config)
+        .map(|delay| delay.max(RPC_FETCH_RETRY_DELAY))
+}
+
 fn match_slots_retry_delay(config: &MatchSlotsConfig) -> Duration {
-    Duration::from_millis(config.retry_interval_ms).max(RPC_FETCH_RETRY_DELAY)
+    Duration::from_millis(config.retry_interval_ms)
 }
 
 impl
@@ -1005,8 +1014,11 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
             {
                 Ok(remote_accounts) => remote_accounts,
                 Err(err) => {
-                    let retry =
-                        next_match_slots_retry(&mut retries, start, &config);
+                    let retry = next_match_slots_rpc_error_retry(
+                        &mut retries,
+                        start,
+                        &config,
+                    );
                     warn!(
                         pubkeys = %pubkeys_str(pubkeys),
                         min_context_slot = ?config.min_context_slot,

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -353,6 +353,7 @@ const HELIUS_CONTEXT_SLOT_NOT_REACHED: i64 = -32603;
 const RPC_FETCH_MAX_RETRIES: u64 = 3;
 const RPC_FETCH_RETRY_DELAY: Duration = Duration::from_millis(400);
 const RPC_FETCH_TIMEOUT: Duration = Duration::from_secs(5);
+const MATCH_SLOTS_MAX_TOTAL_TIME: Duration = Duration::from_secs(10);
 pub struct RemoteAccountProvider<T: ChainRpcClient, U: ChainPubsubClient> {
     /// The RPC client to fetch accounts from chain the first time we receive
     /// a request for them
@@ -434,6 +435,28 @@ impl Default for MatchSlotsConfig {
             min_context_slot: None,
         }
     }
+}
+
+fn next_match_slots_retry(
+    retries: &mut u64,
+    start: std::time::Instant,
+    config: &MatchSlotsConfig,
+) -> Result<Duration, String> {
+    *retries += 1;
+    if *retries == config.max_retries {
+        return Err(format!("max retries {}", config.max_retries));
+    }
+    if start.elapsed() > MATCH_SLOTS_MAX_TOTAL_TIME {
+        return Err(format!(
+            "max total time of {} seconds",
+            MATCH_SLOTS_MAX_TOTAL_TIME.as_secs()
+        ));
+    }
+    Ok(match_slots_retry_delay(config))
+}
+
+fn match_slots_retry_delay(config: &MatchSlotsConfig) -> Duration {
+    Duration::from_millis(config.retry_interval_ms).max(RPC_FETCH_RETRY_DELAY)
 }
 
 impl
@@ -959,7 +982,6 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
             .max(config.min_context_slot.unwrap_or_default());
         // 2. Wait for the slots to match. Once the fast path mixed slots,
         // retry with an RPC-only batch so all accounts share one response slot.
-        const MAX_TOTAL_TIME: Duration = Duration::from_secs(10);
         let start = std::time::Instant::now();
         let mut retries = 0;
         loop {
@@ -983,9 +1005,8 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
             {
                 Ok(remote_accounts) => remote_accounts,
                 Err(err) => {
-                    retries += 1;
-                    let hit_max_retry_limit = retries == config.max_retries;
-                    let hit_time_limit = start.elapsed() > MAX_TOTAL_TIME;
+                    let retry =
+                        next_match_slots_retry(&mut retries, start, &config);
                     warn!(
                         pubkeys = %pubkeys_str(pubkeys),
                         min_context_slot = ?config.min_context_slot,
@@ -994,15 +1015,13 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                         error = %err,
                         "RPC-only account fetch failed while resolving accounts to compatible slots"
                     );
-                    if hit_max_retry_limit || hit_time_limit {
-                        return Err(err);
+                    match retry {
+                        Ok(retry_delay) => {
+                            tokio::time::sleep(retry_delay).await;
+                            continue;
+                        }
+                        Err(_) => return Err(err),
                     }
-                    let retry_delay = tokio::time::Duration::from_millis(
-                        config.retry_interval_ms,
-                    )
-                    .max(RPC_FETCH_RETRY_DELAY);
-                    tokio::time::sleep(retry_delay).await;
-                    continue;
                 }
             };
             let slots_match_result = slots_match_and_meet_min_context(
@@ -1013,62 +1032,51 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                 return Ok(remote_accounts);
             }
 
-            retries += 1;
-            let hit_max_retry_limit = retries == config.max_retries;
-            if hit_max_retry_limit || start.elapsed() > MAX_TOTAL_TIME {
-                let remote_account_slots = account_slots(&remote_accounts);
-                let remote_account_sources = remote_accounts
-                    .iter()
-                    .map(|account| account.source())
-                    .collect::<Vec<_>>();
-                let limit = if hit_max_retry_limit {
-                    format!("max retries {}", config.max_retries)
-                } else {
-                    format!(
-                        "max total time of {} seconds",
-                        MAX_TOTAL_TIME.as_secs()
-                    )
-                };
-                warn!(
-                    pubkeys = %pubkeys_str(pubkeys),
-                    slots = ?remote_account_slots,
-                    sources = ?remote_account_sources,
-                    min_context_slot = ?config.min_context_slot,
-                    retries = retries,
-                    elapsed_ms = start.elapsed().as_millis() as u64,
-                    limit = %limit,
-                    "Failed to resolve accounts to compatible slots"
-                );
-                match slots_match_result {
-                    // SAFETY: Match case is already handled and returns
-                    Match => unreachable!("we would have returned above"),
-                    Mismatch => {
-                        return Err(
-                            RemoteAccountProviderError::SlotsDidNotMatch(
-                                pubkeys_str(pubkeys),
-                                remote_account_slots,
-                                limit,
-                            ),
-                        );
-                    }
-                    MatchButBelowMinContextSlot(slot) => {
-                        return Err(
-                            RemoteAccountProviderError::MatchingSlotsNotSatisfyingMinContextSlot(
+            match next_match_slots_retry(&mut retries, start, &config) {
+                Ok(retry_delay) => {
+                    // If the slots don't match then wait for a bit and retry
+                    tokio::time::sleep(retry_delay).await;
+                    continue;
+                }
+                Err(limit) => {
+                    let remote_account_slots = account_slots(&remote_accounts);
+                    let remote_account_sources = remote_accounts
+                        .iter()
+                        .map(|account| account.source())
+                        .collect::<Vec<_>>();
+                    warn!(
+                        pubkeys = %pubkeys_str(pubkeys),
+                        slots = ?remote_account_slots,
+                        sources = ?remote_account_sources,
+                        min_context_slot = ?config.min_context_slot,
+                        retries = retries,
+                        elapsed_ms = start.elapsed().as_millis() as u64,
+                        limit = %limit,
+                        "Failed to resolve accounts to compatible slots"
+                    );
+                    match slots_match_result {
+                        // SAFETY: Match case is already handled and returns
+                        Match => unreachable!("we would have returned above"),
+                        Mismatch => {
+                            return Err(
+                                RemoteAccountProviderError::SlotsDidNotMatch(
+                                    pubkeys_str(pubkeys),
+                                    remote_account_slots,
+                                    limit,
+                                ),
+                            );
+                        }
+                        MatchButBelowMinContextSlot(slot) => {
+                            return Err(RemoteAccountProviderError::MatchingSlotsNotSatisfyingMinContextSlot(
                                 pubkeys_str(pubkeys),
                                 remote_account_slots,
                                 slot,
-                                limit
-                            )
-                        );
+                                limit,
+                            ));
+                        }
                     }
                 }
             }
-
-            // If the slots don't match then wait for a bit and retry
-            tokio::time::sleep(tokio::time::Duration::from_millis(
-                config.retry_interval_ms,
-            ))
-            .await;
         }
     }
 
@@ -1657,11 +1665,6 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
         let mark_empty_if_not_found =
             mark_empty_if_not_found.unwrap_or(&[]).to_vec();
         let program_ids = program_ids.map(|ids| ids.to_vec());
-        let method = if pubkeys.len() == 1 {
-            "get_account"
-        } else {
-            "get_multiple_accounts"
-        };
         tokio::spawn(async move {
             use RemoteAccount::*;
 
@@ -1670,7 +1673,6 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
             let notify_error = |error_msg: &str| {
                 let mut fetching = fetching_accounts.lock().unwrap();
                 warn!(
-                    method = method,
                     pubkey_count = pubkeys.len(),
                     pubkeys = %pubkeys_str(&pubkeys),
                     min_context_slot = min_context_slot,
@@ -1839,7 +1841,6 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                         let attempt =
                             RPC_FETCH_MAX_RETRIES - remaining_retries + 1;
                         warn!(
-                            method = method,
                             pubkey_count = pubkeys.len(),
                             pubkeys = %pubkeys_str(&pubkeys),
                             attempt = attempt,

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -350,6 +350,9 @@ unsafe impl Sync for ForwardedSubscriptionUpdate {}
 
 // Not sure why helius uses a different code for this error
 const HELIUS_CONTEXT_SLOT_NOT_REACHED: i64 = -32603;
+const RPC_FETCH_MAX_RETRIES: u64 = 3;
+const RPC_FETCH_RETRY_DELAY: Duration = Duration::from_millis(400);
+const RPC_FETCH_TIMEOUT: Duration = Duration::from_secs(5);
 pub struct RemoteAccountProvider<T: ChainRpcClient, U: ChainPubsubClient> {
     /// The RPC client to fetch accounts from chain the first time we receive
     /// a request for them
@@ -935,7 +938,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
 
         // 1. Fetch the _normal_ way and hope the slots match and if required
         //    the min_context_slot is met
-        let remote_accounts = self
+        let mut remote_accounts = self
             .try_get_multi(pubkeys, None, fetch_origin, None, None)
             .await?;
         if let Match = slots_match_and_meet_min_context(
@@ -954,31 +957,8 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
             .chain_slot
             .load()
             .max(config.min_context_slot.unwrap_or_default());
-        // 2. Force a re-fetch unless all the accounts are already pending which
-        //    means someone else already requested a re-fetch for all of them
-        let refetch = {
-            let fetching = self.fetching_accounts.lock().unwrap();
-            pubkeys.iter().any(|pk| !fetching.contains_key(pk))
-        };
-        if refetch {
-            if tracing::enabled!(tracing::Level::TRACE) {
-                trace!(
-                    "Triggering re-fetch for accounts [{}] at slot {}",
-                    pubkeys_str(pubkeys),
-                    fetch_start_slot
-                );
-            }
-            self.fetch(
-                pubkeys.to_vec(),
-                HashMap::new(),
-                None,
-                fetch_start_slot,
-                fetch_origin,
-                None,
-            );
-        }
-
-        // 3. Wait for the slots to match
+        // 2. Wait for the slots to match. Once the fast path mixed slots,
+        // retry with an RPC-only batch so all accounts share one response slot.
         const MAX_TOTAL_TIME: Duration = Duration::from_secs(10);
         let start = std::time::Instant::now();
         let mut retries = 0;
@@ -997,15 +977,34 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                     pubkey_slots
                 );
             }
-            let remote_accounts = self
-                .try_get_multi(
-                    pubkeys,
-                    None,
-                    fetch_origin,
-                    None,
-                    Some(fetch_start_slot),
-                )
-                .await?;
+            remote_accounts = match self
+                .fetch_multi_rpc_only(pubkeys, fetch_start_slot, fetch_origin)
+                .await
+            {
+                Ok(remote_accounts) => remote_accounts,
+                Err(err) => {
+                    retries += 1;
+                    let hit_max_retry_limit = retries == config.max_retries;
+                    let hit_time_limit = start.elapsed() > MAX_TOTAL_TIME;
+                    warn!(
+                        pubkeys = %pubkeys_str(pubkeys),
+                        min_context_slot = ?config.min_context_slot,
+                        retries = retries,
+                        elapsed_ms = start.elapsed().as_millis() as u64,
+                        error = %err,
+                        "RPC-only account fetch failed while resolving accounts to compatible slots"
+                    );
+                    if hit_max_retry_limit || hit_time_limit {
+                        return Err(err);
+                    }
+                    let retry_delay = tokio::time::Duration::from_millis(
+                        config.retry_interval_ms,
+                    )
+                    .max(RPC_FETCH_RETRY_DELAY);
+                    tokio::time::sleep(retry_delay).await;
+                    continue;
+                }
+            };
             let slots_match_result = slots_match_and_meet_min_context(
                 &remote_accounts,
                 config.min_context_slot,
@@ -1017,8 +1016,11 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
             retries += 1;
             let hit_max_retry_limit = retries == config.max_retries;
             if hit_max_retry_limit || start.elapsed() > MAX_TOTAL_TIME {
-                let remote_accounts =
-                    remote_accounts.into_iter().map(|a| a.slot()).collect();
+                let remote_account_slots = account_slots(&remote_accounts);
+                let remote_account_sources = remote_accounts
+                    .iter()
+                    .map(|account| account.source())
+                    .collect::<Vec<_>>();
                 let limit = if hit_max_retry_limit {
                     format!("max retries {}", config.max_retries)
                 } else {
@@ -1027,6 +1029,16 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                         MAX_TOTAL_TIME.as_secs()
                     )
                 };
+                warn!(
+                    pubkeys = %pubkeys_str(pubkeys),
+                    slots = ?remote_account_slots,
+                    sources = ?remote_account_sources,
+                    min_context_slot = ?config.min_context_slot,
+                    retries = retries,
+                    elapsed_ms = start.elapsed().as_millis() as u64,
+                    limit = %limit,
+                    "Failed to resolve accounts to compatible slots"
+                );
                 match slots_match_result {
                     // SAFETY: Match case is already handled and returns
                     Match => unreachable!("we would have returned above"),
@@ -1034,7 +1046,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                         return Err(
                             RemoteAccountProviderError::SlotsDidNotMatch(
                                 pubkeys_str(pubkeys),
-                                remote_accounts,
+                                remote_account_slots,
                                 limit,
                             ),
                         );
@@ -1043,7 +1055,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                         return Err(
                             RemoteAccountProviderError::MatchingSlotsNotSatisfyingMinContextSlot(
                                 pubkeys_str(pubkeys),
-                                remote_accounts,
+                                remote_account_slots,
                                 slot,
                                 limit
                             )
@@ -1211,6 +1223,78 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                     .join(",\n"),
             ))
         }
+    }
+
+    async fn fetch_multi_rpc_only(
+        &self,
+        pubkeys: &[Pubkey],
+        min_context_slot: u64,
+        fetch_origin: AccountFetchOrigin,
+    ) -> RemoteAccountProviderResult<Vec<RemoteAccount>> {
+        let config = RpcAccountInfoConfig {
+            commitment: Some(self.rpc_client.commitment()),
+            min_context_slot: Some(min_context_slot),
+            encoding: Some(UiAccountEncoding::Base64Zstd),
+            data_slice: None,
+        };
+
+        metrics::inc_remote_account_provider_a_count();
+        let response = tokio::time::timeout(RPC_FETCH_TIMEOUT, async {
+            self.rpc_client
+                .get_multiple_accounts_with_config(pubkeys, config)
+                .await
+        })
+        .await
+        .map_err(|_| {
+            RemoteAccountProviderError::AccountResolutionsFailed(format!(
+                "RPC call timeout fetching accounts {} after {}ms",
+                pubkeys_str(pubkeys),
+                RPC_FETCH_TIMEOUT.as_millis()
+            ))
+        })?
+        .map_err(|err| {
+            RemoteAccountProviderError::AccountResolutionsFailed(format!(
+                "RpcError fetching accounts {}: {err:?}",
+                pubkeys_str(pubkeys)
+            ))
+        })?;
+
+        let response_slot = response.context.slot;
+        if response_slot < min_context_slot {
+            return Err(RemoteAccountProviderError::AccountResolutionsFailed(
+                format!(
+                    "Response slot {response_slot} < {min_context_slot} fetching accounts {}",
+                    pubkeys_str(pubkeys)
+                ),
+            ));
+        }
+
+        let mut found_count = 0u64;
+        let mut not_found_count = 0u64;
+        let remote_accounts = response
+            .value
+            .into_iter()
+            .map(|account| match account {
+                Some(account) => {
+                    found_count += 1;
+                    RemoteAccount::from_fresh_account(
+                        account,
+                        response_slot,
+                        RemoteAccountUpdateSource::Fetch,
+                    )
+                }
+                None => {
+                    not_found_count += 1;
+                    RemoteAccount::NotFound(response_slot)
+                }
+            })
+            .collect();
+
+        inc_account_fetches_success(pubkeys.len() as u64);
+        inc_account_fetches_found(fetch_origin, found_count);
+        inc_account_fetches_not_found(fetch_origin, not_found_count);
+
+        Ok(remote_accounts)
     }
 
     async fn setup_subscriptions(
@@ -1567,22 +1651,35 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
         fetch_origin: AccountFetchOrigin,
         program_ids: Option<&[Pubkey]>,
     ) {
-        const MAX_RETRIES: u64 = 10;
-        const RPC_CALL_TIMEOUT: Duration = Duration::from_secs(2);
-
         let rpc_client = self.rpc_client.clone();
         let fetching_accounts = self.fetching_accounts.clone();
         let commitment = self.rpc_client.commitment();
         let mark_empty_if_not_found =
             mark_empty_if_not_found.unwrap_or(&[]).to_vec();
         let program_ids = program_ids.map(|ids| ids.to_vec());
+        let method = if pubkeys.len() == 1 {
+            "get_account"
+        } else {
+            "get_multiple_accounts"
+        };
         tokio::spawn(async move {
             use RemoteAccount::*;
 
+            let fetch_started_at = std::time::Instant::now();
             // Helper to notify all pending requests of fetch failure
             let notify_error = |error_msg: &str| {
                 let mut fetching = fetching_accounts.lock().unwrap();
-                warn!("{error_msg}");
+                warn!(
+                    method = method,
+                    pubkey_count = pubkeys.len(),
+                    pubkeys = %pubkeys_str(&pubkeys),
+                    min_context_slot = min_context_slot,
+                    commitment = ?commitment,
+                    fetch_origin = %fetch_origin,
+                    elapsed_ms = fetch_started_at.elapsed().as_millis() as u64,
+                    error = %error_msg,
+                    "{error_msg}"
+                );
                 inc_account_fetches_failed(pubkeys.len() as u64);
                 if let Some(program_ids) = &program_ids {
                     for program_id in program_ids {
@@ -1616,7 +1713,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                 }
             };
 
-            let mut remaining_retries: u64 = MAX_RETRIES;
+            let mut remaining_retries: u64 = RPC_FETCH_MAX_RETRIES;
 
             if tracing::enabled!(tracing::Level::TRACE) {
                 trace!(pubkeys = pubkeys_str(&pubkeys), "Fetching accounts");
@@ -1627,11 +1724,11 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                     trace!($msg);
                     remaining_retries -= 1;
                     if remaining_retries <= 0 {
-                        let err_msg = format!("Max retries {MAX_RETRIES} reached, giving up on fetching accounts: {pubkeys:?}");
+                        let err_msg = format!("Max retries {RPC_FETCH_MAX_RETRIES} reached, giving up on fetching accounts: {pubkeys:?}");
                         notify_error(&err_msg);
                         return;
                     }
-                    tokio::time::sleep(Duration::from_millis(400)).await;
+                    tokio::time::sleep(RPC_FETCH_RETRY_DELAY).await;
                     continue;
                 }};
             }
@@ -1640,7 +1737,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                 // its account cache. Otherwise we could just keep fetching the accounts
                 // until the context slot is high enough.
                 metrics::inc_remote_account_provider_a_count();
-                match tokio::time::timeout(RPC_CALL_TIMEOUT, async {
+                match tokio::time::timeout(RPC_FETCH_TIMEOUT, async {
                     let config = RpcAccountInfoConfig {
                         commitment: Some(commitment),
                         min_context_slot: Some(min_context_slot),
@@ -1739,14 +1836,29 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                         }
                     },
                     Err(_) => {
-                        warn!("RPC call timeout. Retrying...");
+                        let attempt =
+                            RPC_FETCH_MAX_RETRIES - remaining_retries + 1;
+                        warn!(
+                            method = method,
+                            pubkey_count = pubkeys.len(),
+                            pubkeys = %pubkeys_str(&pubkeys),
+                            attempt = attempt,
+                            max_retries = RPC_FETCH_MAX_RETRIES,
+                            remaining_retries = remaining_retries.saturating_sub(1),
+                            timeout_ms = RPC_FETCH_TIMEOUT.as_millis() as u64,
+                            elapsed_ms = fetch_started_at.elapsed().as_millis() as u64,
+                            min_context_slot = min_context_slot,
+                            commitment = ?commitment,
+                            fetch_origin = %fetch_origin,
+                            "RPC call timeout. Retrying..."
+                        );
                         remaining_retries -= 1;
                         if remaining_retries == 0 {
-                            let err_msg = format!("Max retries {MAX_RETRIES} reached, giving up on fetching accounts: {pubkeys:?}");
+                            let err_msg = format!("Max retries {RPC_FETCH_MAX_RETRIES} reached, giving up on fetching accounts: {pubkeys:?}");
                             notify_error(&err_msg);
                             return;
                         }
-                        tokio::time::sleep(Duration::from_millis(400)).await;
+                        tokio::time::sleep(RPC_FETCH_RETRY_DELAY).await;
                         continue;
                     }
                 };

--- a/magicblock-chainlink/src/remote_account_provider/tests.rs
+++ b/magicblock-chainlink/src/remote_account_provider/tests.rs
@@ -883,6 +883,117 @@ async fn test_get_accounts_until_slots_match_finding_matching_slot() {
 }
 
 #[tokio::test]
+async fn test_get_accounts_until_slots_match_refetches_mixed_sources_as_rpc_batch(
+) {
+    const CURRENT_SLOT: u64 = 42;
+    let pubkey1 = random_pubkey();
+    let pubkey2 = random_pubkey();
+    let account1 = Account {
+        lamports: 555,
+        data: vec![],
+        owner: system_program::id(),
+        executable: false,
+        rent_epoch: 0,
+    };
+    let account2 = Account {
+        lamports: 666,
+        data: vec![],
+        owner: system_program::id(),
+        executable: false,
+        rent_epoch: 0,
+    };
+    let subscription_account = Account {
+        lamports: 777,
+        ..account1.clone()
+    };
+    let rpc_client = ChainRpcClientMockBuilder::new()
+        .slot(CURRENT_SLOT)
+        .account(pubkey1, account1)
+        .account(pubkey2, account2)
+        .build();
+    let (updates_tx, updates_rx) = mpsc::channel(100);
+    let pubsub_client = ChainPubsubClientMock::new(updates_tx, updates_rx);
+    let (forward_tx, _forward_rx) = mpsc::channel(100);
+    let (subscribed_accounts, config) = create_test_lru_cache(1000);
+    let provider = Arc::new(
+        RemoteAccountProvider::new(
+            rpc_client.clone(),
+            pubsub_client.clone(),
+            forward_tx,
+            &config,
+            subscribed_accounts,
+            ChainSlot::new(Arc::<AtomicU64>::default()),
+        )
+        .await
+        .unwrap(),
+    );
+
+    rpc_client.block_fetches();
+    let task_handle = tokio::spawn({
+        let provider = provider.clone();
+        async move {
+            provider
+                .try_get_multi_until_slots_match(
+                    &[pubkey1, pubkey2],
+                    Some(MatchSlotsConfig {
+                        max_retries: 3,
+                        retry_interval_ms: 10,
+                        min_context_slot: None,
+                    }),
+                    AccountFetchOrigin::GetAccount,
+                )
+                .await
+        }
+    });
+
+    let start = tokio::time::Instant::now();
+    loop {
+        let subscriptions = pubsub_client.subscriptions_union();
+        if subscriptions.contains(&pubkey1) && subscriptions.contains(&pubkey2)
+        {
+            break;
+        }
+        assert!(start.elapsed() < Duration::from_secs(2));
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
+    pubsub_client
+        .send_account_update(pubkey1, CURRENT_SLOT + 1, &subscription_account)
+        .await;
+    let start = tokio::time::Instant::now();
+    loop {
+        if !provider.is_pending(&pubkey1) && provider.is_pending(&pubkey2) {
+            break;
+        }
+        assert!(start.elapsed() < Duration::from_secs(2));
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    rpc_client.allow_fetches();
+
+    let remote_accounts =
+        tokio::time::timeout(Duration::from_secs(2), task_handle)
+            .await
+            .expect("slot-match task should complete")
+            .expect("slot-match task should not panic")
+            .expect("slot-match fetch should succeed");
+
+    assert_eq!(remote_accounts.len(), 2);
+    assert_eq!(
+        remote_accounts[0].source(),
+        Some(RemoteAccountUpdateSource::Fetch)
+    );
+    assert_eq!(
+        remote_accounts[1].source(),
+        Some(RemoteAccountUpdateSource::Fetch)
+    );
+    assert_eq!(remote_accounts[0].slot(), CURRENT_SLOT);
+    assert_eq!(remote_accounts[1].slot(), CURRENT_SLOT);
+    assert_eq!(remote_accounts[0].fresh_lamports(), Some(555));
+    assert_eq!(remote_accounts[1].fresh_lamports(), Some(666));
+    assert_eq!(rpc_client.multi_account_fetches(), 2);
+}
+
+#[tokio::test]
 async fn test_get_accounts_until_slots_match_not_finding_matching_slot() {
     const CURRENT_SLOT: u64 = 42;
     let pubkey1 = random_pubkey();

--- a/magicblock-chainlink/src/remote_account_provider/tests.rs
+++ b/magicblock-chainlink/src/remote_account_provider/tests.rs
@@ -1114,6 +1114,17 @@ async fn test_get_accounts_until_slots_match_finding_matching_slot_but_one_accou
     assert!(!accs[1].is_found());
 }
 
+#[test]
+fn test_match_slots_retry_delay_honors_configured_interval() {
+    let config = MatchSlotsConfig {
+        max_retries: 10,
+        retry_interval_ms: 50,
+        min_context_slot: None,
+    };
+
+    assert_eq!(match_slots_retry_delay(&config), Duration::from_millis(50));
+}
+
 // -----------------
 // LRU Cache/Eviction/Removal
 // -----------------


### PR DESCRIPTION
## Summary
- retry same-slot account resolution with a single RPC batch after a mixed-source mismatch. This avoids slots never matching due to RPC/Ws races. Observed in production, resulting in "RPC call timeout. Retrying..." errors 
- remove the extra non-waiter refetch that could amplify RPC load
- add structured timeout/slot-mismatch logging and coverage for mixed subscription/fetch results

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RPC fetch reliability with configurable retry logic and timeout handling.
  * Enhanced slot-matching validation with automatic re-fetching when compatibility issues occur.

* **Improvements**
  * Better error messages for account resolution failures.
  * Richer diagnostic logging during account fetch operations, including retry attempts and timing information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/magicblock-labs/magicblock-validator/pull/1242?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->