### PR TITLE
fix: replication protocol 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4238,7 +4238,6 @@ dependencies = [
  "futures",
  "machineid-rs",
  "magicblock-accounts-db",
- "magicblock-chainlink",
  "magicblock-config",
  "magicblock-core",
  "magicblock-ledger",

--- a/magicblock-accounts-db/src/index.rs
+++ b/magicblock-accounts-db/src/index.rs
@@ -341,14 +341,14 @@ impl AccountsDbIndex {
         program: &Pubkey,
     ) -> AccountsDbResult<OffsetPubkeyIter<'_>> {
         let txn = self.env.begin_ro_txn()?;
-        OffsetPubkeyIter::new(&self.programs, txn, Some(program))
+        OffsetPubkeyIter::new_programs(&self.programs, txn, Some(program))
     }
 
     pub(crate) fn get_all_accounts(
         &self,
     ) -> AccountsDbResult<OffsetPubkeyIter<'_>> {
         let txn = self.env.begin_ro_txn()?;
-        OffsetPubkeyIter::new(&self.programs, txn, None)
+        OffsetPubkeyIter::new_accounts(&self.accounts, txn)
     }
 
     pub(crate) fn offset_finder(

--- a/magicblock-accounts-db/src/index/iterator.rs
+++ b/magicblock-accounts-db/src/index/iterator.rs
@@ -18,13 +18,21 @@ pub struct OffsetPubkeyIter<'env> {
     /// The read-only transaction.
     /// Kept alive to maintain the validity of the cursor.
     _txn: RoTransaction<'env>,
+    layout: Layout,
+}
+
+#[derive(Clone, Copy)]
+enum Layout {
+    ProgramValue,
+    AccountKey,
 }
 
 impl<'env> OffsetPubkeyIter<'env> {
-    pub(super) fn new(
+    fn new(
         table: &Table,
         txn: RoTransaction<'env>,
         pubkey: Option<&Pubkey>,
+        layout: Layout,
     ) -> AccountsDbResult<Self> {
         let cursor = table.cursor_ro(&txn)?;
 
@@ -59,7 +67,23 @@ impl<'env> OffsetPubkeyIter<'env> {
             iter,
             _cursor: cursor,
             _txn: txn,
+            layout,
         })
+    }
+
+    pub(super) fn new_programs(
+        table: &Table,
+        txn: RoTransaction<'env>,
+        pubkey: Option<&Pubkey>,
+    ) -> AccountsDbResult<Self> {
+        Self::new(table, txn, pubkey, Layout::ProgramValue)
+    }
+
+    pub(super) fn new_accounts(
+        table: &Table,
+        txn: RoTransaction<'env>,
+    ) -> AccountsDbResult<Self> {
+        Self::new(table, txn, None, Layout::AccountKey)
     }
 }
 
@@ -69,10 +93,21 @@ impl Iterator for OffsetPubkeyIter<'_> {
     fn next(&mut self) -> Option<Self::Item> {
         // Retrieve the next record from the LMDB iterator.
         // The iterator returns `(&[u8], &[u8])` representing (key, value).
-        let (_, value_bytes) = self.iter.next()?.ok()?;
+        let (key_bytes, value_bytes) = self.iter.next()?.ok()?;
 
-        // Unpack the value which contains the Offset and Pubkey.
-        // Usage matches the `programs` index layout: [Offset (4 bytes) | Pubkey (32 bytes)]
-        Some(bytes!(#unpack, value_bytes, Offset, Pubkey))
+        match self.layout {
+            Layout::ProgramValue => {
+                // `programs` values are `[offset | pubkey]`.
+                Some(bytes!(#unpack, value_bytes, Offset, Pubkey))
+            }
+            Layout::AccountKey => {
+                // `accounts` keys are the pubkey; values are `[offset | blocks]`.
+                let pubkey = Pubkey::try_from(key_bytes).ok()?;
+                let offset = unsafe {
+                    (value_bytes.as_ptr() as *const Offset).read_unaligned()
+                };
+                Some((offset, pubkey))
+            }
+        }
     }
 }

--- a/magicblock-accounts-db/src/index/iterator.rs
+++ b/magicblock-accounts-db/src/index/iterator.rs
@@ -103,6 +103,12 @@ impl Iterator for OffsetPubkeyIter<'_> {
             Layout::AccountKey => {
                 // `accounts` keys are the pubkey; values are `[offset | blocks]`.
                 let pubkey = Pubkey::try_from(key_bytes).ok()?;
+                // SAFETY: In the `Layout::AccountKey` path, `value_bytes` comes
+                // from the `accounts` index, whose values are always encoded as
+                // `[Offset | Blocks]`. That guarantees `value_bytes` has at least
+                // `size_of::<Offset>()` bytes, and `read_unaligned` does not
+                // require aligned input. The first bytes therefore represent a
+                // valid `Offset` for the `Pubkey::try_from(key_bytes)` entry.
                 let offset = unsafe {
                     (value_bytes.as_ptr() as *const Offset).read_unaligned()
                 };

--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -251,7 +251,6 @@ impl MagicValidator {
                     mode_tx.clone(),
                     accountsdb.clone(),
                     ledger.clone(),
-                    chainlink.stub(),
                     dispatch.transaction_scheduler.clone(),
                     messages_rx,
                     token.clone(),

--- a/magicblock-chainlink/src/chainlink/mod.rs
+++ b/magicblock-chainlink/src/chainlink/mod.rs
@@ -491,21 +491,6 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
             .map(|provider| provider.is_watching(pubkey))
             .unwrap_or(false)
     }
-
-    /// A temporary hacky method to clone chainlink with accountsdb only,
-    /// for it's used by the replication service to clean up accountsdb
-    ///
-    /// TODO(bmuddha):
-    /// remove all accountsdb management from chainlink, after accountsdb refactoring
-    pub fn stub(&self) -> StubbedChainlink<V> {
-        Chainlink {
-            accounts_bank: self.accounts_bank.clone(),
-            fetch_cloner: None,
-            removed_accounts_sub: None,
-            validator_id: self.validator_id,
-            remove_confined_accounts: self.remove_confined_accounts,
-        }
-    }
 }
 
 // -----------------

--- a/magicblock-processor/src/scheduler/mod.rs
+++ b/magicblock-processor/src/scheduler/mod.rs
@@ -164,7 +164,9 @@ impl TransactionScheduler {
         let mut hasher = Hasher::new();
         let slot_ticker = interval(state.block_time);
         let latest_block = state.ledger.latest_block().clone();
-        hasher.update(latest_block.load().blockhash.as_ref());
+        hasher.update(
+            Self::initial_blockhash(&state.accountsdb, &latest_block).as_ref(),
+        );
         let slot = state.accountsdb.slot() + 1;
 
         Self {
@@ -186,6 +188,30 @@ impl TransactionScheduler {
             slot,
             index: 0,
         }
+    }
+
+    fn initial_blockhash(
+        accountsdb: &AccountsDb,
+        latest_block: &LatestBlock,
+    ) -> Hash {
+        let ledger_hash = latest_block.load().blockhash;
+        if ledger_hash != Hash::default() {
+            return ledger_hash;
+        }
+
+        let snapshot_hash = accountsdb
+            .get_account(&slot_hashes::ID)
+            .and_then(|account| from_account::<SlotHashes, _>(&account))
+            .and_then(|hashes| {
+                hashes.slot_hashes().first().map(|(_, hash)| *hash)
+            });
+        if let Some(hash) = snapshot_hash {
+            return hash;
+        }
+
+        warn!("initial blockhash was not found, starting with an empty one");
+
+        Hash::default()
     }
 
     /// Spawns the scheduler's event loop in a dedicated OS thread.

--- a/magicblock-replicator/Cargo.toml
+++ b/magicblock-replicator/Cargo.toml
@@ -14,7 +14,6 @@ bytes = { workspace = true }
 futures = { workspace = true }
 machineid-rs = { workspace = true }
 magicblock-accounts-db = { workspace = true }
-magicblock-chainlink = { workspace = true }
 magicblock-config = { workspace = true }
 magicblock-core = { workspace = true }
 magicblock-ledger = { workspace = true }

--- a/magicblock-replicator/src/nats/broker.rs
+++ b/magicblock-replicator/src/nats/broker.rs
@@ -9,7 +9,8 @@ use async_nats::{
         stream::{self, Compression},
         Context, ContextBuilder,
     },
-    ConnectOptions, Event, ServerAddr, Subject,
+    header::NATS_MESSAGE_ID,
+    ConnectOptions, Event, HeaderMap, ServerAddr, Subject,
 };
 use bytes::Bytes;
 use magicblock_core::Slot;
@@ -115,9 +116,16 @@ impl Broker {
         &mut self,
         subject: Subject,
         payload: Bytes,
+        msg_id: Option<&str>,
         ack: bool,
     ) -> Result<()> {
-        let f = self.ctx.publish(subject, payload).await?;
+        let f = if let Some(msg_id) = msg_id {
+            let mut headers = HeaderMap::new();
+            headers.insert(NATS_MESSAGE_ID, msg_id);
+            self.ctx.publish_with_headers(subject, headers, payload).await?
+        } else {
+            self.ctx.publish(subject, payload).await?
+        };
         if ack {
             self.sequence = f.await?.sequence;
         }

--- a/magicblock-replicator/src/nats/broker.rs
+++ b/magicblock-replicator/src/nats/broker.rs
@@ -3,13 +3,13 @@
 use std::time::Duration;
 
 use async_nats::{
+    header::NATS_MESSAGE_ID,
     jetstream::{
         kv,
         object_store::{self, GetErrorKind, ObjectMetadata},
         stream::{self, Compression},
         Context, ContextBuilder,
     },
-    header::NATS_MESSAGE_ID,
     ConnectOptions, Event, HeaderMap, ServerAddr, Subject,
 };
 use bytes::Bytes;
@@ -122,7 +122,9 @@ impl Broker {
         let f = if let Some(msg_id) = msg_id {
             let mut headers = HeaderMap::new();
             headers.insert(NATS_MESSAGE_ID, msg_id);
-            self.ctx.publish_with_headers(subject, headers, payload).await?
+            self.ctx
+                .publish_with_headers(subject, headers, payload)
+                .await?
         } else {
             self.ctx.publish(subject, payload).await?
         };

--- a/magicblock-replicator/src/service/context.rs
+++ b/magicblock-replicator/src/service/context.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 
 use machineid_rs::IdBuilder;
 use magicblock_accounts_db::AccountsDb;
-use magicblock_chainlink::StubbedChainlink;
 use magicblock_core::{
     link::{
         replication::{Block, Message, SuperBlock},
@@ -39,10 +38,6 @@ pub struct ReplicationContext {
     pub mode_tx: Sender<SchedulerMode>,
     /// Accounts database.
     pub accountsdb: Arc<AccountsDb>,
-    /// Mocked chainlink to reset accountsdb
-    /// TODO(bmuddha): this is a temporary hack, which will be removed
-    /// once the accounts management is moved to the accountsdb
-    pub chainlink: StubbedChainlink<AccountsDb>,
     /// Transaction ledger.
     pub ledger: Arc<Ledger>,
     /// Transaction scheduler.
@@ -61,7 +56,6 @@ impl ReplicationContext {
         mode_tx: Sender<SchedulerMode>,
         accountsdb: Arc<AccountsDb>,
         ledger: Arc<Ledger>,
-        chainlink: StubbedChainlink<AccountsDb>,
         scheduler: TransactionSchedulerHandle,
         cancel: CancellationToken,
     ) -> Result<Self> {
@@ -82,7 +76,6 @@ impl ReplicationContext {
             cancel,
             mode_tx,
             accountsdb,
-            chainlink,
             ledger,
             scheduler,
             slot,
@@ -178,9 +171,6 @@ impl ReplicationContext {
         messages: Receiver<Message>,
     ) -> Result<Primary> {
         let snapshots = self.create_snapshot_watcher()?;
-        // TODO(bmuddha): remove dependency on the chainlink
-        let _guard = self.scheduler.wait_for_idle().await;
-        self.chainlink.reset_accounts_bank()?;
         self.enter_primary_mode().await;
         Ok(Primary::new(self, producer, messages, snapshots))
     }

--- a/magicblock-replicator/src/service/mod.rs
+++ b/magicblock-replicator/src/service/mod.rs
@@ -27,7 +27,6 @@ use std::{sync::Arc, thread::JoinHandle, time::Duration};
 
 pub use context::ReplicationContext;
 use magicblock_accounts_db::AccountsDb;
-use magicblock_chainlink::StubbedChainlink;
 use magicblock_config::config::validator::ReplicationMode;
 use magicblock_core::link::{
     replication::Message,
@@ -73,7 +72,6 @@ impl Service {
         mode_tx: Sender<SchedulerMode>,
         accountsdb: Arc<AccountsDb>,
         ledger: Arc<Ledger>,
-        chainlink: StubbedChainlink<AccountsDb>,
         scheduler: TransactionSchedulerHandle,
         messages: Receiver<Message>,
         cancel: CancellationToken,
@@ -81,7 +79,7 @@ impl Service {
         mode: &ReplicationMode,
     ) -> crate::Result<Option<Self>> {
         let ctx = ReplicationContext::new(
-            broker, mode_tx, accountsdb, ledger, chainlink, scheduler, cancel,
+            broker, mode_tx, accountsdb, ledger, scheduler, cancel,
         )
         .await?;
 

--- a/magicblock-replicator/src/service/primary.rs
+++ b/magicblock-replicator/src/service/primary.rs
@@ -1,7 +1,9 @@
 //! Primary node: publishes events and holds leader lock.
 
+use std::time::Duration;
+
 use magicblock_core::link::replication::Message;
-use tokio::sync::mpsc::Receiver;
+use tokio::{sync::mpsc::Receiver, time::Instant};
 use tracing::{error, info, instrument, warn};
 
 use super::{ReplicationContext, LOCK_REFRESH_INTERVAL};
@@ -11,12 +13,52 @@ use crate::{
     Result,
 };
 
+const LOCK_RETRY_WARN_INTERVAL: Duration = Duration::from_secs(5);
+
 /// Primary node: publishes events and holds leader lock.
 pub struct Primary {
     pub(crate) ctx: ReplicationContext,
     producer: Producer,
     messages: Receiver<Message>,
     snapshots: SnapshotWatcher,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum LockState {
+    Held,
+    Reacquiring { last_warned_at: Option<Instant> },
+}
+
+impl LockState {
+    fn can_publish(self) -> bool {
+        matches!(self, Self::Held)
+    }
+
+    fn on_refresh_lost(&mut self) {
+        *self = Self::Reacquiring {
+            last_warned_at: None,
+        };
+    }
+
+    fn on_reacquire_result(&mut self, acquired: bool) {
+        if acquired {
+            *self = Self::Held;
+        }
+    }
+
+    fn should_warn(&mut self, now: Instant) -> bool {
+        let Self::Reacquiring { last_warned_at } = self else {
+            return true;
+        };
+
+        let should_warn = last_warned_at
+            .map(|last| now.duration_since(last) >= LOCK_RETRY_WARN_INTERVAL)
+            .unwrap_or(true);
+        if should_warn {
+            *last_warned_at = Some(now);
+        }
+        should_warn
+    }
 }
 
 impl Primary {
@@ -41,6 +83,8 @@ impl Primary {
         info!("entering primary replication mode");
         let mut lock_tick = tokio::time::interval(LOCK_REFRESH_INTERVAL);
         let mut draining = self.ctx.cancel.is_cancelled();
+        let mut lock_state = LockState::Held;
+        let mut pending = None;
 
         loop {
             tokio::select! {
@@ -49,32 +93,62 @@ impl Primary {
                     draining = true;
                     info!("shutdown received, draining replication messages");
                 }
+                _ = async {}, if lock_state.can_publish() && pending.is_some() => {
+                    if let Some(msg) = pending.as_ref() {
+                        while let Err(error) = self.publish(msg).await {
+                            warn!(%error, "failed to publish the message");
+                        }
+                    }
+                    pending = None;
+                }
                 _ = lock_tick.tick() => {
-                    loop {
-                        match self.producer.refresh().await {
-                            Ok(locked) if locked => {
-                                break;
-                            },
-                            Ok(_) => {
-                                warn!("primary lock lost, should never happen, trying to renew");
+                    match lock_state {
+                        LockState::Held => match self.producer.refresh().await {
+                            Ok(true) => {}
+                            Ok(false) => {
+                                warn!("primary lock lost, waiting to reacquire");
+                                lock_state.on_refresh_lost();
                             }
                             Err(e) => {
-                                warn!(%e, "lock refresh failed");
+                                warn!(%e, "lock refresh failed, waiting to reacquire");
+                                lock_state.on_refresh_lost();
+                            }
+                        },
+                        LockState::Reacquiring { .. } => match self.producer.acquire().await {
+                            Ok(true) => {
+                                info!("primary lock reacquired");
+                                lock_state.on_reacquire_result(true);
+                            }
+                            Ok(false) => {
+                                if lock_state.should_warn(Instant::now()) {
+                                    warn!("primary lock still unavailable, retrying");
+                                }
+                            }
+                            Err(e) => {
+                                if lock_state.should_warn(Instant::now()) {
+                                    warn!(%e, "failed to reacquire primary lock");
+                                }
                             }
                         }
                     }
                 }
-                msg = self.messages.recv() => {
+                msg = self.messages.recv(), if pending.is_none() => {
                     let Some(msg) = msg else {
-                        if let Err(error) = self.producer.release().await {
-                            warn!(%error, "failed to release the lock");
+                        if lock_state.can_publish() {
+                            if let Err(error) = self.producer.release().await {
+                                warn!(%error, "failed to release the lock");
+                            }
                         }
                         return;
                     };
-                    while let Err(error) = self.publish(&msg).await {
-                        // publish should not easily fail, if that happens, it means
-                        // the message broker has become unrecoverably unreacheable
-                        warn!(%error, "failed to publish the message");
+                    if lock_state.can_publish() {
+                        while let Err(error) = self.publish(&msg).await {
+                            // publish should not easily fail, if that happens, it means
+                            // the message broker has become unrecoverably unreacheable
+                            warn!(%error, "failed to publish the message");
+                        }
+                    } else {
+                        pending = Some(msg);
                     }
                 }
                 snapshot = self.snapshots.recv(), if !draining => {
@@ -98,13 +172,18 @@ impl Primary {
         };
         let subject = Subjects::from_message(msg);
         let (slot, index) = msg.slot_and_index();
+        let msg_id = message_id(slot, index);
         let ack = matches!(msg, Message::SuperBlock(_));
 
         self.ctx
             .broker
-            .publish(subject, payload.into(), ack)
+            .publish(subject, payload.into(), Some(msg_id.as_str()), ack)
             .await?;
         self.ctx.update_position(slot, index);
         Ok(())
     }
+}
+
+fn message_id(slot: u64, index: u32) -> String {
+    format!("{slot}:{index}")
 }

--- a/magicblock-replicator/src/service/primary.rs
+++ b/magicblock-replicator/src/service/primary.rs
@@ -14,6 +14,9 @@ use crate::{
 };
 
 const LOCK_RETRY_WARN_INTERVAL: Duration = Duration::from_secs(5);
+const PUBLISH_RETRY_BASE_DELAY: Duration = Duration::from_millis(50);
+const PUBLISH_RETRY_MAX_DELAY: Duration = Duration::from_secs(1);
+const PUBLISH_RETRY_LIMIT: usize = 5;
 
 /// Primary node: publishes events and holds leader lock.
 pub struct Primary {
@@ -95,11 +98,10 @@ impl Primary {
                 }
                 _ = async {}, if lock_state.can_publish() && pending.is_some() => {
                     if let Some(msg) = pending.as_ref() {
-                        while let Err(error) = self.publish(msg).await {
-                            warn!(%error, "failed to publish the message");
+                        if self.publish_with_retry(msg).await {
+                            pending = None;
                         }
                     }
-                    pending = None;
                 }
                 _ = lock_tick.tick() => {
                     match lock_state {
@@ -142,10 +144,8 @@ impl Primary {
                         return;
                     };
                     if lock_state.can_publish() {
-                        while let Err(error) = self.publish(&msg).await {
-                            // publish should not easily fail, if that happens, it means
-                            // the message broker has become unrecoverably unreacheable
-                            warn!(%error, "failed to publish the message");
+                        if !self.publish_with_retry(&msg).await {
+                            pending = Some(msg);
                         }
                     } else {
                         pending = Some(msg);
@@ -181,6 +181,37 @@ impl Primary {
             .await?;
         self.ctx.update_position(slot, index);
         Ok(())
+    }
+
+    async fn publish_with_retry(&mut self, msg: &Message) -> bool {
+        let mut delay = PUBLISH_RETRY_BASE_DELAY;
+
+        for attempt in 0..PUBLISH_RETRY_LIMIT {
+            if self.ctx.cancel.is_cancelled() {
+                return false;
+            }
+
+            match self.publish(msg).await {
+                Ok(()) => return true,
+                Err(error) => {
+                    warn!(
+                        %error,
+                        attempt = attempt + 1,
+                        max_attempts = PUBLISH_RETRY_LIMIT,
+                        "failed to publish the message"
+                    );
+                }
+            }
+
+            if attempt + 1 == PUBLISH_RETRY_LIMIT {
+                break;
+            }
+
+            tokio::time::sleep(delay).await;
+            delay = (delay * 2).min(PUBLISH_RETRY_MAX_DELAY);
+        }
+
+        false
     }
 }
 

--- a/test-integration/Cargo.lock
+++ b/test-integration/Cargo.lock
@@ -4777,7 +4777,6 @@ dependencies = [
  "futures",
  "machineid-rs",
  "magicblock-accounts-db",
- "magicblock-chainlink",
  "magicblock-config",
  "magicblock-core",
  "magicblock-ledger",


### PR DESCRIPTION
This PR introduces several replication related fixes: 
1. Removed chainlink dependency to purge the accountsdb 
2. Correct accountsdb checksum compute which uses deterministic ordering
3. Fixed lock re-acquisition logic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added message ID tracking to NATS publisher for improved message observability and debugging.
  * Implemented automatic leader lock recovery with deferred message handling during lock state transitions.
  * Enhanced system initialization with improved blockhash derivation and fallback strategies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/magicblock-labs/magicblock-validator/pull/1247?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->