### PR TITLE
Reconcile lookup table state on extension errors

### DIFF
--- a/magicblock-table-mania/src/lookup_table_rc.rs
+++ b/magicblock-table-mania/src/lookup_table_rc.rs
@@ -70,6 +70,19 @@ impl RefcountedPubkeys {
         }
     }
 
+    /// Adds pubkeys already present on chain without creating local
+    /// reservations for them.
+    fn insert_unreserved_many(&mut self, pubkeys: &[Pubkey]) -> usize {
+        let mut inserted = 0;
+        for pubkey in pubkeys {
+            if !self.pubkeys.contains_key(pubkey) {
+                self.pubkeys.insert(*pubkey, AtomicUsize::new(0));
+                inserted += 1;
+            }
+        }
+        inserted
+    }
+
     /// Add a reservation to the pubkey if it is part of this table
     /// - *pubkey* to reserve
     /// - *returns* `true` if the pubkey could be reserved
@@ -331,6 +344,49 @@ impl LookupTableRc {
     pub fn get_refcount(&self, pubkey: &Pubkey) -> Option<usize> {
         self.pubkeys()?.get_refcount(pubkey)
     }
+
+    /// Reconciles local capacity tracking with the on-chain lookup table.
+    ///
+    /// Remote-only keys are added with refcount 0 so existing reservations are
+    /// preserved while local fullness reflects chain state.
+    pub async fn reconcile_with_chain(
+        &self,
+        rpc_client: &MagicblockRpcClient,
+    ) -> TableManiaResult<()> {
+        if self.is_deactivated() {
+            return Err(TableManiaError::CannotExtendDeactivatedTable(
+                *self.table_address(),
+            ));
+        }
+
+        let Some(chain_pubkeys) = self.get_chain_pubkeys(rpc_client).await?
+        else {
+            debug!(
+                table_address = %self.table_address(),
+                "Skipping lookup table reconciliation; remote table missing"
+            );
+            return Ok(());
+        };
+
+        let Some(mut local_pubkeys) = self.pubkeys_mut() else {
+            return Err(TableManiaError::CannotExtendDeactivatedTable(
+                *self.table_address(),
+            ));
+        };
+        let inserted = local_pubkeys.insert_unreserved_many(&chain_pubkeys);
+        if inserted > 0 {
+            debug!(
+                table_address = %self.table_address(),
+                inserted,
+                remote_count = chain_pubkeys.len(),
+                local_count = local_pubkeys.len(),
+                "Reconciled lookup table pubkeys from chain"
+            );
+        }
+
+        Ok(())
+    }
+
     /// Returns `true` if the we requested to deactivate this table.
     /// NOTE: this doesn't mean that the deactivation period passed, thus
     ///       the table could still be considered _deactivating_ on chain.

--- a/magicblock-table-mania/src/lookup_table_rc.rs
+++ b/magicblock-table-mania/src/lookup_table_rc.rs
@@ -813,23 +813,41 @@ impl LookupTableRc {
             latest_blockhash,
         );
 
-        let outcome = rpc_client
+        let send_result = rpc_client
             .send_transaction(
                 &tx,
                 &Self::get_send_transaction_config(rpc_client),
             )
-            .await?;
+            .await;
 
-        let (signature, error) = outcome.into_signature_and_error();
-        if let Some(error) = &error {
-            debug!(
-                error = ?error,
-                signature = %signature,
-                "Error closing lookup table - may need longer deactivation time"
-            );
-        }
+        let signature = match send_result {
+            Ok(outcome) => {
+                let (sig, error) = outcome.into_signature_and_error();
+                if let Some(error) = &error {
+                    debug!(
+                        error = ?error,
+                        signature = %sig,
+                        "Error closing lookup table - may need longer deactivation time"
+                    );
+                }
+                Some(sig)
+            }
+            Err(err) => {
+                // The ALT program returns InvalidAccountOwner when the table
+                // account no longer exists (e.g. a prior close attempt landed
+                // on chain but its outcome was lost, or it was closed out of
+                // band). Without this salvage the GC would re-issue the close
+                // every cycle indefinitely.
+                let sig = err.signature();
+                if self.is_closed(rpc_client).await.unwrap_or(false) {
+                    return Ok((true, sig));
+                }
+                return Err(err.into());
+            }
+        };
+
         let is_closed = self.is_closed(rpc_client).await?;
-        Ok((is_closed, Some(signature)))
+        Ok((is_closed, signature))
     }
 
     pub async fn get_meta(

--- a/magicblock-table-mania/src/manager.rs
+++ b/magicblock-table-mania/src/manager.rs
@@ -60,6 +60,12 @@ pub struct TableMania {
     compute_budgets: TableManiaComputeBudgets,
 }
 
+#[derive(Debug, Clone, Copy)]
+enum ExistingPubkeyAction {
+    Reserve,
+    LeaveUnreserved,
+}
+
 impl TableMania {
     pub fn new(
         rpc_client: MagicblockRpcClient,
@@ -157,7 +163,12 @@ impl TableMania {
         }
 
         // 2. Add new reservations for pubkeys that are not in any table
-        self.reserve_new_pubkeys(authority, &remaining).await
+        self.reserve_new_pubkeys(
+            authority,
+            &remaining,
+            ExistingPubkeyAction::Reserve,
+        )
+        .await
     }
 
     /// Ensures that pubkeys exist in any active table without increasing reference counts.
@@ -195,7 +206,12 @@ impl TableMania {
 
         // 2. If any pubkeys dont exist, create tables for them
         if !remaining.is_empty() {
-            self.reserve_new_pubkeys(authority, &remaining).await?;
+            self.reserve_new_pubkeys(
+                authority,
+                &remaining,
+                ExistingPubkeyAction::LeaveUnreserved,
+            )
+            .await?;
         }
 
         Ok(())
@@ -226,6 +242,7 @@ impl TableMania {
         &self,
         authority: &Keypair,
         pubkeys: &HashSet<Pubkey>,
+        existing_pubkey_action: ExistingPubkeyAction,
     ) -> TableManiaResult<()> {
         self.check_authority(authority)?;
 
@@ -247,9 +264,10 @@ impl TableMania {
                 // Try to use the last table if it's not full
                 if let Some(table) = active_tables_write_lock.last() {
                     table.reconcile_with_chain(&self.rpc_client).await?;
-                    Self::reserve_pubkeys_present_in_table(
+                    Self::filter_pubkeys_present_in_table(
                         table,
                         &mut remaining,
+                        existing_pubkey_action,
                     );
                     if remaining.is_empty() {
                         stored_in_existing = true;
@@ -290,9 +308,10 @@ impl TableMania {
                 // Double-check if a new table was created while we were waiting for the lock
                 if let Some(table) = active_tables_write_lock.last() {
                     table.reconcile_with_chain(&self.rpc_client).await?;
-                    Self::reserve_pubkeys_present_in_table(
+                    Self::filter_pubkeys_present_in_table(
                         table,
                         &mut remaining,
+                        existing_pubkey_action,
                     );
                     if remaining.is_empty() {
                         continue;
@@ -323,11 +342,15 @@ impl TableMania {
         Ok(())
     }
 
-    fn reserve_pubkeys_present_in_table(
+    fn filter_pubkeys_present_in_table(
         table: &LookupTableRc,
         remaining: &mut Vec<Pubkey>,
+        existing_pubkey_action: ExistingPubkeyAction,
     ) {
-        remaining.retain(|pk| !table.reserve_pubkey(pk));
+        remaining.retain(|pk| match existing_pubkey_action {
+            ExistingPubkeyAction::Reserve => !table.reserve_pubkey(pk),
+            ExistingPubkeyAction::LeaveUnreserved => !table.contains_key(pk),
+        });
     }
 
     /// Extends the table to store as many of the provided pubkeys as possile.

--- a/magicblock-table-mania/src/manager.rs
+++ b/magicblock-table-mania/src/manager.rs
@@ -246,6 +246,7 @@ impl TableMania {
 
                 // Try to use the last table if it's not full
                 if let Some(table) = active_tables_write_lock.last() {
+                    table.reconcile_with_chain(&self.rpc_client).await?;
                     if !table.is_full() {
                         if let Err(err) = self
                             .extend_table(
@@ -282,6 +283,7 @@ impl TableMania {
 
                 // Double-check if a new table was created while we were waiting for the lock
                 if let Some(table) = active_tables_write_lock.last() {
+                    table.reconcile_with_chain(&self.rpc_client).await?;
                     if !table.is_full() {
                         // Another task created a table we can use, so drop the write lock
                         // and try again with the read lock

--- a/magicblock-table-mania/src/manager.rs
+++ b/magicblock-table-mania/src/manager.rs
@@ -383,11 +383,7 @@ impl TableMania {
                 // landed but its outcome was lost). Reconcile so the next
                 // outer iteration sees accurate fullness, and reserve any of
                 // `storing` that turned out to already be on chain.
-                if table
-                    .reconcile_with_chain(&self.rpc_client)
-                    .await
-                    .is_ok()
-                {
+                if table.reconcile_with_chain(&self.rpc_client).await.is_ok() {
                     Self::filter_pubkeys_present_in_table(
                         table,
                         remaining,

--- a/magicblock-table-mania/src/manager.rs
+++ b/magicblock-table-mania/src/manager.rs
@@ -247,7 +247,13 @@ impl TableMania {
                 // Try to use the last table if it's not full
                 if let Some(table) = active_tables_write_lock.last() {
                     table.reconcile_with_chain(&self.rpc_client).await?;
-                    if !table.is_full() {
+                    Self::reserve_pubkeys_present_in_table(
+                        table,
+                        &mut remaining,
+                    );
+                    if remaining.is_empty() {
+                        stored_in_existing = true;
+                    } else if !table.is_full() {
                         if let Err(err) = self
                             .extend_table(
                                 table,
@@ -284,6 +290,13 @@ impl TableMania {
                 // Double-check if a new table was created while we were waiting for the lock
                 if let Some(table) = active_tables_write_lock.last() {
                     table.reconcile_with_chain(&self.rpc_client).await?;
+                    Self::reserve_pubkeys_present_in_table(
+                        table,
+                        &mut remaining,
+                    );
+                    if remaining.is_empty() {
+                        continue;
+                    }
                     if !table.is_full() {
                         // Another task created a table we can use, so drop the write lock
                         // and try again with the read lock
@@ -308,6 +321,13 @@ impl TableMania {
         }
 
         Ok(())
+    }
+
+    fn reserve_pubkeys_present_in_table(
+        table: &LookupTableRc,
+        remaining: &mut Vec<Pubkey>,
+    ) {
+        remaining.retain(|pk| !table.reserve_pubkey(pk));
     }
 
     /// Extends the table to store as many of the provided pubkeys as possile.

--- a/magicblock-table-mania/src/manager.rs
+++ b/magicblock-table-mania/src/manager.rs
@@ -263,21 +263,14 @@ impl TableMania {
 
                 // Try to use the last table if it's not full
                 if let Some(table) = active_tables_write_lock.last() {
-                    table.reconcile_with_chain(&self.rpc_client).await?;
-                    Self::filter_pubkeys_present_in_table(
-                        table,
-                        &mut remaining,
-                        existing_pubkey_action,
-                    );
-                    if remaining.is_empty() {
-                        stored_in_existing = true;
-                    } else if !table.is_full() {
+                    if !table.is_full() {
                         if let Err(err) = self
                             .extend_table(
                                 table,
                                 authority,
                                 &mut remaining,
                                 &mut tables_used,
+                                existing_pubkey_action,
                             )
                             .await
                         {
@@ -307,15 +300,6 @@ impl TableMania {
 
                 // Double-check if a new table was created while we were waiting for the lock
                 if let Some(table) = active_tables_write_lock.last() {
-                    table.reconcile_with_chain(&self.rpc_client).await?;
-                    Self::filter_pubkeys_present_in_table(
-                        table,
-                        &mut remaining,
-                        existing_pubkey_action,
-                    );
-                    if remaining.is_empty() {
-                        continue;
-                    }
                     if !table.is_full() {
                         // Another task created a table we can use, so drop the write lock
                         // and try again with the read lock
@@ -371,6 +355,7 @@ impl TableMania {
         authority: &Keypair,
         remaining: &mut Vec<Pubkey>,
         tables_used: &mut HashSet<Pubkey>,
+        existing_pubkey_action: ExistingPubkeyAction,
     ) -> TableManiaResult<()> {
         let remaining_len = remaining.len();
         let storing_len =
@@ -383,14 +368,35 @@ impl TableMania {
         };
 
         let storing = remaining[..storing_len].to_vec();
-        let stored = table
+        let stored = match table
             .extend_respecting_capacity(
                 &self.rpc_client,
                 authority,
                 &storing,
                 &self.compute_budgets.extend,
             )
-            .await?;
+            .await
+        {
+            Ok(stored) => stored,
+            Err(err) => {
+                // Extend failed; chain may be ahead of local (a prior extend
+                // landed but its outcome was lost). Reconcile so the next
+                // outer iteration sees accurate fullness, and reserve any of
+                // `storing` that turned out to already be on chain.
+                if table
+                    .reconcile_with_chain(&self.rpc_client)
+                    .await
+                    .is_ok()
+                {
+                    Self::filter_pubkeys_present_in_table(
+                        table,
+                        remaining,
+                        existing_pubkey_action,
+                    );
+                }
+                return Err(err);
+            }
+        };
         let stored_len = stored.len();
         tracing::Span::current().record("stored_count", stored_len);
         trace!("Pubkeys stored");


### PR DESCRIPTION
## Summary

- Reconcile local lookup table pubkey tracking with the on-chain table before deciding whether an active table can be extended.
- Add remote-only lookup table entries locally with refcount 0 so existing reservations are preserved while capacity checks reflect chain state.

## Root cause

TableMania used its local refcounted pubkey set as the source of truth for lookup table capacity. If the on-chain ALT had been extended outside the current local state, TableMania could attempt to extend a table that was already full on base chain.

## Impact

When local ALT state is stale, a remotely full table is now treated as full before extension, allowing the reservation flow to create a new lookup table for remaining pubkeys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Improved pubkey reservation reliability by automatically synchronizing lookup table state with on-chain records before allocating new entries, ensuring consistency and preventing conflicts across operations.
* Enhanced table capacity validation by checking on-chain state when extending existing tables and creating new ones, ensuring accurate tracking and preventing allocation errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/magicblock-labs/magicblock-validator/pull/1250?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->