### PR TITLE
Claim validator fees during primary startup

### DIFF
--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -65,7 +65,7 @@ use magicblock_program::{
 use magicblock_replicator::{nats::Broker, ReplicationService};
 use magicblock_services::actions_callback_service::ActionsCallbackService;
 use magicblock_task_scheduler::{SchedulerDatabase, TaskSchedulerService};
-use magicblock_validator_admin::claim_fees::ClaimFeesTask;
+use magicblock_validator_admin::claim_fees::{claim_fees, ClaimFeesTask};
 use mdp::state::{
     features::FeaturesSet,
     record::{CountryCode, ErRecord},
@@ -837,6 +837,22 @@ impl MagicValidator {
                 std::process::exit(1);
             }
             if let Some(ref config) = chain_operation_config {
+                if !config.claim_fees_frequency.is_zero() {
+                    let step_start = Instant::now();
+                    if let Err(err) = claim_fees(rpc_url.clone()).await {
+                        error!(
+                            error = ?err,
+                            "Failed to claim validator fees on startup"
+                        );
+                    }
+                    log_timing(
+                        "startup_background",
+                        "claim_fees_on_startup",
+                        step_start,
+                    );
+                }
+            }
+            if let Some(ref config) = chain_operation_config {
                 let step_start = Instant::now();
                 if let Err(error) = MagicValidator::register_validator_on_chain(
                     &rpc_url,
@@ -896,9 +912,7 @@ impl MagicValidator {
             .config
             .chain_operation
             .as_ref()
-            .filter(|_| {
-                CoordinationMode::current().needs_onchain_interactions()
-            })
+            .filter(|_| self.is_standalone)
             .filter(|co| !co.claim_fees_frequency.is_zero())
             .map(|co| co.claim_fees_frequency)
         {

--- a/magicblock-validator-admin/src/claim_fees.rs
+++ b/magicblock-validator-admin/src/claim_fees.rs
@@ -81,7 +81,7 @@ async fn run_claim_fees_loop(
 }
 
 #[instrument(fields(validator = %validator_authority().pubkey()))]
-async fn claim_fees(url: String) -> Result<(), MagicBlockRpcClientError> {
+pub async fn claim_fees(url: String) -> Result<(), MagicBlockRpcClientError> {
     info!("Claiming validator fees");
 
     let rpc_client =


### PR DESCRIPTION
## Summary
- claim validator fees once during primary startup after the magic fee vault setup succeeds
- keep the periodic claim loop limited to standalone primary validators
- expose the existing claim helper for startup use

## Validation
- cargo fmt
- cargo check -p magicblock-validator-admin
- cargo check -p magicblock-api
- git diff --check
