### PR TITLE
Filter Slack review notifications

### DIFF
--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   notify-review-requested:
-    if: github.event_name == 'pull_request' && github.event.action == 'review_requested'
+    if: github.event_name == 'pull_request' && github.event.action == 'review_requested' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Build Slack review message
@@ -70,7 +70,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   notify-review:
-    if: github.event_name == 'pull_request_review' && github.event.action == 'submitted'
+    if: github.event_name == 'pull_request_review' && github.event.action == 'submitted' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Build Slack review message
@@ -91,6 +91,20 @@ jobs:
             const pr = context.payload.pull_request;
             const reviewer = context.payload.review.user.login;
             const author = pr.user.login;
+            const reviewerKey = reviewer.toLowerCase();
+            const authorKey = author.toLowerCase();
+            const ignoredReviewers = new Set([
+              "codex",
+              "codex[bot]",
+              "coderabbit",
+              "coderabbit[bot]",
+              "coderabbitai",
+              "coderabbitai[bot]",
+            ]);
+            if (ignoredReviewers.has(reviewerKey) || reviewerKey === authorKey) {
+              core.setOutput("should_notify", "false");
+              return;
+            }
             const states = {
               approved: "approved",
               changes_requested: "changes requested",
@@ -99,9 +113,11 @@ jobs:
             const state = states[context.payload.review.state] || context.payload.review.state || "submitted";
             const text = `📝 ${mention(author)} *${escapeMrkdwn(reviewer)}* submitted a *${escapeMrkdwn(state)}* review for PR #${pr.number}: <${pr.html_url}|${escapeMrkdwn(pr.title)}>.`;
 
+            core.setOutput("should_notify", "true");
             core.setOutput("text", text);
 
       - name: Send Slack Notification
+        if: steps.message.outputs.should_notify == 'true'
         uses: slackapi/slack-github-action@v1.24.0
         with:
           payload: |


### PR DESCRIPTION
## Summary
- Skip Slack review notifications for forked PRs.
- Suppress selected bot review submissions and self-reviews before sending Slack payloads.

## Validation
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/slack-notify.yml"); puts "ok"'