### PR TITLE
Reduce chainlink log noise

### DIFF
--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -958,7 +958,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                                     None
                                 } else {
                                     // Subscription is stale, put the fetch tracking back
-                                    warn!(pubkey = %update.pubkey, slot = slot, fetch_start_slot = state.fetch_start_slot, generation, "Received stale subscription update");
+                                    debug!(pubkey = %update.pubkey, slot = slot, fetch_start_slot = state.fetch_start_slot, generation, "Received stale subscription update");
                                     fetching.insert(update.pubkey, state);
                                     None
                                 }
@@ -1065,7 +1065,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                         start,
                         &config,
                     );
-                    warn!(
+                    debug!(
                         pubkeys = %pubkeys_str(pubkeys),
                         min_context_slot = ?config.min_context_slot,
                         retries = retries,

--- a/magicblock-chainlink/src/submux/mod.rs
+++ b/magicblock-chainlink/src/submux/mod.rs
@@ -1059,7 +1059,7 @@ where
         {
             let mut subs = self.program_subs.lock().unwrap();
             if subs.contains(&program_id) {
-                warn!(program_id = %program_id, "Program subscription already exists");
+                debug!(program_id = %program_id, "Program subscription already exists");
                 return Ok(());
             }
             // Add to program_subs before subscribing to clients


### PR DESCRIPTION
## Summary
- Move duplicate program subscription logs from warn to debug.
- Move stale subscription update logs from warn to debug.
- Move retryable RPC-only compatible-slot fetch failures from warn to debug.

## Why
These paths are expected during normal subscription dedupe, fetch/subscription races, and retry handling. The final account-resolution failure still logs at warning level, and real intent execution failures still surface as errors.

## Validation
- cargo fmt --package magicblock-chainlink
- cargo check -p magicblock-chainlink --features dev-context
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted logging levels to reduce noise in routine operational events. Minor logging refinements for improved log clarity without functional changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/magicblock-labs/magicblock-validator/pull/1260?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->