### PR TITLE
chore: remove per-program fetch metric

### DIFF
--- a/magicblock-aperture/src/requests/http/mod.rs
+++ b/magicblock-aperture/src/requests/http/mod.rs
@@ -158,7 +158,6 @@ impl HttpDispatcher {
                 &[*pubkey],
                 Some(&mark_empty_if_not_found),
                 AccountFetchOrigin::GetAccount,
-                None,
             )
             .await
             .inspect_err(|e| {
@@ -193,7 +192,6 @@ impl HttpDispatcher {
                 pubkeys,
                 Some(pubkeys),
                 AccountFetchOrigin::GetMultipleAccounts,
-                None,
             )
             .await
             .inspect_err(|e| {

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -381,7 +381,6 @@ where
         mark_empty_if_not_found: bool,
         slot: Option<u64>,
         fetch_origin: AccountFetchOrigin,
-        program_ids: Option<Vec<Pubkey>>,
     ) {
         let this = self.clone();
         let pending = self.pending_requests.clone();
@@ -390,13 +389,11 @@ where
             let pubkeys = vec![pubkey];
             let mark_empty = mark_empty_if_not_found.then_some(vec![pubkey]);
             let mark_empty_ref = mark_empty.as_deref();
-            let program_ids_ref = program_ids.as_deref();
             let work = this.fetch_and_clone_accounts(
                 &pubkeys,
                 mark_empty_ref,
                 slot,
                 fetch_origin,
-                program_ids_ref,
             );
             let terminal = tokio::select! {
                 biased;
@@ -803,7 +800,6 @@ where
                 None,
                 Some(remote_slot),
                 AccountFetchOrigin::GetAccount,
-                None,
             )
             .await?;
         if result.missing_delegation_record.is_empty() {
@@ -932,7 +928,6 @@ where
                 None,
                 Some(account.remote_slot()),
                 AccountFetchOrigin::GetAccount,
-                None,
             )
             .await
         {
@@ -1581,14 +1576,13 @@ where
     /// - **slot**: optional slot to use as minimum context slot for the accounts being cloned
     ///
     /// NOTE: accounts fetched here have not been found in the bank
-    #[instrument(skip(self, pubkeys, mark_empty_if_not_found, program_ids), fields(tx_sig = tracing::field::Empty))]
+    #[instrument(skip(self, pubkeys, mark_empty_if_not_found), fields(tx_sig = tracing::field::Empty))]
     async fn fetch_and_clone_accounts(
         &self,
         pubkeys: &[Pubkey],
         mark_empty_if_not_found: Option<&[Pubkey]>,
         slot: Option<u64>,
         fetch_origin: AccountFetchOrigin,
-        program_ids: Option<&[Pubkey]>,
     ) -> ChainlinkResult<FetchAndCloneResult> {
         if let Some(sig) = fetch_origin.signature() {
             tracing::Span::current().record("tx_sig", sig.to_string());
@@ -1613,7 +1607,6 @@ where
                 pubkeys,
                 mark_empty_if_not_found,
                 fetch_origin,
-                program_ids,
                 min_context_slot,
             )
             .await?;
@@ -1812,7 +1805,6 @@ where
                     &action_dependencies_to_fetch,
                     None,
                     fetch_origin,
-                    None,
                     min_context_slot,
                 )
                 .await?;
@@ -2056,14 +2048,13 @@ where
     ///
     /// Note: since we fetch each account only once in parallel, we also avoid fetching
     /// the same delegation record in parallel.
-    #[instrument(skip(self, pubkeys, mark_empty_if_not_found, program_ids))]
+    #[instrument(skip(self, pubkeys, mark_empty_if_not_found))]
     pub async fn fetch_and_clone_accounts_with_dedup(
         &self,
         pubkeys: &[Pubkey],
         mark_empty_if_not_found: Option<&[Pubkey]>,
         slot: Option<u64>,
         fetch_origin: AccountFetchOrigin,
-        program_ids: Option<&[Pubkey]>,
     ) -> ChainlinkResult<FetchAndCloneResult> {
         // We cannot clone blacklisted accounts, thus either they are already
         // in the bank (e.g. native programs) or they don't exist and the transaction
@@ -2212,7 +2203,6 @@ where
                         mark_empty_set.contains(&waiter_pubkey),
                         slot,
                         fetch_origin,
-                        program_ids.map(|p| p.to_vec()),
                     );
                     waiters.push(waiter);
                 }

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -373,7 +373,6 @@ async fn test_fetch_and_clone_single_non_delegated_account() {
             None,
             None,
             AccountFetchOrigin::GetAccount,
-            None,
         )
         .await;
 
@@ -412,7 +411,6 @@ async fn test_fetch_and_clone_single_non_existing_account() {
             None,
             None,
             AccountFetchOrigin::GetAccount,
-            None,
         )
         .await;
 
@@ -473,7 +471,6 @@ async fn test_fetch_and_clone_single_delegated_account_with_valid_delegation_rec
             None,
             None,
             AccountFetchOrigin::GetAccount,
-            None,
         )
         .await;
 
@@ -629,7 +626,6 @@ async fn test_fetch_and_clone_single_delegated_account_with_different_authority(
             None,
             None,
             AccountFetchOrigin::GetAccount,
-            None,
         )
         .await;
 
@@ -710,7 +706,6 @@ async fn test_fetch_and_clone_single_delegated_account_without_delegation_record
             None,
             None,
             AccountFetchOrigin::GetAccount,
-            None,
         )
         .await;
     assert!(result.is_ok());
@@ -725,7 +720,6 @@ async fn test_fetch_and_clone_single_delegated_account_without_delegation_record
             None,
             None,
             AccountFetchOrigin::GetAccount,
-            None,
         )
         .await;
 
@@ -825,7 +819,6 @@ async fn test_fetch_and_clone_multiple_accounts_mixed_types() {
             None,
             None,
             AccountFetchOrigin::GetAccount,
-            None,
         )
         .await;
 
@@ -927,7 +920,6 @@ async fn test_fetch_and_clone_valid_delegated_account_and_account_with_invalid_d
             None,
             None,
             AccountFetchOrigin::GetAccount,
-            None,
         )
         .await;
 
@@ -999,7 +991,6 @@ async fn test_deleg_record_stale() {
             None,
             None,
             AccountFetchOrigin::GetAccount,
-            None,
         )
         .await;
 
@@ -1021,7 +1012,6 @@ async fn test_deleg_record_stale() {
             None,
             None,
             AccountFetchOrigin::GetAccount,
-            None,
         )
         .await;
     debug!(result = ?result, "Test result after updating delegation record");
@@ -1077,7 +1067,6 @@ async fn test_account_stale() {
             None,
             None,
             AccountFetchOrigin::GetAccount,
-            None,
         )
         .await;
 
@@ -1098,7 +1087,6 @@ async fn test_account_stale() {
             None,
             None,
             AccountFetchOrigin::GetAccount,
-            None,
         )
         .await;
     debug!(result = ?result, "Test result after updating account");
@@ -1161,7 +1149,6 @@ async fn test_delegation_record_unsub_race_condition_prevention() {
                     None,
                     None,
                     AccountFetchOrigin::GetAccount,
-                    None,
                 )
                 .await
         })
@@ -1231,7 +1218,6 @@ async fn test_fetch_and_clone_with_dedup_concurrent_requests() {
                     None,
                     None,
                     AccountFetchOrigin::GetAccount,
-                    None,
                 )
                 .await
         })
@@ -1309,7 +1295,6 @@ async fn test_undelegation_requested_subscription_behavior() {
             None,
             None,
             AccountFetchOrigin::GetAccount,
-            None,
         )
         .await;
     assert!(result.is_ok());
@@ -1384,7 +1369,6 @@ async fn test_delegated_discovered_after_direct_subscribe_releases_direct_withou
             None,
             None,
             AccountFetchOrigin::GetAccount,
-            None,
         )
         .await
         .expect("delegated account fetch should succeed");
@@ -1680,7 +1664,6 @@ async fn test_delegated_subscription_update_keeps_externally_acquired_undelegati
             None,
             None,
             AccountFetchOrigin::GetAccount,
-            None,
         )
         .await
         .expect("delegated account fetch should succeed");
@@ -1864,7 +1847,6 @@ async fn test_parallel_fetch_prevention_multiple_accounts() {
                     None,
                     None,
                     AccountFetchOrigin::GetAccount,
-                    None,
                 )
                 .await
         })
@@ -1951,7 +1933,6 @@ async fn test_fetch_with_some_acounts_marked_as_empty_if_not_found() {
             Some(&[marked_non_existing_account_pubkey]),
             None,
             AccountFetchOrigin::GetAccount,
-            None,
         )
         .await
         .expect("Fetch and clone failed");
@@ -2054,7 +2035,6 @@ async fn test_confined_delegation_behavior() {
             None,
             None,
             AccountFetchOrigin::GetAccount,
-            None,
         )
         .await
         .expect("Failed to fetch and clone accounts");
@@ -2127,7 +2107,6 @@ async fn test_fetch_and_clone_undelegating_account_that_is_closed_on_chain() {
             None,
             None,
             AccountFetchOrigin::GetAccount,
-            None,
         )
         .await;
 
@@ -2346,7 +2325,6 @@ async fn test_allowed_programs_filters_programs() {
             None,
             None,
             AccountFetchOrigin::GetAccount,
-            Some(&[program_id_allowed, program_id_blocked]),
         )
         .await;
 
@@ -2419,7 +2397,6 @@ async fn test_allowed_programs_none_allows_all() {
             None,
             None,
             AccountFetchOrigin::GetAccount,
-            Some(&[program_id1, program_id2]),
         )
         .await;
 
@@ -2491,7 +2468,6 @@ async fn test_allowed_programs_empty_allows_all() {
             None,
             None,
             AccountFetchOrigin::GetAccount,
-            Some(&[program_id1, program_id2]),
         )
         .await;
 
@@ -2558,7 +2534,6 @@ async fn test_subscribe_to_original_owner_program_on_delegated_account_fetch() {
             None,
             None,
             AccountFetchOrigin::GetAccount,
-            None,
         )
         .await;
 
@@ -2627,7 +2602,6 @@ async fn test_no_program_subscription_for_undelegated_account() {
             None,
             None,
             AccountFetchOrigin::GetAccount,
-            None,
         )
         .await;
 
@@ -2873,7 +2847,6 @@ async fn test_fetch_and_clone_non_raw_eata_owned_account_as_delegated() {
             None,
             None,
             AccountFetchOrigin::GetAccount,
-            None,
         )
         .await
         .expect("Failed to fetch and clone delegated EATA-owned account");
@@ -3946,7 +3919,6 @@ async fn test_fetch_subscription_race_duplicate_clone() {
                 None,
                 None,
                 AccountFetchOrigin::GetAccount,
-                None,
             )
             .await
         })
@@ -4067,7 +4039,6 @@ async fn test_delegated_account_fetch_subscription_race() {
                 None,
                 Some(CURRENT_SLOT),
                 AccountFetchOrigin::GetAccount,
-                None,
             )
             .await
         })
@@ -4175,7 +4146,6 @@ async fn test_clone_ownership_failure_propagates_to_waiters() {
                 None,
                 None,
                 AccountFetchOrigin::GetAccount,
-                None,
             )
             .await
         })
@@ -4210,7 +4180,6 @@ async fn test_clone_ownership_failure_propagates_to_waiters() {
             None,
             None,
             AccountFetchOrigin::GetAccount,
-            None,
         )
         .await;
     assert!(
@@ -4267,7 +4236,6 @@ async fn test_ata_projection_releases_ata_direct_ref_after_fetch() {
             None,
             None,
             AccountFetchOrigin::GetAccount,
-            None,
         )
         .await
         .expect("ATA projection fetch should not fail");
@@ -4338,7 +4306,6 @@ async fn test_fetch_keeps_undelegating_projected_ata_in_bank() {
             None,
             None,
             AccountFetchOrigin::GetAccount,
-            None,
         )
         .await
         .expect("fetch should succeed");
@@ -4598,7 +4565,6 @@ async fn test_owned_operation_concurrent_calls_spawn_one_owner_fetch() {
                     None,
                     None,
                     AccountFetchOrigin::GetAccount,
-                    None,
                 )
                 .await
         })
@@ -4665,7 +4631,6 @@ async fn test_owned_operation_waiters_share_not_found_metadata() {
                     None,
                     None,
                     AccountFetchOrigin::GetAccount,
-                    None,
                 )
                 .await
         })
@@ -4736,7 +4701,6 @@ async fn test_owned_operation_waiters_share_missing_delegation_record_metadata()
                     None,
                     None,
                     AccountFetchOrigin::GetAccount,
-                    None,
                 )
                 .await
         })
@@ -4869,7 +4833,6 @@ async fn test_owned_operation_waiter_cancellation_is_local() {
                     None,
                     None,
                     AccountFetchOrigin::GetAccount,
-                    None,
                 )
                 .await
         })
@@ -4887,7 +4850,6 @@ async fn test_owned_operation_waiter_cancellation_is_local() {
                     None,
                     None,
                     AccountFetchOrigin::GetAccount,
-                    None,
                 )
                 .await
         })
@@ -4967,7 +4929,6 @@ async fn test_owned_operation_owner_timeout_cleans_up_pending() {
                     None,
                     None,
                     AccountFetchOrigin::GetAccount,
-                    None,
                 )
                 .await
         })
@@ -4983,7 +4944,6 @@ async fn test_owned_operation_owner_timeout_cleans_up_pending() {
                     None,
                     None,
                     AccountFetchOrigin::GetAccount,
-                    None,
                 )
                 .await
         })
@@ -5073,7 +5033,6 @@ async fn test_cancel_pending_terminates_owner_and_all_waiters() {
                     None,
                     None,
                     AccountFetchOrigin::GetAccount,
-                    None,
                 )
                 .await
         })
@@ -5089,7 +5048,6 @@ async fn test_cancel_pending_terminates_owner_and_all_waiters() {
                     None,
                     None,
                     AccountFetchOrigin::GetAccount,
-                    None,
                 )
                 .await
         })
@@ -5103,7 +5061,6 @@ async fn test_cancel_pending_terminates_owner_and_all_waiters() {
                     None,
                     None,
                     AccountFetchOrigin::GetAccount,
-                    None,
                 )
                 .await
         })
@@ -5200,7 +5157,6 @@ async fn test_cancel_all_pending_on_shutdown() {
                         None,
                         None,
                         AccountFetchOrigin::GetAccount,
-                        None,
                     )
                     .await
             }),
@@ -5222,7 +5178,6 @@ async fn test_cancel_all_pending_on_shutdown() {
                         None,
                         None,
                         AccountFetchOrigin::GetAccount,
-                        None,
                     )
                     .await
             }),
@@ -5305,7 +5260,6 @@ async fn test_owned_operation_waiters_do_not_refetch_after_owner_success() {
                     None,
                     None,
                     AccountFetchOrigin::GetAccount,
-                    None,
                 )
                 .await
         })
@@ -5323,7 +5277,6 @@ async fn test_owned_operation_waiters_do_not_refetch_after_owner_success() {
                     None,
                     None,
                     AccountFetchOrigin::GetAccount,
-                    None,
                 )
                 .await
         })
@@ -5493,7 +5446,6 @@ async fn test_delegated_account_owned_by_token_program_does_not_subscribe_progra
             None,
             None,
             AccountFetchOrigin::GetAccount,
-            None,
         )
         .await;
     assert!(result.is_ok());

--- a/magicblock-chainlink/src/chainlink/mod.rs
+++ b/magicblock-chainlink/src/chainlink/mod.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, path::Path, sync::Arc};
+use std::{path::Path, sync::Arc};
 
 use dlp_api::pda::ephemeral_balance_pda_from_payer;
 use errors::{ChainlinkError, ChainlinkResult};
@@ -132,7 +132,6 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
         pubkeys: &[Pubkey],
         mark_empty_if_not_found: Option<&[Pubkey]>,
         fetch_origin: AccountFetchOrigin,
-        program_ids: Option<&[Pubkey]>,
     ) -> ChainlinkResult<FetchAndCloneResult> {
         match self {
             Self::Enabled(chainlink) => {
@@ -141,7 +140,6 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
                         pubkeys,
                         mark_empty_if_not_found,
                         fetch_origin,
-                        program_ids,
                     )
                     .await
             }
@@ -167,13 +165,10 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
         &self,
         pubkeys: &[Pubkey],
         fetch_origin: AccountFetchOrigin,
-        program_ids: Option<&[Pubkey]>,
     ) -> ChainlinkResult<Vec<Option<AccountSharedData>>> {
         match self {
             Self::Enabled(chainlink) => {
-                chainlink
-                    .fetch_accounts(pubkeys, fetch_origin, program_ids)
-                    .await
+                chainlink.fetch_accounts(pubkeys, fetch_origin).await
             }
             Self::Disabled { .. } => Ok(vec![None; pubkeys.len()]),
         }
@@ -495,16 +490,12 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
         // Mark *all* pubkeys as empty-if-not-found
         let mark_empty_if_not_found = Some(pubkeys.as_slice());
 
-        // Extract programs from transaction instructions for metrics
-        let program_ids = extract_program_ids_from_transaction(tx);
-
         // Ensure accounts
         let res = self
             .ensure_accounts(
                 &pubkeys,
                 mark_empty_if_not_found,
                 AccountFetchOrigin::SendTransaction(*tx.signature()),
-                Some(&program_ids),
             )
             .await?;
 
@@ -514,13 +505,12 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
     /// Same as fetch accounts, but does not return the accounts, just
     /// ensures were cloned into our validator if they exist on chain.
     /// If we're offline and not syncing accounts then this is a no-op.
-    #[instrument(skip(self, pubkeys, mark_empty_if_not_found, program_ids))]
+    #[instrument(skip(self, pubkeys, mark_empty_if_not_found))]
     pub async fn ensure_accounts(
         &self,
         pubkeys: &[Pubkey],
         mark_empty_if_not_found: Option<&[Pubkey]>,
         fetch_origin: AccountFetchOrigin,
-        program_ids: Option<&[Pubkey]>,
     ) -> ChainlinkResult<FetchAndCloneResult> {
         let Some(fetch_cloner) = self.fetch_cloner() else {
             return Ok(FetchAndCloneResult::default());
@@ -530,7 +520,6 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
             pubkeys,
             mark_empty_if_not_found,
             fetch_origin,
-            program_ids,
         )
         .await
     }
@@ -539,12 +528,11 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
     /// Otherwise ensures that the accounts exist on chain and were cloned into our validator
     /// and returns their state from the bank (which may be None if the account does not
     /// exist locally or on chain).
-    #[instrument(skip(self, pubkeys, program_ids))]
+    #[instrument(skip(self, pubkeys))]
     pub async fn fetch_accounts(
         &self,
         pubkeys: &[Pubkey],
         fetch_origin: AccountFetchOrigin,
-        program_ids: Option<&[Pubkey]>,
     ) -> ChainlinkResult<Vec<Option<AccountSharedData>>> {
         if tracing::enabled!(tracing::Level::TRACE) {
             let count = pubkeys.len();
@@ -558,13 +546,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
                 .collect());
         };
         let _ = self
-            .fetch_accounts_common(
-                fetch_cloner,
-                pubkeys,
-                None,
-                fetch_origin,
-                program_ids,
-            )
+            .fetch_accounts_common(fetch_cloner, pubkeys, None, fetch_origin)
             .await?;
 
         let accounts = pubkeys
@@ -574,20 +556,13 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
         Ok(accounts)
     }
 
-    #[instrument(skip(
-        self,
-        fetch_cloner,
-        pubkeys,
-        mark_empty_if_not_found,
-        program_ids
-    ))]
+    #[instrument(skip(self, fetch_cloner, pubkeys, mark_empty_if_not_found,))]
     async fn fetch_accounts_common(
         &self,
         fetch_cloner: &FetchCloner<T, U, V, C>,
         pubkeys: &[Pubkey],
         mark_empty_if_not_found: Option<&[Pubkey]>,
         fetch_origin: AccountFetchOrigin,
-        program_ids: Option<&[Pubkey]>,
     ) -> ChainlinkResult<FetchAndCloneResult> {
         if tracing::enabled!(tracing::Level::TRACE) {
             let count = pubkeys.len();
@@ -607,7 +582,6 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
                 mark_empty_if_not_found,
                 None,
                 fetch_origin,
-                program_ids,
             )
             .await?;
         trace!("Fetched and cloned accounts");
@@ -660,18 +634,6 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
 // Helper Functions
 // -----------------
 
-/// Extracts all unique program IDs from a transaction's instructions.
-fn extract_program_ids_from_transaction(
-    tx: &SanitizedTransaction,
-) -> Vec<Pubkey> {
-    let program_ids = tx
-        .message()
-        .program_instructions_iter()
-        .map(|(program_id, _)| *program_id)
-        .collect::<HashSet<_>>();
-    program_ids.into_iter().collect()
-}
-
 #[cfg(test)]
 mod tests {
     use std::{sync::Arc, time::Duration};
@@ -723,12 +685,7 @@ mod tests {
         let pubkey = Pubkey::new_unique();
 
         let result = chainlink
-            .ensure_accounts(
-                &[pubkey],
-                None,
-                AccountFetchOrigin::GetAccount,
-                None,
-            )
+            .ensure_accounts(&[pubkey], None, AccountFetchOrigin::GetAccount)
             .await;
 
         assert!(result
@@ -745,11 +702,7 @@ mod tests {
         let pubkeys = vec![Pubkey::new_unique(), Pubkey::new_unique()];
 
         let result = chainlink
-            .fetch_accounts(
-                &pubkeys,
-                AccountFetchOrigin::GetMultipleAccounts,
-                None,
-            )
+            .fetch_accounts(&pubkeys, AccountFetchOrigin::GetMultipleAccounts)
             .await;
 
         let accounts = result.expect("disabled fetch_accounts should succeed");

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -70,8 +70,7 @@ use magicblock_metrics::{
     metrics::{
         inc_account_fetches_failed, inc_account_fetches_found,
         inc_account_fetches_not_found, inc_account_fetches_success,
-        inc_per_program_account_fetch_stats, set_monitored_accounts_count,
-        AccountFetchOrigin, ProgramFetchResult,
+        set_monitored_accounts_count, AccountFetchOrigin,
     },
 };
 pub use remote_account::{ResolvedAccount, ResolvedAccountSharedData};
@@ -1902,7 +1901,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
         let commitment = self.rpc_client.commitment();
         let mark_empty_if_not_found =
             mark_empty_if_not_found.unwrap_or(&[]).to_vec();
-        let program_ids = program_ids.map(|ids| ids.to_vec());
+        let _ = program_ids;
         tokio::spawn(async move {
             use RemoteAccount::*;
 
@@ -1921,15 +1920,6 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                     "{error_msg}"
                 );
                 inc_account_fetches_failed(pubkeys.len() as u64);
-                if let Some(program_ids) = &program_ids {
-                    for program_id in program_ids {
-                        inc_per_program_account_fetch_stats(
-                            &program_id.to_string(),
-                            ProgramFetchResult::Failed,
-                            pubkeys.len() as u64,
-                        );
-                    }
-                }
 
                 for pubkey in &pubkeys {
                     // Update metrics
@@ -2147,26 +2137,6 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
             inc_account_fetches_success(pubkeys.len() as u64);
             inc_account_fetches_found(fetch_origin, found_count);
             inc_account_fetches_not_found(fetch_origin, not_found_count);
-
-            // Record per-program metrics if programs were provided
-            if let Some(program_ids) = &program_ids {
-                for program_id in program_ids {
-                    if found_count > 0 {
-                        inc_per_program_account_fetch_stats(
-                            &program_id.to_string(),
-                            ProgramFetchResult::Found,
-                            found_count,
-                        );
-                    }
-                    if not_found_count > 0 {
-                        inc_per_program_account_fetch_stats(
-                            &program_id.to_string(),
-                            ProgramFetchResult::NotFound,
-                            not_found_count,
-                        );
-                    }
-                }
-            }
 
             if tracing::enabled!(tracing::Level::TRACE) {
                 let pubkeys = pubkeys

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -997,7 +997,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
         pubkey: Pubkey,
         fetch_origin: AccountFetchOrigin,
     ) -> RemoteAccountProviderResult<RemoteAccount> {
-        self.try_get_multi(&[pubkey], None, fetch_origin, None, None)
+        self.try_get_multi(&[pubkey], None, fetch_origin, None)
             .await
             // SAFETY: we are guaranteed to have a single result here as
             // otherwise we would have gotten an error
@@ -1016,7 +1016,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
         // 1. Fetch the _normal_ way and hope the slots match and if required
         //    the min_context_slot is met
         let mut remote_accounts = self
-            .try_get_multi(pubkeys, None, fetch_origin, None, None)
+            .try_get_multi(pubkeys, None, fetch_origin, None)
             .await?;
         if let Match = slots_match_and_meet_min_context(
             &remote_accounts,
@@ -1140,13 +1140,12 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
     /// Gets the accounts for the given pubkeys by fetching from RPC.
     /// Always fetches fresh data. FetchCloner handles request deduplication.
     /// Subscribes first to catch any updates that arrive during fetch.
-    #[instrument(skip(self, pubkeys, mark_empty_if_not_found, program_ids))]
+    #[instrument(skip(self, pubkeys, mark_empty_if_not_found))]
     pub async fn try_get_multi(
         &self,
         pubkeys: &[Pubkey],
         mark_empty_if_not_found: Option<&[Pubkey]>,
         fetch_origin: AccountFetchOrigin,
-        program_ids: Option<&[Pubkey]>,
         fetch_start_slot: Option<u64>,
     ) -> RemoteAccountProviderResult<Vec<RemoteAccount>> {
         if pubkeys.is_empty() {
@@ -1232,7 +1231,6 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                 mark_empty_if_not_found,
                 min_context_slot,
                 fetch_origin,
-                program_ids,
             );
         }
 
@@ -1894,14 +1892,12 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
         mark_empty_if_not_found: Option<&[Pubkey]>,
         min_context_slot: u64,
         fetch_origin: AccountFetchOrigin,
-        program_ids: Option<&[Pubkey]>,
     ) {
         let rpc_client = self.rpc_client.clone();
         let fetching_accounts = self.fetching_accounts.clone();
         let commitment = self.rpc_client.commitment();
         let mark_empty_if_not_found =
             mark_empty_if_not_found.unwrap_or(&[]).to_vec();
-        let _ = program_ids;
         tokio::spawn(async move {
             use RemoteAccount::*;
 

--- a/magicblock-chainlink/src/remote_account_provider/tests.rs
+++ b/magicblock-chainlink/src/remote_account_provider/tests.rs
@@ -170,7 +170,6 @@ async fn test_try_get_multi_setup_subscriptions_failure_cleans_up_pending_entry(
                     None,
                     AccountFetchOrigin::GetAccount,
                     None,
-                    None,
                 )
                 .await
         }
@@ -193,13 +192,7 @@ async fn test_try_get_multi_setup_subscriptions_failure_cleans_up_pending_entry(
 
     _pubsub_client.try_reconnect().await.unwrap();
     let retry = provider
-        .try_get_multi(
-            &[pubkey],
-            None,
-            AccountFetchOrigin::GetAccount,
-            None,
-            None,
-        )
+        .try_get_multi(&[pubkey], None, AccountFetchOrigin::GetAccount, None)
         .await
         .expect("retry after cleanup should succeed");
     assert_eq!(retry.len(), 1);
@@ -234,7 +227,6 @@ async fn test_try_get_multi_waiter_receives_setup_subscriptions_failure() {
                     None,
                     AccountFetchOrigin::GetAccount,
                     None,
-                    None,
                 )
                 .await
         }
@@ -251,7 +243,6 @@ async fn test_try_get_multi_waiter_receives_setup_subscriptions_failure() {
                     &[pubkey],
                     None,
                     AccountFetchOrigin::GetAccount,
-                    None,
                     None,
                 )
                 .await
@@ -810,7 +801,6 @@ async fn test_try_get_multi_owner_success_cleans_up_pending_entry() {
                     &[pubkey],
                     None,
                     AccountFetchOrigin::GetAccount,
-                    None,
                     None,
                 )
                 .await

--- a/magicblock-chainlink/tests/01_ensure-accounts.rs
+++ b/magicblock-chainlink/tests/01_ensure-accounts.rs
@@ -41,7 +41,6 @@ async fn test_write_non_existing_account() {
             &pubkeys,
             None,
             AccountFetchOrigin::GetMultipleAccounts,
-            None,
         )
         .await
         .unwrap();
@@ -73,7 +72,6 @@ async fn test_existing_account_undelegated() {
             &pubkeys,
             None,
             AccountFetchOrigin::GetMultipleAccounts,
-            None,
         )
         .await
         .unwrap();
@@ -110,7 +108,6 @@ async fn test_existing_account_missing_delegation_record() {
             &pubkeys,
             None,
             AccountFetchOrigin::GetMultipleAccounts,
-            None,
         )
         .await
         .unwrap();
@@ -152,7 +149,6 @@ async fn test_write_existing_account_valid_delegation_record() {
             &pubkeys,
             None,
             AccountFetchOrigin::GetMultipleAccounts,
-            None,
         )
         .await
         .unwrap();
@@ -198,7 +194,6 @@ async fn test_write_existing_account_other_authority() {
             &pubkeys,
             None,
             AccountFetchOrigin::GetMultipleAccounts,
-            None,
         )
         .await
         .unwrap();
@@ -254,7 +249,6 @@ async fn test_write_undelegating_account_undelegated_to_other_validator() {
             &pubkeys,
             None,
             AccountFetchOrigin::GetMultipleAccounts,
-            None,
         )
         .await
         .unwrap();
@@ -303,7 +297,6 @@ async fn test_write_undelegating_account_still_being_undelegated() {
             &pubkeys,
             None,
             AccountFetchOrigin::GetMultipleAccounts,
-            None,
         )
         .await
         .unwrap();
@@ -347,7 +340,6 @@ async fn test_write_existing_account_invalid_delegation_record() {
             &[pubkey],
             None,
             AccountFetchOrigin::GetMultipleAccounts,
-            None,
         )
         .await;
     debug!(result = ?res, "Ensure accounts completed");

--- a/magicblock-chainlink/tests/03_deleg_after_sub.rs
+++ b/magicblock-chainlink/tests/03_deleg_after_sub.rs
@@ -59,7 +59,6 @@ async fn test_deleg_after_subscribe_case2() {
                 &[pubkey],
                 None,
                 AccountFetchOrigin::GetMultipleAccounts,
-                None,
             )
             .await
             .unwrap();
@@ -89,7 +88,6 @@ async fn test_deleg_after_subscribe_case2() {
                 &[pubkey],
                 None,
                 AccountFetchOrigin::GetMultipleAccounts,
-                None,
             )
             .await
             .unwrap();

--- a/magicblock-chainlink/tests/08_subupdate-ordering.rs
+++ b/magicblock-chainlink/tests/08_subupdate-ordering.rs
@@ -61,7 +61,6 @@ async fn test_subs_receive_out_of_order_updates() {
             &[pubkey],
             None,
             AccountFetchOrigin::GetMultipleAccounts,
-            None,
         )
         .await
         .unwrap();

--- a/magicblock-chainlink/tests/09_waiter_reconciliation_race.rs
+++ b/magicblock-chainlink/tests/09_waiter_reconciliation_race.rs
@@ -96,7 +96,6 @@ async fn test_owned_pending_operation_dedups_concurrent_delegated_fetches() {
                 &[account_pubkey],
                 None,
                 AccountFetchOrigin::GetMultipleAccounts,
-                None,
             )
             .await
     });
@@ -108,7 +107,6 @@ async fn test_owned_pending_operation_dedups_concurrent_delegated_fetches() {
                 &[account_pubkey],
                 None,
                 AccountFetchOrigin::GetMultipleAccounts,
-                None,
             )
             .await
     });
@@ -120,7 +118,6 @@ async fn test_owned_pending_operation_dedups_concurrent_delegated_fetches() {
                 &[account_pubkey],
                 None,
                 AccountFetchOrigin::GetMultipleAccounts,
-                None,
             )
             .await
     });
@@ -193,7 +190,6 @@ async fn test_multiple_concurrent_requests_with_valid_delegated_state() {
                 &[account_pubkey],
                 None,
                 AccountFetchOrigin::GetMultipleAccounts,
-                None,
             )
             .await
     });
@@ -204,7 +200,6 @@ async fn test_multiple_concurrent_requests_with_valid_delegated_state() {
                 &[account_pubkey],
                 None,
                 AccountFetchOrigin::GetMultipleAccounts,
-                None,
             )
             .await
     });
@@ -215,7 +210,6 @@ async fn test_multiple_concurrent_requests_with_valid_delegated_state() {
                 &[account_pubkey],
                 None,
                 AccountFetchOrigin::GetMultipleAccounts,
-                None,
             )
             .await
     });

--- a/magicblock-chainlink/tests/basics.rs
+++ b/magicblock-chainlink/tests/basics.rs
@@ -50,7 +50,6 @@ async fn test_remote_slot_of_accounts_read_from_bank() {
             &[pubkey],
             None,
             AccountFetchOrigin::GetMultipleAccounts,
-            None,
         )
         .await
         .unwrap();
@@ -63,7 +62,6 @@ async fn test_remote_slot_of_accounts_read_from_bank() {
             &[pubkey],
             None,
             AccountFetchOrigin::GetMultipleAccounts,
-            None,
         )
         .await
         .unwrap();
@@ -107,7 +105,6 @@ async fn test_remote_slot_of_ensure_accounts_from_bank() {
             &[pubkey],
             None,
             AccountFetchOrigin::GetMultipleAccounts,
-            None,
         )
         .await
         .unwrap();
@@ -123,7 +120,6 @@ async fn test_remote_slot_of_ensure_accounts_from_bank() {
             &[pubkey],
             None,
             AccountFetchOrigin::GetMultipleAccounts,
-            None,
         )
         .await
         .unwrap();

--- a/magicblock-chainlink/tests/utils/test_context.rs
+++ b/magicblock-chainlink/tests/utils/test_context.rs
@@ -214,7 +214,6 @@ impl TestContext {
                 &[*pubkey],
                 None,
                 AccountFetchOrigin::GetMultipleAccounts,
-                None,
             )
             .await
     }

--- a/magicblock-metrics/src/metrics/mod.rs
+++ b/magicblock-metrics/src/metrics/mod.rs
@@ -7,7 +7,6 @@ use prometheus::{
 };
 pub use types::{
     AccountClone, AccountCommit, AccountFetchOrigin, LabelValue, Outcome,
-    ProgramFetchResult,
 };
 
 mod types;
@@ -286,14 +285,6 @@ lazy_static::lazy_static! {
     )
     .unwrap();
 
-    pub static ref PER_PROGRAM_ACCOUNT_FETCH_STATS: IntCounterVec = IntCounterVec::new(
-        Opts::new(
-            "per_program_account_fetch_stats",
-            "Per-program account fetch statistics (failed/found/not_found)",
-        ),
-        &["program", "result"],
-    )
-    .unwrap();
 
     pub static ref PER_PROGRAM_ACCOUNT_UPDATES_COUNT: IntCounterVec =
         IntCounterVec::new(
@@ -607,7 +598,6 @@ pub(crate) fn register() {
         register!(ACCOUNT_FETCHES_FAILED_COUNT);
         register!(ACCOUNT_FETCHES_FOUND_COUNT);
         register!(ACCOUNT_FETCHES_NOT_FOUND_COUNT);
-        register!(PER_PROGRAM_ACCOUNT_FETCH_STATS);
         register!(PER_PROGRAM_ACCOUNT_UPDATES_COUNT);
         register!(UNDELEGATION_REQUESTED_COUNT);
         register!(UNDELEGATION_COMPLETED_COUNT);
@@ -846,16 +836,6 @@ pub fn inc_account_subscription_activations_count(client_id: &impl LabelValue) {
     ACCOUNT_SUBSCRIPTION_ACTIVATIONS_COUNT
         .with_label_values(&[client_id.value()])
         .inc();
-}
-
-pub fn inc_per_program_account_fetch_stats(
-    program_id: &str,
-    result: ProgramFetchResult,
-    count: u64,
-) {
-    PER_PROGRAM_ACCOUNT_FETCH_STATS
-        .with_label_values(&[program_id, result.value()])
-        .inc_by(count);
 }
 
 pub fn inc_per_program_account_updates_count(

--- a/magicblock-metrics/src/metrics/types.rs
+++ b/magicblock-metrics/src/metrics/types.rs
@@ -138,36 +138,3 @@ where
         }
     }
 }
-
-// -----------------
-// ProgramFetchResult
-// -----------------
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ProgramFetchResult {
-    Failed,
-    Found,
-    NotFound,
-}
-
-impl ProgramFetchResult {
-    pub fn as_str(&self) -> &str {
-        use ProgramFetchResult::*;
-        match self {
-            Failed => "failed",
-            Found => "found",
-            NotFound => "not_found",
-        }
-    }
-}
-
-impl fmt::Display for ProgramFetchResult {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.as_str())
-    }
-}
-
-impl LabelValue for ProgramFetchResult {
-    fn value(&self) -> &str {
-        self.as_str()
-    }
-}

--- a/test-integration/test-chainlink/src/test_context.rs
+++ b/test-integration/test-chainlink/src/test_context.rs
@@ -213,12 +213,7 @@ impl TestContext {
         pubkey: &Pubkey,
     ) -> ChainlinkResult<FetchAndCloneResult> {
         self.chainlink
-            .ensure_accounts(
-                &[*pubkey],
-                None,
-                AccountFetchOrigin::GetAccount,
-                None,
-            )
+            .ensure_accounts(&[*pubkey], None, AccountFetchOrigin::GetAccount)
             .await
     }
 

--- a/test-integration/test-chainlink/tests/ix_01_ensure-accounts.rs
+++ b/test-integration/test-chainlink/tests/ix_01_ensure-accounts.rs
@@ -19,7 +19,7 @@ async fn ixtest_write_non_existing_account() {
     let pubkeys = [pubkey];
     let res = ctx
         .chainlink
-        .ensure_accounts(&pubkeys, None, AccountFetchOrigin::GetAccount, None)
+        .ensure_accounts(&pubkeys, None, AccountFetchOrigin::GetAccount)
         .await
         .unwrap();
     debug!("res: {res:?}");
@@ -44,7 +44,7 @@ async fn ixtest_write_existing_account_undelegated() {
     let pubkeys = [counter_auth.pubkey()];
     let res = ctx
         .chainlink
-        .ensure_accounts(&pubkeys, None, AccountFetchOrigin::GetAccount, None)
+        .ensure_accounts(&pubkeys, None, AccountFetchOrigin::GetAccount)
         .await
         .unwrap();
     debug!("res: {res:?}");
@@ -74,7 +74,7 @@ async fn ixtest_write_existing_account_valid_delegation_record() {
 
     let res = ctx
         .chainlink
-        .ensure_accounts(&pubkeys, None, AccountFetchOrigin::GetAccount, None)
+        .ensure_accounts(&pubkeys, None, AccountFetchOrigin::GetAccount)
         .await
         .unwrap();
     debug!("res: {res:?}");

--- a/test-integration/test-chainlink/tests/ix_03_deleg_after_sub.rs
+++ b/test-integration/test-chainlink/tests/ix_03_deleg_after_sub.rs
@@ -23,10 +23,7 @@ async fn ixtest_deleg_after_subscribe_case2() {
         info!("1. Initially the account does not exist");
         let res = ctx
             .chainlink
-            .ensure_accounts(
-                &pubkeys,
-                None,
-                AccountFetchOrigin::GetAccount)
+            .ensure_accounts(&pubkeys, None, AccountFetchOrigin::GetAccount)
             .await
             .unwrap();
 
@@ -41,10 +38,7 @@ async fn ixtest_deleg_after_subscribe_case2() {
         ctx.init_counter(&counter_auth).await;
 
         ctx.chainlink
-            .ensure_accounts(
-                &pubkeys,
-                None,
-                AccountFetchOrigin::GetAccount)
+            .ensure_accounts(&pubkeys, None, AccountFetchOrigin::GetAccount)
             .await
             .unwrap();
 
@@ -68,10 +62,7 @@ async fn ixtest_deleg_after_subscribe_case2() {
         let deleg_record_pubkey = ctx.delegation_record_pubkey(&counter_pda);
 
         ctx.chainlink
-            .ensure_accounts(
-                &pubkeys,
-                None,
-                AccountFetchOrigin::GetAccount)
+            .ensure_accounts(&pubkeys, None, AccountFetchOrigin::GetAccount)
             .await
             .unwrap();
 

--- a/test-integration/test-chainlink/tests/ix_03_deleg_after_sub.rs
+++ b/test-integration/test-chainlink/tests/ix_03_deleg_after_sub.rs
@@ -26,9 +26,7 @@ async fn ixtest_deleg_after_subscribe_case2() {
             .ensure_accounts(
                 &pubkeys,
                 None,
-                AccountFetchOrigin::GetAccount,
-                None,
-            )
+                AccountFetchOrigin::GetAccount)
             .await
             .unwrap();
 
@@ -46,9 +44,7 @@ async fn ixtest_deleg_after_subscribe_case2() {
             .ensure_accounts(
                 &pubkeys,
                 None,
-                AccountFetchOrigin::GetAccount,
-                None,
-            )
+                AccountFetchOrigin::GetAccount)
             .await
             .unwrap();
 
@@ -75,9 +71,7 @@ async fn ixtest_deleg_after_subscribe_case2() {
             .ensure_accounts(
                 &pubkeys,
                 None,
-                AccountFetchOrigin::GetAccount,
-                None,
-            )
+                AccountFetchOrigin::GetAccount)
             .await
             .unwrap();
 

--- a/test-integration/test-chainlink/tests/ix_06_redeleg_us_separate_slots.rs
+++ b/test-integration/test-chainlink/tests/ix_06_redeleg_us_separate_slots.rs
@@ -34,10 +34,7 @@ async fn ixtest_undelegate_redelegate_to_us_in_separate_slots() {
         info!("1. Account delegated to us");
 
         ctx.chainlink
-            .ensure_accounts(
-                &pubkeys,
-                None,
-                AccountFetchOrigin::GetAccount)
+            .ensure_accounts(&pubkeys, None, AccountFetchOrigin::GetAccount)
             .await
             .unwrap();
         sleep_ms(1_500).await;

--- a/test-integration/test-chainlink/tests/ix_06_redeleg_us_separate_slots.rs
+++ b/test-integration/test-chainlink/tests/ix_06_redeleg_us_separate_slots.rs
@@ -37,9 +37,7 @@ async fn ixtest_undelegate_redelegate_to_us_in_separate_slots() {
             .ensure_accounts(
                 &pubkeys,
                 None,
-                AccountFetchOrigin::GetAccount,
-                None,
-            )
+                AccountFetchOrigin::GetAccount)
             .await
             .unwrap();
         sleep_ms(1_500).await;

--- a/test-integration/test-chainlink/tests/ix_07_redeleg_us_same_slot.rs
+++ b/test-integration/test-chainlink/tests/ix_07_redeleg_us_same_slot.rs
@@ -37,9 +37,7 @@ async fn ixtest_undelegate_redelegate_to_us_in_same_slot() {
             .ensure_accounts(
                 &pubkeys,
                 None,
-                AccountFetchOrigin::GetAccount,
-                None,
-            )
+                AccountFetchOrigin::GetAccount)
             .await
             .unwrap();
         sleep_ms(1_500).await;

--- a/test-integration/test-chainlink/tests/ix_07_redeleg_us_same_slot.rs
+++ b/test-integration/test-chainlink/tests/ix_07_redeleg_us_same_slot.rs
@@ -34,10 +34,7 @@ async fn ixtest_undelegate_redelegate_to_us_in_same_slot() {
         info!("1. Account delegated to us");
 
         ctx.chainlink
-            .ensure_accounts(
-                &pubkeys,
-                None,
-                AccountFetchOrigin::GetAccount)
+            .ensure_accounts(&pubkeys, None, AccountFetchOrigin::GetAccount)
             .await
             .unwrap();
         sleep_ms(1_500).await;

--- a/test-integration/test-chainlink/tests/ix_ata_eata_replace.rs
+++ b/test-integration/test-chainlink/tests/ix_ata_eata_replace.rs
@@ -56,7 +56,7 @@ async fn ixtest_ata_eata_replace_when_delegated_to_us() {
     let pubkeys = [ata_pubkey];
     let res = ctx
         .chainlink
-        .ensure_accounts(&pubkeys, None, AccountFetchOrigin::GetAccount, None)
+        .ensure_accounts(&pubkeys, None, AccountFetchOrigin::GetAccount)
         .await
         .expect("ensure_accounts ok");
     debug!("res: {:?}", res);
@@ -97,7 +97,7 @@ async fn ixtest_ata_eata_no_replace_when_not_delegated() {
     let pubkeys = [ata_pubkey];
     let _res = ctx
         .chainlink
-        .ensure_accounts(&pubkeys, None, AccountFetchOrigin::GetAccount, None)
+        .ensure_accounts(&pubkeys, None, AccountFetchOrigin::GetAccount)
         .await
         .expect("ensure_accounts ok");
 
@@ -147,7 +147,7 @@ async fn ixtest_ata_eata_no_replace_when_not_delegated_to_us() {
     let pubkeys = [ata_pubkey];
     let res = ctx
         .chainlink
-        .ensure_accounts(&pubkeys, None, AccountFetchOrigin::GetAccount, None)
+        .ensure_accounts(&pubkeys, None, AccountFetchOrigin::GetAccount)
         .await
         .expect("ensure_accounts ok");
     debug!("res: {:?}", res);

--- a/test-integration/test-chainlink/tests/ix_exceed_capacity.rs
+++ b/test-integration/test-chainlink/tests/ix_exceed_capacity.rs
@@ -76,17 +76,11 @@ async fn ixtest_read_multiple_accounts_exceeding_capacity() {
     // will be removed, but since they haven't been added yet that does nothing and
     // they get still added later right after. Therefore here we go in steps:
     ctx.chainlink
-        .ensure_accounts(
-            &pubkeys[0..4],
-            None,
-            AccountFetchOrigin::GetAccount)
+        .ensure_accounts(&pubkeys[0..4], None, AccountFetchOrigin::GetAccount)
         .await
         .unwrap();
     ctx.chainlink
-        .ensure_accounts(
-            &pubkeys[4..8],
-            None,
-            AccountFetchOrigin::GetAccount)
+        .ensure_accounts(&pubkeys[4..8], None, AccountFetchOrigin::GetAccount)
         .await
         .unwrap();
 

--- a/test-integration/test-chainlink/tests/ix_exceed_capacity.rs
+++ b/test-integration/test-chainlink/tests/ix_exceed_capacity.rs
@@ -44,7 +44,7 @@ async fn ixtest_read_multiple_accounts_not_exceeding_capacity() {
         setup(subscribed_accounts_lru_capacity, pubkeys_len).await;
 
     ctx.chainlink
-        .ensure_accounts(&pubkeys, None, AccountFetchOrigin::GetAccount, None)
+        .ensure_accounts(&pubkeys, None, AccountFetchOrigin::GetAccount)
         .await
         .unwrap();
 
@@ -79,18 +79,14 @@ async fn ixtest_read_multiple_accounts_exceeding_capacity() {
         .ensure_accounts(
             &pubkeys[0..4],
             None,
-            AccountFetchOrigin::GetAccount,
-            None,
-        )
+            AccountFetchOrigin::GetAccount)
         .await
         .unwrap();
     ctx.chainlink
         .ensure_accounts(
             &pubkeys[4..8],
             None,
-            AccountFetchOrigin::GetAccount,
-            None,
-        )
+            AccountFetchOrigin::GetAccount)
         .await
         .unwrap();
 

--- a/test-integration/test-chainlink/tests/ix_full_scenarios.rs
+++ b/test-integration/test-chainlink/tests/ix_full_scenarios.rs
@@ -165,9 +165,7 @@ async fn ixtest_accounts_for_tx_2_delegated_3_readonly_3_programs_one_native() {
         let (fetched_pubkeys, fetched_strs) = {
             let fetched_accounts = ctx
                 .chainlink
-                .fetch_accounts(
-                    &all_pubkeys,
-                    AccountFetchOrigin::GetAccount)
+                .fetch_accounts(&all_pubkeys, AccountFetchOrigin::GetAccount)
                 .await
                 .unwrap();
             let mut fetched_pubkeys = all_pubkeys
@@ -215,9 +213,7 @@ async fn ixtest_accounts_for_tx_2_delegated_3_readonly_3_programs_one_native() {
         let (fetched_pubkeys, fetched_strs) = {
             let fetched_accounts = ctx
                 .chainlink
-                .fetch_accounts(
-                    &all_pubkeys,
-                    AccountFetchOrigin::GetAccount)
+                .fetch_accounts(&all_pubkeys, AccountFetchOrigin::GetAccount)
                 .await
                 .unwrap();
             let mut fetched_pubkeys = all_pubkeys

--- a/test-integration/test-chainlink/tests/ix_full_scenarios.rs
+++ b/test-integration/test-chainlink/tests/ix_full_scenarios.rs
@@ -167,9 +167,7 @@ async fn ixtest_accounts_for_tx_2_delegated_3_readonly_3_programs_one_native() {
                 .chainlink
                 .fetch_accounts(
                     &all_pubkeys,
-                    AccountFetchOrigin::GetAccount,
-                    None,
-                )
+                    AccountFetchOrigin::GetAccount)
                 .await
                 .unwrap();
             let mut fetched_pubkeys = all_pubkeys
@@ -219,9 +217,7 @@ async fn ixtest_accounts_for_tx_2_delegated_3_readonly_3_programs_one_native() {
                 .chainlink
                 .fetch_accounts(
                     &all_pubkeys,
-                    AccountFetchOrigin::GetAccount,
-                    None,
-                )
+                    AccountFetchOrigin::GetAccount)
                 .await
                 .unwrap();
             let mut fetched_pubkeys = all_pubkeys

--- a/test-integration/test-chainlink/tests/ix_programs.rs
+++ b/test-integration/test-chainlink/tests/ix_programs.rs
@@ -436,7 +436,7 @@ async fn ixtest_clone_memo_v1_loader_program() {
     let pubkeys = [MEMOV1];
 
     ctx.chainlink
-        .ensure_accounts(&pubkeys, None, AccountFetchOrigin::GetAccount, None)
+        .ensure_accounts(&pubkeys, None, AccountFetchOrigin::GetAccount)
         .await
         .unwrap();
 
@@ -464,7 +464,7 @@ async fn ixtest_clone_memo_v2_loader_program() {
     let pubkeys = [MEMOV2];
 
     ctx.chainlink
-        .ensure_accounts(&pubkeys, None, AccountFetchOrigin::GetAccount, None)
+        .ensure_accounts(&pubkeys, None, AccountFetchOrigin::GetAccount)
         .await
         .unwrap();
 
@@ -493,7 +493,7 @@ async fn ixtest_clone_mini_v2_loader_program() {
     let pubkeys = [MINIV2];
 
     ctx.chainlink
-        .ensure_accounts(&pubkeys, None, AccountFetchOrigin::GetAccount, None)
+        .ensure_accounts(&pubkeys, None, AccountFetchOrigin::GetAccount)
         .await
         .unwrap();
 
@@ -520,7 +520,7 @@ async fn ixtest_clone_mini_v3_loader_program() {
     let pubkeys = [MINIV3];
 
     ctx.chainlink
-        .ensure_accounts(&pubkeys, None, AccountFetchOrigin::GetAccount, None)
+        .ensure_accounts(&pubkeys, None, AccountFetchOrigin::GetAccount)
         .await
         .unwrap();
 
@@ -572,7 +572,7 @@ async fn ixtest_clone_mini_v4_loader_program() {
     let pubkeys = [prog_kp.pubkey()];
 
     ctx.chainlink
-        .ensure_accounts(&pubkeys, None, AccountFetchOrigin::GetAccount, None)
+        .ensure_accounts(&pubkeys, None, AccountFetchOrigin::GetAccount)
         .await
         .unwrap();
 
@@ -600,7 +600,7 @@ async fn ixtest_clone_multiple_programs_v1_v2_v3() {
     let pubkeys = [MEMOV1, MEMOV2, MINIV3];
 
     ctx.chainlink
-        .ensure_accounts(&pubkeys, None, AccountFetchOrigin::GetAccount, None)
+        .ensure_accounts(&pubkeys, None, AccountFetchOrigin::GetAccount)
         .await
         .unwrap();
 

--- a/test-integration/test-chainlink/tests/ix_remote_account_provider.rs
+++ b/test-integration/test-chainlink/tests/ix_remote_account_provider.rs
@@ -165,7 +165,8 @@ async fn ixtest_get_multiple_accounts_for_valid_slot() {
                 &all_pubkeys,
                 None,
                 AccountFetchOrigin::GetAccount,
-                None)
+                None,
+            )
             .await
             .unwrap();
 
@@ -196,7 +197,8 @@ async fn ixtest_get_multiple_accounts_for_valid_slot() {
                 &all_pubkeys,
                 None,
                 AccountFetchOrigin::GetAccount,
-                None)
+                None,
+            )
             .await
             .unwrap();
         let remote_lamports =
@@ -229,7 +231,8 @@ async fn ixtest_get_multiple_accounts_for_valid_slot() {
                 &all_pubkeys,
                 None,
                 AccountFetchOrigin::GetAccount,
-                None)
+                None,
+            )
             .await
             .unwrap();
         let remote_lamports =

--- a/test-integration/test-chainlink/tests/ix_remote_account_provider.rs
+++ b/test-integration/test-chainlink/tests/ix_remote_account_provider.rs
@@ -165,9 +165,7 @@ async fn ixtest_get_multiple_accounts_for_valid_slot() {
                 &all_pubkeys,
                 None,
                 AccountFetchOrigin::GetAccount,
-                None,
-                None,
-            )
+                None)
             .await
             .unwrap();
 
@@ -198,9 +196,7 @@ async fn ixtest_get_multiple_accounts_for_valid_slot() {
                 &all_pubkeys,
                 None,
                 AccountFetchOrigin::GetAccount,
-                None,
-                None,
-            )
+                None)
             .await
             .unwrap();
         let remote_lamports =
@@ -233,9 +229,7 @@ async fn ixtest_get_multiple_accounts_for_valid_slot() {
                 &all_pubkeys,
                 None,
                 AccountFetchOrigin::GetAccount,
-                None,
-                None,
-            )
+                None)
             .await
             .unwrap();
         let remote_lamports =


### PR DESCRIPTION
## Summary

Remove the program-specific account fetch metric that tracked fetch results by program ID.

## Details

This PR removes the `per_program_account_fetch_stats` metric and its associated result
type/helpers from `magicblock-metrics`. The existing aggregate account fetch metrics remain in
place for failed, found, not-found, and successful fetches.

### magicblock-chainlink

Account fetch handling no longer records per-program fetch results on either failure or success
paths. Fetch routing and the existing aggregate metrics behavior are preserved.

### magicblock-metrics

The per-program account fetch counter, registration, helper function, and `ProgramFetchResult`
label type were removed. Aggregate bounded account fetch metrics remain available unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed per-program account-fetch metrics and related metric APIs to simplify monitoring.
  * Simplified account-fetching APIs by removing an unused optional filter parameter; call sites and tests updated to match the new signatures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/magicblock-labs/magicblock-validator/pull/1261?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->