### PR TITLE
refactor: rename Magic base actions to pre/post action semantics

### DIFF
--- a/magicblock-committor-service/src/intent_executor/mod.rs
+++ b/magicblock-committor-service/src/intent_executor/mod.rs
@@ -212,8 +212,8 @@ where
 
         if all_committed_pubkeys.is_empty() {
             // Build tasks for commit stage
-            // TODO (snawaz): it's actually MagicBaseIntent::BaseActions scenario, not Commit
-            // scenario, so the related code needs little bit of refactoring and proper renaming.
+            // TODO (snawaz): this is a MagicBaseIntent::BasePreActions scenario,
+            // not a Commit scenario, so this path still needs a small refactor.
             let commit_tasks = TaskBuilderImpl::commit_tasks(
                 &self.task_info_fetcher,
                 &intent_bundle,
@@ -221,7 +221,7 @@ where
             )
             .await?;
 
-            // Standalone actions executed in single stage
+            // Base pre-actions execute in single stage when there are no commits.
             let strategy = TaskStrategist::build_strategy(
                 commit_tasks,
                 &self.authority.pubkey(),

--- a/magicblock-committor-service/src/persist/commit_persister.rs
+++ b/magicblock-committor-service/src/persist/commit_persister.rs
@@ -501,7 +501,7 @@ mod tests {
             commit_and_undelegate: None,
             commit_finalize: None,
             commit_finalize_and_undelegate: None,
-            standalone_actions: vec![],
+            base_pre_actions: vec![],
         }
     }
 
@@ -514,7 +514,7 @@ mod tests {
             }),
             commit_finalize: None,
             commit_finalize_and_undelegate: None,
-            standalone_actions: vec![],
+            base_pre_actions: vec![],
         }
     }
 
@@ -527,7 +527,7 @@ mod tests {
             }),
             commit_finalize: None,
             commit_finalize_and_undelegate: None,
-            standalone_actions: vec![],
+            base_pre_actions: vec![],
         }
     }
 
@@ -537,7 +537,7 @@ mod tests {
             commit_and_undelegate: None,
             commit_finalize: None,
             commit_finalize_and_undelegate: None,
-            standalone_actions: vec![],
+            base_pre_actions: vec![],
         }
     }
 

--- a/magicblock-committor-service/src/stubs/changeset_committor_stub.rs
+++ b/magicblock-committor-service/src/stubs/changeset_committor_stub.rs
@@ -256,9 +256,12 @@ fn count_bundle_callbacks(bundle: &ScheduledIntentBundle) -> usize {
         .as_ref()
         .map(|ct| match ct {
             CommitType::Standalone(_) => 0,
-            CommitType::WithBaseActions { base_actions, .. } => {
-                base_actions.iter().filter(|a| a.callback.is_some()).count()
-            }
+            CommitType::BasePostActions {
+                base_post_actions, ..
+            } => base_post_actions
+                .iter()
+                .filter(|a| a.callback.is_some())
+                .count(),
         })
         .unwrap_or(0);
 
@@ -268,13 +271,16 @@ fn count_bundle_callbacks(bundle: &ScheduledIntentBundle) -> usize {
         .map(|cau| {
             let from_commit_action = match &cau.commit_action {
                 CommitType::Standalone(_) => 0,
-                CommitType::WithBaseActions { base_actions, .. } => {
-                    base_actions.iter().filter(|a| a.callback.is_some()).count()
-                }
+                CommitType::BasePostActions {
+                    base_post_actions, ..
+                } => base_post_actions
+                    .iter()
+                    .filter(|a| a.callback.is_some())
+                    .count(),
             };
             let from_undelegate = match &cau.undelegate_action {
                 UndelegateType::Standalone => 0,
-                UndelegateType::WithBaseActions(actions) => {
+                UndelegateType::BasePostActions(actions) => {
                     actions.iter().filter(|a| a.callback.is_some()).count()
                 }
             };
@@ -282,13 +288,13 @@ fn count_bundle_callbacks(bundle: &ScheduledIntentBundle) -> usize {
         })
         .unwrap_or(0);
 
-    let from_standalone = ib
-        .standalone_actions
+    let from_base_pre_actions = ib
+        .base_pre_actions
         .iter()
         .filter(|a| a.callback.is_some())
         .count();
 
-    from_commit + from_cau + from_standalone
+    from_commit + from_cau + from_base_pre_actions
 }
 
 fn now() -> u64 {

--- a/magicblock-committor-service/src/tasks/task_builder.rs
+++ b/magicblock-committor-service/src/tasks/task_builder.rs
@@ -221,9 +221,9 @@ impl TasksBuilder for TaskBuilderImpl {
         persister: &Option<P>,
     ) -> TaskBuilderResult<Vec<BaseTaskImpl>> {
         let mut tasks = Vec::new();
-        // Add standalone actions first
+        // Add Base pre-actions first.
         tasks.extend(Self::create_action_tasks(
-            intent_bundle.standalone_actions().as_slice(),
+            intent_bundle.base_pre_actions().as_slice(),
         ));
 
         // Fetch data necessary for task creation
@@ -314,16 +314,16 @@ impl TasksBuilder for TaskBuilderImpl {
                 CommitType::Standalone(accounts) => {
                     accounts.iter().map(finalize_task).collect()
                 }
-                CommitType::WithBaseActions {
+                CommitType::BasePostActions {
                     committed_accounts,
-                    base_actions,
+                    base_post_actions,
                 } => {
                     let mut tasks = committed_accounts
                         .iter()
                         .map(finalize_task)
                         .collect::<Vec<_>>();
                     tasks.extend(TaskBuilderImpl::create_action_tasks(
-                        base_actions,
+                        base_post_actions,
                     ));
                     tasks
                 }
@@ -358,7 +358,7 @@ impl TasksBuilder for TaskBuilderImpl {
                 })
                 .collect::<Vec<_>>();
 
-            if let UndelegateType::WithBaseActions(actions) =
+            if let UndelegateType::BasePostActions(actions) =
                 &commit_and_undelegate.undelegate_action
             {
                 tasks.extend(TaskBuilderImpl::create_action_tasks(actions));
@@ -467,11 +467,14 @@ impl<'a> CommitFinalizeBuilder<'a> {
                 .into()
             })
             .collect();
-        if let CommitType::WithBaseActions {
-            ref base_actions, ..
+        if let CommitType::BasePostActions {
+            ref base_post_actions,
+            ..
         } = commit_type
         {
-            tasks.extend(TaskBuilderImpl::create_action_tasks(base_actions));
+            tasks.extend(TaskBuilderImpl::create_action_tasks(
+                base_post_actions,
+            ));
         }
         tasks
     }
@@ -500,11 +503,14 @@ impl<'a> CommitFinalizeAndUndelegateBuilder<'a> {
                 .into()
             })
             .collect();
-        if let CommitType::WithBaseActions {
-            ref base_actions, ..
+        if let CommitType::BasePostActions {
+            ref base_post_actions,
+            ..
         } = commit_type
         {
-            tasks.extend(TaskBuilderImpl::create_action_tasks(base_actions));
+            tasks.extend(TaskBuilderImpl::create_action_tasks(
+                base_post_actions,
+            ));
         }
         tasks
     }

--- a/magicblock-magic-program-api/src/args.rs
+++ b/magicblock-magic-program-api/src/args.rs
@@ -44,9 +44,10 @@ pub struct BaseActionArgs {
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub enum CommitTypeArgs {
     Standalone(Vec<u8>), // indices on accounts
-    WithBaseActions {
+    /// Commit accounts, then execute Base-layer post-actions.
+    BasePostActions {
         committed_accounts: Vec<u8>, // indices of accounts
-        base_actions: Vec<BaseActionArgs>,
+        base_post_actions: Vec<BaseActionArgs>,
     },
 }
 
@@ -54,7 +55,7 @@ impl CommitTypeArgs {
     pub fn committed_accounts_indices(&self) -> &Vec<u8> {
         match self {
             Self::Standalone(value) => value,
-            Self::WithBaseActions {
+            Self::BasePostActions {
                 committed_accounts, ..
             } => committed_accounts,
         }
@@ -64,7 +65,10 @@ impl CommitTypeArgs {
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub enum UndelegateTypeArgs {
     Standalone,
-    WithBaseActions { base_actions: Vec<BaseActionArgs> },
+    /// Execute Base-layer post-actions after undelegation.
+    BasePostActions {
+        base_post_actions: Vec<BaseActionArgs>,
+    },
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
@@ -81,7 +85,9 @@ impl CommitAndUndelegateArgs {
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub enum MagicBaseIntentArgs {
-    BaseActions(Vec<BaseActionArgs>),
+    /// Execute Base-layer pre-actions before lifecycle work if present;
+    /// otherwise this is action-only Base work.
+    BasePreActions(Vec<BaseActionArgs>),
     Commit(CommitTypeArgs),
     CommitAndUndelegate(CommitAndUndelegateArgs),
     CommitFinalize(CommitTypeArgs),
@@ -94,15 +100,15 @@ pub struct MagicIntentBundleArgs {
     pub commit_and_undelegate: Option<CommitAndUndelegateArgs>,
     pub commit_finalize: Option<CommitTypeArgs>,
     pub commit_finalize_and_undelegate: Option<CommitAndUndelegateArgs>,
-    pub standalone_actions: Vec<BaseActionArgs>,
+    pub base_pre_actions: Vec<BaseActionArgs>,
 }
 
 impl From<MagicBaseIntentArgs> for MagicIntentBundleArgs {
     fn from(value: MagicBaseIntentArgs) -> Self {
         let mut this = Self::default();
         match value {
-            MagicBaseIntentArgs::BaseActions(value) => {
-                this.standalone_actions.extend(value)
+            MagicBaseIntentArgs::BasePreActions(value) => {
+                this.base_pre_actions.extend(value)
             }
             MagicBaseIntentArgs::Commit(value) => this.commit = Some(value),
             MagicBaseIntentArgs::CommitAndUndelegate(value) => {
@@ -160,7 +166,7 @@ impl<'a> From<&AccountInfo<'a>> for ShortAccountMeta {
 pub struct AddActionCallbackArgs {
     /// Flat index of the action to attach the callback to, ordered as:
     /// commit actions, commit_and_undelegate commit actions,
-    /// commit_and_undelegate undelegate actions, standalone actions.
+    /// commit_and_undelegate undelegate actions, Base pre-actions.
     pub action_index: u8,
     pub destination_program: Pubkey,
     pub discriminator: Vec<u8>,

--- a/magicblock-magic-program-api/src/instruction.rs
+++ b/magicblock-magic-program-api/src/instruction.rs
@@ -83,7 +83,7 @@ pub enum MagicBlockInstruction {
     ///
     /// A "base intent" is an atomic unit of work executed by the validator on the Base layer,
     /// such as:
-    /// - executing standalone base actions (`BaseActions`)
+    /// - executing Base pre-actions (`BasePreActions`)
     /// - committing a set of accounts (`Commit`)
     /// - committing and undelegating accounts, optionally with post-actions (`CommitAndUndelegate`)
     ///
@@ -136,7 +136,7 @@ pub enum MagicBlockInstruction {
     ///
     /// A "intent bundle" is an atomic unit of work executed by the validator on the Base layer,
     /// such as:
-    /// - standalone base actions
+    /// - Base pre-actions
     /// - an optional `Commit`
     /// - an optional `CommitAndUndelegate`
     ///

--- a/programs/magicblock/src/magic_scheduled_base_intent.rs
+++ b/programs/magicblock/src/magic_scheduled_base_intent.rs
@@ -192,16 +192,17 @@ impl ScheduledIntentBundle {
         self.intent_bundle.is_empty()
     }
 
-    pub fn standalone_actions(&self) -> &Vec<BaseAction> {
-        &self.intent_bundle.standalone_actions
+    pub fn base_pre_actions(&self) -> &Vec<BaseAction> {
+        &self.intent_bundle.base_pre_actions
     }
 }
 
 // BaseIntent user wants to send to base layer
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum MagicBaseIntent {
-    /// Actions without commitment or undelegation
-    BaseActions(Vec<BaseAction>),
+    /// Base-layer pre-actions before lifecycle work if present;
+    /// otherwise action-only Base work.
+    BasePreActions(Vec<BaseAction>),
     Commit(CommitType),
     CommitAndUndelegate(CommitAndUndelegate),
     CommitFinalize(CommitType),
@@ -215,15 +216,15 @@ pub struct MagicIntentBundle {
     pub commit_and_undelegate: Option<CommitAndUndelegate>,
     pub commit_finalize: Option<CommitType>,
     pub commit_finalize_and_undelegate: Option<CommitAndUndelegate>,
-    pub standalone_actions: Vec<BaseAction>,
+    pub base_pre_actions: Vec<BaseAction>,
 }
 
 impl From<MagicBaseIntent> for MagicIntentBundle {
     fn from(value: MagicBaseIntent) -> Self {
         let mut this = Self::default();
         match value {
-            MagicBaseIntent::BaseActions(value) => {
-                this.standalone_actions.extend(value)
+            MagicBaseIntent::BasePreActions(value) => {
+                this.base_pre_actions.extend(value)
             }
             MagicBaseIntent::Commit(value) => this.commit = Some(value),
             MagicBaseIntent::CommitAndUndelegate(value) => {
@@ -269,7 +270,7 @@ impl MagicIntentBundle {
             .transpose()?;
 
         let actions = args
-            .standalone_actions
+            .base_pre_actions
             .into_iter()
             .map(|args| BaseAction::try_from_args(args, context))
             .collect::<Result<Vec<BaseAction>, InstructionError>>()?;
@@ -279,7 +280,7 @@ impl MagicIntentBundle {
             commit_and_undelegate,
             commit_finalize,
             commit_finalize_and_undelegate,
-            standalone_actions: actions,
+            base_pre_actions: actions,
         };
         this.post_validation(context)?;
 
@@ -382,7 +383,7 @@ impl MagicIntentBundle {
         if let Some(ref cau) = self.commit_and_undelegate {
             fee += cau.calculate_fee(commit_nonces)?;
         }
-        fee += calculate_actions_fee(&self.standalone_actions);
+        fee += calculate_actions_fee(&self.base_pre_actions);
         Ok(fee)
     }
 
@@ -539,7 +540,7 @@ impl MagicIntentBundle {
             .map(|el| el.is_empty())
             .unwrap_or(true);
 
-        let no_actions = self.standalone_actions.is_empty();
+        let no_actions = self.base_pre_actions.is_empty();
 
         no_committed
             && no_committed_and_undelegated
@@ -559,10 +560,7 @@ impl MagicIntentBundle {
             .as_ref()
             .map(|el| el.has_callbacks())
             .unwrap_or(false);
-        let z = self
-            .standalone_actions
-            .iter()
-            .any(|el| el.callback.is_some());
+        let z = self.base_pre_actions.iter().any(|el| el.callback.is_some());
 
         x || y || z
     }
@@ -586,7 +584,7 @@ impl MagicIntentBundle {
             offset += count;
         }
 
-        self.standalone_actions.get_mut(index.checked_sub(offset)?)
+        self.base_pre_actions.get_mut(index.checked_sub(offset)?)
     }
 }
 
@@ -596,12 +594,12 @@ impl MagicBaseIntent {
         context: &ConstructionContext<'_, '_, '_>,
     ) -> Result<MagicBaseIntent, InstructionError> {
         match args {
-            MagicBaseIntentArgs::BaseActions(base_actions) => {
-                let base_actions = base_actions
+            MagicBaseIntentArgs::BasePreActions(base_pre_actions) => {
+                let base_pre_actions = base_pre_actions
                     .into_iter()
                     .map(|args| BaseAction::try_from_args(args, context))
                     .collect::<Result<Vec<BaseAction>, InstructionError>>()?;
-                Ok(MagicBaseIntent::BaseActions(base_actions))
+                Ok(MagicBaseIntent::BasePreActions(base_pre_actions))
             }
             MagicBaseIntentArgs::Commit(type_) => {
                 let commit = CommitType::try_from_args(type_, context)?;
@@ -628,7 +626,7 @@ impl MagicBaseIntent {
 
     pub fn is_undelegate(&self) -> bool {
         match &self {
-            MagicBaseIntent::BaseActions(_) => false,
+            MagicBaseIntent::BasePreActions(_) => false,
             MagicBaseIntent::Commit(_) => false,
             MagicBaseIntent::CommitAndUndelegate(_) => true,
             MagicBaseIntent::CommitFinalize(_) => false,
@@ -638,7 +636,7 @@ impl MagicBaseIntent {
 
     pub fn is_commit_finalize(&self) -> bool {
         match &self {
-            MagicBaseIntent::BaseActions(_) => false,
+            MagicBaseIntent::BasePreActions(_) => false,
             MagicBaseIntent::Commit(_) => false,
             MagicBaseIntent::CommitAndUndelegate(_) => false,
             MagicBaseIntent::CommitFinalize(_) => true,
@@ -648,7 +646,7 @@ impl MagicBaseIntent {
 
     pub fn get_committed_accounts(&self) -> Option<&Vec<CommittedAccount>> {
         match self {
-            MagicBaseIntent::BaseActions(_) => None,
+            MagicBaseIntent::BasePreActions(_) => None,
             MagicBaseIntent::Commit(t) => Some(t.get_committed_accounts()),
             MagicBaseIntent::CommitAndUndelegate(t) => {
                 Some(t.get_committed_accounts())
@@ -666,7 +664,7 @@ impl MagicBaseIntent {
         &mut self,
     ) -> Option<&mut Vec<CommittedAccount>> {
         match self {
-            MagicBaseIntent::BaseActions(_) => None,
+            MagicBaseIntent::BasePreActions(_) => None,
             MagicBaseIntent::Commit(t) => Some(t.get_committed_accounts_mut()),
             MagicBaseIntent::CommitAndUndelegate(t) => {
                 Some(t.get_committed_accounts_mut())
@@ -688,7 +686,7 @@ impl MagicBaseIntent {
 
     pub fn is_empty(&self) -> bool {
         match self {
-            MagicBaseIntent::BaseActions(actions) => actions.is_empty(),
+            MagicBaseIntent::BasePreActions(actions) => actions.is_empty(),
             MagicBaseIntent::Commit(t) => t.is_empty(),
             MagicBaseIntent::CommitAndUndelegate(t) => t.is_empty(),
             MagicBaseIntent::CommitFinalize(t) => t.is_empty(),
@@ -778,7 +776,7 @@ impl CommitAndUndelegate {
 
     pub fn has_callbacks(&self) -> bool {
         let x = self.commit_action.has_callbacks();
-        let y = if let UndelegateType::WithBaseActions(actions) =
+        let y = if let UndelegateType::BasePostActions(actions) =
             &self.undelegate_action
         {
             actions.iter().any(|el| el.callback.is_some())
@@ -894,10 +892,10 @@ impl BaseAction {
 pub enum CommitType {
     /// Regular commit without actions
     Standalone(Vec<CommittedAccount>), // accounts to commit
-    /// Commits accounts and runs actions
-    WithBaseActions {
+    /// Commits accounts, then runs Base-layer post-actions.
+    BasePostActions {
         committed_accounts: Vec<CommittedAccount>,
-        base_actions: Vec<BaseAction>,
+        base_post_actions: Vec<BaseAction>,
     },
 }
 
@@ -1001,9 +999,9 @@ impl CommitType {
 
                 Ok(CommitType::Standalone(committed_accounts))
             }
-            CommitTypeArgs::WithBaseActions {
+            CommitTypeArgs::BasePostActions {
                 committed_accounts,
-                base_actions,
+                base_post_actions,
             } => {
                 let committed_accounts_ref = Self::extract_commit_accounts(
                     &committed_accounts,
@@ -1011,7 +1009,7 @@ impl CommitType {
                 )?;
                 Self::validate_accounts(&committed_accounts_ref, context)?;
 
-                let base_actions = base_actions
+                let base_post_actions = base_post_actions
                     .into_iter()
                     .map(|args| BaseAction::try_from_args(args, context))
                     .collect::<Result<Vec<BaseAction>, InstructionError>>()?;
@@ -1027,9 +1025,9 @@ impl CommitType {
                     })
                     .collect::<Result<_, InstructionError>>()?;
 
-                Ok(CommitType::WithBaseActions {
+                Ok(CommitType::BasePostActions {
                     committed_accounts,
-                    base_actions,
+                    base_post_actions,
                 })
             }
         }
@@ -1045,12 +1043,12 @@ impl CommitType {
             CommitType::Standalone(ref committed_accounts) => {
                 fee += calculate_commit_fee(committed_accounts, commit_nonces)?;
             }
-            CommitType::WithBaseActions {
+            CommitType::BasePostActions {
                 committed_accounts,
-                base_actions,
+                base_post_actions,
             } => {
                 fee += calculate_commit_fee(committed_accounts, commit_nonces)?;
-                fee += calculate_actions_fee(base_actions);
+                fee += calculate_actions_fee(base_post_actions);
             }
         }
 
@@ -1060,7 +1058,7 @@ impl CommitType {
     pub fn get_committed_accounts(&self) -> &Vec<CommittedAccount> {
         match self {
             Self::Standalone(committed_accounts) => committed_accounts,
-            Self::WithBaseActions {
+            Self::BasePostActions {
                 committed_accounts, ..
             } => committed_accounts,
         }
@@ -1069,7 +1067,7 @@ impl CommitType {
     pub fn get_committed_accounts_mut(&mut self) -> &mut Vec<CommittedAccount> {
         match self {
             Self::Standalone(committed_accounts) => committed_accounts,
-            Self::WithBaseActions {
+            Self::BasePostActions {
                 committed_accounts, ..
             } => committed_accounts,
         }
@@ -1087,19 +1085,19 @@ impl CommitType {
             Self::Standalone(committed_accounts) => {
                 committed_accounts.is_empty()
             }
-            Self::WithBaseActions {
+            Self::BasePostActions {
                 committed_accounts, ..
             } => committed_accounts.is_empty(),
         }
     }
 
     pub fn has_callbacks(&self) -> bool {
-        if let Self::WithBaseActions {
+        if let Self::BasePostActions {
             committed_accounts: _,
-            base_actions,
+            base_post_actions,
         } = self
         {
-            base_actions.iter().any(|el| el.callback.is_some())
+            base_post_actions.iter().any(|el| el.callback.is_some())
         } else {
             false
         }
@@ -1108,13 +1106,18 @@ impl CommitType {
     pub fn action_count(&self) -> usize {
         match self {
             Self::Standalone(_) => 0,
-            Self::WithBaseActions { base_actions, .. } => base_actions.len(),
+            Self::BasePostActions {
+                base_post_actions, ..
+            } => base_post_actions.len(),
         }
     }
 
     pub fn get_action_mut(&mut self, index: usize) -> Option<&mut BaseAction> {
-        if let Self::WithBaseActions { base_actions, .. } = self {
-            base_actions.get_mut(index)
+        if let Self::BasePostActions {
+            base_post_actions, ..
+        } = self
+        {
+            base_post_actions.get_mut(index)
         } else {
             None
         }
@@ -1125,19 +1128,20 @@ impl CommitType {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum UndelegateType {
     Standalone,
-    WithBaseActions(Vec<BaseAction>),
+    /// Runs Base-layer post-actions after undelegation.
+    BasePostActions(Vec<BaseAction>),
 }
 
 impl UndelegateType {
     pub fn action_count(&self) -> usize {
         match self {
             Self::Standalone => 0,
-            Self::WithBaseActions(actions) => actions.len(),
+            Self::BasePostActions(actions) => actions.len(),
         }
     }
 
     pub fn get_action_mut(&mut self, index: usize) -> Option<&mut BaseAction> {
-        if let Self::WithBaseActions(actions) = self {
+        if let Self::BasePostActions(actions) = self {
             actions.get_mut(index)
         } else {
             None
@@ -1150,14 +1154,14 @@ impl UndelegateType {
     ) -> Result<UndelegateType, InstructionError> {
         match args {
             UndelegateTypeArgs::Standalone => Ok(UndelegateType::Standalone),
-            UndelegateTypeArgs::WithBaseActions { base_actions } => {
-                let base_actions = base_actions
+            UndelegateTypeArgs::BasePostActions { base_post_actions } => {
+                let base_post_actions = base_post_actions
                     .into_iter()
                     .map(|base_action| {
                         BaseAction::try_from_args(base_action, context)
                     })
                     .collect::<Result<Vec<BaseAction>, InstructionError>>()?;
-                Ok(UndelegateType::WithBaseActions(base_actions))
+                Ok(UndelegateType::BasePostActions(base_post_actions))
             }
         }
     }
@@ -1168,7 +1172,7 @@ impl UndelegateType {
     ) -> Result<u64, InstructionError> {
         match self {
             UndelegateType::Standalone => Ok(0),
-            UndelegateType::WithBaseActions(actions) => {
+            UndelegateType::BasePostActions(actions) => {
                 Ok(calculate_actions_fee(actions))
             }
         }
@@ -1363,7 +1367,7 @@ mod tests {
         use solana_hash::Hash;
         use solana_transaction::Transaction;
 
-        // commit WithBaseActions: pk1 above limit (charged), pk2 at limit (free)
+        // commit BasePostActions: pk1 above limit (charged), pk2 at limit (free)
         let pk1 = Pubkey::new_unique();
         let pk2 = Pubkey::new_unique();
         // cau commit: pk3 above limit (charged); undelegate has actions too
@@ -1376,24 +1380,24 @@ mod tests {
             sent_transaction: Transaction::default(),
             payer: Pubkey::new_unique(),
             intent_bundle: MagicIntentBundle {
-                commit: Some(CommitType::WithBaseActions {
+                commit: Some(CommitType::BasePostActions {
                     committed_accounts: vec![
                         make_committed_account(pk1),
                         make_committed_account(pk2),
                     ],
-                    base_actions: vec![make_base_action(200_000)],
+                    base_post_actions: vec![make_base_action(200_000)],
                 }),
                 commit_and_undelegate: Some(CommitAndUndelegate {
                     commit_action: CommitType::Standalone(vec![
                         make_committed_account(pk3),
                     ]),
-                    undelegate_action: UndelegateType::WithBaseActions(vec![
+                    undelegate_action: UndelegateType::BasePostActions(vec![
                         make_base_action(100_000),
                     ]),
                 }),
                 commit_finalize: None,
                 commit_finalize_and_undelegate: None,
-                standalone_actions: vec![make_base_action(50_000)],
+                base_pre_actions: vec![make_base_action(50_000)],
             },
         };
 
@@ -1407,12 +1411,12 @@ mod tests {
 
         // commit: pk1 (100_000) + action 200k CUs (10_000) = 110_000
         // cau:    pk3 (100_000) + undelegate action 100k CUs (5_000) = 105_000
-        // standalone: action 50k CUs (2_500)
+        // base pre-action: action 50k CUs (2_500)
         let expected = COMMIT_FEE_LAMPORTS       // pk1
             + 10_000                             // 200k CU action
             + COMMIT_FEE_LAMPORTS               // pk3
             + 5_000                              // 100k CU undelegate action
-            + 2_500; // 50k CU standalone action
+            + 2_500; // 50k CU base pre-action
         assert_eq!(fee, expected);
     }
 }

--- a/programs/magicblock/src/schedule_transactions/process_schedule_commit_tests.rs
+++ b/programs/magicblock/src/schedule_transactions/process_schedule_commit_tests.rs
@@ -426,7 +426,7 @@ mod tests {
             commit_and_undelegate: None,
             commit_finalize: None,
             commit_finalize_and_undelegate: None,
-            standalone_actions: vec![BaseActionArgs {
+            base_pre_actions: vec![BaseActionArgs {
                 args: ActionArgs::new(vec![1, 2, 3]).with_escrow_index(0),
                 compute_units: 100_000,
                 escrow_authority: 0,
@@ -468,7 +468,7 @@ mod tests {
             bincode::deserialize::<MagicContext>(magic_context_acc.data())
                 .unwrap();
         let scheduled = &magic_context.scheduled_base_intents[0];
-        let actions = scheduled.standalone_actions();
+        let actions = scheduled.base_pre_actions();
 
         assert!(scheduled.get_all_committed_pubkeys().is_empty());
         assert_eq!(actions.len(), 1);

--- a/test-integration/programs/flexi-counter/src/processor/schedule_intent.rs
+++ b/test-integration/programs/flexi-counter/src/processor/schedule_intent.rs
@@ -396,7 +396,7 @@ pub fn process_create_intent_bundle_commit_and_finalize(
                 .collect(),
         )),
         commit_finalize_and_undelegate: None,
-        standalone_actions: vec![],
+        base_pre_actions: vec![],
     };
 
     let mut metas = vec![

--- a/test-integration/test-committor-service/tests/test_intent_executor.rs
+++ b/test-integration/test-committor-service/tests/test_intent_executor.rs
@@ -1206,7 +1206,7 @@ async fn test_action_callback_fired_on_failure() {
     let commit_action = CommitType::Standalone(vec![committed_account.clone()]);
     let undelegate_action =
         failing_undelegate_action(payer.pubkey(), committed_account.pubkey);
-    let UndelegateType::WithBaseActions(ref actions) = undelegate_action else {
+    let UndelegateType::BasePostActions(ref actions) = undelegate_action else {
         panic!("expected base actions");
     };
     let expected_callback = actions[0].callback.clone().unwrap();
@@ -1260,7 +1260,7 @@ async fn test_action_callback_fired_on_timeout() {
     let commit_action = CommitType::Standalone(vec![committed_account.clone()]);
     let undelegate_action =
         failing_undelegate_action(payer.pubkey(), committed_account.pubkey);
-    let UndelegateType::WithBaseActions(ref actions) = undelegate_action else {
+    let UndelegateType::BasePostActions(ref actions) = undelegate_action else {
         panic!("expected base actions");
     };
     let expected_callback = actions[0].callback.clone().unwrap();
@@ -1336,15 +1336,15 @@ async fn test_callbacks_fired_in_two_stage() {
         remote_slot: Default::default(),
     };
 
-    // commit-stage action: goes into standalone_actions → commit strategy
+    // commit-stage action: goes into base_pre_actions → commit strategy
     let commit_base_action =
         succeeding_commit_action(payer.pubkey(), counter_pubkey);
     let expected_commit_callback = commit_base_action.callback.clone().unwrap();
 
-    // finalize-stage action: goes into UndelegateType::WithBaseActions → finalize strategy
+    // finalize-stage action: goes into UndelegateType::BasePostActions → finalize strategy
     let undelegate_action =
         succeeding_undelegate_action(payer.pubkey(), counter_pubkey);
-    let UndelegateType::WithBaseActions(ref actions) = undelegate_action else {
+    let UndelegateType::BasePostActions(ref actions) = undelegate_action else {
         panic!("expected base actions");
     };
     let expected_finalize_callback = actions[0].callback.clone().unwrap();
@@ -1356,7 +1356,7 @@ async fn test_callbacks_fired_in_two_stage() {
             ]),
             undelegate_action,
         }),
-        standalone_actions: vec![commit_base_action],
+        base_pre_actions: vec![commit_base_action],
         ..Default::default()
     });
     let committed_pubkeys = intent.get_all_committed_pubkeys();
@@ -1383,7 +1383,7 @@ async fn test_callbacks_fired_in_two_stage() {
         .await
         .expect("commit must succeed");
 
-    // standalone_actions land in the commit strategy as a BaseAction
+    // base_pre_actions land in the commit strategy as a BaseAction
     let calls = callback_executor.calls();
     assert_eq!(
         calls.len(),
@@ -1520,7 +1520,7 @@ fn succeeding_undelegate_action(
         },
     ];
 
-    UndelegateType::WithBaseActions(vec![BaseAction {
+    UndelegateType::BasePostActions(vec![BaseAction {
         compute_units: 100_000,
         destination_program: program_flexi_counter::id(),
         source_program: Some(program_flexi_counter::id()),
@@ -1563,7 +1563,7 @@ fn failing_undelegate_action(
         },
     ];
 
-    UndelegateType::WithBaseActions(vec![BaseAction {
+    UndelegateType::BasePostActions(vec![BaseAction {
         compute_units: 100_000,
         destination_program: program_flexi_counter::id(),
         source_program: Some(program_flexi_counter::id()),

--- a/test-integration/test-committor-service/tests/test_transaction_preparator.rs
+++ b/test-integration/test-committor-service/tests/test_transaction_preparator.rs
@@ -171,7 +171,7 @@ async fn test_prepare_commit_tx_with_multiple_accounts() {
 }
 
 #[tokio::test]
-async fn test_prepare_commit_tx_with_base_actions() {
+async fn test_prepare_commit_tx_with_base_post_actions() {
     let fixture = TestFixture::new().await;
     let preparator = fixture.create_transaction_preparator();
 


### PR DESCRIPTION
<!--
PR title must match: type(scope): summary
Types: feat|fix|docs|chore|refactor|test|perf|ci|build
Examples:
  fix: avoid panic on empty slot
  feat(rpc): add getFoo endpoint
-->

## Summary
<!-- One sentence. Link to issue if applicable. -->


## Breaking Changes
- [ ] None
- [ ] Yes — migration path described below


## Test Plan
<!-- How you verified this works. e.g., "unit tests", "ran locally against testnet", "existing tests pass" -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated action execution flow documentation to reflect refined terminology for action handling and processing order.

* **Chores**
  * Reorganized internal intent action structure and processing logic across the execution pipeline.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/magicblock-labs/magicblock-validator/pull/1267?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->