### PR TITLE
Allow same-slot delegated clone override

### DIFF
--- a/programs/magicblock/src/clone_account/common.rs
+++ b/programs/magicblock/src/clone_account/common.rs
@@ -237,7 +237,9 @@ pub fn set_account_from_fields(
     // In the same slot, we do not expect an account to be delegated,
     // undelegated and then delegated. So if we see the same account being
     // delegated twice (ore more) in the same slot, we consider such cases
-    // as "duplicates".
+    // as "duplicates". A delegated clone is still allowed to override a
+    // same-slot plain clone, which can happen when an eATA projection catches
+    // up after the underlying ATA was cloned without delegation metadata.
     //
     // Under current design, we clone with "CONFIRMED" commitment and thus:
     //
@@ -247,7 +249,10 @@ pub fn set_account_from_fields(
     //
     // Given this, same slot re-delegation is impossible therefore this this totally acceptable.
     //
-    if fields.delegated && acc.remote_slot() == fields.remote_slot {
+    if fields.delegated
+        && acc.delegated()
+        && acc.remote_slot() == fields.remote_slot
+    {
         return Err(
             MagicBlockProgramError::DuplicateDelegatedAccountClone.into()
         );

--- a/programs/magicblock/src/clone_account/tests.rs
+++ b/programs/magicblock/src/clone_account/tests.rs
@@ -152,6 +152,66 @@ fn test_clone_account_rejects_stale_slot() {
 }
 
 #[test]
+fn test_clone_account_allows_same_slot_delegated_update_over_plain_account() {
+    init_logger!();
+    let pubkey = Pubkey::new_unique();
+    let accounts = setup_with_account(pubkey, 100, 42);
+
+    let mut fields = clone_fields(200, 42);
+    fields.delegated = true;
+
+    let ix = InstructionUtils::clone_account_instruction(
+        pubkey,
+        vec![],
+        fields,
+        None,
+    );
+
+    let mut result = process_instruction(
+        &ix.data,
+        tx_accounts(accounts, &ix.accounts),
+        ix.accounts,
+        Ok(()),
+    );
+    result.drain(0..1);
+    let account = result.drain(0..1).next().unwrap();
+
+    assert_eq!(account.lamports(), 200);
+    assert!(account.delegated());
+    assert_eq!(account.remote_slot(), 42);
+}
+
+#[test]
+fn test_clone_account_rejects_same_slot_duplicate_delegated_update() {
+    init_logger!();
+    let pubkey = Pubkey::new_unique();
+    let mut account = AccountSharedData::new(100, 0, &pubkey);
+    account.set_delegated(true);
+    account.set_undelegating(true);
+    account.set_remote_slot(42);
+    let mut accounts = HashMap::new();
+    accounts.insert(pubkey, account);
+    ensure_started_validator(&mut accounts, None);
+
+    let mut fields = clone_fields(200, 42);
+    fields.delegated = true;
+
+    let ix = InstructionUtils::clone_account_instruction(
+        pubkey,
+        vec![],
+        fields,
+        None,
+    );
+
+    process_instruction(
+        &ix.data,
+        tx_accounts(accounts, &ix.accounts),
+        ix.accounts,
+        Err(MagicBlockProgramError::DuplicateDelegatedAccountClone.into()),
+    );
+}
+
+#[test]
 fn test_clone_account_rejects_delegated_account() {
     init_logger!();
     let pubkey = Pubkey::new_unique();


### PR DESCRIPTION
## Summary

- Allow a same-slot delegated clone to override an existing not delegated account clone.
- Keep duplicate delegated-account clone protection when the destination is already delegated.
- Add clone-account regression coverage for both the allowed plain-to-delegated transition and the rejected duplicate delegated update.

 ## Note on Scope

  This PR fixes the observed `InvalidWritableAccount` regression by allowing a same-slot delegated clone to override an existing plain ATA clone. In the failing flow, Chainlink first cloned the raw ATA as `delegated=false`, then later synthesized
  the delegated ATA from the companion eATA/delegation state at the same `remote_slot`. The previous clone guard rejected that projection as a duplicate.

  This is a pragmatic hotfix, not the ideal long-term boundary. The underlying issue is projection provenance: eATA-derived ATA state is currently emitted through the generic `CloneAccount` path, which makes a locally synthesized projection look
  like raw RPC account state. A follow-up should keep `CloneAccount` semantics strict and add a projection-specific materialization/update path, or an explicit projection source/version marker, for same-slot eATA projections.