### PR TITLE
Reduce committor RPC confirmation calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4219,7 +4219,9 @@ dependencies = [
 name = "magicblock-rpc-client"
 version = "0.11.3"
 dependencies = [
+ "async-trait",
  "futures-util",
+ "magicblock-metrics",
  "serde_json",
  "solana-account 3.4.0",
  "solana-account-decoder-client-types",
@@ -4229,6 +4231,7 @@ dependencies = [
  "solana-hash 3.1.0",
  "solana-instruction 3.4.0",
  "solana-pubkey 3.0.0",
+ "solana-pubsub-client",
  "solana-rpc-client",
  "solana-rpc-client-api",
  "solana-signature 3.4.0",

--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -469,6 +469,10 @@ impl MagicValidator {
             committor_persist_path,
             ChainConfig {
                 rpc_uri: config.rpc_url().to_owned(),
+                websocket_uri: config
+                    .websocket_urls()
+                    .next()
+                    .map(ToOwned::to_owned),
                 commitment: CommitmentConfig::confirmed(),
                 compute_budget_config: ComputeBudgetConfig::new(
                     config.commit.compute_unit_price,

--- a/magicblock-committor-service/src/committor_processor.rs
+++ b/magicblock-committor-service/src/committor_processor.rs
@@ -70,10 +70,22 @@ impl CommittorProcessor {
             chain_config.commitment,
         );
         let rpc_client = Arc::new(rpc_client);
-        let magic_block_rpc_client = if let Some(chain_slot) = chain_slot {
-            MagicblockRpcClient::new_with_chain_slot(rpc_client, chain_slot)
-        } else {
-            MagicblockRpcClient::new(rpc_client)
+        let websocket_uri = chain_config.websocket_uri.clone();
+        let magic_block_rpc_client = match (chain_slot, websocket_uri) {
+            (Some(chain_slot), websocket_uri) => {
+                MagicblockRpcClient::new_with_chain_slot_and_websocket(
+                    rpc_client,
+                    chain_slot,
+                    websocket_uri,
+                )
+            }
+            (None, Some(websocket_uri)) => {
+                MagicblockRpcClient::new_with_websocket(
+                    rpc_client,
+                    Some(websocket_uri),
+                )
+            }
+            (None, None) => MagicblockRpcClient::new(rpc_client),
         };
 
         // Create TableMania

--- a/magicblock-committor-service/src/config.rs
+++ b/magicblock-committor-service/src/config.rs
@@ -9,6 +9,7 @@ pub const DEFAULT_ACTIONS_TIMEOUT: Duration = Duration::from_secs(60);
 #[derive(Debug, Clone)]
 pub struct ChainConfig {
     pub rpc_uri: String,
+    pub websocket_uri: Option<String>,
     pub commitment: CommitmentConfig,
     pub compute_budget_config: ComputeBudgetConfig,
     pub actions_timeout: Duration,
@@ -18,6 +19,7 @@ impl ChainConfig {
     pub fn devnet(compute_budget_config: ComputeBudgetConfig) -> Self {
         Self {
             rpc_uri: "https://api.devnet.solana.com".to_string(),
+            websocket_uri: None,
             commitment: CommitmentConfig::confirmed(),
             compute_budget_config,
             actions_timeout: DEFAULT_ACTIONS_TIMEOUT,
@@ -27,6 +29,7 @@ impl ChainConfig {
     pub fn mainnet(compute_budget_config: ComputeBudgetConfig) -> Self {
         Self {
             rpc_uri: "https://api.mainnet-beta.solana.com".to_string(),
+            websocket_uri: None,
             commitment: CommitmentConfig::confirmed(),
             compute_budget_config,
             actions_timeout: DEFAULT_ACTIONS_TIMEOUT,
@@ -36,6 +39,7 @@ impl ChainConfig {
     pub fn local(compute_budget_config: ComputeBudgetConfig) -> Self {
         Self {
             rpc_uri: "http://localhost:7799".to_string(),
+            websocket_uri: None,
             commitment: CommitmentConfig::processed(),
             compute_budget_config,
             actions_timeout: DEFAULT_ACTIONS_TIMEOUT,

--- a/magicblock-metrics/src/metrics/mod.rs
+++ b/magicblock-metrics/src/metrics/mod.rs
@@ -403,6 +403,31 @@ lazy_static::lazy_static! {
         "table_mania_closed_a_count", "Get account counter"
     ).unwrap();
 
+    static ref RPC_CLIENT_SIGNATURE_WS_SUBSCRIBE_COUNT: IntCounter = IntCounter::new(
+        "rpc_client_signature_ws_subscribe_count",
+        "Number of signatureSubscribe registrations created by MagicblockRpcClient"
+    ).unwrap();
+
+    static ref RPC_CLIENT_SIGNATURE_WS_NOTIFICATION_COUNT: IntCounter = IntCounter::new(
+        "rpc_client_signature_ws_notification_count",
+        "Number of signatureSubscribe notifications received by MagicblockRpcClient"
+    ).unwrap();
+
+    static ref RPC_CLIENT_SIGNATURE_WS_FALLBACK_COUNT: IntCounter = IntCounter::new(
+        "rpc_client_signature_ws_fallback_count",
+        "Number of signature confirmations that fell back to batched polling"
+    ).unwrap();
+
+    static ref RPC_CLIENT_SIGNATURE_STATUS_BATCH_COUNT: IntCounter = IntCounter::new(
+        "rpc_client_signature_status_batch_count",
+        "Number of batched getSignatureStatuses requests sent by MagicblockRpcClient"
+    ).unwrap();
+
+    static ref RPC_CLIENT_SIGNATURE_STATUS_BATCH_SIGNATURES_COUNT: IntCounter = IntCounter::new(
+        "rpc_client_signature_status_batch_signatures_count",
+        "Number of signatures included in batched getSignatureStatuses requests"
+    ).unwrap();
+
 
     static ref COMMITTOR_INTENT_TASK_PREPARATION_TIME: HistogramVec = HistogramVec::new(
         HistogramOpts::new(
@@ -620,6 +645,11 @@ pub(crate) fn register() {
         register!(TASK_INFO_FETCHER_RETIRING_GAUGE);
         register!(TABLE_MANIA_A_COUNT);
         register!(TABLE_MANIA_CLOSED_A_COUNT);
+        register!(RPC_CLIENT_SIGNATURE_WS_SUBSCRIBE_COUNT);
+        register!(RPC_CLIENT_SIGNATURE_WS_NOTIFICATION_COUNT);
+        register!(RPC_CLIENT_SIGNATURE_WS_FALLBACK_COUNT);
+        register!(RPC_CLIENT_SIGNATURE_STATUS_BATCH_COUNT);
+        register!(RPC_CLIENT_SIGNATURE_STATUS_BATCH_SIGNATURES_COUNT);
         register!(CONNECTED_PUBSUB_CLIENTS_GAUGE);
         register!(CONNECTED_DIRECT_PUBSUB_CLIENTS_GAUGE);
         register!(PUBSUB_CLIENT_UPTIME_GAUGE);
@@ -897,6 +927,26 @@ pub fn inc_table_mania_a_count() {
 
 pub fn inc_table_mania_close_a_count() {
     TABLE_MANIA_CLOSED_A_COUNT.inc()
+}
+
+pub fn inc_rpc_client_signature_ws_subscribe_count() {
+    RPC_CLIENT_SIGNATURE_WS_SUBSCRIBE_COUNT.inc()
+}
+
+pub fn inc_rpc_client_signature_ws_notification_count() {
+    RPC_CLIENT_SIGNATURE_WS_NOTIFICATION_COUNT.inc()
+}
+
+pub fn inc_rpc_client_signature_ws_fallback_count() {
+    RPC_CLIENT_SIGNATURE_WS_FALLBACK_COUNT.inc()
+}
+
+pub fn inc_rpc_client_signature_status_batch_count() {
+    RPC_CLIENT_SIGNATURE_STATUS_BATCH_COUNT.inc()
+}
+
+pub fn inc_rpc_client_signature_status_batch_signatures_count(count: u64) {
+    RPC_CLIENT_SIGNATURE_STATUS_BATCH_SIGNATURES_COUNT.inc_by(count)
 }
 
 pub fn set_connected_pubsub_clients_count(count: usize) {

--- a/magicblock-rpc-client/Cargo.toml
+++ b/magicblock-rpc-client/Cargo.toml
@@ -12,6 +12,8 @@ doctest = false
 
 [dependencies]
 tracing = { workspace = true }
+magicblock-metrics = { workspace = true }
+solana-pubsub-client = { workspace = true }
 solana-rpc-client = { workspace = true }
 solana-rpc-client-api = { workspace = true }
 solana-transaction-status-client-types = { workspace = true }
@@ -34,4 +36,5 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 
 [dev-dependencies]
+async-trait = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros"] }

--- a/magicblock-rpc-client/src/lib.rs
+++ b/magicblock-rpc-client/src/lib.rs
@@ -1,8 +1,10 @@
 #![allow(deprecated)]
 
+mod signature_confirmer;
 pub mod utils;
 
 use std::{
+    collections::HashMap,
     sync::{
         atomic::{AtomicU64, Ordering},
         Arc,
@@ -12,6 +14,7 @@ use std::{
 
 use futures_util::future::try_join_all;
 use serde_json::json;
+use signature_confirmer::{SignatureConfirmer, SignatureConfirmerConfig};
 use solana_account::Account;
 use solana_account_decoder_client_types::UiAccountEncoding;
 use solana_address_lookup_table_interface::state::{
@@ -38,7 +41,7 @@ use solana_transaction_error::{TransactionError, TransactionResult};
 use solana_transaction_status_client_types::{
     EncodedConfirmedTransactionWithStatusMeta, UiTransactionEncoding,
 };
-use tokio::{sync::Mutex as TMutex, time::sleep};
+use tokio::sync::Mutex as TMutex;
 use tracing::*;
 
 /// The encoding to use when sending transactions
@@ -241,8 +244,14 @@ const SLOT_CACHE_TTL: Duration = Duration::from_millis(400);
 
 #[derive(Default)]
 struct RpcClientCache {
-    blockhash: TMutex<Option<CachedBlockhash>>,
+    blockhash: TMutex<BlockhashCache>,
     slot: TMutex<Option<CachedSlot>>,
+}
+
+#[derive(Default)]
+struct BlockhashCache {
+    latest: Option<CachedBlockhash>,
+    recent: HashMap<Hash, CachedBlockhash>,
 }
 
 #[derive(Clone, Copy)]
@@ -266,6 +275,7 @@ pub struct MagicblockRpcClient {
     client: Arc<RpcClient>,
     cache: Arc<RpcClientCache>,
     chain_slot: Option<Arc<AtomicU64>>,
+    confirmer: Arc<SignatureConfirmer>,
 }
 
 impl From<RpcClient> for MagicblockRpcClient {
@@ -277,21 +287,45 @@ impl From<RpcClient> for MagicblockRpcClient {
 impl MagicblockRpcClient {
     /// Create a new [MagicBlockRpcClient] from an existing [RpcClient].
     pub fn new(client: Arc<RpcClient>) -> Self {
-        Self {
-            client,
-            cache: Arc::new(RpcClientCache::default()),
-            chain_slot: None,
-        }
+        Self::new_with_options(client, None, None)
     }
 
     pub fn new_with_chain_slot(
         client: Arc<RpcClient>,
         chain_slot: Arc<AtomicU64>,
     ) -> Self {
+        Self::new_with_options(client, Some(chain_slot), None)
+    }
+
+    pub fn new_with_websocket(
+        client: Arc<RpcClient>,
+        websocket_url: Option<String>,
+    ) -> Self {
+        Self::new_with_options(client, None, websocket_url)
+    }
+
+    pub fn new_with_chain_slot_and_websocket(
+        client: Arc<RpcClient>,
+        chain_slot: Arc<AtomicU64>,
+        websocket_url: Option<String>,
+    ) -> Self {
+        Self::new_with_options(client, Some(chain_slot), websocket_url)
+    }
+
+    fn new_with_options(
+        client: Arc<RpcClient>,
+        chain_slot: Option<Arc<AtomicU64>>,
+        websocket_url: Option<String>,
+    ) -> Self {
+        let confirmer = Arc::new(SignatureConfirmer::new(
+            client.clone(),
+            SignatureConfirmerConfig::with_websocket_url(websocket_url),
+        ));
         Self {
             client,
             cache: Arc::new(RpcClientCache::default()),
-            chain_slot: Some(chain_slot),
+            chain_slot,
+            confirmer,
         }
     }
 
@@ -305,12 +339,15 @@ impl MagicblockRpcClient {
 
         let (blockhash, context_slot, last_valid_block_height) =
             self.fetch_latest_blockhash_with_context().await?;
-        *cached = Some(CachedBlockhash {
-            blockhash,
-            context_slot,
-            last_valid_block_height,
-            fetched_at: Instant::now(),
-        });
+        Self::cache_blockhash(
+            &mut cached,
+            CachedBlockhash {
+                blockhash,
+                context_slot,
+                last_valid_block_height,
+                fetched_at: Instant::now(),
+            },
+        );
         drop(cached);
 
         self.record_observed_slot(context_slot).await;
@@ -376,13 +413,12 @@ impl MagicblockRpcClient {
 
     pub async fn invalidate_cached_blockhash(&self) {
         let mut cached = self.cache.blockhash.lock().await;
-        *cached = None;
+        cached.latest = None;
     }
 
-    fn fresh_cached_blockhash(
-        cached: &Option<CachedBlockhash>,
-    ) -> Option<Hash> {
+    fn fresh_cached_blockhash(cached: &BlockhashCache) -> Option<Hash> {
         cached
+            .latest
             .as_ref()
             .filter(|value| value.fetched_at.elapsed() < BLOCKHASH_CACHE_TTL)
             .map(|value| {
@@ -393,6 +429,25 @@ impl MagicblockRpcClient {
                 );
                 value.blockhash
             })
+    }
+
+    fn cache_blockhash(
+        cached: &mut BlockhashCache,
+        blockhash: CachedBlockhash,
+    ) {
+        cached.latest = Some(blockhash);
+        cached.recent.insert(blockhash.blockhash, blockhash);
+        cached.recent.retain(|_, value| {
+            value.fetched_at.elapsed() < DEFAULT_MAX_TIME_TO_PROCESSED
+        });
+    }
+
+    async fn cached_blockhash_metadata(
+        &self,
+        blockhash: &Hash,
+    ) -> Option<CachedBlockhash> {
+        let cached = self.cache.blockhash.lock().await;
+        cached.recent.get(blockhash).copied()
     }
 
     fn fresh_cached_slot(cached: &Option<CachedSlot>) -> Option<Slot> {
@@ -580,8 +635,8 @@ impl MagicblockRpcClient {
 
     /// Sends a transaction skipping preflight checks and then attempts to confirm
     /// it if so configured
-    /// To confirm a transaction it uses the `client.commitment()` when requesting
-    /// `get_signature_status_with_commitment`
+    /// To confirm a transaction it uses the `client.commitment()` when waiting
+    /// for a signature status.
     ///
     /// Does not support:
     /// - durable nonce transactions
@@ -672,83 +727,40 @@ impl MagicblockRpcClient {
         recent_blockhash: &Hash,
         timeout: Duration,
         check_interval: Duration,
-        blockhash_valid_timeout: &Option<Duration>,
+        _blockhash_valid_timeout: &Option<Duration>,
     ) -> MagicBlockRpcClientResult<TransactionResult<()>> {
-        let mut last_err =
-            MagicBlockRpcClientError::CannotGetTransactionSignatureStatus(
-                *signature,
-                "blockhash was not found".into(),
-            );
-
-        let start = Instant::now();
-        while start.elapsed() < timeout {
-            let status = self
-                .client
-                .get_signature_status_with_commitment(
-                    signature,
-                    CommitmentConfig::processed(),
-                )
-                .await;
-            let status = match status {
-                Ok(value) => value,
-                Err(err) => {
-                    trace!(error = ?err, "Failed to get signature status");
-                    last_err = err.into();
-                    sleep(check_interval).await;
-                    continue;
-                }
-            };
-
-            if let Some(status) = status {
-                return Ok(status);
-            }
-
-            // Check if blockhash is still valid
-            let Some(blockhash_valid_timeout) = blockhash_valid_timeout else {
-                return Err(MagicBlockRpcClientError::CannotGetTransactionSignatureStatus(
-                    *signature,
-                    "timed out finding blockhash".to_string()
-                ));
-            };
-
-            let blockhash_found = self
-                .client
-                .is_blockhash_valid(
-                    recent_blockhash,
-                    CommitmentConfig::processed(),
-                )
-                .await;
-            let blockhash_found = match blockhash_found {
-                Ok(value) => value,
-                Err(err) => {
-                    trace!(error = ?err, "Failed to check blockhash validity");
-                    last_err = err.into();
-                    sleep(check_interval).await;
-                    continue;
-                }
-            };
-
-            if !blockhash_found && &start.elapsed() < blockhash_valid_timeout {
-                trace!(
-                    elapsed_ms = start.elapsed().as_millis() as u64,
-                    "Waiting for blockhash validity"
-                );
-                tokio::time::sleep(Duration::from_millis(400)).await;
-                continue;
-            } else {
-                last_err = MagicBlockRpcClientError::CannotGetTransactionSignatureStatus(
-                    *signature,
-                    format!("blockhash {} found", if blockhash_found {
-                        "was"
-                    } else {
-                        "was not"
-                    }),
-                );
-                tokio::time::sleep(check_interval).await;
-            }
+        if let Some(status) = Box::pin(self.confirmer.wait_for_status(
+            signature,
+            CommitmentConfig::processed(),
+            timeout,
+            check_interval,
+        ))
+        .await
+        {
+            return Ok(status);
         }
 
-        Err(last_err)
+        let blockhash_message = match (
+            self.cached_blockhash_metadata(recent_blockhash).await,
+            self.observed_chain_slot(),
+        ) {
+            (Some(blockhash), Some(slot))
+                if slot <= blockhash.last_valid_block_height =>
+            {
+                "timed out while blockhash was still within observed slot window"
+            }
+            (Some(_), Some(_)) => {
+                "timed out waiting for processed signature status"
+            }
+            _ => "timed out waiting for processed signature status",
+        };
+
+        Err(
+            MagicBlockRpcClientError::CannotGetTransactionSignatureStatus(
+                *signature,
+                blockhash_message.to_string(),
+            ),
+        )
     }
 
     /// Waits for a transaction to reach confirmed status
@@ -758,33 +770,26 @@ impl MagicblockRpcClient {
         timeout: &Duration,
         check_interval: &Option<Duration>,
     ) -> MagicBlockRpcClientResult<TransactionResult<()>> {
-        let start = Instant::now();
         let check_interval =
             check_interval.unwrap_or_else(|| Duration::from_millis(200));
 
-        loop {
-            let status = self
-                .client
-                .get_signature_status_with_commitment(
-                    signature,
-                    self.client.commitment(),
-                )
-                .await;
-
-            if let Ok(Some(status)) = status {
-                return Ok(status);
-            }
-
-            if &start.elapsed() < timeout {
-                tokio::time::sleep(check_interval).await;
-                continue;
-            } else {
-                return Err(MagicBlockRpcClientError::CannotConfirmTransactionSignatureStatus(
-                    *signature,
-                    self.client.commitment().commitment,
-                ));
-            }
+        if let Some(status) = Box::pin(self.confirmer.wait_for_status(
+            signature,
+            self.client.commitment(),
+            *timeout,
+            check_interval,
+        ))
+        .await
+        {
+            return Ok(status);
         }
+
+        Err(
+            MagicBlockRpcClientError::CannotConfirmTransactionSignatureStatus(
+                *signature,
+                self.client.commitment().commitment,
+            ),
+        )
     }
 
     pub async fn get_transaction(

--- a/magicblock-rpc-client/src/signature_confirmer.rs
+++ b/magicblock-rpc-client/src/signature_confirmer.rs
@@ -1,0 +1,671 @@
+use std::{
+    collections::HashMap,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+    time::{Duration, Instant},
+};
+
+use futures_util::StreamExt;
+use magicblock_metrics::metrics;
+use solana_commitment_config::CommitmentConfig;
+use solana_pubsub_client::nonblocking::pubsub_client::PubsubClient;
+use solana_rpc_client::nonblocking::rpc_client::RpcClient;
+use solana_rpc_client_api::{
+    config::RpcSignatureSubscribeConfig, response::RpcSignatureResult,
+};
+use solana_signature::Signature;
+use solana_transaction_error::{TransactionError, TransactionResult};
+use solana_transaction_status_client_types::TransactionStatus;
+use tokio::{
+    sync::{oneshot, Mutex},
+    time::{sleep, timeout},
+};
+use tracing::*;
+
+const DEFAULT_SIGNATURE_STATUS_BATCH_SIZE: usize = 256;
+const DEFAULT_STATUS_CACHE_TTL: Duration = Duration::from_secs(30);
+const DEFAULT_WS_FALLBACK_DELAY: Duration = Duration::from_secs(2);
+const DEFAULT_POLL_COALESCE_DELAY: Duration = Duration::from_millis(25);
+
+#[derive(Clone, Debug)]
+pub(crate) struct SignatureConfirmerConfig {
+    pub(crate) websocket_url: Option<String>,
+    pub(crate) batch_size: usize,
+    pub(crate) status_cache_ttl: Duration,
+    pub(crate) websocket_fallback_delay: Duration,
+    pub(crate) poll_coalesce_delay: Duration,
+}
+
+impl Default for SignatureConfirmerConfig {
+    fn default() -> Self {
+        Self {
+            websocket_url: None,
+            batch_size: DEFAULT_SIGNATURE_STATUS_BATCH_SIZE,
+            status_cache_ttl: DEFAULT_STATUS_CACHE_TTL,
+            websocket_fallback_delay: DEFAULT_WS_FALLBACK_DELAY,
+            poll_coalesce_delay: DEFAULT_POLL_COALESCE_DELAY,
+        }
+    }
+}
+
+impl SignatureConfirmerConfig {
+    pub(crate) fn with_websocket_url(websocket_url: Option<String>) -> Self {
+        Self {
+            websocket_url,
+            ..Self::default()
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct SignatureConfirmer {
+    rpc_client: Arc<RpcClient>,
+    config: SignatureConfirmerConfig,
+    poll_state: Arc<Mutex<PollState>>,
+    pubsub_client: Arc<Mutex<Option<Arc<PubsubClient>>>>,
+    next_waiter_id: Arc<AtomicU64>,
+}
+
+impl SignatureConfirmer {
+    pub(crate) fn new(
+        rpc_client: Arc<RpcClient>,
+        config: SignatureConfirmerConfig,
+    ) -> Self {
+        let mut config = config;
+        if config.batch_size == 0 {
+            config.batch_size = DEFAULT_SIGNATURE_STATUS_BATCH_SIZE;
+        }
+        Self {
+            rpc_client,
+            config,
+            poll_state: Arc::new(Mutex::new(PollState::default())),
+            pubsub_client: Arc::new(Mutex::new(None)),
+            next_waiter_id: Arc::new(AtomicU64::new(1)),
+        }
+    }
+
+    pub(crate) async fn wait_for_status(
+        &self,
+        signature: &Signature,
+        commitment: CommitmentConfig,
+        timeout_duration: Duration,
+        poll_interval: Duration,
+    ) -> Option<TransactionResult<()>> {
+        if timeout_duration.is_zero() {
+            return self.cached_status(signature, commitment).await;
+        }
+
+        if self.config.websocket_url.is_some() {
+            self.wait_with_websocket_then_poll(
+                signature,
+                commitment,
+                timeout_duration,
+                poll_interval,
+            )
+            .await
+        } else {
+            self.wait_with_batched_polling(
+                signature,
+                commitment,
+                timeout_duration,
+                poll_interval,
+            )
+            .await
+        }
+    }
+
+    async fn wait_with_websocket_then_poll(
+        &self,
+        signature: &Signature,
+        commitment: CommitmentConfig,
+        timeout_duration: Duration,
+        poll_interval: Duration,
+    ) -> Option<TransactionResult<()>> {
+        let start = Instant::now();
+        let fallback_delay = std::cmp::min(
+            timeout_duration,
+            self.config.websocket_fallback_delay,
+        );
+        let pubsub_client = match timeout(fallback_delay, self.pubsub_client())
+            .await
+        {
+            Ok(Some(pubsub_client)) => pubsub_client,
+            Ok(None) => {
+                metrics::inc_rpc_client_signature_ws_fallback_count();
+                return self
+                    .wait_with_batched_polling(
+                        signature,
+                        commitment,
+                        timeout_duration.saturating_sub(start.elapsed()),
+                        poll_interval,
+                    )
+                    .await;
+            }
+            Err(_) => {
+                warn!(
+                    signature = %signature,
+                    "Signature confirmation websocket connection timed out; falling back to batched polling"
+                );
+                metrics::inc_rpc_client_signature_ws_fallback_count();
+                return self
+                    .wait_with_batched_polling(
+                        signature,
+                        commitment,
+                        timeout_duration.saturating_sub(start.elapsed()),
+                        poll_interval,
+                    )
+                    .await;
+            }
+        };
+
+        let config = RpcSignatureSubscribeConfig {
+            commitment: Some(commitment),
+            enable_received_notification: Some(false),
+        };
+        let subscribe_timeout = fallback_delay.saturating_sub(start.elapsed());
+        let (mut notifications, unsubscribe) = match timeout(
+            subscribe_timeout,
+            pubsub_client.signature_subscribe(signature, Some(config)),
+        )
+        .await
+        {
+            Ok(Ok(subscription)) => subscription,
+            Ok(Err(err)) => {
+                warn!(
+                    signature = %signature,
+                    error = ?err,
+                    "Signature confirmation websocket subscription failed; falling back to batched polling"
+                );
+                metrics::inc_rpc_client_signature_ws_fallback_count();
+                self.clear_pubsub_client().await;
+                return self
+                    .wait_with_batched_polling(
+                        signature,
+                        commitment,
+                        timeout_duration,
+                        poll_interval,
+                    )
+                    .await;
+            }
+            Err(_) => {
+                warn!(
+                    signature = %signature,
+                    "Signature confirmation websocket subscription timed out; falling back to batched polling"
+                );
+                metrics::inc_rpc_client_signature_ws_fallback_count();
+                return self
+                    .wait_with_batched_polling(
+                        signature,
+                        commitment,
+                        timeout_duration.saturating_sub(start.elapsed()),
+                        poll_interval,
+                    )
+                    .await;
+            }
+        };
+        let mut unsubscribe = Some(unsubscribe);
+        metrics::inc_rpc_client_signature_ws_subscribe_count();
+
+        let fallback_delay = fallback_delay.saturating_sub(start.elapsed());
+        let fallback = async {
+            sleep(fallback_delay).await;
+            metrics::inc_rpc_client_signature_ws_fallback_count();
+            let remaining = timeout_duration.saturating_sub(start.elapsed());
+            self.wait_with_batched_polling(
+                signature,
+                commitment,
+                remaining,
+                poll_interval,
+            )
+            .await
+        };
+        tokio::pin!(fallback);
+
+        loop {
+            tokio::select! {
+                notification = notifications.next() => {
+                    match notification {
+                        Some(notification) => {
+                            if let Some(status) = Self::status_from_websocket_notification(notification.value) {
+                                if let Some(unsubscribe) = unsubscribe.take() {
+                                    unsubscribe().await;
+                                }
+                                metrics::inc_rpc_client_signature_ws_notification_count();
+                                return Some(status);
+                            }
+                        }
+                        None => {
+                            if let Some(unsubscribe) = unsubscribe.take() {
+                                unsubscribe().await;
+                            }
+                            let remaining = timeout_duration.saturating_sub(start.elapsed());
+                            return self
+                                .wait_with_batched_polling(
+                                    signature,
+                                    commitment,
+                                    remaining,
+                                    poll_interval,
+                                )
+                                .await;
+                        }
+                    }
+                }
+                status = &mut fallback => {
+                    if let Some(unsubscribe) = unsubscribe.take() {
+                        unsubscribe().await;
+                    }
+                    return status;
+                }
+            }
+        }
+    }
+
+    fn status_from_websocket_notification(
+        notification: RpcSignatureResult,
+    ) -> Option<TransactionResult<()>> {
+        match notification {
+            RpcSignatureResult::ProcessedSignature(status) => {
+                Some(match status.err {
+                    Some(err) => Err(TransactionError::from(err)),
+                    None => Ok(()),
+                })
+            }
+            RpcSignatureResult::ReceivedSignature(_) => None,
+        }
+    }
+
+    async fn pubsub_client(&self) -> Option<Arc<PubsubClient>> {
+        let websocket_url = self.config.websocket_url.as_ref()?;
+        let mut cached = self.pubsub_client.lock().await;
+        if let Some(client) = cached.as_ref() {
+            return Some(client.clone());
+        }
+
+        match PubsubClient::new(websocket_url).await {
+            Ok(client) => {
+                let client = Arc::new(client);
+                *cached = Some(client.clone());
+                Some(client)
+            }
+            Err(err) => {
+                warn!(
+                    error = ?err,
+                    "Signature confirmation websocket connection failed; using batched polling"
+                );
+                None
+            }
+        }
+    }
+
+    async fn clear_pubsub_client(&self) {
+        let mut cached = self.pubsub_client.lock().await;
+        *cached = None;
+    }
+
+    async fn wait_with_batched_polling(
+        &self,
+        signature: &Signature,
+        commitment: CommitmentConfig,
+        timeout_duration: Duration,
+        poll_interval: Duration,
+    ) -> Option<TransactionResult<()>> {
+        if timeout_duration.is_zero() {
+            return self.cached_status(signature, commitment).await;
+        }
+
+        let waiter_id = self.next_waiter_id.fetch_add(1, Ordering::Relaxed);
+        let (sender, receiver) = oneshot::channel();
+        let start_worker = {
+            let mut state = self.poll_state.lock().await;
+            state.prune_status_cache(self.config.status_cache_ttl);
+            if let Some(status) = state.cached_status(signature, commitment) {
+                return Some(status);
+            }
+            state
+                .waiters
+                .entry(*signature)
+                .or_default()
+                .push(StatusWaiter {
+                    id: waiter_id,
+                    commitment,
+                    sender,
+                });
+            if state.worker_running {
+                false
+            } else {
+                state.worker_running = true;
+                true
+            }
+        };
+
+        if start_worker {
+            let confirmer = self.clone();
+            tokio::spawn(async move {
+                confirmer.poll_loop(poll_interval).await;
+            });
+        }
+
+        match timeout(timeout_duration, receiver).await {
+            Ok(Ok(status)) => Some(status),
+            Ok(Err(_)) => None,
+            Err(_) => {
+                self.remove_waiter(signature, waiter_id).await;
+                None
+            }
+        }
+    }
+
+    async fn cached_status(
+        &self,
+        signature: &Signature,
+        commitment: CommitmentConfig,
+    ) -> Option<TransactionResult<()>> {
+        let mut state = self.poll_state.lock().await;
+        state.prune_status_cache(self.config.status_cache_ttl);
+        state.cached_status(signature, commitment)
+    }
+
+    async fn remove_waiter(&self, signature: &Signature, waiter_id: u64) {
+        let mut state = self.poll_state.lock().await;
+        if let Some(waiters) = state.waiters.get_mut(signature) {
+            waiters.retain(|waiter| waiter.id != waiter_id);
+            if waiters.is_empty() {
+                state.waiters.remove(signature);
+            }
+        }
+    }
+
+    async fn poll_loop(self, poll_interval: Duration) {
+        let mut delay = self.config.poll_coalesce_delay;
+        loop {
+            sleep(delay).await;
+            let signatures = {
+                let mut state = self.poll_state.lock().await;
+                state.prune_status_cache(self.config.status_cache_ttl);
+                if state.waiters.is_empty() {
+                    state.worker_running = false;
+                    return;
+                }
+                state.waiters.keys().copied().collect::<Vec<_>>()
+            };
+
+            let statuses = self.fetch_statuses(&signatures).await;
+            if !statuses.is_empty() {
+                self.apply_statuses(statuses).await;
+            }
+            delay = poll_interval;
+        }
+    }
+
+    async fn fetch_statuses(
+        &self,
+        signatures: &[Signature],
+    ) -> Vec<(Signature, TransactionStatus)> {
+        let mut fetched = Vec::new();
+        for chunk in signatures.chunks(self.config.batch_size) {
+            metrics::inc_rpc_client_signature_status_batch_count();
+            metrics::inc_rpc_client_signature_status_batch_signatures_count(
+                chunk.len() as u64,
+            );
+            match self.rpc_client.get_signature_statuses(chunk).await {
+                Ok(response) => {
+                    fetched.extend(
+                        chunk
+                            .iter()
+                            .copied()
+                            .zip(response.value.into_iter())
+                            .filter_map(|(signature, status)| {
+                                status.map(|status| (signature, status))
+                            }),
+                    );
+                }
+                Err(err) => {
+                    trace!(
+                        error = ?err,
+                        signatures = chunk.len(),
+                        "Failed to fetch batched signature statuses"
+                    );
+                }
+            }
+        }
+        fetched
+    }
+
+    async fn apply_statuses(
+        &self,
+        statuses: Vec<(Signature, TransactionStatus)>,
+    ) {
+        let mut state = self.poll_state.lock().await;
+        let now = Instant::now();
+        for (signature, status) in statuses {
+            state.cached_statuses.insert(
+                signature,
+                CachedSignatureStatus {
+                    status: status.clone(),
+                    fetched_at: now,
+                },
+            );
+
+            let Some(waiters) = state.waiters.remove(&signature) else {
+                continue;
+            };
+            let mut pending = Vec::new();
+            for waiter in waiters {
+                if let Some(result) =
+                    status_result_for_commitment(&status, waiter.commitment)
+                {
+                    let _ = waiter.sender.send(result);
+                } else {
+                    pending.push(waiter);
+                }
+            }
+            if !pending.is_empty() {
+                state.waiters.insert(signature, pending);
+            }
+        }
+    }
+}
+
+#[derive(Default)]
+struct PollState {
+    waiters: HashMap<Signature, Vec<StatusWaiter>>,
+    cached_statuses: HashMap<Signature, CachedSignatureStatus>,
+    worker_running: bool,
+}
+
+impl PollState {
+    fn cached_status(
+        &self,
+        signature: &Signature,
+        commitment: CommitmentConfig,
+    ) -> Option<TransactionResult<()>> {
+        self.cached_statuses.get(signature).and_then(|status| {
+            status_result_for_commitment(&status.status, commitment)
+        })
+    }
+
+    fn prune_status_cache(&mut self, ttl: Duration) {
+        self.cached_statuses
+            .retain(|_, status| status.fetched_at.elapsed() < ttl);
+    }
+}
+
+struct StatusWaiter {
+    id: u64,
+    commitment: CommitmentConfig,
+    sender: oneshot::Sender<TransactionResult<()>>,
+}
+
+struct CachedSignatureStatus {
+    status: TransactionStatus,
+    fetched_at: Instant,
+}
+
+fn status_result_for_commitment(
+    status: &TransactionStatus,
+    commitment: CommitmentConfig,
+) -> Option<TransactionResult<()>> {
+    if status.err.is_some() || status.satisfies_commitment(commitment) {
+        Some(status.status.clone())
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Mutex as StdMutex,
+    };
+
+    use async_trait::async_trait;
+    use serde_json::Value;
+    use solana_rpc_client::{
+        rpc_client::RpcClientConfig,
+        rpc_sender::{RpcSender, RpcTransportStats},
+    };
+    use solana_rpc_client_api::{
+        client_error::Result as RpcResult,
+        request::RpcRequest,
+        response::{Response, RpcResponseContext},
+    };
+    use solana_transaction_status_client_types::TransactionConfirmationStatus;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn batches_concurrent_waiters() {
+        let sender = RecordingSender::ok();
+        let calls = sender.calls.clone();
+        let batch_sizes = sender.batch_sizes.clone();
+        let confirmer = test_confirmer(sender);
+        let signature_a = test_signature(1);
+        let signature_b = test_signature(2);
+
+        let (status_a, status_b) = tokio::join!(
+            confirmer.wait_for_status(
+                &signature_a,
+                CommitmentConfig::processed(),
+                Duration::from_secs(1),
+                Duration::from_millis(20),
+            ),
+            confirmer.wait_for_status(
+                &signature_b,
+                CommitmentConfig::processed(),
+                Duration::from_secs(1),
+                Duration::from_millis(20),
+            ),
+        );
+
+        assert_eq!(status_a, Some(Ok(())));
+        assert_eq!(status_b, Some(Ok(())));
+        assert_eq!(calls.load(Ordering::Relaxed), 1);
+        assert_eq!(*batch_sizes.lock().unwrap(), vec![2]);
+    }
+
+    #[tokio::test]
+    async fn caches_completed_statuses() {
+        let sender = RecordingSender::ok();
+        let calls = sender.calls.clone();
+        let confirmer = test_confirmer(sender);
+        let signature = test_signature(1);
+
+        let first = confirmer
+            .wait_for_status(
+                &signature,
+                CommitmentConfig::processed(),
+                Duration::from_secs(1),
+                Duration::from_millis(20),
+            )
+            .await;
+        let second = confirmer
+            .wait_for_status(
+                &signature,
+                CommitmentConfig::confirmed(),
+                Duration::from_secs(1),
+                Duration::from_millis(20),
+            )
+            .await;
+
+        assert_eq!(first, Some(Ok(())));
+        assert_eq!(second, Some(Ok(())));
+        assert_eq!(calls.load(Ordering::Relaxed), 1);
+    }
+
+    fn test_confirmer(sender: RecordingSender) -> SignatureConfirmer {
+        let rpc_client =
+            RpcClient::new_sender(sender, RpcClientConfig::default());
+        SignatureConfirmer::new(
+            Arc::new(rpc_client),
+            SignatureConfirmerConfig {
+                poll_coalesce_delay: Duration::from_millis(5),
+                ..SignatureConfirmerConfig::default()
+            },
+        )
+    }
+
+    fn test_signature(byte: u8) -> Signature {
+        Signature::from([byte; 64])
+    }
+
+    #[derive(Clone)]
+    struct RecordingSender {
+        calls: Arc<AtomicUsize>,
+        batch_sizes: Arc<StdMutex<Vec<usize>>>,
+        status: TransactionStatus,
+    }
+
+    impl RecordingSender {
+        fn ok() -> Self {
+            let status = Ok(());
+            Self {
+                calls: Arc::new(AtomicUsize::new(0)),
+                batch_sizes: Arc::new(StdMutex::new(Vec::new())),
+                status: TransactionStatus {
+                    status: status.clone(),
+                    slot: 1,
+                    confirmations: None,
+                    err: status.err(),
+                    confirmation_status: Some(
+                        TransactionConfirmationStatus::Finalized,
+                    ),
+                },
+            }
+        }
+    }
+
+    #[async_trait]
+    impl RpcSender for RecordingSender {
+        async fn send(
+            &self,
+            request: RpcRequest,
+            params: Value,
+        ) -> RpcResult<Value> {
+            assert_eq!(request, RpcRequest::GetSignatureStatuses);
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            let signature_count =
+                params.as_array().unwrap()[0].as_array().unwrap().len();
+            self.batch_sizes.lock().unwrap().push(signature_count);
+            let statuses = vec![Some(self.status.clone()); signature_count];
+            Ok(serde_json::to_value(Response {
+                context: RpcResponseContext {
+                    slot: 1,
+                    api_version: None,
+                },
+                value: statuses,
+            })
+            .unwrap())
+        }
+
+        fn get_transport_stats(&self) -> RpcTransportStats {
+            RpcTransportStats::default()
+        }
+
+        fn url(&self) -> String {
+            "recording".to_string()
+        }
+    }
+}

--- a/magicblock-rpc-client/src/signature_confirmer.rs
+++ b/magicblock-rpc-client/src/signature_confirmer.rs
@@ -507,7 +507,7 @@ fn status_result_for_commitment(
     status: &TransactionStatus,
     commitment: CommitmentConfig,
 ) -> Option<TransactionResult<()>> {
-    if status.err.is_some() || status.satisfies_commitment(commitment) {
+    if status.satisfies_commitment(commitment) {
         Some(status.status.clone())
     } else {
         None
@@ -593,6 +593,33 @@ mod tests {
         assert_eq!(first, Some(Ok(())));
         assert_eq!(second, Some(Ok(())));
         assert_eq!(calls.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn transaction_errors_wait_for_requested_commitment() {
+        let err = TransactionError::AccountNotFound;
+        let status = TransactionStatus {
+            status: Err(err.clone()),
+            slot: 1,
+            confirmations: Some(1),
+            err: Some(err.clone()),
+            confirmation_status: Some(TransactionConfirmationStatus::Processed),
+        };
+
+        assert_eq!(
+            status_result_for_commitment(
+                &status,
+                CommitmentConfig::confirmed()
+            ),
+            None
+        );
+        assert_eq!(
+            status_result_for_commitment(
+                &status,
+                CommitmentConfig::processed()
+            ),
+            Some(Err(err))
+        );
     }
 
     fn test_confirmer(sender: RecordingSender) -> SignatureConfirmer {

--- a/test-integration/Cargo.lock
+++ b/test-integration/Cargo.lock
@@ -4777,6 +4777,7 @@ name = "magicblock-rpc-client"
 version = "0.11.3"
 dependencies = [
  "futures-util",
+ "magicblock-metrics",
  "serde_json",
  "solana-account",
  "solana-account-decoder-client-types",
@@ -4786,6 +4787,7 @@ dependencies = [
  "solana-hash 3.1.0",
  "solana-instruction",
  "solana-pubkey 3.0.0",
+ "solana-pubsub-client",
  "solana-rpc-client",
  "solana-rpc-client-api",
  "solana-signature",


### PR DESCRIPTION
## Summary

- Add a shared signature confirmer for `MagicblockRpcClient` that prefers `signatureSubscribe` when a WebSocket URL is available.
- Fall back to coalesced, batched `getSignatureStatuses` polling with short-lived terminal status caching.
- Stop checking `isBlockhashValid` during every missing processed-status poll and reuse cached blockhash metadata for timeout context.
- Thread the validator WebSocket URL into the committor RPC client and add metrics for WebSocket/fallback/batch confirmation paths.

## Why

The committor confirmation loop was issuing per-transaction status polls and blockhash-validity checks under concurrency. This change moves confirmation to subscriptions first and batched polling as fallback, reducing upstream RPC calls while preserving the existing send path for already-built transactions.
