### PR TITLE
fix: preserve streams on optimize failure

### DIFF
--- a/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/mock.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/mock.rs
@@ -8,7 +8,7 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 use super::{LaserResult, StreamFactory};
 use crate::remote_account_provider::{
     chain_laser_actor::{LaserStreamWithHandle, StreamHandle},
-    RemoteAccountProviderResult,
+    RemoteAccountProviderError, RemoteAccountProviderResult,
 };
 
 /// A test mock that captures subscription requests and allows driving
@@ -30,6 +30,12 @@ pub struct MockStreamFactory {
     /// side becomes the returned stream, and the tx side is stored
     /// here so the test can drive updates.
     stream_senders: Arc<Mutex<Vec<Arc<mpsc::UnboundedSender<LaserResult>>>>>,
+
+    /// Total number of calls made to `subscribe()`.
+    subscribe_calls: Arc<Mutex<usize>>,
+
+    /// If set, the 1-based `subscribe()` call number that should fail.
+    fail_on_subscribe_call: Arc<Mutex<Option<usize>>>,
 }
 
 impl MockStreamFactory {
@@ -39,7 +45,28 @@ impl MockStreamFactory {
             captured_requests: Arc::new(Mutex::new(Vec::new())),
             handle_requests: Arc::new(Mutex::new(Vec::new())),
             stream_senders: Arc::new(Mutex::new(Vec::new())),
+            subscribe_calls: Arc::new(Mutex::new(0)),
+            fail_on_subscribe_call: Arc::new(Mutex::new(None)),
         }
+    }
+
+    /// Fail the given 1-based `subscribe()` call number.
+    #[allow(dead_code)]
+    pub fn fail_on_subscribe_call(&self, call_number: usize) {
+        assert!(call_number > 0, "subscribe call numbers are 1-based");
+        *self.fail_on_subscribe_call.lock().unwrap() = Some(call_number);
+    }
+
+    /// Clear any configured `subscribe()` failure.
+    #[allow(dead_code)]
+    pub fn clear_subscribe_failure(&self) {
+        *self.fail_on_subscribe_call.lock().unwrap() = None;
+    }
+
+    /// Return the number of `subscribe()` calls seen so far.
+    #[allow(dead_code)]
+    pub fn subscribe_call_count(&self) -> usize {
+        *self.subscribe_calls.lock().unwrap()
     }
 
     /// Get the captured subscription requests (from `subscribe()`)
@@ -114,6 +141,27 @@ impl StreamFactory<MockStreamHandle> for MockStreamFactory {
         request: SubscribeRequest,
     ) -> RemoteAccountProviderResult<LaserStreamWithHandle<MockStreamHandle>>
     {
+        let call_number = {
+            let mut calls = self.subscribe_calls.lock().unwrap();
+            *calls += 1;
+            *calls
+        };
+
+        if self
+            .fail_on_subscribe_call
+            .lock()
+            .unwrap()
+            .is_some_and(|fail_call| fail_call == call_number)
+        {
+            return Err(
+                RemoteAccountProviderError::GrpcSubscriptionUpdateFailed(
+                    "mock subscribe".to_string(),
+                    0,
+                    format!("mock subscribe failure on call {call_number}"),
+                ),
+            );
+        }
+
         // Record the initial subscribe request
         self.captured_requests.lock().unwrap().push(request.clone());
 

--- a/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/stream_manager.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/stream_manager.rs
@@ -1078,6 +1078,44 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_optimize_failure_preserves_existing_account_topology() {
+        let (mut mgr, factory) = create_manager();
+
+        // Create three promoted unoptimized streams and no optimized streams.
+        let pks = subscribe_in_batches(&mut mgr, 18, 6).await;
+        assert_eq!(mgr.unoptimized_old_stream_count(), 3);
+        assert_eq!(mgr.optimized_old_stream_count(), 0);
+        assert_eq!(mgr.current_new_sub_count(), 0);
+        assert_eq!(mgr.account_stream_count(), 3);
+
+        // Fail the second replacement stream creation so the test covers
+        // a partial local rebuild attempt.
+        let fail_call = factory.subscribe_call_count() + 2;
+        factory.fail_on_subscribe_call(fail_call);
+
+        let err = mgr.optimize(&COMMITMENT).await.unwrap_err();
+        assert!(
+            err.to_string().contains("mock subscribe failure"),
+            "unexpected error: {err:?}",
+        );
+
+        assert_eq!(mgr.unoptimized_old_stream_count(), 3);
+        assert_eq!(mgr.optimized_old_stream_count(), 0);
+        assert_eq!(mgr.current_new_sub_count(), 0);
+        assert_eq!(mgr.account_stream_count(), 3);
+        assert_subscriptions_eq(&mgr, &pks);
+
+        factory.clear_subscribe_failure();
+        mgr.optimize(&COMMITMENT).await.unwrap();
+
+        assert_eq!(mgr.unoptimized_old_stream_count(), 0);
+        assert_eq!(mgr.optimized_old_stream_count(), 2);
+        assert_eq!(mgr.current_new_sub_count(), 0);
+        assert_eq!(mgr.account_stream_count(), 2);
+        assert_subscriptions_eq(&mgr, &pks);
+    }
+
+    #[tokio::test]
     async fn test_optimize_clears_unoptimized_old_streams() {
         let (mut mgr, _factory) = create_manager();
         // Create several unoptimized old streams.

--- a/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/stream_manager.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/stream_manager.rs
@@ -465,9 +465,31 @@ impl<S: StreamHandle, SF: StreamFactory<S>> StreamManager<S, SF> {
         &mut self,
         commitment: &CommitmentLevel,
     ) -> RemoteAccountProviderResult<()> {
-        // Remove all account streams from the map but keep them
-        // alive until the new optimized streams are created to
-        // avoid a gap without any active streams (race condition).
+        // Collect all active subscriptions and chunk them.
+        let all_pks: Vec<Pubkey> =
+            self.subscriptions.read().iter().copied().collect();
+        let from_slot = self.compute_from_slot();
+
+        // Create replacement streams before mutating existing account
+        // topology. If any subscribe call fails, the previous topology
+        // remains unchanged.
+        let mut new_optimized_streams = Vec::new();
+        let mut new_optimized_handles = Vec::new();
+        for (i, chunk) in all_pks
+            .chunks(self.config.max_subs_in_old_optimized)
+            .enumerate()
+        {
+            let refs: Vec<&Pubkey> = chunk.iter().collect();
+            let LaserStreamWithHandle { stream, handle } = self
+                .stream_factory
+                .subscribe(Self::build_account_request(
+                    &refs, commitment, from_slot,
+                ))
+                .await?;
+            new_optimized_streams.push((StreamKey::OptimizedOld(i), stream));
+            new_optimized_handles.push(handle);
+        }
+
         let prev_current_new = self.stream_map.remove(&StreamKey::CurrentNew);
         let prev_unoptimized: Vec<_> = (0..self.unoptimized_old_handles.len())
             .filter_map(|i| {
@@ -482,32 +504,12 @@ impl<S: StreamHandle, SF: StreamFactory<S>> StreamManager<S, SF> {
             + prev_unoptimized.len()
             + prev_optimized.len();
 
-        // Collect all active subscriptions and chunk them.
-        let all_pks: Vec<Pubkey> =
-            self.subscriptions.read().iter().copied().collect();
-
-        // Build optimized old streams from chunks.
-        let from_slot = self.compute_from_slot();
-        self.optimized_old_handles = Vec::new();
-        for (i, chunk) in all_pks
-            .chunks(self.config.max_subs_in_old_optimized)
-            .enumerate()
-        {
-            let refs: Vec<&Pubkey> = chunk.iter().collect();
-            let LaserStreamWithHandle { stream, handle } = self
-                .stream_factory
-                .subscribe(Self::build_account_request(
-                    &refs, commitment, from_slot,
-                ))
-                .await?;
-            self.stream_map.insert(StreamKey::OptimizedOld(i), stream);
-            self.optimized_old_handles.push(handle);
+        for (key, stream) in new_optimized_streams {
+            self.stream_map.insert(key, stream);
         }
 
-        // Clear unoptimized old handles.
+        self.optimized_old_handles = new_optimized_handles;
         self.unoptimized_old_handles.clear();
-
-        // Reset the current-new stream.
         self.current_new_subs.clear();
         self.current_new_handle = None;
 


### PR DESCRIPTION
## Summary

Fixes stream optimization so failed ChainLaser resubscriptions do not leave accounts without their existing active streams.

## Details

### magicblock-chainlink

- Updates the ChainLaser stream manager to build replacement optimized streams before changing the current account stream topology.
- Keeps the previous unoptimized/current stream set intact when an optimization subscribe call fails, avoiding a temporary drop of active account coverage.
- Adds mock stream-factory support for targeted subscribe failures and a regression test covering partial optimization failure followed by a successful retry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved failure handling during stream optimization to ensure existing stream configuration is preserved if errors occur during updates.

* **Tests**
  * Added test coverage for failure recovery scenarios during stream rebuilding operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->