### PR TITLE
fix: limit pending intent recovery window

### DIFF
--- a/magicblock-committor-service/src/committor_processor.rs
+++ b/magicblock-committor-service/src/committor_processor.rs
@@ -42,7 +42,8 @@ use crate::{
     },
 };
 
-const RECOVERY_MIN_AGE_SECS: u64 = 30 * 60;
+const RECOVERY_MIN_AGE_SECS: u64 = 5 * 60;
+const RECOVERY_MAX_AGE_SECS: u64 = 14 * 24 * 60 * 60;
 
 pub(crate) struct CommittorProcessor {
     pub(crate) magicblock_rpc_client: MagicblockRpcClient,
@@ -165,7 +166,11 @@ impl CommittorProcessor {
     pub async fn pending_intent_bundles(
         &self,
     ) -> CommittorServiceResult<Vec<ScheduledIntentBundle>> {
-        let rows = self.persister.get_pending_commit_statuses()?;
+        let recovery_time = unix_timestamp();
+        let rows = self.persister.get_pending_commit_statuses(
+            recovery_time.saturating_sub(RECOVERY_MAX_AGE_SECS),
+            recovery_time.saturating_sub(RECOVERY_MIN_AGE_SECS),
+        )?;
         if rows.is_empty() {
             return Ok(Vec::new());
         }
@@ -175,7 +180,7 @@ impl CommittorProcessor {
             rows,
             self.auth_pubkey(),
             recovery_base_slot,
-            unix_timestamp(),
+            recovery_time,
         );
         if !bundles.is_empty() {
             let accounts_count: usize = bundles
@@ -262,13 +267,13 @@ fn pending_rows_to_scheduled_intent_bundles(
     grouped_rows
         .into_iter()
         .filter_map(|(message_id, rows)| {
-            if rows
-                .iter()
-                .any(|row| !pending_row_is_old_enough(row, recovery_time))
+            if rows.iter().any(|row| {
+                !pending_row_is_in_recovery_window(row, recovery_time)
+            })
             {
                 warn!(
                     intent_id = message_id,
-                    "Skipping pending commit intent because it is not old enough to recover"
+                    "Skipping pending commit intent outside recovery window"
                 );
                 return None;
             }
@@ -331,11 +336,12 @@ fn pending_rows_to_scheduled_intent_bundles(
         .collect()
 }
 
-fn pending_row_is_old_enough(
+fn pending_row_is_in_recovery_window(
     row: &CommitStatusRow,
     recovery_time: u64,
 ) -> bool {
     recovery_time.saturating_sub(row.last_retried_at) > RECOVERY_MIN_AGE_SECS
+        && recovery_time.saturating_sub(row.created_at) <= RECOVERY_MAX_AGE_SECS
 }
 
 fn unix_timestamp() -> u64 {
@@ -415,6 +421,24 @@ mod tests {
         }
     }
 
+    fn pending_row_with_timestamps(
+        message_id: u64,
+        created_at: u64,
+        last_retried_at: u64,
+    ) -> CommitStatusRow {
+        let mut row = pending_row(
+            message_id,
+            Pubkey::new_unique(),
+            Pubkey::new_unique(),
+            Hash::new_unique(),
+            false,
+            Some(vec![1]),
+        );
+        row.created_at = created_at;
+        row.last_retried_at = last_retried_at;
+        row
+    }
+
     #[test]
     fn pending_rows_reconstruct_commit_finalize_bundle() {
         let payer = Pubkey::new_unique();
@@ -461,5 +485,47 @@ mod tests {
         assert_eq!(undelegate_accounts[0].pubkey, undelegate_pubkey);
         assert_eq!(undelegate_accounts[0].account.owner, owner);
         assert!(bundle.has_undelegate_intent());
+    }
+
+    #[test]
+    fn pending_rows_skip_intents_outside_recovery_window() {
+        let payer = Pubkey::new_unique();
+        let recovery_time = RECOVERY_MAX_AGE_SECS + RECOVERY_MIN_AGE_SECS;
+
+        let recoverable = pending_rows_to_scheduled_intent_bundles(
+            vec![pending_row_with_timestamps(
+                1,
+                recovery_time - RECOVERY_MAX_AGE_SECS,
+                recovery_time - RECOVERY_MIN_AGE_SECS - 1,
+            )],
+            payer,
+            7,
+            recovery_time,
+        );
+        assert_eq!(recoverable.len(), 1);
+
+        let too_recent = pending_rows_to_scheduled_intent_bundles(
+            vec![pending_row_with_timestamps(
+                2,
+                recovery_time - RECOVERY_MIN_AGE_SECS,
+                recovery_time - RECOVERY_MIN_AGE_SECS,
+            )],
+            payer,
+            7,
+            recovery_time,
+        );
+        assert!(too_recent.is_empty());
+
+        let too_old = pending_rows_to_scheduled_intent_bundles(
+            vec![pending_row_with_timestamps(
+                3,
+                recovery_time - RECOVERY_MAX_AGE_SECS - 1,
+                recovery_time - RECOVERY_MAX_AGE_SECS - 1,
+            )],
+            payer,
+            7,
+            recovery_time,
+        );
+        assert!(too_old.is_empty());
     }
 }

--- a/magicblock-committor-service/src/persist/commit_persister.rs
+++ b/magicblock-committor-service/src/persist/commit_persister.rs
@@ -59,6 +59,8 @@ pub trait IntentPersister: Send + Sync + Clone + 'static {
     ) -> CommitPersistResult<Vec<CommitStatusRow>>;
     fn get_pending_commit_statuses(
         &self,
+        min_created_at: u64,
+        max_last_retried_at: u64,
     ) -> CommitPersistResult<Vec<CommitStatusRow>>;
     fn get_commit_status_by_message(
         &self,
@@ -248,11 +250,13 @@ impl IntentPersister for IntentPersisterImpl {
 
     fn get_pending_commit_statuses(
         &self,
+        min_created_at: u64,
+        max_last_retried_at: u64,
     ) -> CommitPersistResult<Vec<CommitStatusRow>> {
         self.commits_db
             .lock()
             .expect(POISONED_MUTEX_MSG)
-            .get_pending_commit_statuses()
+            .get_pending_commit_statuses(min_created_at, max_last_retried_at)
     }
 
     fn get_commit_status_by_message(
@@ -403,9 +407,14 @@ impl<T: IntentPersister> IntentPersister for Option<T> {
 
     fn get_pending_commit_statuses(
         &self,
+        min_created_at: u64,
+        max_last_retried_at: u64,
     ) -> CommitPersistResult<Vec<CommitStatusRow>> {
         match self {
-            Some(persister) => persister.get_pending_commit_statuses(),
+            Some(persister) => persister.get_pending_commit_statuses(
+                min_created_at,
+                max_last_retried_at,
+            ),
             None => Ok(Vec::new()),
         }
     }

--- a/magicblock-committor-service/src/persist/db.rs
+++ b/magicblock-committor-service/src/persist/db.rs
@@ -559,12 +559,22 @@ impl CommittsDb {
 
     pub(crate) fn get_pending_commit_statuses(
         &self,
+        min_created_at: u64,
+        max_last_retried_at: u64,
     ) -> CommitPersistResult<Vec<CommitStatusRow>> {
         let query = format!(
-            "{SELECT_ALL_COMMIT_STATUS_COLUMNS} WHERE commit_status = ?1 ORDER BY message_id, created_at, pubkey"
+            "{SELECT_ALL_COMMIT_STATUS_COLUMNS}
+             WHERE commit_status = ?1
+               AND created_at >= ?2
+               AND last_retried_at < ?3
+             ORDER BY message_id, created_at, pubkey"
         );
         let stmt = &mut self.conn.prepare(&query)?;
-        let mut rows = stmt.query(params![CommitStatus::Pending.as_str()])?;
+        let mut rows = stmt.query(params![
+            CommitStatus::Pending.as_str(),
+            u64_into_i64(min_created_at),
+            u64_into_i64(max_last_retried_at)
+        ])?;
 
         extract_committor_rows(&mut rows)
     }
@@ -854,7 +864,27 @@ mod tests {
         db.insert_commit_status_rows(&[pending.clone(), succeeded])
             .unwrap();
 
-        let rows = db.get_pending_commit_statuses().unwrap();
+        let rows = db.get_pending_commit_statuses(0, u64::MAX).unwrap();
+        assert_eq!(rows, vec![pending]);
+    }
+
+    #[test]
+    fn test_get_pending_commit_statuses_filters_recovery_window() {
+        let (mut db, _file) = setup_test_db();
+        let mut pending = create_test_row(1, 0);
+        pending.created_at = 10;
+        pending.last_retried_at = 19;
+        let mut too_old = create_test_row(2, 0);
+        too_old.created_at = 9;
+        too_old.last_retried_at = 9;
+        let mut too_recent = create_test_row(3, 0);
+        too_recent.created_at = 20;
+        too_recent.last_retried_at = 20;
+
+        db.insert_commit_status_rows(&[pending.clone(), too_old, too_recent])
+            .unwrap();
+
+        let rows = db.get_pending_commit_statuses(10, 20).unwrap();
         assert_eq!(rows, vec![pending]);
     }
 

--- a/magicblock-committor-service/src/persist/db.rs
+++ b/magicblock-committor-service/src/persist/db.rs
@@ -563,10 +563,19 @@ impl CommittsDb {
         max_last_retried_at: u64,
     ) -> CommitPersistResult<Vec<CommitStatusRow>> {
         let query = format!(
-            "{SELECT_ALL_COMMIT_STATUS_COLUMNS}
+            "WITH eligible_messages AS (
+                 SELECT message_id
+                 FROM commit_status
+                 WHERE commit_status = ?1
+                 GROUP BY message_id
+                 HAVING MIN(created_at) >= ?2
+                    AND MAX(last_retried_at) < ?3
+             )
+             {SELECT_ALL_COMMIT_STATUS_COLUMNS}
              WHERE commit_status = ?1
-               AND created_at >= ?2
-               AND last_retried_at < ?3
+               AND message_id IN (
+                   SELECT message_id FROM eligible_messages
+               )
              ORDER BY message_id, created_at, pubkey"
         );
         let stmt = &mut self.conn.prepare(&query)?;
@@ -864,7 +873,7 @@ mod tests {
         db.insert_commit_status_rows(&[pending.clone(), succeeded])
             .unwrap();
 
-        let rows = db.get_pending_commit_statuses(0, u64::MAX).unwrap();
+        let rows = db.get_pending_commit_statuses(0, 1001).unwrap();
         assert_eq!(rows, vec![pending]);
     }
 
@@ -874,18 +883,34 @@ mod tests {
         let mut pending = create_test_row(1, 0);
         pending.created_at = 10;
         pending.last_retried_at = 19;
+        let mut pending_same_message = create_test_row(1, 0);
+        pending_same_message.created_at = 11;
+        pending_same_message.last_retried_at = 18;
         let mut too_old = create_test_row(2, 0);
         too_old.created_at = 9;
         too_old.last_retried_at = 9;
         let mut too_recent = create_test_row(3, 0);
         too_recent.created_at = 20;
         too_recent.last_retried_at = 20;
+        let mut partially_eligible = create_test_row(4, 0);
+        partially_eligible.created_at = 10;
+        partially_eligible.last_retried_at = 19;
+        let mut partially_too_recent = create_test_row(4, 0);
+        partially_too_recent.created_at = 10;
+        partially_too_recent.last_retried_at = 20;
 
-        db.insert_commit_status_rows(&[pending.clone(), too_old, too_recent])
-            .unwrap();
+        db.insert_commit_status_rows(&[
+            pending.clone(),
+            pending_same_message.clone(),
+            too_old,
+            too_recent,
+            partially_eligible,
+            partially_too_recent,
+        ])
+        .unwrap();
 
         let rows = db.get_pending_commit_statuses(10, 20).unwrap();
-        assert_eq!(rows, vec![pending]);
+        assert_eq!(rows, vec![pending, pending_same_message]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- recover persisted pending committor intents only when they are older than 5 minutes and newer than 2 weeks
- push the recovery window into the SQLite pending-status query to avoid loading stale pending rows
- add focused coverage for DB filtering and recovery reconstruction bounds