### PR TITLE
feat: bundle session-key program in mb-test-validator

### DIFF
--- a/.github/packages/npm-package/mbTestValidator.ts
+++ b/.github/packages/npm-package/mbTestValidator.ts
@@ -53,6 +53,9 @@ function runMbTestValidator(): void {
     "--bpf-program",
     "DmnRGfyyftzacFb1XadYhWF6vWqXwtQk5tbr6XgR3BA1",
     p("DmnRGfyyftzacFb1XadYhWF6vWqXwtQk5tbr6XgR3BA1.so"),
+    "--bpf-program",
+    "KeyspM2ssCJbqUhQ4k7sveSiY4WjnYsrXkC8oDbwde5",
+    p("KeyspM2ssCJbqUhQ4k7sveSiY4WjnYsrXkC8oDbwde5.so"),
     // accounts
     "--account",
     "mAGicPQYBMvcYveUZA5F5UNNwyHvfYh5xkLS2Fr1mev",
@@ -94,6 +97,7 @@ function runMbTestValidator(): void {
     "EnhkomtzKms55jXi3ijn9XsMKYpMT4BJjmbuDQmPo3YS.so",
     "SPLxh1LVZzEkX99H6rqYizhytLWPZVV296zyYDPagv2.so",
     "DmnRGfyyftzacFb1XadYhWF6vWqXwtQk5tbr6XgR3BA1.so",
+    "KeyspM2ssCJbqUhQ4k7sveSiY4WjnYsrXkC8oDbwde5.so",
     "mAGicPQYBMvcYveUZA5F5UNNwyHvfYh5xkLS2Fr1mev.json",
     "EpJnX7ueXk7fKojBymqmVuCuwyhDQsYcLVL1XMsBbvDX.json",
     "7JrkjmZPprHwtuvtuGTXp9hwfGYFAQLnLeFM52kqAgXg.json",

--- a/.github/packages/npm-package/scripts/fetch-local-dumps.sh
+++ b/.github/packages/npm-package/scripts/fetch-local-dumps.sh
@@ -43,6 +43,7 @@ programs=(
   ACLseoPoyC3cBqoUtkbjZ4aDrkurZW86v19pXz2XQnp1
   EnhkomtzKms55jXi3ijn9XsMKYpMT4BJjmbuDQmPo3YS
   SPLxh1LVZzEkX99H6rqYizhytLWPZVV296zyYDPagv2
+  KeyspM2ssCJbqUhQ4k7sveSiY4WjnYsrXkC8oDbwde5
 )
 
 for prog in "${programs[@]}"; do


### PR DESCRIPTION
## Summary
Adds the session-key program (`KeyspM2ssCJbqUhQ4k7sveSiY4WjnYsrXkC8oDbwde5`) to the `@magicblock-labs/ephemeral-validator` npm package so it is dumped at build time and loaded by `mb-test-validator`.

## Breaking Changes
- [x] None
- [ ] Yes — migration path described below

## Test Plan
- Ran `npm install && npm run build` in `.github/packages/npm-package/`; confirmed `KeyspM2ssCJbqUhQ4k7sveSiY4WjnYsrXkC8oDbwde5.so` is fetched into `lib/bin/local-dumps/`.
- Ran `mb-test-validator` and verified the session-key program loads with no missing-dump warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development testing infrastructure to include an additional program in local test fixtures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->