### PR TITLE
feat: added vrf ephemeral test queue, delegation record and metadata for mb-test-validator

### DIFF
--- a/.github/packages/npm-package/mbTestValidator.ts
+++ b/.github/packages/npm-package/mbTestValidator.ts
@@ -87,6 +87,15 @@ function runMbTestValidator(): void {
     "--account",
     "FRqXJqfCi3o6gF3Yqnkx1gKA3YnbRDJbBs6hKpme3NHJ",
     p("FRqXJqfCi3o6gF3Yqnkx1gKA3YnbRDJbBs6hKpme3NHJ.json"),
+    "--account",
+    "Sc9MJUngNbQXSXGP3F67KvKwVnhaYn6kcioxXNVowYT",
+    p("Sc9MJUngNbQXSXGP3F67KvKwVnhaYn6kcioxXNVowYT.json"),
+    "--account",
+    "9yvg9551MmE8mhWd88jAPLE3noTXHoopYG1BDhmtkCeR",
+    p("9yvg9551MmE8mhWd88jAPLE3noTXHoopYG1BDhmtkCeR.json"),
+    "--account",
+    "7L9eCRv52UpGVePGj9P1zop8kzmh4SpYzYn6YhoAKHBg",
+    p("7L9eCRv52UpGVePGj9P1zop8kzmh4SpYzYn6YhoAKHBg.json"),
   ];
 
   const expectedFiles = [
@@ -108,6 +117,9 @@ function runMbTestValidator(): void {
     "CXMc1eCiEp9YXjanBNB6HUvbWCmxeVmhcR3bPXw8exJA.json",
     "GKE6d7iv8kCBrsxr78W3xVdjGLLLJnxsGiuzrsZCGEvb.json",
     "FRqXJqfCi3o6gF3Yqnkx1gKA3YnbRDJbBs6hKpme3NHJ.json",
+    "Sc9MJUngNbQXSXGP3F67KvKwVnhaYn6kcioxXNVowYT.json",
+    "9yvg9551MmE8mhWd88jAPLE3noTXHoopYG1BDhmtkCeR.json",
+    "7L9eCRv52UpGVePGj9P1zop8kzmh4SpYzYn6YhoAKHBg.json",
   ];
   const missingFiles = expectedFiles
     .map((f) => p(f))

--- a/.github/packages/npm-package/scripts/fetch-local-dumps.sh
+++ b/.github/packages/npm-package/scripts/fetch-local-dumps.sh
@@ -17,13 +17,16 @@ accounts=(
   mAGicPQYBMvcYveUZA5F5UNNwyHvfYh5xkLS2Fr1mev
   EpJnX7ueXk7fKojBymqmVuCuwyhDQsYcLVL1XMsBbvDX
   7JrkjmZPprHwtuvtuGTXp9hwfGYFAQLnLeFM52kqAgXg
-  Cuj97ggrhhidhbu39TijNVqE74xvKJ69gDervRUXAxGh
-  5hBR571xnXppuCPveTrctfTU7tJLSN94nq7kv7FRK5Tc
+  Cuj97ggrhhidhbu39TijNVqE74xvKJ69gDervRUXAxGh  # vrf oracle queue
+  5hBR571xnXppuCPveTrctfTU7tJLSN94nq7kv7FRK5Tc  # vrf oracle ephemeral queue
   F72HqCR8nwYsVyeVd38pgKkjXmXFzVAM8rjZZsXWbdE
   paywJiVATrVDLYLmowJqzG6MsaCt77L8WyTnBb2754t   # vrf oracle identity
   CXMc1eCiEp9YXjanBNB6HUvbWCmxeVmhcR3bPXw8exJA  # vrf oracle data
   GKE6d7iv8kCBrsxr78W3xVdjGLLLJnxsGiuzrsZCGEvb  # queue for paywJiVATrVDLYLmowJqzG6MsaCt77L8WyTnBb2754t
   FRqXJqfCi3o6gF3Yqnkx1gKA3YnbRDJbBs6hKpme3NHJ  # deleted queue for paywJiVATrVDLYLmowJqzG6MsaCt77L8WyTnBb2754t
+  Sc9MJUngNbQXSXGP3F67KvKwVnhaYn6kcioxXNVowYT  # ephemeral (delegated) test queue, index 1 for paywJ
+  9yvg9551MmE8mhWd88jAPLE3noTXHoopYG1BDhmtkCeR  # delegation record for Sc9MJ ephemeral test queue
+  7L9eCRv52UpGVePGj9P1zop8kzmh4SpYzYn6YhoAKHBg  # delegation metadata for Sc9MJ ephemeral test queue
 )
 
 for acc in "${accounts[@]}"; do


### PR DESCRIPTION
## Summary
Adds a feature-gated ephemeral test queue (Sc9MJUng…) that is exempt from the per-request VRF fee — the same treatment as the canonical DEFAULT_EPHEMERAL_QUEUE — so a locally-created delegated queue can be served inside an Ephemeral Rollup without a fee-payer escrow. The exemption is centralized in is_fee_exempt_ephemeral_queue() and applied consistently across request_randomness, provide_randomness, and purge_expired_requests; the test queue is only compiled in under the ephemeral-test-queue Cargo feature, so production builds are unchanged.

## Breaking Changes
-  None
(Feature is off by default. Without ephemeral-test-queue, only DEFAULT_EPHEMERAL_QUEUE/5hBR5… is exempt — identical to current behavior. The three fee call-sites were refactored to a shared helper with no behavior change; the SDK gains additive constants.)

## Test Plan
Both build configs compile: cargo build-sbf --manifest-path program/Cargo.toml (production) and … --features ephemeral-test-queue.
Verified end-to-end locally: solana-test-validator (with the feature build + the pre-delegated Sc9MJ… queue/record/metadata) + ephemeral-validator + vrf-oracle (default paywJ identity) → roll-dice-delegated request was fulfilled in the ER (player state updated), with no fee charged and no Feepayer … was modified without being delegated / Sum of account balances … do not match errors.
Production fee path is unchanged: without the feature, is_fee_exempt_ephemeral_queue only matches DEFAULT_EPHEMERAL_QUEUE.