### PR TITLE
feat: snapshot accountsdb even in the replica mode

### DIFF
--- a/magicblock-processor/src/scheduler/mod.rs
+++ b/magicblock-processor/src/scheduler/mod.rs
@@ -270,7 +270,8 @@ impl TransactionScheduler {
                 biased;
                 Ok(latest) = block_produced.recv() => {
                     if !self.coordinator.is_primary() && latest.slot >= self.slot {
-                        self.transition_to_new_slot(Some(latest)).await;
+                        let slot = self.transition_to_new_slot(Some(latest)).await;
+                        self.handle_superblock(slot).await;
                     }
                 }
                 _ = self.slot_ticker.tick() => {
@@ -342,8 +343,10 @@ impl TransactionScheduler {
             error!("failed to create accountsdb snapshot");
             return;
         };
-        let msg = Message::SuperBlock(SuperBlock { slot, checksum });
-        self.send_replication(msg).await;
+        if self.coordinator.is_primary() {
+            let msg = Message::SuperBlock(SuperBlock { slot, checksum });
+            self.send_replication(msg).await;
+        }
     }
 
     async fn pause_executors_for_snapshot(&mut self) -> OwnedSemaphorePermit {
@@ -380,7 +383,7 @@ impl TransactionScheduler {
             );
         }
 
-        let _permit = self
+        let permit = self
             .pause_permit
             .clone()
             .acquire_owned()
@@ -395,7 +398,13 @@ impl TransactionScheduler {
             .map_err(|error| error.to_string())?;
         self.accountsdb.set_slot(block.slot);
         self.update_sysvars(&block);
-        self.notify_executors_of_block(block).await
+        let slot = block.slot;
+        let result = self.notify_executors_of_block(block).await;
+        drop(permit);
+        if result.is_ok() {
+            self.handle_superblock(slot).await;
+        }
+        result
     }
 
     async fn notify_executors_of_block(

--- a/magicblock-processor/src/scheduler/mod.rs
+++ b/magicblock-processor/src/scheduler/mod.rs
@@ -398,11 +398,16 @@ impl TransactionScheduler {
             .map_err(|error| error.to_string())?;
         self.accountsdb.set_slot(block.slot);
         self.update_sysvars(&block);
+        let slot = block.slot;
         let result = self.notify_executors_of_block(block).await;
         drop(permit);
-        // `ledger.write_block` publishes through latest_block; the
-        // block_produced receiver then calls transition_to_new_slot and
-        // handle_superblock for the replayed slot.
+        // apply_replayed_block advances self.slot before the queued
+        // latest_block notification can be received. The block_produced path
+        // then skips transition_to_new_slot for this already-applied slot, so
+        // handle_superblock must run here for replayed superblock snapshots.
+        if result.is_ok() {
+            self.handle_superblock(slot).await;
+        }
         result
     }
 

--- a/magicblock-processor/src/scheduler/mod.rs
+++ b/magicblock-processor/src/scheduler/mod.rs
@@ -398,12 +398,11 @@ impl TransactionScheduler {
             .map_err(|error| error.to_string())?;
         self.accountsdb.set_slot(block.slot);
         self.update_sysvars(&block);
-        let slot = block.slot;
         let result = self.notify_executors_of_block(block).await;
         drop(permit);
-        if result.is_ok() {
-            self.handle_superblock(slot).await;
-        }
+        // `ledger.write_block` publishes through latest_block; the
+        // block_produced receiver then calls transition_to_new_slot and
+        // handle_superblock for the replayed slot.
         result
     }
 

--- a/magicblock-processor/tests/replica_ordering.rs
+++ b/magicblock-processor/tests/replica_ordering.rs
@@ -9,7 +9,10 @@ use std::{
 };
 
 use guinea::GuineaInstruction;
-use magicblock_core::link::{replication::Block, transactions::ReplayPosition};
+use magicblock_core::link::{
+    replication::{Block, Message},
+    transactions::ReplayPosition,
+};
 use solana_account::ReadableAccount;
 use solana_program::{
     instruction::{AccountMeta, Instruction},
@@ -19,7 +22,7 @@ use solana_pubkey::Pubkey;
 use solana_signature::Signature;
 use solana_transaction::Transaction;
 use test_kit::{ExecutionTestEnv, Signer};
-use tokio::time::timeout;
+use tokio::time::{sleep, timeout};
 
 const STRESS_TIMEOUT: Duration = Duration::from_secs(30);
 const DEFAULT_BALANCE: u64 = LAMPORTS_PER_SOL * 10;
@@ -28,6 +31,17 @@ const DEFAULT_BALANCE: u64 = LAMPORTS_PER_SOL * 10;
 
 fn setup_replica_env(executors: u32) -> ExecutionTestEnv {
     ExecutionTestEnv::new_replica_mode(executors, true)
+}
+
+fn setup_replica_env_with_superblock_size(
+    executors: u32,
+    superblock_size: u64,
+) -> ExecutionTestEnv {
+    ExecutionTestEnv::new_replica_mode_with_superblock_size(
+        executors,
+        true,
+        superblock_size,
+    )
 }
 
 fn create_accounts(env: &mut ExecutionTestEnv, count: usize) -> Vec<Pubkey> {
@@ -214,6 +228,52 @@ async fn test_replay_block_waits_for_queued_transactions() {
     assert_eq!(env.get_account(acc).data()[0], 77);
     assert_eq!(env.ledger.latest_block().load().slot, slot);
     assert_eq!(env.accountsdb.slot(), slot);
+}
+
+#[tokio::test]
+async fn test_replica_replayed_superblock_takes_snapshot_without_publishing() {
+    let mut env = setup_replica_env_with_superblock_size(1, 2);
+    env.run_scheduler();
+    env.yield_to_scheduler().await;
+
+    let slot = 2;
+    let snapshot = env
+        .accountsdb
+        .database_directory()
+        .join(format!("snapshot-{slot:0>12}.tar.gz"));
+    let prev_hash = env.ledger.latest_block().load().blockhash;
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(prev_hash.as_ref());
+    let hash = (*hasher.finalize().as_bytes()).into();
+
+    env.transaction_scheduler
+        .replay_block(Block {
+            slot,
+            hash,
+            timestamp: slot as i64,
+        })
+        .await
+        .expect("failed to apply replayed superblock boundary");
+
+    timeout(Duration::from_secs(5), async {
+        while !snapshot.exists() {
+            sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("timed out waiting for replica accountsdb snapshot");
+
+    let replication = env
+        .dispatch
+        .replication_messages
+        .as_mut()
+        .expect("missing replication receiver");
+    while let Ok(message) = replication.try_recv() {
+        assert!(
+            !matches!(message, Message::SuperBlock(_)),
+            "replica must not publish SuperBlock messages"
+        );
+    }
 }
 
 /// Stress test: Multiple accounts with cross-conflicts.

--- a/test-kit/src/lib.rs
+++ b/test-kit/src/lib.rs
@@ -121,12 +121,43 @@ impl ExecutionTestEnv {
         Self::new_internal(Self::BASE_FEE, executors, defer_startup, false)
     }
 
+    /// Creates a replica-mode environment with a custom superblock interval.
+    pub fn new_replica_mode_with_superblock_size(
+        executors: u32,
+        defer_startup: bool,
+        superblock_size: u64,
+    ) -> Self {
+        Self::new_internal_with_superblock_size(
+            Self::BASE_FEE,
+            executors,
+            defer_startup,
+            false,
+            superblock_size,
+        )
+    }
+
     /// Internal constructor with all parameters.
     fn new_internal(
         fee: u64,
         executors: u32,
         defer_startup: bool,
         primary_mode: bool,
+    ) -> Self {
+        Self::new_internal_with_superblock_size(
+            fee,
+            executors,
+            defer_startup,
+            primary_mode,
+            SUPERBLOCK_SIZE,
+        )
+    }
+
+    fn new_internal_with_superblock_size(
+        fee: u64,
+        executors: u32,
+        defer_startup: bool,
+        primary_mode: bool,
+        superblock_size: u64,
     ) -> Self {
         init_logger!();
         let dir =
@@ -181,7 +212,7 @@ impl ExecutionTestEnv {
             mode_rx,
             pause_permit: validator_channels.pause_permit,
             block_time: BLOCK_TIME,
-            superblock_size: SUPERBLOCK_SIZE,
+            superblock_size,
         };
 
         // Pre-send the target mode so the scheduler picks it up once running.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined replica-mode handling to avoid superblock replication being broadcast incorrectly
  * Improved lifecycle of database pause permits during replica block application to ensure correct notifications

* **Tests**
  * Added integration test verifying replica-mode snapshot behavior without publishing superblock messages
  * Added configurable replica-mode test environment to support superblock-size scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->