### PR TITLE
chore: simplify, rename out_of_order_slot and add a comment

### DIFF
--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -685,7 +685,10 @@ where
                 let same_slot_delegated_refresh = bank_slot == update_slot
                     && account.delegated()
                     && (!in_bank.delegated() || in_bank.undelegating());
-                if bank_slot >= update_slot && !same_slot_delegated_refresh {
+                if bank_slot > update_slot
+                    || (bank_slot == update_slot
+                        && !same_slot_delegated_refresh)
+                {
                     Some(bank_slot)
                 } else {
                     None

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -665,9 +665,20 @@ where
             )
             .await;
 
+        //
         // Ensure that the subscription update isn't out of order, i.e.
-        // we don't already hold a newer version of the account in our bank
-        let out_of_order_slot =
+        // we already hold a newer version of the account in our bank.
+        //
+        // The stricter intent is to ignore non-advancing subscription updates: if the bank
+        // already has the account at the same slot, then a normal/plain update at that slot is
+        // treated as stale/duplicate and should not overwrite local state, with the following
+        // exception:
+        //
+        //  - In the undelegate/redelegate same-slot path, the bank can still hold a plain
+        //    or undelegating version while the subscription update carries the delegated state
+        //    at the same slot, so we must allow that update.
+        //
+        let non_advancing_slot =
             self.accounts_bank.get_account(&pubkey).and_then(|in_bank| {
                 let bank_slot = in_bank.remote_slot();
                 let update_slot = account.remote_slot();
@@ -683,7 +694,8 @@ where
                     None
                 }
             });
-        if let Some(in_bank_slot) = out_of_order_slot {
+
+        if let Some(in_bank_slot) = non_advancing_slot {
             let update_slot = account.remote_slot();
             if in_bank_slot == update_slot {
                 if let Some(projected_ata_clone_request) =

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -685,10 +685,7 @@ where
                 let same_slot_delegated_refresh = bank_slot == update_slot
                     && account.delegated()
                     && (!in_bank.delegated() || in_bank.undelegating());
-                if bank_slot > update_slot
-                    || (bank_slot == update_slot
-                        && !same_slot_delegated_refresh)
-                {
+                if bank_slot >= update_slot && !same_slot_delegated_refresh {
                     Some(bank_slot)
                 } else {
                     None


### PR DESCRIPTION
- context for renaming and comment: https://github.com/magicblock-labs/magicblock-validator/pull/1278#discussion_r3348525471
- fixed the older comment from `"we don't already hold"` to `"we already hold"`.
- ~Simplified if-condition **without changing the semantics**~.

