### PR TITLE
Preflight oversized committor transactions before delivery prep

### DIFF
--- a/magicblock-committor-service/src/intent_executor/error.rs
+++ b/magicblock-committor-service/src/intent_executor/error.rs
@@ -51,6 +51,7 @@ impl InternalError {
                     RpcClientErrorKind::RpcError(
                         RpcError::RpcResponseError { code: -32602, message, .. }
                     ) if message.contains("VersionedTransaction too large")
+                        || message.contains("base64 encoded too large")
                 )
         }
 
@@ -433,13 +434,15 @@ mod tests {
 
     use super::{InternalError, TransactionStrategyExecutionError};
 
-    fn send_transaction_too_large_error() -> TransactionStrategyExecutionError {
+    fn send_transaction_error(
+        message: impl Into<String>,
+    ) -> TransactionStrategyExecutionError {
         let rpc_error = RpcClientError {
             request: Some(RpcRequest::SendTransaction),
             kind: Box::new(RpcClientErrorKind::RpcError(
                 RpcError::RpcResponseError {
                     code: -32602,
-                    message: "base64 encoded solana_transaction::versioned::VersionedTransaction too large: 1684 bytes (max: encoded/raw 1644/1232)".to_string(),
+                    message: message.into(),
                     data: RpcResponseErrorData::Empty,
                 },
             )),
@@ -454,7 +457,18 @@ mod tests {
 
     #[test]
     fn send_transaction_too_large_triggers_single_stage_split() {
-        let err = send_transaction_too_large_error();
+        let err = send_transaction_error(
+            "base64 encoded solana_transaction::versioned::VersionedTransaction too large: 1684 bytes (max: encoded/raw 1644/1232)",
+        );
+
+        assert!(err.is_single_stage_split_limit_error());
+    }
+
+    #[test]
+    fn send_transaction_short_too_large_message_triggers_single_stage_split() {
+        let err = send_transaction_error(
+            "Invalid Request: ErrorObject { code: InvalidParams, message: \"Invalid Request: base64 encoded too large\", data: None }",
+        );
 
         assert!(err.is_single_stage_split_limit_error());
     }

--- a/magicblock-committor-service/src/intent_executor/mod.rs
+++ b/magicblock-committor-service/src/intent_executor/mod.rs
@@ -326,7 +326,7 @@ where
         // We can recover that Error by splitting execution
         // in 2 stages - commit & finalize
         // Otherwise we return error
-        let execution_err = match res {
+        let (execution_err, cleanup_lookup_tables) = match res {
             Err(IntentExecutorError::FailedToFinalizeError {
                 err,
                 commit_signature: _,
@@ -334,17 +334,28 @@ where
             }) if !committed_pubkeys.is_empty()
                 && err.is_single_stage_split_limit_error() =>
             {
-                Some(err)
+                (Some(err), true)
             }
             Err(IntentExecutorError::FailedFinalizePreparationError(
                 TransactionPreparatorError::FailedToFitError,
-            )) if !committed_pubkeys.is_empty() => None,
+            )) if !committed_pubkeys.is_empty() => (None, true),
+            Err(IntentExecutorError::FailedFinalizePreparationError(
+                TransactionPreparatorError::PreflightFailedToFitError,
+            )) if !committed_pubkeys.is_empty() => (None, false),
             res => {
                 let signature = res.as_ref().ok().copied();
                 single_stage_executor
                     .execute_callbacks(signature, res.as_ref().map(|_| ()));
-                let transaction_strategy =
+                let mut transaction_strategy =
                     single_stage_executor.consume_strategy();
+                if matches!(
+                    &res,
+                    Err(IntentExecutorError::FailedFinalizePreparationError(
+                        TransactionPreparatorError::PreflightFailedToFitError
+                    ))
+                ) {
+                    transaction_strategy.lookup_tables_keys.clear();
+                }
                 execution_report.dispose(transaction_strategy);
                 return res.map(ExecutionOutput::SingleStage);
             }
@@ -355,7 +366,11 @@ where
         // Note that this not necessarily will pass at the end due to the same reason
         let strategy = single_stage_executor.consume_strategy();
         let (commit_strategy, finalize_strategy, cleanup) =
-            handle_cpi_limit_error(&self.authority.pubkey(), strategy);
+            handle_cpi_limit_error(
+                &self.authority.pubkey(),
+                strategy,
+                cleanup_lookup_tables,
+            );
         execution_report.dispose(cleanup);
         if let Some(execution_err) = execution_err {
             execution_report.add_patched_error(execution_err);
@@ -469,7 +484,8 @@ where
                 TransactionPreparatorError::SignerError(_),
             )) => Some(CommitStatus::Failed),
             Err(IntentExecutorError::FailedCommitPreparationError(
-                TransactionPreparatorError::FailedToFitError,
+                TransactionPreparatorError::FailedToFitError
+                | TransactionPreparatorError::PreflightFailedToFitError,
             )) => Some(CommitStatus::PartOfTooLargeBundleToProcess),
             Err(IntentExecutorError::FailedCommitPreparationError(
                 TransactionPreparatorError::DeliveryPreparationError(_),

--- a/magicblock-committor-service/src/intent_executor/mod.rs
+++ b/magicblock-committor-service/src/intent_executor/mod.rs
@@ -334,8 +334,11 @@ where
             }) if !committed_pubkeys.is_empty()
                 && err.is_single_stage_split_limit_error() =>
             {
-                err
+                Some(err)
             }
+            Err(IntentExecutorError::FailedFinalizePreparationError(
+                TransactionPreparatorError::FailedToFitError,
+            )) if !committed_pubkeys.is_empty() => None,
             res => {
                 let signature = res.as_ref().ok().copied();
                 single_stage_executor
@@ -354,7 +357,9 @@ where
         let (commit_strategy, finalize_strategy, cleanup) =
             handle_cpi_limit_error(&self.authority.pubkey(), strategy);
         execution_report.dispose(cleanup);
-        execution_report.add_patched_error(execution_err);
+        if let Some(execution_err) = execution_err {
+            execution_report.add_patched_error(execution_err);
+        }
 
         self.two_stage_execution_flow(
             &committed_pubkeys,

--- a/magicblock-committor-service/src/intent_executor/utils.rs
+++ b/magicblock-committor-service/src/intent_executor/utils.rs
@@ -143,6 +143,7 @@ pub(in crate::intent_executor) async fn handle_commit_id_error<
 pub(in crate::intent_executor) fn handle_cpi_limit_error(
     authority: &Pubkey,
     strategy: TransactionStrategy,
+    cleanup_lookup_tables: bool,
 ) -> (
     TransactionStrategy,
     TransactionStrategy,
@@ -197,7 +198,11 @@ pub(in crate::intent_executor) fn handle_cpi_limit_error(
     // We clean up only ALTs
     let to_cleanup = TransactionStrategy {
         optimized_tasks: vec![],
-        lookup_tables_keys: strategy.lookup_tables_keys,
+        lookup_tables_keys: if cleanup_lookup_tables {
+            strategy.lookup_tables_keys
+        } else {
+            vec![]
+        },
         standalone_action_nonce: None,
     };
 

--- a/magicblock-committor-service/src/tasks/utils.rs
+++ b/magicblock-committor-service/src/tasks/utils.rs
@@ -12,8 +12,12 @@ use solana_pubkey::{pubkey, Pubkey};
 use solana_signer::Signer;
 use solana_transaction::versioned::VersionedTransaction;
 
-use crate::tasks::{
-    task_strategist::TaskStrategistResult, BaseTask, BaseTaskImpl,
+use crate::{
+    tasks::{
+        task_strategist::{TaskStrategistError, TaskStrategistResult},
+        BaseTask, BaseTaskImpl,
+    },
+    transactions::{serialize_and_encode_base64, MAX_ENCODED_TRANSACTION_SIZE},
 };
 
 pub struct TransactionUtils;
@@ -146,6 +150,11 @@ impl TransactionUtils {
             &[authority],
         )?;
 
+        if serialize_and_encode_base64(&tx).len() > MAX_ENCODED_TRANSACTION_SIZE
+        {
+            return Err(TaskStrategistError::FailedToFitError);
+        }
+
         Ok(tx)
     }
 
@@ -198,5 +207,26 @@ impl TransactionUtils {
                 compute_unit_price,
             ),
         ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tasks::task_strategist::TaskStrategistError;
+
+    #[test]
+    fn assemble_tx_raw_rejects_oversized_transaction() {
+        let authority = Keypair::new();
+        let ix = Instruction {
+            program_id: Pubkey::new_unique(),
+            accounts: vec![],
+            data: vec![0; MAX_ENCODED_TRANSACTION_SIZE],
+        };
+
+        let result =
+            TransactionUtils::assemble_tx_raw(&authority, &[ix], &[], &[]);
+
+        assert!(matches!(result, Err(TaskStrategistError::FailedToFitError)));
     }
 }

--- a/magicblock-committor-service/src/transaction_preparator/delivery_preparator.rs
+++ b/magicblock-committor-service/src/transaction_preparator/delivery_preparator.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashSet, ops::ControlFlow, time::Duration};
 
-use futures_util::future::{join, join_all, try_join_all};
+use futures_util::future::{join_all, try_join_all};
 use magicblock_committor_program::{
     instruction_chunks::chunk_realloc_ixs, Chunks,
 };
@@ -58,13 +58,13 @@ impl DeliveryPreparator {
         }
     }
 
-    /// Prepares buffers and necessary pieces for optimized TX
-    pub async fn prepare_for_delivery<P: IntentPersister>(
+    /// Prepares buffers for optimized TX
+    pub async fn prepare_tasks_for_delivery<P: IntentPersister>(
         &self,
         authority: &Keypair,
         strategy: &mut TransactionStrategy,
         persister: &Option<P>,
-    ) -> DeliveryPreparatorResult<Vec<AddressLookupTableAccount>> {
+    ) -> DeliveryPreparatorResult<()> {
         let preparation_futures =
             strategy.optimized_tasks.iter_mut().map(|task| async move {
                 let _timer =
@@ -75,21 +75,39 @@ impl DeliveryPreparator {
                     .await
             });
 
-        let task_preparations = join_all(preparation_futures);
-        let alts_preparations = async {
-            let _timer =
-                metrics::observe_committor_intent_alt_preparation_time();
-            self.prepare_lookup_tables(authority, &strategy.lookup_tables_keys)
-                .await
-        };
-
-        let (res1, res2) = join(task_preparations, alts_preparations).await;
-        res1.into_iter()
+        join_all(preparation_futures)
+            .await
+            .into_iter()
             .collect::<Result<Vec<_>, _>>()
             .map_err(DeliveryPreparatorError::FailedToPrepareBufferAccounts)?;
-        let lookup_tables =
-            res2.map_err(DeliveryPreparatorError::FailedToCreateALTError)?;
 
+        Ok(())
+    }
+
+    /// Prepares ALTs for optimized TX
+    pub async fn prepare_lookup_tables_for_delivery(
+        &self,
+        authority: &Keypair,
+        strategy: &TransactionStrategy,
+    ) -> DeliveryPreparatorResult<Vec<AddressLookupTableAccount>> {
+        let _timer = metrics::observe_committor_intent_alt_preparation_time();
+        self.prepare_lookup_tables(authority, &strategy.lookup_tables_keys)
+            .await
+            .map_err(DeliveryPreparatorError::FailedToCreateALTError)
+    }
+
+    /// Prepares buffers and necessary pieces for optimized TX
+    pub async fn prepare_for_delivery<P: IntentPersister>(
+        &self,
+        authority: &Keypair,
+        strategy: &mut TransactionStrategy,
+        persister: &Option<P>,
+    ) -> DeliveryPreparatorResult<Vec<AddressLookupTableAccount>> {
+        let lookup_tables = self
+            .prepare_lookup_tables_for_delivery(authority, strategy)
+            .await?;
+        self.prepare_tasks_for_delivery(authority, strategy, persister)
+            .await?;
         Ok(lookup_tables)
     }
 

--- a/magicblock-committor-service/src/transaction_preparator/error.rs
+++ b/magicblock-committor-service/src/transaction_preparator/error.rs
@@ -11,6 +11,8 @@ use crate::{
 pub enum TransactionPreparatorError {
     #[error("Failed to fit in single TX")]
     FailedToFitError,
+    #[error("Preflight failed to fit in single TX")]
+    PreflightFailedToFitError,
     #[error("SignerError: {0}")]
     SignerError(#[from] SignerError),
     #[error("DeliveryPreparationError: {0}")]

--- a/magicblock-committor-service/src/transaction_preparator/mod.rs
+++ b/magicblock-committor-service/src/transaction_preparator/mod.rs
@@ -8,14 +8,16 @@ use solana_pubkey::Pubkey;
 use crate::{
     persist::IntentPersister,
     tasks::{
-        commit_task::CommitBufferStage, task_strategist::TransactionStrategy,
-        utils::TransactionUtils, BaseTaskImpl,
+        commit_task::CommitBufferStage,
+        task_strategist::{TaskStrategistError, TransactionStrategy},
+        utils::TransactionUtils,
+        BaseTaskImpl,
     },
     transaction_preparator::{
         delivery_preparator::{
             BufferExecutionError, DeliveryPreparator, DeliveryPreparatorResult,
         },
-        error::PreparatorResult,
+        error::{PreparatorResult, TransactionPreparatorError},
     },
     ComputeBudgetConfig,
 };
@@ -90,7 +92,15 @@ impl TransactionPreparator for TransactionPreparatorImpl {
                 self.compute_budget_config.compute_unit_price,
                 &dummy_lookup_tables,
                 tx_strategy.standalone_action_nonce,
-            )?;
+            )
+            .map_err(|err| match err {
+                TaskStrategistError::FailedToFitError => {
+                    TransactionPreparatorError::PreflightFailedToFitError
+                }
+                TaskStrategistError::SignerError(err) => {
+                    TransactionPreparatorError::SignerError(err)
+                }
+            })?;
         }
 
         // Prepare lookup tables before buffers so real ALT layout is checked

--- a/magicblock-committor-service/src/transaction_preparator/mod.rs
+++ b/magicblock-committor-service/src/transaction_preparator/mod.rs
@@ -93,24 +93,31 @@ impl TransactionPreparator for TransactionPreparatorImpl {
             )?;
         }
 
-        // Pre tx preparations. Create buffer accs + lookup tables
+        // Prepare lookup tables before buffers so real ALT layout is checked
+        // before creating buffer accounts.
         let lookup_tables = self
             .delivery_preparator
-            .prepare_for_delivery(authority, tx_strategy, intent_persister)
+            .prepare_lookup_tables_for_delivery(authority, tx_strategy)
             .await?;
 
-        let message =
+        let tx =
             TransactionUtils::assemble_tasks_tx_with_standalone_action_nonce(
                 authority,
                 &tx_strategy.optimized_tasks,
                 self.compute_budget_config.compute_unit_price,
                 &lookup_tables,
                 tx_strategy.standalone_action_nonce,
-            )
-            .expect("Possibility to assemble checked above")
-            .message;
+            )?;
 
-        Ok(message)
+        self.delivery_preparator
+            .prepare_tasks_for_delivery(
+                authority,
+                tx_strategy,
+                intent_persister,
+            )
+            .await?;
+
+        Ok(tx.message)
     }
 
     async fn cleanup_for_strategy(


### PR DESCRIPTION
## Summary
- Reject oversized assembled committor transactions with `FailedToFitError` before they are sent.
- Split delivery preparation so the real ALT-backed transaction layout is checked before buffer accounts are created.
- Route pre-send `FailedToFitError` through the existing single-stage split fallback and recognize the shorter RPC `base64 encoded too large` error message.

## Root cause
Oversized single-stage transactions could still reach delivery preparation, or be classified only after `sendTransaction`, because the final assembled transaction size was not checked at the same boundary used for actual submission.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced detection of oversized transactions to catch additional error scenarios.
  * Improved error recovery handling for transaction preparation edge cases.

* **Refactor**
  * Optimized transaction preparation process with better sequencing of internal operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->