### PR TITLE
Handle ALT extend invalid instruction data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4285,6 +4285,7 @@ dependencies = [
  "solana-signer",
  "solana-slot-hashes 3.0.1",
  "solana-transaction",
+ "solana-transaction-error 3.2.0",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/magicblock-table-mania/Cargo.toml
+++ b/magicblock-table-mania/Cargo.toml
@@ -30,6 +30,7 @@ solana-transaction = { workspace = true }
 solana-compute-budget-interface = { workspace = true }
 solana-instruction = { workspace = true }
 solana-message = { workspace = true }
+solana-transaction-error = { workspace = true }
 tokio = { workspace = true }
 
 [features]

--- a/magicblock-table-mania/src/error.rs
+++ b/magicblock-table-mania/src/error.rs
@@ -35,4 +35,67 @@ impl TableManiaError {
             _ => None,
         }
     }
+
+    pub fn is_sent_transaction_invalid_instruction_data_at(
+        &self,
+        instruction_index: u8,
+    ) -> bool {
+        use magicblock_rpc_client::MagicBlockRpcClientError;
+        use solana_instruction::error::InstructionError;
+        use solana_transaction_error::TransactionError;
+
+        match self {
+            TableManiaError::MagicBlockRpcClientError(
+                MagicBlockRpcClientError::SentTransactionError(
+                    TransactionError::InstructionError(
+                        index,
+                        InstructionError::InvalidInstructionData,
+                    ),
+                    _,
+                ),
+            ) => *index == instruction_index,
+            _ => false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use magicblock_rpc_client::MagicBlockRpcClientError;
+    use solana_instruction::error::InstructionError;
+    use solana_signature::Signature;
+    use solana_transaction_error::TransactionError;
+
+    use super::TableManiaError;
+
+    #[test]
+    fn classifies_sent_transaction_invalid_instruction_data_at_index() {
+        let err = TableManiaError::MagicBlockRpcClientError(
+            MagicBlockRpcClientError::SentTransactionError(
+                TransactionError::InstructionError(
+                    2,
+                    InstructionError::InvalidInstructionData,
+                ),
+                Signature::default(),
+            ),
+        );
+
+        assert!(err.is_sent_transaction_invalid_instruction_data_at(2));
+        assert!(!err.is_sent_transaction_invalid_instruction_data_at(1));
+    }
+
+    #[test]
+    fn does_not_classify_other_sent_transaction_errors() {
+        let err = TableManiaError::MagicBlockRpcClientError(
+            MagicBlockRpcClientError::SentTransactionError(
+                TransactionError::InstructionError(
+                    2,
+                    InstructionError::InvalidArgument,
+                ),
+                Signature::default(),
+            ),
+        );
+
+        assert!(!err.is_sent_transaction_invalid_instruction_data_at(2));
+    }
 }

--- a/magicblock-table-mania/src/lookup_table_rc.rs
+++ b/magicblock-table-mania/src/lookup_table_rc.rs
@@ -3,7 +3,7 @@ use std::{
     fmt,
     ops::Deref,
     sync::{
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
         Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard,
     },
     time::Instant,
@@ -200,6 +200,7 @@ pub enum LookupTableRc {
         creation_sub_slot: u64,
         init_signature: Signature,
         extend_signatures: Mutex<Vec<Signature>>,
+        extendable: AtomicBool,
     },
     Deactivated {
         derived_auth: Keypair,
@@ -220,6 +221,7 @@ impl fmt::Display for LookupTableRc {
                 creation_sub_slot,
                 init_signature,
                 extend_signatures,
+                ..
             } => {
                 let comma_separated_pubkeys = pubkeys
                     .read()
@@ -349,8 +351,24 @@ impl LookupTableRc {
 
     /// Returns `true` if the table has more capacity to add pubkeys
     pub fn has_more_capacity(&self) -> bool {
-        self.pubkeys()
-            .is_some_and(|x| x.len() < LOOKUP_TABLE_MAX_ADDRESSES)
+        match self {
+            Self::Active {
+                pubkeys,
+                extendable,
+                ..
+            } => {
+                extendable.load(Ordering::Relaxed)
+                    && pubkeys.read().expect("pubkeys rwlock poisoned").len()
+                        < LOOKUP_TABLE_MAX_ADDRESSES
+            }
+            Self::Deactivated { .. } => false,
+        }
+    }
+
+    pub fn mark_non_extendable(&self) {
+        if let Self::Active { extendable, .. } = self {
+            extendable.store(false, Ordering::Relaxed);
+        }
     }
 
     pub fn is_full(&self) -> bool {
@@ -581,6 +599,7 @@ impl LookupTableRc {
             creation_sub_slot: sub_slot,
             init_signature: signature,
             extend_signatures: vec![].into(),
+            extendable: AtomicBool::new(true),
         })
     }
 

--- a/magicblock-table-mania/src/manager.rs
+++ b/magicblock-table-mania/src/manager.rs
@@ -320,6 +320,7 @@ impl TableMania {
                                         table_address = %table.table_address(),
                                         "Failed to extend table with invalid instruction data; creating a new table"
                                     );
+                                    table.mark_non_extendable();
                                     force_new_table = true;
                                 }
                                 ExtendTableErrorAction::Retry => {

--- a/magicblock-table-mania/src/manager.rs
+++ b/magicblock-table-mania/src/manager.rs
@@ -33,6 +33,11 @@ const REMOTE_TABLE_FINALIZATION_SLOT_TIME: Duration =
 const REMOTE_TABLE_FINALIZATION_BUFFER: Duration = Duration::from_millis(200);
 const REMOTE_TABLE_FALLBACK_POLL_INTERVAL: Duration =
     Duration::from_millis(500);
+const MAX_ALLOWED_EXTEND_ERRORS: u8 = 5;
+/// Keep the create+extend fallback payload minimal after an existing table rejects an extend.
+const FALLBACK_NEW_TABLE_INIT_PUBKEYS: usize = 1;
+/// Existing-table extend transactions are: compute budget, compute unit price, extend ALT.
+const EXTEND_LOOKUP_TABLE_INSTRUCTION_INDEX: u8 = 2;
 
 fn remote_table_finalization_delay() -> Duration {
     REMOTE_TABLE_FINALIZATION_SLOT_TIME
@@ -88,6 +93,13 @@ struct MatchingTableReadiness {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct RemoteReadinessTarget {
     wall_clock_deadline: Option<Instant>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum ExtendTableErrorAction {
+    CreateNewTable,
+    Retry,
+    ReturnError,
 }
 
 impl TableMania {
@@ -273,13 +285,13 @@ impl TableMania {
         let mut remaining = pubkeys.iter().cloned().collect::<Vec<_>>();
         let mut tables_used = HashSet::new();
 
-        const MAX_ALLOWED_EXTEND_ERRORS: u8 = 5;
         let mut extend_errors = 0;
 
         // Keep trying to store pubkeys until we're done
         while !remaining.is_empty() {
             // First try to use existing tables
             let mut stored_in_existing = false;
+            let mut force_new_table = false;
             {
                 // Taking a write lock here to prevent multiple tasks from
                 // updating tables at the same time
@@ -298,15 +310,28 @@ impl TableMania {
                             )
                             .await
                         {
-                            error!(
-                                error = ?err,
-                                table_address = %table.table_address(),
-                                "Failed to extend table"
-                            );
-                            if extend_errors <= MAX_ALLOWED_EXTEND_ERRORS {
-                                extend_errors += 1;
-                            } else {
-                                return Err(err);
+                            match Self::handle_extend_table_error(
+                                &err,
+                                &mut extend_errors,
+                            ) {
+                                ExtendTableErrorAction::CreateNewTable => {
+                                    error!(
+                                        error = ?err,
+                                        table_address = %table.table_address(),
+                                        "Failed to extend table with invalid instruction data; creating a new table"
+                                    );
+                                    force_new_table = true;
+                                }
+                                ExtendTableErrorAction::Retry => {
+                                    error!(
+                                        error = ?err,
+                                        table_address = %table.table_address(),
+                                        "Failed to extend table"
+                                    );
+                                }
+                                ExtendTableErrorAction::ReturnError => {
+                                    return Err(err);
+                                }
                             }
                         } else {
                             stored_in_existing = true;
@@ -323,18 +348,29 @@ impl TableMania {
                     self.active_tables.write().await;
 
                 // Double-check if a new table was created while we were waiting for the lock
-                if let Some(table) = active_tables_write_lock.last() {
-                    if !table.is_full() {
-                        // Another task created a table we can use, so drop the write lock
-                        // and try again with the read lock
-                        drop(active_tables_write_lock);
-                        continue;
+                if !force_new_table {
+                    if let Some(table) = active_tables_write_lock.last() {
+                        if !table.is_full() {
+                            // Another task created a table we can use, so drop the write lock
+                            // and try again with the read lock
+                            drop(active_tables_write_lock);
+                            continue;
+                        }
                     }
                 }
 
                 // Create a new table and add it to active_tables
+                let initial_pubkey_limit = if force_new_table {
+                    FALLBACK_NEW_TABLE_INIT_PUBKEYS
+                } else {
+                    MAX_ENTRIES_AS_PART_OF_EXTEND as usize
+                };
                 let table = self
-                    .create_new_table_and_extend(authority, &mut remaining)
+                    .create_new_table_and_extend(
+                        authority,
+                        &mut remaining,
+                        initial_pubkey_limit,
+                    )
                     .await?;
 
                 tables_used.insert(*table.table_address());
@@ -348,6 +384,22 @@ impl TableMania {
         }
 
         Ok(())
+    }
+
+    fn handle_extend_table_error(
+        err: &TableManiaError,
+        extend_errors: &mut u8,
+    ) -> ExtendTableErrorAction {
+        if err.is_sent_transaction_invalid_instruction_data_at(
+            EXTEND_LOOKUP_TABLE_INSTRUCTION_INDEX,
+        ) {
+            return ExtendTableErrorAction::CreateNewTable;
+        }
+        if *extend_errors < MAX_ALLOWED_EXTEND_ERRORS {
+            *extend_errors += 1;
+            return ExtendTableErrorAction::Retry;
+        }
+        ExtendTableErrorAction::ReturnError
     }
 
     fn filter_pubkeys_present_in_table(
@@ -448,6 +500,7 @@ impl TableMania {
         &self,
         authority: &Keypair,
         pubkeys: &mut Vec<Pubkey>,
+        initial_pubkey_limit: usize,
     ) -> TableManiaResult<LookupTableRc> {
         static SUB_SLOT: AtomicU64 = AtomicU64::new(0);
 
@@ -469,7 +522,9 @@ impl TableMania {
             }
         }
 
-        let len = pubkeys_len.min(MAX_ENTRIES_AS_PART_OF_EXTEND as usize);
+        let len = pubkeys_len
+            .min(initial_pubkey_limit)
+            .min(MAX_ENTRIES_AS_PART_OF_EXTEND as usize);
         let table = LookupTableRc::init(
             &self.rpc_client,
             authority,
@@ -970,5 +1025,61 @@ fn randomize_lookup_table_slot() -> bool {
     #[cfg(not(feature = "randomize_lookup_table_slot"))]
     {
         std::env::var("RANDOMIZE_LOOKUP_TABLE_SLOT").is_ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use magicblock_rpc_client::MagicBlockRpcClientError;
+    use solana_instruction::error::InstructionError;
+    use solana_signature::Signature;
+    use solana_transaction_error::TransactionError;
+
+    use super::{
+        ExtendTableErrorAction, TableMania, TableManiaError,
+        MAX_ALLOWED_EXTEND_ERRORS,
+    };
+
+    fn sent_transaction_error(
+        instruction_error: InstructionError,
+    ) -> TableManiaError {
+        TableManiaError::MagicBlockRpcClientError(
+            MagicBlockRpcClientError::SentTransactionError(
+                TransactionError::InstructionError(2, instruction_error),
+                Signature::default(),
+            ),
+        )
+    }
+
+    #[test]
+    fn invalid_instruction_data_forces_new_table_without_retrying() {
+        let mut extend_errors = 0;
+        let err =
+            sent_transaction_error(InstructionError::InvalidInstructionData);
+
+        assert_eq!(
+            TableMania::handle_extend_table_error(&err, &mut extend_errors),
+            ExtendTableErrorAction::CreateNewTable
+        );
+        assert_eq!(extend_errors, 0);
+    }
+
+    #[test]
+    fn other_extend_errors_use_retry_budget() {
+        let mut extend_errors = 0;
+        let err = sent_transaction_error(InstructionError::InvalidArgument);
+
+        for expected_errors in 1..=MAX_ALLOWED_EXTEND_ERRORS {
+            assert_eq!(
+                TableMania::handle_extend_table_error(&err, &mut extend_errors),
+                ExtendTableErrorAction::Retry
+            );
+            assert_eq!(extend_errors, expected_errors);
+        }
+
+        assert_eq!(
+            TableMania::handle_extend_table_error(&err, &mut extend_errors),
+            ExtendTableErrorAction::ReturnError
+        );
     }
 }

--- a/magicblock-table-mania/src/manager.rs
+++ b/magicblock-table-mania/src/manager.rs
@@ -291,7 +291,7 @@ impl TableMania {
         while !remaining.is_empty() {
             // First try to use existing tables
             let mut stored_in_existing = false;
-            let mut force_new_table = false;
+            let mut force_new_table_after = None;
             {
                 // Taking a write lock here to prevent multiple tasks from
                 // updating tables at the same time
@@ -321,7 +321,8 @@ impl TableMania {
                                         "Failed to extend table with invalid instruction data; creating a new table"
                                     );
                                     table.mark_non_extendable();
-                                    force_new_table = true;
+                                    force_new_table_after =
+                                        Some(*table.table_address());
                                 }
                                 ExtendTableErrorAction::Retry => {
                                     error!(
@@ -349,19 +350,19 @@ impl TableMania {
                     self.active_tables.write().await;
 
                 // Double-check if a new table was created while we were waiting for the lock
-                if !force_new_table {
-                    if let Some(table) = active_tables_write_lock.last() {
-                        if !table.is_full() {
-                            // Another task created a table we can use, so drop the write lock
-                            // and try again with the read lock
-                            drop(active_tables_write_lock);
-                            continue;
-                        }
+                if let Some(table) = active_tables_write_lock.last() {
+                    if !table.is_full()
+                        && force_new_table_after != Some(*table.table_address())
+                    {
+                        // Another task created a table we can use, so drop the write lock
+                        // and try again with the read lock
+                        drop(active_tables_write_lock);
+                        continue;
                     }
                 }
 
                 // Create a new table and add it to active_tables
-                let initial_pubkey_limit = if force_new_table {
+                let initial_pubkey_limit = if force_new_table_after.is_some() {
                     FALLBACK_NEW_TABLE_INIT_PUBKEYS
                 } else {
                     MAX_ENTRIES_AS_PART_OF_EXTEND as usize

--- a/test-integration/Cargo.lock
+++ b/test-integration/Cargo.lock
@@ -4841,6 +4841,7 @@ dependencies = [
  "solana-signer",
  "solana-slot-hashes",
  "solana-transaction",
+ "solana-transaction-error",
  "thiserror 2.0.18",
  "tokio",
  "tracing",


### PR DESCRIPTION
## Summary

Problem: Table Mania retried the same active lookup table when an ALT extend transaction failed with `InstructionError(2, InvalidInstructionData)`. That could keep replaying the same rejected extend path and let committor preparation fail instead of moving the reservation forward.

Solution: classify `InvalidInstructionData` at the existing-table ALT extend instruction, skip the normal retry path for that table, and create a fresh lookup table with a minimal one-key init payload. Other extend failures still use the existing bounded retry behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced lookup table extension with improved error detection and resilience mechanisms
  * Added automatic retry and fallback strategies when table extension encounters specific errors

* **Chores**
  * Updated dependencies for error handling capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->