### PR TITLE
fix: reject short account responses

### DIFF
--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -1332,6 +1332,17 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
             ));
         }
 
+        let response_value_len = response.value.len();
+        if response_value_len != pubkeys.len() {
+            return Err(RemoteAccountProviderError::AccountResolutionsFailed(
+                format!(
+                    "RPC returned {response_value_len} account results for {} requested accounts: {}",
+                    pubkeys.len(),
+                    pubkeys_str(pubkeys)
+                ),
+            ));
+        }
+
         let mut found_count = 0u64;
         let mut not_found_count = 0u64;
         let remote_accounts = response
@@ -2092,6 +2103,17 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
             // TODO: should we retry if not or respond with an error?
             let (response_slot, response_value) = response;
             assert!(response_slot >= min_context_slot);
+
+            if response_value.len() != pubkeys.len() {
+                let err_msg = format!(
+                    "RPC returned {} account results for {} requested accounts: {}",
+                    response_value.len(),
+                    pubkeys.len(),
+                    pubkeys_str(&pubkeys)
+                );
+                notify_error(&err_msg);
+                return;
+            }
 
             let mut found_count = 0u64;
             let mut not_found_count = 0u64;

--- a/magicblock-chainlink/src/remote_account_provider/tests.rs
+++ b/magicblock-chainlink/src/remote_account_provider/tests.rs
@@ -83,6 +83,69 @@ struct TestSlotConfig {
     account2_slot: u64,
 }
 
+#[tokio::test]
+async fn test_try_get_multi_short_multi_account_response_returns_error() {
+    init_logger();
+
+    let pubkey1 = solana_pubkey::Pubkey::new_unique();
+    let pubkey2 = solana_pubkey::Pubkey::new_unique();
+    let account1 = Account {
+        lamports: 1_000_000,
+        data: vec![1, 2, 3, 4],
+        owner: solana_pubkey::Pubkey::new_unique(),
+        executable: false,
+        rent_epoch: 0,
+    };
+    let account2 = Account {
+        lamports: 2_000_000,
+        data: vec![5, 6, 7, 8],
+        owner: solana_pubkey::Pubkey::new_unique(),
+        executable: false,
+        rent_epoch: 0,
+    };
+
+    let rpc_client = ChainRpcClientMockBuilder::new()
+        .slot(100)
+        .clock_sysvar_for_slot(100)
+        .account(pubkey1, account1)
+        .account(pubkey2, account2)
+        .truncate_multi_account_response_to(1)
+        .build();
+
+    let (updates_sender, updates_receiver) = mpsc::channel(1_000);
+    let pubsub_client =
+        ChainPubsubClientMock::new(updates_sender, updates_receiver);
+
+    let (forward_tx, _forward_rx) = mpsc::channel(1_000);
+    let (subscribed_accounts, config) = create_test_lru_cache(1000);
+    let chain_slot = Arc::<AtomicU64>::default();
+
+    let provider = RemoteAccountProvider::new(
+        rpc_client,
+        pubsub_client,
+        forward_tx,
+        &config,
+        subscribed_accounts,
+        ChainSlot::new(chain_slot),
+    )
+    .await
+    .unwrap();
+
+    let result = tokio::time::timeout(
+        Duration::from_millis(500),
+        provider.try_get_multi(
+            &[pubkey1, pubkey2],
+            None,
+            AccountFetchOrigin::GetAccount,
+            None,
+        ),
+    )
+    .await;
+
+    let fetch_result = result.expect("try_get_multi should not hang");
+    assert!(fetch_result.is_err());
+}
+
 async fn setup_matching_slots(
     config: TestSlotConfig,
     pubkey1: Pubkey,

--- a/magicblock-chainlink/src/testing/rpc_client_mock.rs
+++ b/magicblock-chainlink/src/testing/rpc_client_mock.rs
@@ -36,6 +36,7 @@ pub struct ChainRpcClientMockBuilder {
     accounts: HashMap<Pubkey, AccountAtSlot>,
     current_slot: u64,
     clock_sysvar: Option<Clock>,
+    multi_account_response_truncate: Option<usize>,
 }
 
 #[cfg(any(test, feature = "dev-context"))]
@@ -53,6 +54,7 @@ impl ChainRpcClientMockBuilder {
             accounts: HashMap::new(),
             current_slot: 0,
             clock_sysvar: None,
+            multi_account_response_truncate: None,
         }
     }
 
@@ -110,6 +112,11 @@ impl ChainRpcClientMockBuilder {
         self
     }
 
+    pub fn truncate_multi_account_response_to(mut self, len: usize) -> Self {
+        self.multi_account_response_truncate = Some(len);
+        self
+    }
+
     pub fn build(self) -> ChainRpcClientMock {
         let mock = ChainRpcClientMock {
             commitment: self.commitment,
@@ -119,6 +126,8 @@ impl ChainRpcClientMockBuilder {
             multi_account_fetches: Arc::<AtomicU64>::default(),
             block_fetches: Arc::new(AtomicBool::new(false)),
             fetch_block_notify: Arc::new(Notify::new()),
+            multi_account_response_truncate: self
+                .multi_account_response_truncate,
         };
         if let Some(clock_sysvar) = self.clock_sysvar {
             mock.set_clock_sysvar(clock_sysvar);
@@ -144,6 +153,7 @@ pub struct ChainRpcClientMock {
     multi_account_fetches: Arc<AtomicU64>,
     block_fetches: Arc<AtomicBool>,
     fetch_block_notify: Arc<Notify>,
+    multi_account_response_truncate: Option<usize>,
 }
 
 #[cfg(any(test, feature = "dev-context"))]
@@ -157,6 +167,7 @@ impl ChainRpcClientMock {
             multi_account_fetches: Arc::<AtomicU64>::default(),
             block_fetches: Arc::new(AtomicBool::new(false)),
             fetch_block_notify: Arc::new(Notify::new()),
+            multi_account_response_truncate: None,
         }
     }
 
@@ -368,6 +379,9 @@ impl ChainRpcClient for ChainRpcClientMock {
                 .await?
                 .value;
             accounts.push(val);
+        }
+        if let Some(len) = self.multi_account_response_truncate {
+            accounts.truncate(len);
         }
 
         let res = Response {


### PR DESCRIPTION
## Summary

Reject malformed multi-account RPC responses when the result count does not match the requested
account count.

## Details

### magicblock-chainlink

- Validates multi-account RPC response lengths before converting results into remote accounts.
- Returns the existing structured account-resolution error for malformed RPC-only fetch results.
- Uses the existing pending-request error notification path for background fetches so all waiters are resolved and pending fetch state is cleaned up.
- Adds regression coverage for shortened multi-account responses by extending the RPC test mock with an opt-in truncation mode.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Improved error handling for blockchain RPC responses to verify returned account data matches the number of accounts requested. The system now detects and reports mismatches, preventing unresponsive behavior when RPC servers return incomplete or truncated results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->