### PR TITLE
fix(committor): race-condition on cleanup

### DIFF
--- a/magicblock-committor-service/src/intent_execution_manager/intent_execution_engine.rs
+++ b/magicblock-committor-service/src/intent_execution_manager/intent_execution_engine.rs
@@ -283,6 +283,7 @@ where
 
         // Execute an Intent
         let result = executor.execute(intent.clone(), persister).await;
+        let execution_succeeded = result.inner.is_ok();
         let _ = result.inner.as_ref().inspect_err(|err| {
             error!(intent_id = intent.id, error = ?err, "Failed to execute intent bundle");
         });
@@ -307,17 +308,24 @@ where
             .complete(&intent)
             .expect("Valid completion of previously scheduled message");
 
-        tokio::spawn(async move {
-            // Cleanup after intent
-            // Note: in some cases it maybe critical to execute cleanup synchronously
-            // Example: if commit nonces were invalid during execution
-            // next intent could use wrongly initiated buffers by current intent
-            // We assume that this case is highly unlikely since it would mean:
-            // user redelegates amd reaches current commit id faster than we execute transactions below
-            if let Err(err) = executor.cleanup().await {
-                error!(error = ?err, "Failed to cleanup after intent");
-            }
-        });
+        // Cleaning buffers on failure isn't safe due to potential race condition:
+        // Assume pubkey set A being committed
+        // Intent1 fails and cleans up, another Intent2 with set A executes right away
+        // That could lead for Intent2 init of buffers executing prior of Intent1 buffer cleanup
+        // With same set A buffers will have same address
+        //
+        // To avoid this race on buffers we cleanup only succesfully executed intents
+        // With intent retries all buffers will be eventually closed once intent succeeds
+        //
+        // Note: not sure this is safa for TableMania as it susceptible to same race condition
+        // unless it does handle it internally somehow
+        if execution_succeeded {
+            tokio::spawn(async move {
+                if let Err(err) = executor.cleanup().await {
+                    error!(error = ?err, "Failed to cleanup after intent");
+                }
+            });
+        }
 
         // Free worker
         drop(execution_permit);

--- a/magicblock-committor-service/src/transaction_preparator/delivery_preparator.rs
+++ b/magicblock-committor-service/src/transaction_preparator/delivery_preparator.rs
@@ -25,7 +25,6 @@ use solana_signature::Signature;
 use solana_signer::{Signer, SignerError};
 use solana_transaction::versioned::VersionedTransaction;
 use solana_transaction_error::TransactionError;
-use tokio::try_join;
 use tracing::{error, info};
 
 use crate::{
@@ -496,7 +495,7 @@ impl DeliveryPreparator {
         join_all(close_futs)
             .await
             .into_iter()
-            .map(|(cleanup_tasks, res)| {
+            .try_for_each(|(cleanup_tasks, res)| {
                 res.inspect_err(|err| {
                     let buffer_pdas = cleanup_tasks
                         .into_iter()
@@ -505,7 +504,6 @@ impl DeliveryPreparator {
                     error!(error = ?err, "Failed to cleanup buffers: {:?}", buffer_pdas);
                 })
             })
-            .collect::<Result<(), _>>()
     }
 }
 

--- a/magicblock-committor-service/src/transaction_preparator/delivery_preparator.rs
+++ b/magicblock-committor-service/src/transaction_preparator/delivery_preparator.rs
@@ -498,7 +498,7 @@ impl DeliveryPreparator {
             .try_for_each(|(cleanup_tasks, res)| {
                 res.inspect_err(|err| {
                     let buffer_pdas = cleanup_tasks
-                        .into_iter()
+                        .iter()
                         .map(|el| el.buffer_pda(&authority.pubkey()))
                         .collect::<Vec<_>>();
                     error!(error = ?err, "Failed to cleanup buffers: {:?}", buffer_pdas);

--- a/magicblock-committor-service/src/transaction_preparator/delivery_preparator.rs
+++ b/magicblock-committor-service/src/transaction_preparator/delivery_preparator.rs
@@ -25,6 +25,7 @@ use solana_signature::Signature;
 use solana_signer::{Signer, SignerError};
 use solana_transaction::versioned::VersionedTransaction;
 use solana_transaction_error::TransactionError;
+use tokio::try_join;
 use tracing::{error, info};
 
 use crate::{
@@ -447,12 +448,19 @@ impl DeliveryPreparator {
         cleanup_tasks: &[CleanupTask],
         lookup_table_keys: &[Pubkey],
     ) -> DeliveryPreparatorResult<(), BufferExecutionError> {
-        self.table_mania
-            .release_pubkeys(&HashSet::from_iter(
-                lookup_table_keys.iter().cloned(),
-            ))
-            .await;
+        let fut1 = self.cleanup_buffers(authority, cleanup_tasks);
+        let alt_set = HashSet::from_iter(lookup_table_keys.iter().cloned());
+        let fut2 = self.table_mania.release_pubkeys(&alt_set);
 
+        let (res, ()) = join(fut1, fut2).await;
+        res
+    }
+
+    async fn cleanup_buffers(
+        &self,
+        authority: &Keypair,
+        cleanup_tasks: &[CleanupTask],
+    ) -> DeliveryPreparatorResult<(), BufferExecutionError> {
         if cleanup_tasks.is_empty() {
             return Ok(());
         }

--- a/magicblock-committor-service/src/transaction_preparator/delivery_preparator.rs
+++ b/magicblock-committor-service/src/transaction_preparator/delivery_preparator.rs
@@ -169,7 +169,7 @@ impl DeliveryPreparator {
                     signature,
                 ),
             )) => {
-                info!(error = ?err, signature = ?signature, "Buffer already initialized");
+                info!(error = ?err, signature = ?signature, "Buffer already was initialized");
             }
             // Return in any other case
             res => return res,
@@ -477,17 +477,25 @@ impl DeliveryPreparator {
                 );
 
                 async move {
-                    self.send_ixs_with_retry(&instructions, authority, 1).await
+                    (
+                        cleanup_tasks,
+                        self.send_ixs_with_retry(&instructions, authority, 1)
+                            .await,
+                    )
                 }
             });
 
         join_all(close_futs)
             .await
             .into_iter()
-            .inspect(|res| {
-                if let Err(err) = res {
-                    error!(error = ?err, "Failed to cleanup buffers");
-                }
+            .map(|(cleanup_tasks, res)| {
+                res.inspect_err(|err| {
+                    let buffer_pdas = cleanup_tasks
+                        .into_iter()
+                        .map(|el| el.buffer_pda(&authority.pubkey()))
+                        .collect::<Vec<_>>();
+                    error!(error = ?err, "Failed to cleanup buffers: {:?}", buffer_pdas);
+                })
             })
             .collect::<Result<(), _>>()
     }


### PR DESCRIPTION
<!--
PR title must match: type(scope): summary
Types: feat|fix|docs|chore|refactor|test|perf|ci|build
Examples:
  fix: avoid panic on empty slot
  feat(rpc): add getFoo endpoint
-->

## Summary
<!-- One sentence. Link to issue if applicable. -->
Cleaning buffers on failure isn't safe due to potential race condition:
Assume pubkey set A being committed
Intent1 fails and cleans up, another Intent2 with set A executes right away
That could lead for Intent2 init of buffers executing prior of Intent1 buffer cleanup
With same set A buffers will have same address

Due to this PR cleans up only once intent succeeded. This is safe for buffers as commit_nonce advances and next buffers address will be different

## Breaking Changes
- [ ] None
- [ ] Yes — migration path described below


## Test Plan
<!-- How you verified this works. e.g., "unit tests", "ran locally against testnet", "existing tests pass" -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Strengthened buffer cleanup reliability by refining execution timing to occur only after successful intent bundle processing, preventing potential race conditions when multiple operations target the same buffers simultaneously
* Enhanced error diagnostics for buffer cleanup failures by including specific buffer address information in error logs, improving troubleshooting capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->