### PR TITLE
Recover recent pending intents on restart

### DIFF
--- a/magicblock-committor-service/src/committor_processor.rs
+++ b/magicblock-committor-service/src/committor_processor.rs
@@ -42,7 +42,6 @@ use crate::{
     },
 };
 
-const RECOVERY_MIN_AGE_SECS: u64 = 5 * 60;
 const RECOVERY_MAX_AGE_SECS: u64 = 14 * 24 * 60 * 60;
 
 pub(crate) struct CommittorProcessor {
@@ -181,7 +180,6 @@ impl CommittorProcessor {
         let recovery_time = unix_timestamp();
         let rows = self.persister.get_pending_commit_statuses(
             recovery_time.saturating_sub(RECOVERY_MAX_AGE_SECS),
-            recovery_time.saturating_sub(RECOVERY_MIN_AGE_SECS),
         )?;
         if rows.is_empty() {
             return Ok(Vec::new());
@@ -352,8 +350,7 @@ fn pending_row_is_in_recovery_window(
     row: &CommitStatusRow,
     recovery_time: u64,
 ) -> bool {
-    recovery_time.saturating_sub(row.last_retried_at) > RECOVERY_MIN_AGE_SECS
-        && recovery_time.saturating_sub(row.created_at) <= RECOVERY_MAX_AGE_SECS
+    recovery_time.saturating_sub(row.created_at) <= RECOVERY_MAX_AGE_SECS
 }
 
 fn unix_timestamp() -> u64 {
@@ -473,7 +470,7 @@ mod tests {
             ],
             payer,
             7,
-            RECOVERY_MIN_AGE_SECS + 2,
+            2,
         );
 
         assert_eq!(bundles.len(), 1);
@@ -500,15 +497,15 @@ mod tests {
     }
 
     #[test]
-    fn pending_rows_skip_intents_outside_recovery_window() {
+    fn pending_rows_skip_intents_older_than_recovery_window() {
         let payer = Pubkey::new_unique();
-        let recovery_time = RECOVERY_MAX_AGE_SECS + RECOVERY_MIN_AGE_SECS;
+        let recovery_time = RECOVERY_MAX_AGE_SECS + 1;
 
         let recoverable = pending_rows_to_scheduled_intent_bundles(
             vec![pending_row_with_timestamps(
                 1,
                 recovery_time - RECOVERY_MAX_AGE_SECS,
-                recovery_time - RECOVERY_MIN_AGE_SECS - 1,
+                recovery_time,
             )],
             payer,
             7,
@@ -516,17 +513,13 @@ mod tests {
         );
         assert_eq!(recoverable.len(), 1);
 
-        let too_recent = pending_rows_to_scheduled_intent_bundles(
-            vec![pending_row_with_timestamps(
-                2,
-                recovery_time - RECOVERY_MIN_AGE_SECS,
-                recovery_time - RECOVERY_MIN_AGE_SECS,
-            )],
+        let recent = pending_rows_to_scheduled_intent_bundles(
+            vec![pending_row_with_timestamps(2, recovery_time, recovery_time)],
             payer,
             7,
             recovery_time,
         );
-        assert!(too_recent.is_empty());
+        assert_eq!(recent.len(), 1);
 
         let too_old = pending_rows_to_scheduled_intent_bundles(
             vec![pending_row_with_timestamps(

--- a/magicblock-committor-service/src/persist/commit_persister.rs
+++ b/magicblock-committor-service/src/persist/commit_persister.rs
@@ -60,7 +60,6 @@ pub trait IntentPersister: Send + Sync + Clone + 'static {
     fn get_pending_commit_statuses(
         &self,
         min_created_at: u64,
-        max_last_retried_at: u64,
     ) -> CommitPersistResult<Vec<CommitStatusRow>>;
     fn get_commit_status_by_message(
         &self,
@@ -251,12 +250,11 @@ impl IntentPersister for IntentPersisterImpl {
     fn get_pending_commit_statuses(
         &self,
         min_created_at: u64,
-        max_last_retried_at: u64,
     ) -> CommitPersistResult<Vec<CommitStatusRow>> {
         self.commits_db
             .lock()
             .expect(POISONED_MUTEX_MSG)
-            .get_pending_commit_statuses(min_created_at, max_last_retried_at)
+            .get_pending_commit_statuses(min_created_at)
     }
 
     fn get_commit_status_by_message(
@@ -408,13 +406,11 @@ impl<T: IntentPersister> IntentPersister for Option<T> {
     fn get_pending_commit_statuses(
         &self,
         min_created_at: u64,
-        max_last_retried_at: u64,
     ) -> CommitPersistResult<Vec<CommitStatusRow>> {
         match self {
-            Some(persister) => persister.get_pending_commit_statuses(
-                min_created_at,
-                max_last_retried_at,
-            ),
+            Some(persister) => {
+                persister.get_pending_commit_statuses(min_created_at)
+            }
             None => Ok(Vec::new()),
         }
     }

--- a/magicblock-committor-service/src/persist/db.rs
+++ b/magicblock-committor-service/src/persist/db.rs
@@ -560,7 +560,6 @@ impl CommittsDb {
     pub(crate) fn get_pending_commit_statuses(
         &self,
         min_created_at: u64,
-        max_last_retried_at: u64,
     ) -> CommitPersistResult<Vec<CommitStatusRow>> {
         let query = format!(
             "WITH eligible_messages AS (
@@ -569,7 +568,6 @@ impl CommittsDb {
                  WHERE commit_status = ?1
                  GROUP BY message_id
                  HAVING MIN(created_at) >= ?2
-                    AND MAX(last_retried_at) < ?3
              )
              {SELECT_ALL_COMMIT_STATUS_COLUMNS}
              WHERE commit_status = ?1
@@ -581,8 +579,7 @@ impl CommittsDb {
         let stmt = &mut self.conn.prepare(&query)?;
         let mut rows = stmt.query(params![
             CommitStatus::Pending.as_str(),
-            u64_into_i64(min_created_at),
-            u64_into_i64(max_last_retried_at)
+            u64_into_i64(min_created_at)
         ])?;
 
         extract_committor_rows(&mut rows)
@@ -873,7 +870,7 @@ mod tests {
         db.insert_commit_status_rows(&[pending.clone(), succeeded])
             .unwrap();
 
-        let rows = db.get_pending_commit_statuses(0, 1001).unwrap();
+        let rows = db.get_pending_commit_statuses(0).unwrap();
         assert_eq!(rows, vec![pending]);
     }
 
@@ -903,14 +900,23 @@ mod tests {
             pending.clone(),
             pending_same_message.clone(),
             too_old,
-            too_recent,
-            partially_eligible,
-            partially_too_recent,
+            too_recent.clone(),
+            partially_eligible.clone(),
+            partially_too_recent.clone(),
         ])
         .unwrap();
 
-        let rows = db.get_pending_commit_statuses(10, 20).unwrap();
-        assert_eq!(rows, vec![pending, pending_same_message]);
+        let rows = db.get_pending_commit_statuses(10).unwrap();
+        assert_eq!(
+            rows,
+            vec![
+                pending,
+                pending_same_message,
+                too_recent,
+                partially_eligible,
+                partially_too_recent
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Remove the 5-minute minimum-age filter from pending intent restart recovery.
- Keep the 14-day maximum recovery window for stale pending rows.
- Update the SQLite recovery query and unit tests so fresh pending rows are included.