### PR TITLE
fix: prevent ephemeral accounts from being evicted

### DIFF
--- a/programs/magicblock/src/clone_account/process_evict.rs
+++ b/programs/magicblock/src/clone_account/process_evict.rs
@@ -34,12 +34,19 @@ pub(crate) fn process_evict_account(
             ic_msg!(
                 invoke_context,
                 "EvictAccount: account {} is delegated={} \
-                 undelegating={}, rejecting",
+                 undelegating={}, rejecting eviction",
                 pubkey,
                 acc.delegated(),
                 acc.undelegating()
             );
             return Err(MagicBlockProgramError::AccountIsDelegated.into());
+        } else if acc.ephemeral() {
+            ic_msg!(
+                invoke_context,
+                "EvictAccount: account {} is ephemeral, rejecting eviction",
+                pubkey,
+            );
+            return Err(MagicBlockProgramError::AccountIsEphemeral.into());
         }
     }
 

--- a/test-integration/Cargo.lock
+++ b/test-integration/Cargo.lock
@@ -4237,7 +4237,7 @@ dependencies = [
  "flate2",
  "lmdb-rkv",
  "magicblock-config",
- "magicblock-magic-program-api 0.11.4",
+ "magicblock-magic-program-api 0.12.0",
  "memmap2 0.9.9",
  "parking_lot",
  "reflink-copy",


### PR DESCRIPTION
Currently ephemeral accounts are being evicted:

> EvictAccount: evicted ‘29Bdguts6QpejFEoLCnW7MojGzW3syHQ5rxQJZ6ak7tv’

After this PR (though, ideally, the prevention should be on the caller side):

<img width="1138" height="212" alt="image" src="https://github.com/user-attachments/assets/b6b6a50b-4393-4702-9238-68a9ecd5a7fc" />