### PR TITLE
Increase undelegation compute budget

### DIFF
--- a/magicblock-committor-service/src/tasks/mod.rs
+++ b/magicblock-committor-service/src/tasks/mod.rs
@@ -81,7 +81,7 @@ impl BaseTask for BaseTaskImpl {
             Self::CommitFinalize(value) => value.compute_units(),
             Self::BaseAction(value) => value.compute_units(),
             Self::Finalize(_) => 70_000,
-            Self::Undelegate(_) => 70_000,
+            Self::Undelegate(_) => 105_000,
         }
     }
 


### PR DESCRIPTION
## Summary
- Increase the task-based undelegation compute budget from 70,000 to 105,000 CUs.

## Root Cause
Undelegation can consume extra compute when PDA bump grinding is expensive. In commit + finalize + undelegate transactions, the previous 70,000 CU task budget could leave too little headroom for the final undelegation CPI.

## Validation
- `cargo check -p magicblock-committor-service`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved performance and stability for undelegation operations by optimizing resource allocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->