### PR TITLE
fix: RPC worker count underflow on single-CPU hosts

### DIFF
--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -390,7 +390,7 @@ impl MagicValidator {
         log_timing("startup", "aperture_init", step_start);
         let rpc_handle = thread::spawn(move || {
             let step_start = Instant::now();
-            let workers = (num_cpus::get() / 2 - 1).max(1);
+            let workers = (num_cpus::get() / 2).saturating_sub(1).max(1);
             let runtime = Builder::new_multi_thread()
                 .worker_threads(workers)
                 .enable_all()


### PR DESCRIPTION
## Summary

Fixes an integer underflow in the RPC runtime worker-count calculation that could
crash the validator on single-CPU hosts (single-vCPU containers or constrained
cpusets).

## Details

When computing the number of Tokio worker threads for the RPC runtime, the old
formula `(num_cpus::get() / 2 - 1).max(1)` subtracts `1` *before* clamping with
`.max(1)`. On a host with a single CPU, `num_cpus::get() / 2` is `0`, so the
subtraction underflows:

- in debug/test builds it panics during startup
- in release builds (no overflow checks in the workspace profile) it wraps to a
  huge `usize` that gets passed to Tokio as the worker thread count, producing an
  impossible runtime configuration

Since this runs in the RPC thread spawned during `MagicValidator::try_new`, a valid
low-resource deployment could fail to provide RPC service or crash on startup.

The fix switches to the same saturating pattern already used for the transaction
executor count, so the subtraction can never underflow before the `.max(1)` clamp:

```rust
let workers = (num_cpus::get() / 2).saturating_sub(1).max(1);
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed RPC thread worker count calculation to properly support systems with very low CPU counts. Enhanced the computation logic to prevent underflow and guarantee a minimum of one worker thread is allocated. This improves reliability and stability when running on minimal hardware configurations or resource-constrained environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->