### PR TITLE
hotfix: increase CU for Commit/Finalize/Undelegate

### DIFF
--- a/magicblock-committor-service/src/tasks/commit_finalize_task.rs
+++ b/magicblock-committor-service/src/tasks/commit_finalize_task.rs
@@ -235,7 +235,7 @@ impl BaseTask for CommitFinalizeTask {
     }
 
     fn compute_units(&self) -> u32 {
-        70_000
+        120_000
     }
 
     fn accounts_size_budget(&self) -> u32 {

--- a/magicblock-committor-service/src/tasks/commit_task.rs
+++ b/magicblock-committor-service/src/tasks/commit_task.rs
@@ -275,7 +275,7 @@ impl BaseTask for CommitTask {
     }
 
     fn compute_units(&self) -> u32 {
-        70_000
+        120_000
     }
 
     fn accounts_size_budget(&self) -> u32 {

--- a/magicblock-committor-service/src/tasks/mod.rs
+++ b/magicblock-committor-service/src/tasks/mod.rs
@@ -80,8 +80,8 @@ impl BaseTask for BaseTaskImpl {
             Self::Commit(value) => value.compute_units(),
             Self::CommitFinalize(value) => value.compute_units(),
             Self::BaseAction(value) => value.compute_units(),
-            Self::Finalize(_) => 70_000,
-            Self::Undelegate(_) => 105_000,
+            Self::Finalize(_) => 120_000,
+            Self::Undelegate(_) => 120_000,
         }
     }
 


### PR DESCRIPTION
For some tx, CU consumption is higher than our estimate, both on mainnet and devnet. (See the note for [the proper fix][fix], will be implemented in later PRs).


[mainnet][1]:

<img width="743" height="203" alt="image" src="https://github.com/user-attachments/assets/0c2df898-aaff-48b9-9ae9-a056b5bd01f9" />

[devnet][2]:

<img width="602" height="195" alt="image" src="https://github.com/user-attachments/assets/2a8df957-03b1-4418-a079-7c15d381ecd0" />

[1]: https://explorer.solana.com/tx/xSmtni1zzDUDZkNBga1dLMFwruAURpTDQmUdhkHPto9C2U3AAyhfge4AHxQUcfhyeVDkk1vQLPvq4uU2ZLf3VTX

[2]: https://solscan.io/tx/5mgbNgXMBoTbR1sUsnAAHgmHxmEcCa15ctG2Y6BZ2T4nKojX4Kt1wVeyDyKFnqL7Cb95gAjYJCAftrFVJ83JGzcf?cluster=devnet

[fix]: https://github.com/magicblock-labs/magicblock-validator/issues/1313

# proper fix

a proper fix would be to avoid using `find_program_address` onchain and pass bumps in args, or store in accounts (if possible). 

The analysis of the mainnet error leads to this conclusion: bumbs are too low as a result of which more CU is consumed to find the PDA (and some checks repeatedly call `find_program_address` for the same seeds).

<img width="2478" height="278" alt="image" src="https://github.com/user-attachments/assets/eca80570-360d-424c-8182-8ad4d873ba28" />

<img width="1606" height="312" alt="image" src="https://github.com/user-attachments/assets/bec2c85d-d900-470a-88d6-c1473543b2dd" />
