### PR TITLE
hotfix: map "too large" into ExecutionErrors

### DIFF
--- a/magicblock-committor-service/src/intent_executor/error.rs
+++ b/magicblock-committor-service/src/intent_executor/error.rs
@@ -51,6 +51,7 @@ impl InternalError {
                     RpcClientErrorKind::RpcError(
                         RpcError::RpcResponseError { code: -32602, message, .. }
                     ) if message.contains("VersionedTransaction too large")
+                        || message.contains("base64 encoded too large")
                 )
         }
 
@@ -178,6 +179,8 @@ pub enum TransactionStrategyExecutionError {
     ),
     #[error("Unfinalized account error: {0}, {1:?}")]
     UnfinalizedAccountError(#[source] TransactionError, Option<Signature>),
+    #[error("Transaction too large to send over the wire: {0}")]
+    TransactionTooLargeError(#[source] InternalError),
     #[error("InternalError: {0}")]
     InternalError(#[from] InternalError),
 }
@@ -201,12 +204,9 @@ impl TransactionStrategyExecutionError {
         )
     }
 
-    pub fn is_single_stage_split_limit_error(&self) -> bool {
+    pub fn is_recoverable_by_two_stage(&self) -> bool {
         self.is_cpi_limit_error()
-            || matches!(
-                self,
-                Self::InternalError(err) if err.is_transaction_too_large()
-            )
+            || matches!(self, Self::TransactionTooLargeError(_))
     }
 
     pub fn task_index(&self) -> Option<u8> {
@@ -238,6 +238,7 @@ impl TransactionStrategyExecutionError {
     pub fn signature(&self) -> Option<Signature> {
         match self {
             Self::InternalError(err) => err.signature(),
+            Self::TransactionTooLargeError(err) => err.signature(),
             Self::CommitIDError(_, signature)
             | Self::ActionsError(_, signature)
             | Self::UndelegationError(_, signature)
@@ -365,6 +366,7 @@ impl metrics::LabelValue for TransactionStrategyExecutionError {
             Self::CommitIDError(_, _) => "commit_nonce_failed",
             Self::UndelegationError(_, _) => "undelegation_failed",
             Self::UnfinalizedAccountError(_, _) => "unfinalized_account_failed",
+            Self::TransactionTooLargeError(_) => "transaction_too_large",
             _ => "failed",
         }
     }
@@ -456,7 +458,7 @@ mod tests {
     fn send_transaction_too_large_triggers_single_stage_split() {
         let err = send_transaction_too_large_error();
 
-        assert!(err.is_single_stage_split_limit_error());
+        assert!(err.is_recoverable_by_two_stage());
     }
 
     #[test]
@@ -469,6 +471,6 @@ mod tests {
             )),
         );
 
-        assert!(!err.is_single_stage_split_limit_error());
+        assert!(!err.is_recoverable_by_two_stage());
     }
 }

--- a/magicblock-committor-service/src/intent_executor/error.rs
+++ b/magicblock-committor-service/src/intent_executor/error.rs
@@ -435,29 +435,43 @@ mod tests {
 
     use super::{InternalError, TransactionStrategyExecutionError};
 
-    fn send_transaction_too_large_error() -> TransactionStrategyExecutionError {
+    const TX_TOO_LARGE_SOLANA: &str = "base64 encoded too large";
+    const TX_TOO_LARGE_MAGICBLOCK: &str =
+        "base64 encoded solana_transaction::versioned::VersionedTransaction too large: 1684 bytes (max: encoded/raw 1644/1232)";
+
+    fn make_send_transaction_error(message: &str) -> InternalError {
         let rpc_error = RpcClientError {
             request: Some(RpcRequest::SendTransaction),
             kind: Box::new(RpcClientErrorKind::RpcError(
                 RpcError::RpcResponseError {
                     code: -32602,
-                    message: "base64 encoded solana_transaction::versioned::VersionedTransaction too large: 1684 bytes (max: encoded/raw 1644/1232)".to_string(),
+                    message: message.to_string(),
                     data: RpcResponseErrorData::Empty,
                 },
             )),
         };
-
-        TransactionStrategyExecutionError::InternalError(
-            InternalError::MagicBlockRpcClientError(Box::new(
-                MagicBlockRpcClientError::SendTransaction(Box::new(rpc_error)),
-            )),
-        )
+        InternalError::MagicBlockRpcClientError(Box::new(
+            MagicBlockRpcClientError::SendTransaction(Box::new(rpc_error)),
+        ))
     }
 
     #[test]
-    fn send_transaction_too_large_triggers_single_stage_split() {
-        let err = send_transaction_too_large_error();
+    fn is_transaction_too_large_matches_solana_format() {
+        let err = make_send_transaction_error(TX_TOO_LARGE_SOLANA);
+        assert!(err.is_transaction_too_large());
+    }
 
+    #[test]
+    fn is_transaction_too_large_matches_magicblock_format() {
+        let err = make_send_transaction_error(TX_TOO_LARGE_MAGICBLOCK);
+        assert!(err.is_transaction_too_large());
+    }
+
+    #[test]
+    fn transaction_too_large_error_is_recoverable_by_two_stage() {
+        let inner = make_send_transaction_error(TX_TOO_LARGE_MAGICBLOCK);
+        let err =
+            TransactionStrategyExecutionError::TransactionTooLargeError(inner);
         assert!(err.is_recoverable_by_two_stage());
     }
 
@@ -470,7 +484,6 @@ mod tests {
                 ),
             )),
         );
-
         assert!(!err.is_recoverable_by_two_stage());
     }
 }

--- a/magicblock-committor-service/src/intent_executor/intent_execution_client.rs
+++ b/magicblock-committor-service/src/intent_executor/intent_execution_client.rs
@@ -59,6 +59,9 @@ impl IntentExecutionClient {
         {
             type ExecutionError = TransactionStrategyExecutionError;
             fn map(&self, error: InternalError) -> Self::ExecutionError {
+                if error.is_transaction_too_large() {
+                    return TransactionStrategyExecutionError::TransactionTooLargeError(error);
+                }
                 match error {
                     InternalError::MagicBlockRpcClientError(err) => {
                         map_magicblock_client_error(

--- a/magicblock-committor-service/src/intent_executor/mod.rs
+++ b/magicblock-committor-service/src/intent_executor/mod.rs
@@ -332,7 +332,7 @@ where
                 commit_signature: _,
                 finalize_signature: _,
             }) if !committed_pubkeys.is_empty()
-                && err.is_single_stage_split_limit_error() =>
+                && err.is_recoverable_by_two_stage() =>
             {
                 err
             }

--- a/magicblock-committor-service/src/intent_executor/single_stage_executor.rs
+++ b/magicblock-committor-service/src/intent_executor/single_stage_executor.rs
@@ -254,7 +254,8 @@ where
                 Ok(ControlFlow::Continue(to_cleanup))
             }
             TransactionStrategyExecutionError::CpiLimitError(_, _)
-            | TransactionStrategyExecutionError::LoadedAccountsDataSizeExceeded(_, _) => {
+            | TransactionStrategyExecutionError::LoadedAccountsDataSizeExceeded(_, _)
+            | TransactionStrategyExecutionError::TransactionTooLargeError(_) => {
                 // Can't be handled in scope of single stage execution
                 // We signal flow break
                 Ok(ControlFlow::Break(()))

--- a/magicblock-committor-service/src/intent_executor/two_stage_executor.rs
+++ b/magicblock-committor-service/src/intent_executor/two_stage_executor.rs
@@ -255,7 +255,8 @@ where
             | TransactionStrategyExecutionError::LoadedAccountsDataSizeExceeded(
                 _,
                 _,
-            ) => {
+            )
+            | TransactionStrategyExecutionError::TransactionTooLargeError(_) => {
                 // Can't be handled
                 error!(error = ?err, "Commit tasks exceeded execution limit");
                 Ok(ControlFlow::Break(()))
@@ -495,7 +496,8 @@ where
                 Ok(ControlFlow::Continue(to_cleanup))
             }
             TransactionStrategyExecutionError::CpiLimitError(_, _)
-            | TransactionStrategyExecutionError::LoadedAccountsDataSizeExceeded(_, _) => {
+            | TransactionStrategyExecutionError::LoadedAccountsDataSizeExceeded(_, _)
+            | TransactionStrategyExecutionError::TransactionTooLargeError(_) => {
                 // Can't be handled
                 warn!(error = ?err, "Finalization tasks exceeded execution limit");
                 Ok(ControlFlow::Break(()))


### PR DESCRIPTION
<!--
PR title must match: type(scope): summary
Types: feat|fix|docs|chore|refactor|test|perf|ci|build
Examples:
  fix: avoid panic on empty slot
  feat(rpc): add getFoo endpoint
-->

## Summary
<!-- One sentence. Link to issue if applicable. -->
Map " base64 encoded too large" into TooLarge error and retry it with TwoStage

## Breaking Changes
- [ ] None
- [ ] Yes — migration path described below


## Test Plan
<!-- How you verified this works. e.g., "unit tests", "ran locally against testnet", "existing tests pass" -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of "transaction too large" errors across additional RPC message formats.
  * Transactions identified as too large now trigger an automatic two-stage execution fallback, reducing failures for large operations.
* **Tests**
  * Unit tests updated to verify new error detection and recoverability behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->