### PR TITLE
fix(chainlink): report error when response_slot < min_context_slot

### DIFF
--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -2126,9 +2126,15 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                 };
             };
 
-            // TODO: should we retry if not or respond with an error?
             let (response_slot, response_value) = response;
-            assert!(response_slot >= min_context_slot);
+            if response_slot < min_context_slot {
+                let err_msg = format!(
+                    "Response slot {response_slot} < {min_context_slot} fetching accounts {}",
+                    pubkeys_str(&pubkeys)
+                );
+                notify_error(&err_msg);
+                return;
+            }
 
             if response_value.len() != pubkeys.len() {
                 let err_msg = format!(


### PR DESCRIPTION
## Summary
Report error inside `RemoteAccountProvider::fetch()` when `response_slot < min_context_slot` instead of panicking on `assert!`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for remote account provider to gracefully handle cases where response slots don't meet minimum requirements. Pending requests are now properly notified instead of causing system failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->