### PR TITLE
feat(shutdown): central fatal-error coordinator for validator shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3975,6 +3975,7 @@ dependencies = [
 name = "magicblock-core"
 version = "0.12.3"
 dependencies = [
+ "arc-swap",
  "bincode",
  "bytes",
  "console-subscriber",
@@ -3996,6 +3997,7 @@ dependencies = [
  "spl-token-2022-interface",
  "spl-token-interface",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-log",
  "tracing-subscriber",

--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -40,6 +40,7 @@ use magicblock_core::{
         replication::Message,
         transactions::{SchedulerMode, TransactionSchedulerHandle},
     },
+    shutdown::{init_global, ShutdownHandle},
     Slot,
 };
 use magicblock_ledger::{
@@ -106,6 +107,7 @@ type ChainlinkImpl = ProdChainlink<ChainlinkCloner>;
 pub struct MagicValidator {
     config: ValidatorParams,
     exit: Arc<AtomicBool>,
+    shutdown: ShutdownHandle,
     token: CancellationToken,
     accountsdb: Arc<AccountsDb>,
     ledger: Arc<Ledger>,
@@ -138,7 +140,9 @@ impl MagicValidator {
         mut config: ValidatorParams,
     ) -> ApiResult<Self> {
         // TODO(thlorenz): this will need to be recreated on each start
-        let token = CancellationToken::new();
+        let shutdown = ShutdownHandle::new();
+        init_global(shutdown.clone());
+        let token = shutdown.token();
         let identity_keypair = config.validator.keypair.insecure_clone();
 
         let validator_pubkey = identity_keypair.pubkey();
@@ -224,6 +228,7 @@ impl MagicValidator {
             &config,
             ledger.latest_block(),
             shared_chain_slot.clone(),
+            shutdown.clone(),
         )
         .await?;
         log_timing("startup", "committor_service_init", step_start);
@@ -429,6 +434,7 @@ impl MagicValidator {
             accountsdb,
             config,
             exit,
+            shutdown,
             _metrics: (metrics_service, system_metrics_ticker),
             // NOTE: set during [Self::start]
             slot_ticker: None,
@@ -452,11 +458,12 @@ impl MagicValidator {
         })
     }
 
-    #[instrument(skip(config, latest_block))]
+    #[instrument(skip(config, latest_block, shutdown))]
     async fn init_committor_service(
         config: &ValidatorParams,
         latest_block: &LatestBlock,
         chain_slot: Option<Arc<AtomicU64>>,
+        shutdown: ShutdownHandle,
     ) -> ApiResult<Option<Arc<CommittorService>>> {
         let committor_persist_path =
             config.storage.join("committor_service.sqlite");
@@ -484,6 +491,7 @@ impl MagicValidator {
             },
             chain_slot,
             actions_callback_executor,
+            Some(shutdown),
         )?));
 
         Ok(committor_service)
@@ -1171,6 +1179,10 @@ impl MagicValidator {
 
     pub fn ledger(&self) -> &Ledger {
         &self.ledger
+    }
+
+    pub fn shutdown(&self) -> &ShutdownHandle {
+        &self.shutdown
     }
 
     /// Prepares RocksDB for shutdown by cancelling all Manual compactions

--- a/magicblock-committor-service/Cargo.toml
+++ b/magicblock-committor-service/Cargo.toml
@@ -49,7 +49,7 @@ solana-transaction-error = { workspace = true }
 solana-transaction-status-client-types = { workspace = true }
 static_assertions = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt", "sync", "time"] }
 tokio-util = { workspace = true }
 
 [dev-dependencies]

--- a/magicblock-committor-service/src/committor_processor.rs
+++ b/magicblock-committor-service/src/committor_processor.rs
@@ -6,7 +6,9 @@ use std::{
 };
 
 use magicblock_core::{
-    intent::CommittedAccount, traits::ActionsCallbackScheduler,
+    intent::CommittedAccount,
+    shutdown::{request_fatal_shutdown, ShutdownHandle},
+    traits::ActionsCallbackScheduler,
 };
 use magicblock_program::magic_scheduled_base_intent::{
     CommitAndUndelegate, CommitType, MagicIntentBundle, ScheduledIntentBundle,
@@ -51,6 +53,7 @@ pub(crate) struct CommittorProcessor {
     persister: IntentPersisterImpl,
     commits_scheduler: IntentExecutionManager<DummyDB>,
     task_info_fetcher: Arc<CacheTaskInfoFetcher<RpcTaskInfoFetcher>>,
+    shutdown: Option<ShutdownHandle>,
 }
 
 impl CommittorProcessor {
@@ -60,6 +63,7 @@ impl CommittorProcessor {
         chain_config: ChainConfig,
         chain_slot: Option<Arc<AtomicU64>>,
         actions_callback_executor: A,
+        shutdown: Option<ShutdownHandle>,
     ) -> CommittorServiceResult<Self>
     where
         P: AsRef<Path>,
@@ -116,6 +120,7 @@ impl CommittorProcessor {
                 actions_timeout: chain_config.actions_timeout,
             },
             actions_callback_executor,
+            shutdown.clone(),
         );
 
         Ok(Self {
@@ -125,6 +130,7 @@ impl CommittorProcessor {
             commits_scheduler,
             persister,
             task_info_fetcher,
+            shutdown,
         })
     }
 
@@ -213,10 +219,12 @@ impl CommittorProcessor {
         intent_bundles: Vec<ScheduledIntentBundle>,
     ) -> CommittorServiceResult<()> {
         if let Err(err) = self.persister.start_base_intents(&intent_bundles) {
-            // We will still try to perform the commits, but the fact that we cannot
-            // persist the intent is very serious and we should probably restart the
-            // valiator
             error!(error = ?err, "DB EXCEPTION: Failed to persist changeset");
+            request_fatal_shutdown(
+                "committor.persist",
+                format!("Failed to persist changeset: {err}"),
+                self.shutdown.as_ref(),
+            );
         };
 
         self.commits_scheduler

--- a/magicblock-committor-service/src/committor_processor.rs
+++ b/magicblock-committor-service/src/committor_processor.rs
@@ -225,7 +225,8 @@ impl CommittorProcessor {
                 format!("Failed to persist changeset: {err}"),
                 self.shutdown.as_ref(),
             );
-        };
+            return Err(err.into());
+        }
 
         self.commits_scheduler
             .schedule(intent_bundles)

--- a/magicblock-committor-service/src/intent_execution_manager.rs
+++ b/magicblock-committor-service/src/intent_execution_manager.rs
@@ -5,7 +5,10 @@ pub mod intent_scheduler;
 use std::sync::Arc;
 
 pub use intent_execution_engine::BroadcastedIntentExecutionResult;
-use magicblock_core::traits::ActionsCallbackScheduler;
+use magicblock_core::{
+    shutdown::ShutdownHandle,
+    traits::ActionsCallbackScheduler,
+};
 use magicblock_program::magic_scheduled_base_intent::ScheduledIntentBundle;
 use magicblock_rpc_client::MagicblockRpcClient;
 use magicblock_table_mania::TableMania;
@@ -38,6 +41,7 @@ impl<D: DB> IntentExecutionManager<D> {
         table_mania: TableMania,
         executor_config: ExecutorConfig,
         actions_callback_executor: A,
+        shutdown: Option<ShutdownHandle>,
     ) -> Self
     where
         A: ActionsCallbackScheduler,
@@ -59,6 +63,7 @@ impl<D: DB> IntentExecutionManager<D> {
             executor_factory,
             intent_persister,
             receiver,
+            shutdown,
         );
         let result_subscriber = worker.spawn();
 
@@ -118,4 +123,6 @@ pub enum IntentExecutionManagerError {
     ChannelClosed,
     #[error("DBError: {0}")]
     DBError(#[from] db::Error),
+    #[error("Unrecoverable committor engine failure")]
+    Fatal,
 }

--- a/magicblock-committor-service/src/intent_execution_manager/intent_execution_engine.rs
+++ b/magicblock-committor-service/src/intent_execution_manager/intent_execution_engine.rs
@@ -5,7 +5,10 @@ use std::{
 };
 
 use futures_util::{stream::FuturesUnordered, StreamExt};
-use magicblock_core::traits::CallbackScheduleError;
+use magicblock_core::{
+    shutdown::{request_fatal_shutdown, ShutdownHandle},
+    traits::CallbackScheduleError,
+};
 use magicblock_metrics::metrics;
 use magicblock_program::magic_scheduled_base_intent::ScheduledIntentBundle;
 use solana_signature::Signature;
@@ -93,6 +96,7 @@ pub(crate) struct IntentExecutionEngine<D, P, F> {
     executor_factory: F,
     intents_persister: Option<P>,
     receiver: mpsc::Receiver<ScheduledIntentBundle>,
+    shutdown: Option<ShutdownHandle>,
 
     inner: Arc<Mutex<IntentScheduler>>,
     running_executors: FuturesUnordered<JoinHandle<()>>,
@@ -111,12 +115,14 @@ where
         executor_factory: F,
         intents_persister: Option<P>,
         receiver: mpsc::Receiver<ScheduledIntentBundle>,
+        shutdown: Option<ShutdownHandle>,
     ) -> Self {
         Self {
             db,
             intents_persister,
             executor_factory,
             receiver,
+            shutdown,
             running_executors: FuturesUnordered::new(),
             executors_semaphore: Arc::new(Semaphore::new(
                 MAX_EXECUTORS as usize,
@@ -125,12 +131,36 @@ where
         }
     }
 
+    fn lock_scheduler(&self) -> Result<std::sync::MutexGuard<'_, IntentScheduler>, IntentExecutionManagerError> {
+        self.inner.lock().map_err(|_| {
+            request_fatal_shutdown(
+                "committor.intent_scheduler",
+                POISONED_INNER_MSG,
+                self.shutdown.as_ref(),
+            );
+            IntentExecutionManagerError::Fatal
+        })
+    }
+
     /// Spawns `main_loop` and return `Receiver` listening to results
     pub fn spawn(self) -> ResultSubscriber {
         let (result_sender, _) = broadcast::channel(100);
-        tokio::spawn(self.main_loop(result_sender.clone()));
+        let shutdown = self.shutdown.clone();
+        let subscriber_sender = result_sender.clone();
+        tokio::spawn(async move {
+            self.main_loop(result_sender).await;
+            if let Some(shutdown) = shutdown {
+                if !shutdown.is_triggered() {
+                    request_fatal_shutdown(
+                        "committor.intent_engine",
+                        "Intent execution engine stopped unexpectedly",
+                        Some(&shutdown),
+                    );
+                }
+            }
+        });
 
-        ResultSubscriber(result_sender)
+        ResultSubscriber(subscriber_sender)
     }
 
     /// Main loop that:
@@ -151,8 +181,14 @@ where
                 }
                 Err(IntentExecutionManagerError::DBError(err)) => {
                     error!(error = ?err, "Failed to fetch intent");
+                    request_fatal_shutdown(
+                        "committor.intent_engine",
+                        format!("Failed to fetch intent: {err}"),
+                        self.shutdown.as_ref(),
+                    );
                     break;
                 }
+                Err(IntentExecutionManagerError::Fatal) => break,
             };
             let Some(intent) = intent else {
                 // We couldn't pick up intent for execution due to:
@@ -163,23 +199,41 @@ where
             };
 
             // Waiting until there's available executor
-            let permit = self
+            let permit = match self
                 .executors_semaphore
                 .clone()
                 .acquire_owned()
                 .await
-                .expect(SEMAPHORE_CLOSED_MSG);
+            {
+                Ok(permit) => permit,
+                Err(_) => {
+                    if !self
+                        .shutdown
+                        .as_ref()
+                        .is_some_and(ShutdownHandle::is_triggered)
+                    {
+                        request_fatal_shutdown(
+                            "committor.intent_engine",
+                            SEMAPHORE_CLOSED_MSG,
+                            self.shutdown.as_ref(),
+                        );
+                    }
+                    break;
+                }
+            };
 
             // Spawn executor
             let executor = self.executor_factory.create_instance();
             let persister = self.intents_persister.clone();
             let inner = self.inner.clone();
+            let shutdown = self.shutdown.clone();
 
             let handle = tokio::spawn(Self::execute(
                 executor,
                 persister,
                 intent,
                 inner,
+                shutdown,
                 permit,
                 result_sender.clone(),
             ));
@@ -200,18 +254,17 @@ where
         // Limit on number of intents that can be stored in scheduler
         const SCHEDULER_CAPACITY: usize = 1000;
 
-        let can_receive = || {
-            let num_blocked_intents = self
-                .inner
-                .lock()
-                .expect(POISONED_INNER_MSG)
-                .intents_blocked();
-            if num_blocked_intents < SCHEDULER_CAPACITY {
-                true
-            } else {
-                warn!(blocked_count = num_blocked_intents, "Capacity exceeded");
-                false
+        let can_receive = match self.lock_scheduler() {
+            Ok(scheduler) => {
+                let num_blocked_intents = scheduler.intents_blocked();
+                if num_blocked_intents < SCHEDULER_CAPACITY {
+                    true
+                } else {
+                    warn!(blocked_count = num_blocked_intents, "Capacity exceeded");
+                    false
+                }
             }
+            Err(err) => return Err(err),
         };
 
         let running_executors = &mut self.running_executors;
@@ -221,23 +274,31 @@ where
             // Notify polled first to prioritize unblocked intents over new one
             biased;
             Some(result) = running_executors.next() => {
-                if let Err(err) = result {
+                if let Err(err) = &result {
                     error!(error = ?err, "Executor failed");
+                    if err.is_panic() {
+                        request_fatal_shutdown(
+                            "committor.intent_engine.executor",
+                            format!("Intent executor task panicked: {err}"),
+                            self.shutdown.as_ref(),
+                        );
+                        return Err(IntentExecutionManagerError::Fatal);
+                    }
                 };
                 trace!("Worker executed intent bundle, fetching new available one");
-                self.inner.lock().expect(POISONED_INNER_MSG).pop_next_scheduled_intent()
+                self.lock_scheduler()?.pop_next_scheduled_intent()
             },
-            result = Self::get_new_intent(receiver, db), if can_receive() => {
+            result = Self::get_new_intent(receiver, db), if can_receive => {
                 let intent = result?;
-                self.inner.lock().expect(POISONED_INNER_MSG).schedule(intent)
+                self.lock_scheduler()?.schedule(intent)
             },
             else => {
-                // Shouldn't be possible:
-                // 1. If no executors spawned -> we can receive
-                // 2. If can't receive ->  there are MAX_EXECUTORS running executors
-                // We can't receive new message as there's no available Executor
-                // that could pick up the task.
-                unreachable!("next_scheduled_intent")
+                request_fatal_shutdown(
+                    "committor.intent_engine",
+                    "next_scheduled_intent entered unreachable state",
+                    self.shutdown.as_ref(),
+                );
+                return Err(IntentExecutionManagerError::Fatal);
             }
         };
 
@@ -270,12 +331,13 @@ where
     }
 
     /// Wrapper on [`IntentExecutor`] that handles its results and drops execution permit
-    #[instrument(skip(executor, persister, intent, inner_scheduler, execution_permit, result_sender), fields(intent_id = intent.id))]
+    #[instrument(skip(executor, persister, intent, inner_scheduler, shutdown, execution_permit, result_sender), fields(intent_id = intent.id))]
     async fn execute(
         mut executor: E,
         persister: Option<P>,
         intent: ScheduledIntentBundle,
         inner_scheduler: Arc<Mutex<IntentScheduler>>,
+        shutdown: Option<ShutdownHandle>,
         execution_permit: OwnedSemaphorePermit,
         result_sender: broadcast::Sender<BroadcastedIntentExecutionResult>,
     ) {
@@ -302,11 +364,28 @@ where
         // SAFETY: Self::execute is called ONLY after IntentScheduler
         // successfully is able to schedule execution of some Intent
         // that means that the same Intent is SAFE to complete
-        inner_scheduler
-            .lock()
-            .expect(POISONED_INNER_MSG)
-            .complete(&intent)
-            .expect("Valid completion of previously scheduled message");
+        match inner_scheduler.lock() {
+            Ok(mut scheduler) => {
+                if let Err(err) = scheduler.complete(&intent) {
+                    error!(intent_id = intent.id, error = ?err, "Failed to complete scheduled intent");
+                    request_fatal_shutdown(
+                        "committor.intent_engine.executor",
+                        format!(
+                            "Failed to complete previously scheduled intent {}: {err}",
+                            intent.id
+                        ),
+                        shutdown.as_ref(),
+                    );
+                }
+            }
+            Err(_) => {
+                request_fatal_shutdown(
+                    "committor.intent_scheduler",
+                    POISONED_INNER_MSG,
+                    shutdown.as_ref(),
+                );
+            }
+        }
 
         // Cleaning buffers on failure isn't safe due to potential race condition:
         // Assume pubkey set A being committed
@@ -428,6 +507,7 @@ mod tests {
             executor_factory,
             None::<IntentPersisterImpl>,
             receiver,
+            None,
         );
 
         (sender, worker)
@@ -726,6 +806,112 @@ mod tests {
             max_observed >= 1 && max_observed <= MAX_EXECUTORS as usize,
             "Concurrency {} outside expected range",
             max_observed
+        );
+    }
+
+    struct FailingPopDB;
+
+    #[async_trait::async_trait]
+    impl DB for FailingPopDB {
+        async fn store_intent_bundle(
+            &self,
+            _intent_bundle: ScheduledIntentBundle,
+        ) -> crate::intent_execution_manager::db::DBResult<()> {
+            Ok(())
+        }
+
+        async fn store_intent_bundles(
+            &self,
+            _intent_bundles: Vec<ScheduledIntentBundle>,
+        ) -> crate::intent_execution_manager::db::DBResult<()> {
+            Ok(())
+        }
+
+        async fn pop_intent_bundle(
+            &self,
+        ) -> crate::intent_execution_manager::db::DBResult<
+            Option<ScheduledIntentBundle>,
+        > {
+            Err(crate::intent_execution_manager::db::Error::FetchError)
+        }
+
+        fn is_empty(&self) -> bool {
+            true
+        }
+    }
+
+    #[tokio::test]
+    async fn db_fetch_error_triggers_shutdown() {
+        use magicblock_core::shutdown::{ShutdownHandle, ShutdownReason};
+
+        test_utils::init_test_logger();
+        let shutdown = ShutdownHandle::new();
+        let (_sender, receiver) = mpsc::channel(1);
+        let worker = IntentExecutionEngine::new(
+            Arc::new(FailingPopDB),
+            MockIntentExecutorFactory::new(),
+            None::<IntentPersisterImpl>,
+            receiver,
+            Some(shutdown.clone()),
+        );
+        worker.spawn();
+        shutdown.requested().await;
+        assert_eq!(
+            shutdown.reason(),
+            Some(ShutdownReason::Fatal {
+                source: "committor.intent_engine",
+                message: "Failed to fetch intent: FetchError".into(),
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn unexpected_engine_stop_triggers_shutdown() {
+        use magicblock_core::shutdown::{ShutdownHandle, ShutdownReason};
+
+        test_utils::init_test_logger();
+        let shutdown = ShutdownHandle::new();
+        let (sender, receiver) = mpsc::channel(1);
+        let worker = IntentExecutionEngine::new(
+            Arc::new(DummyDB::new()),
+            MockIntentExecutorFactory::new(),
+            None::<IntentPersisterImpl>,
+            receiver,
+            Some(shutdown.clone()),
+        );
+        worker.spawn();
+        drop(sender);
+        shutdown.requested().await;
+        assert_eq!(
+            shutdown.reason(),
+            Some(ShutdownReason::Fatal {
+                source: "committor.intent_engine",
+                message: "Intent execution engine stopped unexpectedly".into(),
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn engine_stop_after_shutdown_is_not_fatal() {
+        use magicblock_core::shutdown::{ShutdownHandle, ShutdownReason};
+
+        test_utils::init_test_logger();
+        let shutdown = ShutdownHandle::new();
+        let (sender, receiver) = mpsc::channel(1);
+        let worker = IntentExecutionEngine::new(
+            Arc::new(DummyDB::new()),
+            MockIntentExecutorFactory::new(),
+            None::<IntentPersisterImpl>,
+            receiver,
+            Some(shutdown.clone()),
+        );
+        worker.spawn();
+        shutdown.trigger(ShutdownReason::Signal("SIGTERM"));
+        drop(sender);
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(
+            shutdown.reason(),
+            Some(ShutdownReason::Signal("SIGTERM"))
         );
     }
 

--- a/magicblock-committor-service/src/service.rs
+++ b/magicblock-committor-service/src/service.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use magicblock_core::{
-    shutdown::{spawn_critical, ShutdownHandle},
+    shutdown::{ShutdownHandle, ShutdownReason},
     traits::ActionsCallbackScheduler,
 };
 use magicblock_program::magic_scheduled_base_intent::ScheduledIntentBundle;
@@ -379,8 +379,15 @@ impl CommittorService {
                 shutdown.clone(),
             )?;
             if let Some(shutdown) = shutdown {
-                spawn_critical("committor.actor", shutdown, async move {
-                    actor.run(cancel_token).await;
+                tokio::spawn(async move {
+                    actor.run(cancel_token.clone()).await;
+                    if cancel_token.is_cancelled() || shutdown.is_triggered() {
+                        return;
+                    }
+                    shutdown.trigger(ShutdownReason::Fatal {
+                        source: "committor.actor",
+                        message: "Committor actor stopped unexpectedly".into(),
+                    });
                 });
             } else {
                 tokio::spawn(async move {

--- a/magicblock-committor-service/src/service.rs
+++ b/magicblock-committor-service/src/service.rs
@@ -5,7 +5,10 @@ use std::{
     time::Instant,
 };
 
-use magicblock_core::traits::ActionsCallbackScheduler;
+use magicblock_core::{
+    shutdown::{spawn_critical, ShutdownHandle},
+    traits::ActionsCallbackScheduler,
+};
 use magicblock_program::magic_scheduled_base_intent::ScheduledIntentBundle;
 use solana_keypair::Keypair;
 use solana_pubkey::Pubkey;
@@ -129,6 +132,7 @@ impl CommittorActor {
         chain_config: ChainConfig,
         chain_slot: Option<Arc<AtomicU64>>,
         actions_callback_executor: A,
+        shutdown: Option<ShutdownHandle>,
     ) -> CommittorServiceResult<Self>
     where
         P: AsRef<Path>,
@@ -140,6 +144,7 @@ impl CommittorActor {
             chain_config,
             chain_slot,
             actions_callback_executor,
+            shutdown,
         )?);
 
         Ok(Self {
@@ -353,6 +358,7 @@ impl CommittorService {
         chain_config: ChainConfig,
         chain_slot: Option<Arc<AtomicU64>>,
         actions_callback_executor: A,
+        shutdown: Option<ShutdownHandle>,
     ) -> CommittorServiceResult<Self>
     where
         P: AsRef<Path>,
@@ -370,10 +376,17 @@ impl CommittorService {
                 chain_config,
                 chain_slot,
                 actions_callback_executor,
+                shutdown.clone(),
             )?;
-            tokio::spawn(async move {
-                actor.run(cancel_token).await;
-            });
+            if let Some(shutdown) = shutdown {
+                spawn_critical("committor.actor", shutdown, async move {
+                    actor.run(cancel_token).await;
+                });
+            } else {
+                tokio::spawn(async move {
+                    actor.run(cancel_token).await;
+                });
+            }
         }
         Ok(Self {
             sender,

--- a/magicblock-core/Cargo.toml
+++ b/magicblock-core/Cargo.toml
@@ -8,9 +8,10 @@ license.workspace = true
 edition.workspace = true
 
 [dependencies]
-
+arc-swap = { workspace = true }
 console-subscriber = { workspace = true, optional = true }
-tokio = { workspace = true, features = ["sync"] }
+tokio = { workspace = true, features = ["macros", "rt", "sync"] }
+tokio-util = { workspace = true }
 flume = { workspace = true }
 bincode = { workspace = true }
 bytes = { workspace = true }

--- a/magicblock-core/src/lib.rs
+++ b/magicblock-core/src/lib.rs
@@ -19,6 +19,7 @@ pub mod coordination_mode;
 pub mod intent;
 pub mod link;
 pub mod logger;
+pub mod shutdown;
 pub mod tls;
 pub mod token_programs;
 pub mod traits;

--- a/magicblock-core/src/shutdown.rs
+++ b/magicblock-core/src/shutdown.rs
@@ -1,0 +1,244 @@
+use std::sync::{Arc, OnceLock};
+
+use arc_swap::ArcSwapOption;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+use tracing::error;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ShutdownReason {
+    /// Operator-initiated shutdown (SIGTERM / Ctrl-C).
+    Signal(&'static str),
+    /// A subsystem hit an unrecoverable error.
+    Fatal {
+        source: &'static str,
+        message: String,
+    },
+}
+
+/// Process-wide shutdown coordinator.
+///
+/// Owns the master [`CancellationToken`] shared by validator subsystems and
+/// records the first shutdown reason.
+#[derive(Clone)]
+pub struct ShutdownHandle {
+    token: CancellationToken,
+    reason: Arc<ArcSwapOption<ShutdownReason>>,
+}
+
+impl ShutdownHandle {
+    pub fn new() -> Self {
+        Self {
+            token: CancellationToken::new(),
+            reason: Arc::new(ArcSwapOption::empty()),
+        }
+    }
+
+    /// Requests graceful shutdown. Only the first reason is retained.
+    pub fn trigger(&self, reason: ShutdownReason) {
+        if self.token.is_cancelled() {
+            return;
+        }
+        error!(?reason, "Shutdown requested");
+        self.reason.store(Some(std::sync::Arc::new(reason)));
+        self.token.cancel();
+    }
+
+    pub fn is_triggered(&self) -> bool {
+        self.token.is_cancelled()
+    }
+
+    pub fn reason(&self) -> Option<ShutdownReason> {
+        self.reason.load_full().map(|reason| (*reason).clone())
+    }
+
+    pub fn token(&self) -> CancellationToken {
+        self.token.clone()
+    }
+
+    pub fn child_token(&self) -> CancellationToken {
+        self.token.child_token()
+    }
+
+    pub async fn requested(&self) {
+        self.token.cancelled().await;
+    }
+}
+
+impl Default for ShutdownHandle {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+static GLOBAL: OnceLock<ShutdownHandle> = OnceLock::new();
+
+/// Installs the process-wide shutdown handle once at validator startup.
+pub fn init_global(handle: ShutdownHandle) {
+    let _ = GLOBAL.set(handle);
+}
+
+/// Requests shutdown from anywhere in the process after [`init_global`].
+pub fn trigger_shutdown(reason: ShutdownReason) {
+    if let Some(handle) = GLOBAL.get() {
+        handle.trigger(reason);
+    } else {
+        error!(?reason, "Shutdown requested before coordinator init");
+    }
+}
+
+/// Returns the process-wide shutdown handle if installed.
+pub fn global() -> Option<ShutdownHandle> {
+    GLOBAL.get().cloned()
+}
+
+/// Spawns a task that must run for the validator's whole lifetime.
+///
+/// If the task returns or panics while shutdown has not yet been requested, a
+/// fatal shutdown is triggered.
+pub fn spawn_critical<F>(
+    name: &'static str,
+    shutdown: ShutdownHandle,
+    fut: F,
+) -> JoinHandle<()>
+where
+    F: std::future::Future<Output = ()> + Send + 'static,
+{
+    tokio::spawn(async move {
+        let inner = tokio::spawn(fut);
+        match inner.await {
+            Ok(()) => {
+                if !shutdown.is_triggered() {
+                    shutdown.trigger(ShutdownReason::Fatal {
+                        source: name,
+                        message: format!(
+                            "critical task '{name}' exited unexpectedly"
+                        ),
+                    });
+                }
+            }
+            Err(join_err) => {
+                if shutdown.is_triggered() {
+                    return;
+                }
+                let message = if join_err.is_panic() {
+                    format!("critical task '{name}' panicked")
+                } else {
+                    format!("critical task '{name}' was cancelled")
+                };
+                shutdown.trigger(ShutdownReason::Fatal {
+                    source: name,
+                    message,
+                });
+            }
+        }
+    })
+}
+
+/// Requests validator shutdown for an unrecoverable subsystem error.
+pub fn request_fatal_shutdown(
+    source: &'static str,
+    message: impl Into<String>,
+    shutdown: Option<&ShutdownHandle>,
+) {
+    let message = message.into();
+    if let Some(handle) = shutdown {
+        handle.trigger(ShutdownReason::Fatal { source, message });
+    } else if let Some(handle) = global() {
+        handle.trigger(ShutdownReason::Fatal { source, message });
+    } else {
+        error!(
+            source,
+            %message,
+            "Fatal committor error without shutdown coordinator"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn first_reason_wins() {
+        let shutdown = ShutdownHandle::new();
+        shutdown.trigger(ShutdownReason::Signal("SIGTERM"));
+        shutdown.trigger(ShutdownReason::Fatal {
+            source: "test",
+            message: "later".into(),
+        });
+
+        assert_eq!(shutdown.reason(), Some(ShutdownReason::Signal("SIGTERM")));
+    }
+
+    #[tokio::test]
+    async fn requested_resolves_on_trigger() {
+        let shutdown = ShutdownHandle::new();
+        let waiter = shutdown.clone();
+        let trigger = shutdown.clone();
+
+        let wait_task = tokio::spawn(async move {
+            waiter.requested().await;
+            waiter.reason()
+        });
+
+        trigger.trigger(ShutdownReason::Signal("SIGINT"));
+        assert_eq!(
+            wait_task.await.unwrap(),
+            Some(ShutdownReason::Signal("SIGINT"))
+        );
+    }
+
+    #[tokio::test]
+    async fn child_token_cancels_on_master_trigger() {
+        let shutdown = ShutdownHandle::new();
+        let child = shutdown.child_token();
+        let child_wait = tokio::spawn(async move {
+            child.cancelled().await;
+        });
+
+        shutdown.trigger(ShutdownReason::Signal("SIGTERM"));
+        child_wait.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn spawn_critical_triggers_on_unexpected_exit() {
+        let shutdown = ShutdownHandle::new();
+        let _handle = spawn_critical("test.task", shutdown.clone(), async {});
+        shutdown.requested().await;
+        assert_eq!(
+            shutdown.reason(),
+            Some(ShutdownReason::Fatal {
+                source: "test.task",
+                message: "critical task 'test.task' exited unexpectedly".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn request_fatal_shutdown_uses_explicit_handle() {
+        let shutdown = ShutdownHandle::new();
+        request_fatal_shutdown("committor.test", "boom", Some(&shutdown));
+        assert_eq!(
+            shutdown.reason(),
+            Some(ShutdownReason::Fatal {
+                source: "committor.test",
+                message: "boom".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn request_fatal_shutdown_falls_back_to_global() {
+        let shutdown = ShutdownHandle::new();
+        init_global(shutdown.clone());
+        request_fatal_shutdown("committor.test", "via global", None);
+        assert_eq!(
+            shutdown.reason(),
+            Some(ShutdownReason::Fatal {
+                source: "committor.test",
+                message: "via global".into(),
+            })
+        );
+    }
+}

--- a/magicblock-core/src/shutdown.rs
+++ b/magicblock-core/src/shutdown.rs
@@ -36,11 +36,18 @@ impl ShutdownHandle {
 
     /// Requests graceful shutdown. Only the first reason is retained.
     pub fn trigger(&self, reason: ShutdownReason) {
-        if self.token.is_cancelled() {
+        if self
+            .reason
+            .compare_and_swap(
+                &None::<Arc<ShutdownReason>>,
+                Some(Arc::new(reason.clone())),
+            )
+            .is_some()
+        {
+            self.token.cancel();
             return;
         }
         error!(?reason, "Shutdown requested");
-        self.reason.store(Some(std::sync::Arc::new(reason)));
         self.token.cancel();
     }
 

--- a/magicblock-validator/src/main.rs
+++ b/magicblock-validator/src/main.rs
@@ -4,15 +4,16 @@ use std::time::Instant;
 
 use magicblock_api::{ledger, magic_validator::MagicValidator};
 use magicblock_config::ValidatorParams;
+use magicblock_core::shutdown::ShutdownHandle;
 #[cfg(feature = "tui")]
 use magicblock_tui_client::{
     enrich_config_from_rpc, init_embedded_logger, run_tui, TuiConfig,
 };
 use solana_signer::Signer;
 use tokio::runtime::Builder;
-use tracing::{debug, error, info, instrument};
+use tracing::{debug, info, instrument};
 
-use crate::shutdown::Shutdown;
+use crate::shutdown::wait_for_shutdown;
 
 fn init_logger() {
     use magicblock_core::logger::{init_with_config, LogStyle, LoggingConfig};
@@ -101,6 +102,8 @@ async fn run() {
         "Validator start completed"
     );
 
+    let shutdown = api.shutdown().clone();
+
     #[cfg(feature = "tui")]
     {
         if !no_tui {
@@ -128,7 +131,7 @@ async fn run() {
             enrich_config_from_rpc(&mut tui_config).await;
 
             if let Err(err) = run_tui(tui_config, validator_log_rx).await {
-                error!(error = ?err, "TUI error");
+                tracing::error!(error = ?err, "TUI error");
             }
         } else {
             run_no_tui(
@@ -137,6 +140,7 @@ async fn run() {
                 &remote_rpc_url,
                 &validator_identity.to_string(),
                 &api,
+                &shutdown,
                 overall_start,
             )
             .await;
@@ -151,6 +155,7 @@ async fn run() {
             &remote_rpc_url,
             &validator_identity.to_string(),
             &api,
+            &shutdown,
             overall_start,
         )
         .await;
@@ -172,6 +177,7 @@ pub async fn run_no_tui(
     remote_rpc_url: &str,
     validator_identity: &str,
     api: &MagicValidator,
+    shutdown: &ShutdownHandle,
     overall_start: Instant,
 ) {
     let version = magicblock_version::Version::default();
@@ -198,9 +204,7 @@ pub async fn run_no_tui(
         "Validator ready"
     );
     let shutdown_wait = Instant::now();
-    if let Err(err) = Shutdown::wait().await {
-        error!(error = ?err, "Failed to gracefully shutdown");
-    }
+    wait_for_shutdown(shutdown).await;
     debug!(
         duration_ms = shutdown_wait.elapsed().as_millis() as u64,
         "Shutdown signal received"

--- a/magicblock-validator/src/shutdown.rs
+++ b/magicblock-validator/src/shutdown.rs
@@ -1,29 +1,60 @@
+use magicblock_core::shutdown::{ShutdownHandle, ShutdownReason};
 use tokio::signal;
 #[cfg(unix)]
 use tokio::signal::unix::SignalKind;
-use tracing::{info, instrument};
+use tracing::{error, info, instrument};
 
 pub struct Shutdown;
 impl Shutdown {
     #[cfg(unix)]
     #[instrument]
-    pub async fn wait() -> std::io::Result<()> {
+    pub async fn wait() -> std::io::Result<&'static str> {
         let mut terminate_signal =
             signal::unix::signal(SignalKind::terminate())?;
-        tokio::select! {
+        let signal = tokio::select! {
             _ = terminate_signal.recv() => {
                 info!(signal = "SIGTERM", "Initiating graceful shutdown");
+                "SIGTERM"
             },
             _ = tokio::signal::ctrl_c() => {
                 info!(signal = "SIGINT", "Initiating graceful shutdown");
+                "SIGINT"
             },
-        }
+        };
 
-        Ok(())
+        Ok(signal)
     }
 
     #[cfg(not(unix))]
-    pub async fn wait() -> std::io::Result<()> {
-        tokio::signal::ctrl_c().await
+    pub async fn wait() -> std::io::Result<&'static str> {
+        tokio::signal::ctrl_c().await?;
+        info!(signal = "SIGINT", "Initiating graceful shutdown");
+        Ok("SIGINT")
+    }
+}
+
+/// Waits until an operator signal or a fatal shutdown request is received.
+#[instrument(skip(shutdown))]
+pub async fn wait_for_shutdown(shutdown: &ShutdownHandle) {
+    tokio::select! {
+        res = Shutdown::wait() => {
+            match res {
+                Ok(signal) => {
+                    shutdown.trigger(ShutdownReason::Signal(signal));
+                }
+                Err(err) => {
+                    error!(error = ?err, "Failed to wait for shutdown signal");
+                    shutdown.trigger(ShutdownReason::Fatal {
+                        source: "validator.signal",
+                        message: format!("Failed to wait for shutdown signal: {err}"),
+                    });
+                }
+            }
+        }
+        _ = shutdown.requested() => {
+            if let Some(reason) = shutdown.reason() {
+                error!(?reason, "Shutdown requested");
+            }
+        }
     }
 }

--- a/test-integration/test-committor-service/tests/test_ix_commit_local.rs
+++ b/test-integration/test-committor-service/tests/test_ix_commit_local.rs
@@ -250,6 +250,7 @@ async fn commit_single_account(
         ChainConfig::local(ComputeBudgetConfig::new(1_000_000)),
         None,
         common::MockActionsCallbackExecutor::default(),
+        None,
     )
     .unwrap();
     let service = CommittorServiceExt::new(Arc::new(service));
@@ -333,6 +334,7 @@ async fn commit_book_order_account(
         ChainConfig::local(ComputeBudgetConfig::new(1_000_000)),
         None,
         common::MockActionsCallbackExecutor::default(),
+        None,
     )
     .unwrap();
     let service = CommittorServiceExt::new(Arc::new(service));
@@ -807,6 +809,7 @@ async fn commit_multiple_accounts(
         ChainConfig::local(ComputeBudgetConfig::new(1_000_000)),
         None,
         common::MockActionsCallbackExecutor::default(),
+        None,
     )
     .unwrap();
     let service = CommittorServiceExt::new(Arc::new(service));
@@ -877,6 +880,7 @@ async fn execute_intent_bundle(
         ChainConfig::local(ComputeBudgetConfig::new(1_000_000)),
         None,
         common::MockActionsCallbackExecutor::default(),
+        None,
     )
     .unwrap();
     let service = CommittorServiceExt::new(Arc::new(service));


### PR DESCRIPTION
## Summary

Introduces a process-wide shutdown coordinator in `magicblock-core` and wires the validator main loop and committor service to request graceful shutdown on unrecoverable errors instead of failing silently or calling `process::exit`.

## Changes

- **`magicblock-core::shutdown`**
  - `ShutdownHandle`, `ShutdownReason`, `init_global` / `trigger_shutdown` / `global`
  - `spawn_critical` for long-lived tasks that must not exit unexpectedly
  - `request_fatal_shutdown` helper (explicit handle or global fallback)

- **`magicblock-validator` / `magicblock-api`**
  - `MagicValidator` owns the coordinator and registers it globally at startup
  - Main loop waits on operator signal **or** coordinator shutdown, then runs existing teardown
  - Committor service receives `Some(shutdown)` from the validator

- **`magicblock-committor-service`**
  - Intent execution engine escalates DB errors, poisoned mutex, executor panics, and unexpected stops
  - Persist failures in `schedule_intent_bundle` trigger fatal shutdown
  - Committor actor spawned via `spawn_critical` when shutdown is configured
  - `try_start(..., shutdown: Option<ShutdownHandle>)` — `None` preserves prior test/integration behavior

## Breaking Changes
- [x] None

## Test Plan

- [x] `cargo test -p magicblock-core shutdown::` — coordinator + `request_fatal_shutdown` (6 tests)
- [x] `cargo test -p magicblock-committor-service` — full crate suite (92 tests), including:
  - `db_fetch_error_triggers_shutdown`
  - `unexpected_engine_stop_triggers_shutdown`
  - `engine_stop_after_shutdown_is_not_fatal`
- [x] `cargo check -p magicblock-api -p magicblock-validator`

Not run: full integration test suite / live validator restart.

## Notes
This PR just introduces the idea of `graceful shutdown` as discussed in [this issue](https://github.com/magicblock-labs/magicblock-validator/issues/524), with only the `magicblock-commitor-service` affected currently.
If the approach feels right after some reviews, I'd wanna continue my efforts and create follow-up PRs to migrate the rest of the core crates & cleanup for current behaviour(as is done today using `AtomicBool`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a global coordinated shutdown handle accessible across validator and committor components, plus a public shutdown-wait helper.

* **Bug Fixes**
  * Trigger fatal coordinated shutdown on unrecoverable engine, persistence, or actor failures to avoid silent stops.

* **Improvements**
  * Safer lock/error handling, clearer shutdown reasons (signal vs fatal), and tasks that detect unexpected exits.

* **Tests**
  * Added tests covering fatal shutdown paths and shutdown propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->