### PR TITLE
fix: Discard zero grpc batch size and use default instead

### DIFF
--- a/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/stream_manager.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/stream_manager.rs
@@ -1,4 +1,7 @@
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    num::NonZeroUsize,
+};
 
 use helius_laserstream::grpc::{
     CommitmentLevel, SubscribeRequest, SubscribeRequestFilterAccounts,
@@ -53,7 +56,7 @@ impl StreamKey {
 #[derive(Debug, Clone, Copy)]
 pub struct StreamManagerConfig {
     /// Max subscriptions per optimized old stream chunk.
-    pub max_subs_in_old_optimized: usize,
+    pub max_subs_in_old_optimized: NonZeroUsize,
     /// Max unoptimized old streams before optimization is triggered.
     pub max_old_unoptimized: usize,
     /// Max subscriptions in the current-new stream before it is
@@ -219,7 +222,7 @@ impl<S: StreamHandle, SF: StreamFactory<S>> StreamManager<S, SF> {
         // account for any existing current_new_subs so the combined
         // count never exceeds the limit. Subsequent chunks use the
         // full limit (since promotion clears current_new_subs).
-        let max = self.config.max_subs_in_old_optimized;
+        let max = self.config.max_subs_in_old_optimized.get();
         let remaining_capacity =
             max.saturating_sub(self.current_new_subs.len());
 
@@ -476,7 +479,7 @@ impl<S: StreamHandle, SF: StreamFactory<S>> StreamManager<S, SF> {
         let mut new_optimized_streams = Vec::new();
         let mut new_optimized_handles = Vec::new();
         for (i, chunk) in all_pks
-            .chunks(self.config.max_subs_in_old_optimized)
+            .chunks(self.config.max_subs_in_old_optimized.get())
             .enumerate()
         {
             let refs: Vec<&Pubkey> = chunk.iter().collect();
@@ -751,7 +754,7 @@ mod tests {
     // -----------------
     fn test_config() -> StreamManagerConfig {
         StreamManagerConfig {
-            max_subs_in_old_optimized: 10,
+            max_subs_in_old_optimized: NonZeroUsize::new(10).unwrap(),
             max_old_unoptimized: 3,
             max_subs_in_new: 5,
         }
@@ -1991,7 +1994,7 @@ mod tests {
         let batch = make_pubkeys(80);
         mgr.account_subscribe(&batch, &COMMITMENT, 0).await.unwrap();
 
-        let max = test_config().max_subs_in_old_optimized;
+        let max = test_config().max_subs_in_old_optimized.get();
 
         // Every request sent via subscribe() or handle.write()
         // must have at most `max` pubkeys.

--- a/magicblock-config/src/config/grpc.rs
+++ b/magicblock-config/src/config/grpc.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroUsize;
+
 use serde::{Deserialize, Serialize};
 
 /// Global configuration for gRPC-based providers (e.g., Helius Laser).
@@ -5,7 +7,7 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "kebab-case", deny_unknown_fields, default)]
 pub struct GrpcConfig {
     /// The maximum number of subscriptions that are added to a single optimized stream
-    pub max_subs_in_old_optimized: usize,
+    pub max_subs_in_old_optimized: NonZeroUsize,
     /// The maximum number of old unoptimized subscriptions streams allowed until optimization is triggered
     pub max_old_unoptimized: usize,
     /// The maximum number of subscriptions held in the current new stream which is updated frequently
@@ -18,7 +20,7 @@ pub struct GrpcConfig {
 impl Default for GrpcConfig {
     fn default() -> Self {
         Self {
-            max_subs_in_old_optimized: 5000,
+            max_subs_in_old_optimized: NonZeroUsize::new(5000).unwrap(),
             max_old_unoptimized: 5,
             max_subs_in_new: 400,
             max_time_without_optimization_secs: 60,

--- a/magicblock-config/src/config/grpc.rs
+++ b/magicblock-config/src/config/grpc.rs
@@ -20,7 +20,8 @@ pub struct GrpcConfig {
 impl Default for GrpcConfig {
     fn default() -> Self {
         Self {
-            max_subs_in_old_optimized: NonZeroUsize::new(5000).unwrap(),
+            max_subs_in_old_optimized: NonZeroUsize::new(5000)
+                .unwrap_or_else(|| unreachable!("Cannot create NonZero value")),
             max_old_unoptimized: 5,
             max_subs_in_new: 400,
             max_time_without_optimization_secs: 60,

--- a/magicblock-config/src/tests.rs
+++ b/magicblock-config/src/tests.rs
@@ -74,7 +74,7 @@ fn test_defaults_are_sane() {
     assert!(!config.accountsdb.defragment_on_startup);
 
     // gRPC defaults
-    assert_eq!(config.grpc.max_subs_in_old_optimized, 5000);
+    assert_eq!(config.grpc.max_subs_in_old_optimized.get(), 5000);
     assert_eq!(config.grpc.max_old_unoptimized, 5);
     assert_eq!(config.grpc.max_subs_in_new, 400);
     assert_eq!(config.grpc.max_time_without_optimization_secs, 60);
@@ -534,10 +534,21 @@ fn test_example_config_full_coverage() {
     // ========================================================================
     // 12. gRPC
     // ========================================================================
-    assert_eq!(config.grpc.max_subs_in_old_optimized, 5000);
+    assert_eq!(config.grpc.max_subs_in_old_optimized.get(), 5000);
     assert_eq!(config.grpc.max_old_unoptimized, 5);
     assert_eq!(config.grpc.max_subs_in_new, 400);
     assert_eq!(config.grpc.max_time_without_optimization_secs, 60);
+}
+
+#[test]
+#[serial]
+fn test_grpc_max_subs_in_old_optimized_zero_is_rejected() {
+    let _guard = EnvVarGuard::new("MBV_GRPC__MAX_SUBS_IN_OLD_OPTIMIZED", "0");
+    let itr = std::iter::once("validator").map(OsString::from);
+    assert!(
+        ValidatorParams::try_new(itr).is_err(),
+        "config with max_subs_in_old_optimized = 0 must be rejected at load"
+    );
 }
 
 #[test]
@@ -620,7 +631,7 @@ fn test_env_vars_full_coverage() {
     assert_eq!(config.aperture.event_processors, 9);
 
     // gRPC
-    assert_eq!(config.grpc.max_subs_in_old_optimized, 1337);
+    assert_eq!(config.grpc.max_subs_in_old_optimized.get(), 1337);
     assert_eq!(config.grpc.max_old_unoptimized, 7);
     assert_eq!(config.grpc.max_subs_in_new, 33);
     assert_eq!(config.grpc.max_time_without_optimization_secs, 42);


### PR DESCRIPTION
## Summary
 max_subs_in_old_optimized = 0 made the Laser stream manager call slice.chunks(0), panicking the gRPC actor on the first account subscription. Changed the field to NonZeroUsize so 0 is rejected at config load (TOML + env) and the chunks(0) panic never occurs.

## Test Plan
unit tests



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved type safety for the “max subscriptions in old optimized” configuration by requiring a non-zero value, preventing invalid zero settings at the configuration level.
  * Updated internal chunking logic and related config assertions to use the underlying numeric value from the validated setting.

* **Tests**
  * Added a test that sets the configuration value to `0` and verifies parsing/loading fails.
  * Updated existing tests to reflect the new validated, non-zero representation of the setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->