### PR TITLE
fix: various correctness related fixes

### DIFF
--- a/magicblock-aperture/src/requests/http/get_signature_statuses.rs
+++ b/magicblock-aperture/src/requests/http/get_signature_statuses.rs
@@ -1,3 +1,4 @@
+use solana_rpc_client_api::request::MAX_GET_SIGNATURE_STATUSES_QUERY_ITEMS;
 use solana_transaction_error::TransactionError;
 use solana_transaction_status::{
     TransactionConfirmationStatus, TransactionStatus,
@@ -23,6 +24,11 @@ impl HttpDispatcher {
     ) -> HandlerResult {
         let signatures = parse_params!(request.params()?, Vec<SerdeSignature>);
         let signatures: Vec<_> = some_or_err!(signatures);
+        if signatures.len() > MAX_GET_SIGNATURE_STATUSES_QUERY_ITEMS {
+            return Err(RpcError::invalid_params(
+                "too many signatures were requested, max allowed: 256",
+            ));
+        }
         let mut statuses = Vec::with_capacity(signatures.len());
 
         for signature in signatures.into_iter().map(Into::into) {

--- a/magicblock-aperture/src/requests/websocket/signature_subscribe.rs
+++ b/magicblock-aperture/src/requests/websocket/signature_subscribe.rs
@@ -29,20 +29,21 @@ impl WsDispatcher {
                 TransactionResultEncoder.encode(s.slot, &s.result, sub_id)
             });
 
-        let (id, subscribed) = if let Some(payload) = cached_status {
+        let id = if let Some(payload) = cached_status {
             // If already cached, send the notification immediately without creating
             // a persistent subscription.
             let _ = self.chan.tx.send(payload).await;
-            (sub_id, Default::default())
+            sub_id
         } else {
             // Otherwise, register a new one-shot subscription.
-            self.subscriptions
+            let (id, subscribed) = self
+                .subscriptions
                 .subscribe_to_signature(signature, self.chan.clone())
-                .await
+                .await;
+            self.signatures.push(signature, self.chan.id, subscribed);
+            id
         };
 
-        // Track the subscription in the per-connection expirer to prevent leaks.
-        self.signatures.push(signature, subscribed);
         Ok(SubResult::SubId(id))
     }
 }

--- a/magicblock-aperture/src/server/websocket/dispatch.rs
+++ b/magicblock-aperture/src/server/websocket/dispatch.rs
@@ -105,7 +105,9 @@ impl WsDispatcher {
         let signature = self.signatures.expire().await;
         // The subscription might have already been fulfilled and removed, so we
         // don't need to handle the case where `remove_async` finds nothing.
-        self.subscriptions.signatures.remove_async(&signature).await;
+        self.subscriptions
+            .remove_signature_subscriber(&signature.signature, signature.conid)
+            .await;
     }
 
     /// Handles a request to unsubscribe from a previously established subscription.
@@ -167,16 +169,4 @@ pub(crate) enum SubResult {
 pub(crate) struct WsDispatchResult {
     pub(crate) id: Value,
     pub(crate) result: SubResult,
-}
-
-impl Drop for WsDispatcher {
-    /// Ensures all of a client's pending `signatureSubscribe` requests
-    /// are removed from the global database when the client disconnects.
-    fn drop(&mut self) {
-        // Drain the per-connection cache and remove each corresponding entry from the
-        // global signature subscription database to prevent orphans (memory leak)
-        for s in self.signatures.cache.drain(..) {
-            self.subscriptions.signatures.remove(&s.signature);
-        }
-    }
 }

--- a/magicblock-aperture/src/server/websocket/mod.rs
+++ b/magicblock-aperture/src/server/websocket/mod.rs
@@ -21,6 +21,8 @@ use crate::{
     RpcResult,
 };
 
+const MAX_BODY_SIZE: usize = 1024 * 1024;
+
 /// The main WebSocket server.
 ///
 /// This server listens for TCP connections and manages the HTTP Upgrade handshake
@@ -127,7 +129,7 @@ async fn handle_upgrade(
     // Spawn a new task to manage the WebSocket communication, freeing up the
     // Hyper service to handle other potential incoming connections.
     tokio::spawn(async move {
-        let ws = match ws.await {
+        let mut ws = match ws.await {
             Ok(ws) => ws,
             Err(e) => {
                 warn!(
@@ -137,6 +139,7 @@ async fn handle_upgrade(
                 return;
             }
         };
+        ws.set_max_message_size(MAX_BODY_SIZE);
         // The `ConnectionHandler` will now take over the WebSocket stream.
         let handler = ConnectionHandler::new(ws, state);
         handler.run().await

--- a/magicblock-aperture/src/state/signatures.rs
+++ b/magicblock-aperture/src/state/signatures.rs
@@ -10,6 +10,8 @@ use std::{
 use solana_signature::Signature;
 use tokio::time::{self, Interval};
 
+use crate::server::websocket::connection::ConnectionID;
+
 /// Manages the lifecycle of `signatureSubscribe` websocket subscriptions.
 ///
 /// `signatureSubscribe` is a one-shot subscription, meaning it is fulfilled by a single
@@ -44,6 +46,8 @@ pub(crate) struct SignaturesExpirer {
 pub(crate) struct ExpiringSignature {
     /// The value of the expirer's `tick` at which this signature should expire.
     ttl: u64,
+    /// The connection whose subscription should expire.
+    pub(crate) conid: ConnectionID,
     /// The transaction signature being tracked.
     pub(crate) signature: Signature,
     /// A shared flag indicating if the subscription is still active. If the subscription
@@ -76,10 +80,12 @@ impl SignaturesExpirer {
     pub(crate) fn push(
         &mut self,
         signature: Signature,
+        conid: ConnectionID,
         subscribed: Arc<AtomicBool>,
     ) {
         let sig = ExpiringSignature {
             signature,
+            conid,
             ttl: self.tick + Self::TTL,
             subscribed,
         };
@@ -95,7 +101,7 @@ impl SignaturesExpirer {
     /// If an expired signature is found and is still marked as `subscribed`,
     /// this method returns it so that it can be removed from subscriptions
     /// database. If the subscription was resolved, it's silently discarded.
-    pub(crate) async fn expire(&mut self) -> Signature {
+    pub(crate) async fn expire(&mut self) -> ExpiringSignature {
         loop {
             // This inner block allows checking the queue multiple times per tick,
             // which efficiently clears out a batch of already-expired signatures.
@@ -117,9 +123,9 @@ impl SignaturesExpirer {
                     break 'expire;
                 };
 
-                // Only return the sibscription that hasn't resolved yet
+                // Only return the subscription that hasn't resolved yet.
                 if s.subscribed.load(Ordering::Relaxed) {
-                    return s.signature;
+                    return s;
                 }
             }
 

--- a/magicblock-aperture/src/state/subscriptions.rs
+++ b/magicblock-aperture/src/state/subscriptions.rs
@@ -35,7 +35,7 @@ pub(crate) type AccountSubscriptionsDb =
 /// Manages subscriptions to accounts owned by a specific program. Maps a program `Pubkey` to its subscribers.
 pub(crate) type ProgramSubscriptionsDb =
     Arc<scc::HashMap<Pubkey, UpdateSubscribers<ProgramAccountEncoder>>>;
-/// Manages one-shot subscriptions for transaction signature statuses. Maps a `Signature` to its subscriber.
+/// Manages one-shot subscriptions for transaction signature statuses.
 pub(crate) type SignatureSubscriptionsDb =
     Arc<scc::HashMap<Signature, UpdateSubscriber<TransactionResultEncoder>>>;
 /// Manages subscriptions to all transaction logs.
@@ -178,13 +178,32 @@ impl SubscriptionsDb {
         signature: Signature,
         chan: WsConnectionChannel,
     ) -> (SubscriptionID, Arc<AtomicBool>) {
-        let encoder = TransactionResultEncoder;
-        let subscriber = self
+        let mut subscriber = self
             .signatures
             .entry_async(signature)
             .await
-            .or_insert_with(|| UpdateSubscriber::new(Some(chan), encoder));
-        (subscriber.id, subscriber.live.clone())
+            .or_insert_with(|| {
+                UpdateSubscriber::new(None, TransactionResultEncoder)
+            });
+        subscriber.txs.insert(chan.id, chan.tx);
+        let id = subscriber.id;
+        let live = subscriber.live.clone();
+        (id, live)
+    }
+
+    /// Removes one pending signature subscription.
+    pub(crate) async fn remove_signature_subscriber(
+        &self,
+        signature: &Signature,
+        conid: ConnectionID,
+    ) {
+        let Some(mut entry) = self.signatures.get_async(signature).await else {
+            return;
+        };
+        entry.txs.remove(&conid);
+        if entry.txs.is_empty() {
+            let _ = entry.remove();
+        }
     }
 
     /// Sends a notification to a signature subscriber and removes the subscription.

--- a/magicblock-aperture/src/tests.rs
+++ b/magicblock-aperture/src/tests.rs
@@ -188,6 +188,38 @@ mod event_processor {
         assert_receives_update(&mut rx, "logs mentions subscription").await;
     }
 
+    /// Verifies that duplicate pending signature subscriptions are notified independently.
+    #[tokio::test]
+    async fn test_duplicate_signature_subscribers_receive_update() {
+        let (state, env) = setup();
+        let acc = env
+            .create_account_with_config(LAMPORTS_PER_SOL, 42, guinea::ID)
+            .pubkey();
+        let ix = Instruction::new_with_bincode(
+            guinea::ID,
+            &GuineaInstruction::PrintSizes,
+            vec![AccountMeta::new_readonly(acc, false)],
+        );
+        let txn = env.build_transaction(&[ix]);
+        let signature = txn.signatures[0];
+        let (tx1, mut rx1) = ws_channel();
+        let (tx2, mut rx2) = ws_channel();
+
+        let (_sig_sub1, _) = state
+            .subscriptions
+            .subscribe_to_signature(signature, tx1)
+            .await;
+        let (_sig_sub2, _) = state
+            .subscriptions
+            .subscribe_to_signature(signature, tx2)
+            .await;
+
+        env.execute_transaction(txn).await.unwrap();
+
+        assert_receives_update(&mut rx1, "first signature subscriber").await;
+        assert_receives_update(&mut rx2, "second signature subscriber").await;
+    }
+
     /// Verifies that multiple `slotSubscribe` clients receive updates for every new slot.
     #[tokio::test]
     async fn test_block_update() {

--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -1009,17 +1009,6 @@ impl MagicValidator {
         }
 
         let step_start = Instant::now();
-        self.slot_ticker = Some(init_slot_ticker(
-            self.accountsdb.clone(),
-            &self.scheduled_commits_processor,
-            self.ledger.latest_block().clone(),
-            self.config.ledger.block_time,
-            self.transaction_scheduler.clone(),
-            self.exit.clone(),
-        ));
-        log_timing("startup", "slot_ticker_start", step_start);
-
-        let step_start = Instant::now();
         self.ledger_truncator.start();
         log_timing("startup", "ledger_truncator_start", step_start);
 
@@ -1070,6 +1059,16 @@ impl MagicValidator {
                     }
                 }
             });
+            let step_start = Instant::now();
+            self.slot_ticker = Some(init_slot_ticker(
+                self.accountsdb.clone(),
+                &self.scheduled_commits_processor,
+                self.ledger.latest_block().clone(),
+                self.config.ledger.block_time,
+                self.transaction_scheduler.clone(),
+                self.exit.clone(),
+            ));
+            log_timing("startup", "slot_ticker_start", step_start);
         }
 
         Ok(())

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -50,9 +50,7 @@ mod types;
 
 pub use self::types::FetchAndCloneResult;
 use self::{
-    pending_clone_guard::{
-        CloneClaim, CloneCompletion, CloneKey, PendingCloneGuard,
-    },
+    pending_clone_guard::{CloneClaim, CloneCompletion, PendingCloneGuard},
     pending_operation::{
         claim_or_join_pending, finish_pending, Pending, PendingClaim,
         PendingFailure, PendingHandles, PendingOwner, PendingTerminal,
@@ -77,7 +75,9 @@ use crate::{
         AccountCloneRequest, Cloner, DelegationActions,
     },
     remote_account_provider::{
-        program_account::get_loaderv3_get_program_data_address,
+        program_account::{
+            get_loaderv3_get_program_data_address, LoadedProgram,
+        },
         pubsub_common::{is_internal_dlp_account_data, SubscriptionSource},
         CapacityEvictionProtection, ChainPubsubClient, ChainRpcClient,
         ForwardedSubscriptionUpdate, MatchSlotsConfig, RemoteAccount,
@@ -123,15 +123,13 @@ where
     /// Negative cache for derived eATAs confirmed missing on chain.
     known_empty_eatas: Arc<PlMutex<LruCache<Pubkey, ()>>>,
 
-    /// Tracks in-flight clone operations per (pubkey, slot).
+    /// Tracks in-flight clone operations.
     /// The first caller to claim a key becomes the owner and performs
     /// the actual clone. Subsequent callers become waiters and receive
     /// the result via oneshot channels. Prevents duplicate clone
     /// submissions across concurrent fetch and subscription paths.
     pending_clones: Arc<
-        Mutex<
-            hash_map::HashMap<CloneKey, Vec<oneshot::Sender<CloneCompletion>>>,
-        >,
+        Mutex<hash_map::HashMap<Pubkey, Vec<oneshot::Sender<CloneCompletion>>>>,
     >,
 
     pending_operation_timeout_ms: Arc<AtomicU64>,
@@ -330,17 +328,16 @@ where
         }
     }
 
-    /// Attempt to claim ownership of a clone operation for (pubkey, slot).
+    /// Attempt to claim ownership of a clone operation for a clone key.
     /// Returns `CloneClaim::Owner` if this caller is the first and should
     /// perform the clone. Returns `CloneClaim::Waiter(rx)` if another
     /// caller already owns this clone and this caller should wait.
-    fn claim_pending_clone(&self, pubkey: Pubkey, slot: u64) -> CloneClaim {
-        let key = (pubkey, slot);
+    fn claim_pending_clone(&self, pubkey: Pubkey) -> CloneClaim {
         let mut map = self
             .pending_clones
             .lock()
             .expect("pending_clones mutex poisoned");
-        match map.entry(key) {
+        match map.entry(pubkey) {
             hash_map::Entry::Vacant(entry) => {
                 entry.insert(Vec::new());
                 CloneClaim::Owner
@@ -355,19 +352,13 @@ where
 
     /// Called by the owner when the clone operation completes.
     /// Removes the pending entry and notifies all waiters.
-    fn finish_pending_clone(
-        &self,
-        pubkey: Pubkey,
-        slot: u64,
-        result: CloneCompletion,
-    ) {
-        let key = (pubkey, slot);
+    fn finish_pending_clone(&self, pubkey: Pubkey, result: CloneCompletion) {
         let waiters = {
             let mut map = self
                 .pending_clones
                 .lock()
                 .expect("pending_clones mutex poisoned");
-            map.remove(&key).unwrap_or_default()
+            map.remove(&pubkey).unwrap_or_default()
         };
         for tx in waiters {
             let _ = tx.send(result);
@@ -444,51 +435,152 @@ where
             .fetch_add(1, Ordering::Relaxed)
     }
 
+    fn local_account_satisfies_clone_request(
+        &self,
+        pubkey: &Pubkey,
+        request_account: &AccountSharedData,
+    ) -> bool {
+        self.accounts_bank
+            .get_account(pubkey)
+            .is_some_and(|account| {
+                let local_slot = account.remote_slot();
+                let request_slot = request_account.remote_slot();
+                local_slot > request_slot
+                    || (local_slot == request_slot
+                        && account == *request_account)
+            })
+    }
+
     /// Submits a clone request through ownership coordination.
-    /// Only one caller per (pubkey, slot) will actually submit the
-    /// clone transaction. All other concurrent callers wait for the
-    /// owner's result.
+    /// Only one account clone per pubkey is submitted at a time. Waiters
+    /// retry local freshness checks after a successful owner so a newer
+    /// request can clone after an older request finishes.
     async fn clone_account_with_ownership(
         &self,
         request: AccountCloneRequest,
     ) -> ClonerResult<Signature> {
         let pubkey = request.pubkey;
-        let slot = request.account.remote_slot();
+        let mut request = Some(request);
 
-        match self.claim_pending_clone(pubkey, slot) {
-            CloneClaim::Owner => {
-                let mut guard = PendingCloneGuard::new(
-                    Arc::clone(&self.pending_clones),
-                    pubkey,
-                    slot,
-                );
-                let result = self.cloner.clone_account(request).await;
-                let completion = if result.is_ok() {
-                    CloneCompletion::Success
-                } else {
-                    CloneCompletion::Failed
-                };
-                self.finish_pending_clone(pubkey, slot, completion);
-                guard.dismiss();
-                result
+        loop {
+            if self.local_account_satisfies_clone_request(
+                &pubkey,
+                &request
+                    .as_ref()
+                    .expect("request must be present before ownership claim")
+                    .account,
+            ) {
+                return Ok(Signature::default());
             }
-            CloneClaim::Waiter(rx) => match rx.await {
-                Ok(CloneCompletion::Success) => Ok(Signature::default()),
-                Ok(CloneCompletion::Failed) => {
-                    Err(ClonerError::FailedToCloneRegularAccount(
+
+            match self.claim_pending_clone(pubkey) {
+                CloneClaim::Owner => {
+                    let mut guard = PendingCloneGuard::new(
+                        Arc::clone(&self.pending_clones),
                         pubkey,
-                        Box::new(ClonerError::CommittorServiceError(
-                            "Clone owner failed".to_string(),
-                        )),
-                    ))
+                    );
+                    let result = self
+                        .cloner
+                        .clone_account(
+                            request
+                                .take()
+                                .expect("owner must still have request"),
+                        )
+                        .await;
+                    let completion = if result.is_ok() {
+                        CloneCompletion::Success
+                    } else {
+                        CloneCompletion::Failed
+                    };
+                    self.finish_pending_clone(pubkey, completion);
+                    guard.dismiss();
+                    return result;
                 }
-                Err(_) => Err(ClonerError::FailedToCloneRegularAccount(
-                    pubkey,
-                    Box::new(ClonerError::CommittorServiceError(
-                        "Clone owner dropped".to_string(),
-                    )),
-                )),
-            },
+                CloneClaim::Waiter(rx) => match rx.await {
+                    Ok(CloneCompletion::Success) => continue,
+                    Ok(CloneCompletion::Failed) => {
+                        return Err(ClonerError::FailedToCloneRegularAccount(
+                            pubkey,
+                            Box::new(ClonerError::CommittorServiceError(
+                                "Clone owner failed".to_string(),
+                            )),
+                        ));
+                    }
+                    Err(_) => {
+                        return Err(ClonerError::FailedToCloneRegularAccount(
+                            pubkey,
+                            Box::new(ClonerError::CommittorServiceError(
+                                "Clone owner dropped".to_string(),
+                            )),
+                        ));
+                    }
+                },
+            }
+        }
+    }
+
+    async fn clone_program_with_ownership(
+        &self,
+        program: LoadedProgram,
+    ) -> ClonerResult<Signature> {
+        let program_id = program.program_id;
+        let remote_slot = program.remote_slot;
+
+        loop {
+            if self
+                .accounts_bank
+                .get_account(&program_id)
+                .is_some_and(|account| account.remote_slot() >= remote_slot)
+            {
+                return Ok(Signature::default());
+            }
+
+            match self.claim_pending_clone(program_id) {
+                CloneClaim::Owner => {
+                    let mut guard = PendingCloneGuard::new(
+                        Arc::clone(&self.pending_clones),
+                        program_id,
+                    );
+
+                    let result = if self
+                        .accounts_bank
+                        .get_account(&program_id)
+                        .is_some_and(|account| {
+                            account.remote_slot() >= remote_slot
+                        }) {
+                        Ok(Signature::default())
+                    } else {
+                        self.cloner.clone_program(program).await
+                    };
+                    let completion = if result.is_ok() {
+                        CloneCompletion::Success
+                    } else {
+                        CloneCompletion::Failed
+                    };
+                    self.finish_pending_clone(program_id, completion);
+                    guard.dismiss();
+                    return result;
+                }
+                CloneClaim::Waiter(rx) => match rx.await {
+                    Ok(CloneCompletion::Success) => continue,
+                    Ok(CloneCompletion::Failed) => {
+                        return Err(ClonerError::FailedToCloneProgram(
+                            program_id,
+                            Box::new(ClonerError::CommittorServiceError(
+                                "Clone owner failed".to_string(),
+                            )),
+                        ));
+                    }
+                    Err(_) => {
+                        return Err(ClonerError::FailedToCloneProgram(
+                            program_id,
+                            Box::new(ClonerError::CommittorServiceError(
+                                "Clone owner dropped".to_string(),
+                            )),
+                        ));
+                    }
+                },
+            }
         }
     }
 

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -298,6 +298,17 @@ where
             .read(pubkey, |_, state| state.waiters.len())
     }
 
+    /// Returns the number of waiters currently joined to the low-level
+    /// clone operation keyed by `pubkey`, or `None` if no clone is pending.
+    #[cfg(any(test, feature = "dev-context"))]
+    pub fn pending_clone_waiter_count(&self, pubkey: &Pubkey) -> Option<usize> {
+        let map = self
+            .pending_clones
+            .lock()
+            .expect("pending_clones mutex poisoned");
+        map.get(pubkey).map(Vec::len)
+    }
+
     /// Cancels the in-flight fetch+clone owner for `pubkey`, if one exists.
     pub fn cancel_pending(&self, pubkey: &Pubkey) {
         self.pending_requests

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/pending_clone_guard.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/pending_clone_guard.rs
@@ -6,8 +6,6 @@ use std::{
 use solana_pubkey::Pubkey;
 use tokio::sync::oneshot;
 
-pub(super) type CloneKey = (Pubkey, u64);
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum CloneCompletion {
     Success,
@@ -24,11 +22,9 @@ pub(super) enum CloneClaim {
 /// leaving waiters hanging forever.
 pub(super) struct PendingCloneGuard {
     pending_clones: Arc<
-        Mutex<
-            hash_map::HashMap<CloneKey, Vec<oneshot::Sender<CloneCompletion>>>,
-        >,
+        Mutex<hash_map::HashMap<Pubkey, Vec<oneshot::Sender<CloneCompletion>>>>,
     >,
-    key: CloneKey,
+    key: Pubkey,
     dismissed: bool,
 }
 
@@ -37,17 +33,16 @@ impl PendingCloneGuard {
         pending_clones: Arc<
             Mutex<
                 hash_map::HashMap<
-                    CloneKey,
+                    Pubkey,
                     Vec<oneshot::Sender<CloneCompletion>>,
                 >,
             >,
         >,
         pubkey: Pubkey,
-        slot: u64,
     ) -> Self {
         Self {
             pending_clones,
-            key: (pubkey, slot),
+            key: pubkey,
             dismissed: false,
         }
     }

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/pipeline.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/pipeline.rs
@@ -704,8 +704,10 @@ where
             debug!(program_id = %acc.program_id, "Skipping clone of program");
             continue;
         }
-        let cloner = this.cloner.clone();
-        program_join_set.spawn(async move { cloner.clone_program(acc).await });
+        let this_clone = this.clone();
+        program_join_set.spawn(async move {
+            this_clone.clone_program_with_ownership(acc).await
+        });
     }
     program_join_set
         .join_all()

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/program_loader.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/program_loader.rs
@@ -126,7 +126,7 @@ pub(crate) async fn handle_executable_sub_update<T, U, V, C>(
             return;
         }
     };
-    if let Err(err) = this.cloner.clone_program(loaded_program).await {
+    if let Err(err) = this.clone_program_with_ownership(loaded_program).await {
         warn!(pubkey = %pubkey, error = %err, "Failed to clone program into bank");
     }
 

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -374,6 +374,32 @@ async fn wait_for_pending_waiter_count(
     );
 }
 
+async fn wait_for_pending_clone_waiter_count(
+    fetch_cloner: &Arc<
+        FetchCloner<
+            ChainRpcClientMock,
+            ChainPubsubClientMock,
+            AccountsBankStub,
+            ClonerStub,
+        >,
+    >,
+    pubkey: Pubkey,
+    expected: usize,
+) {
+    let start = tokio::time::Instant::now();
+    let timeout = Duration::from_secs(2);
+    while fetch_cloner.pending_clone_waiter_count(&pubkey) != Some(expected)
+        && start.elapsed() < timeout
+    {
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    assert_eq!(
+        fetch_cloner.pending_clone_waiter_count(&pubkey),
+        Some(expected),
+        "pending clone waiter count for {pubkey} should be {expected}"
+    );
+}
+
 async fn wait_for_rpc_fetch_activity(
     rpc_client: &ChainRpcClientMock,
     expected_minimum: u64,
@@ -2739,7 +2765,7 @@ async fn test_concurrent_same_slot_program_clone_submits_once() {
         validator_keypair.insecure_clone(),
     )
     .await;
-    cloner.set_program_clone_delay(Duration::from_millis(200));
+    cloner.block_clone_completion();
 
     let program = loaded_test_program(program_id, CURRENT_SLOT, vec![1, 2, 3]);
     let first_task = {
@@ -2757,6 +2783,8 @@ async fn test_concurrent_same_slot_program_clone_submits_once() {
             fetch_cloner.clone_program_with_ownership(program).await
         })
     };
+    wait_for_pending_clone_waiter_count(&fetch_cloner, program_id, 1).await;
+    cloner.allow_clone_completion();
 
     first_task.await.unwrap().unwrap();
     second_task.await.unwrap().unwrap();
@@ -2799,7 +2827,7 @@ async fn test_newer_program_clone_waits_then_replaces_older_slot() {
         validator_keypair.insecure_clone(),
     )
     .await;
-    cloner.set_program_clone_delay(Duration::from_millis(200));
+    cloner.block_clone_completion();
 
     let old_program = loaded_test_program(program_id, OLD_SLOT, vec![1, 2, 3]);
     let new_program = loaded_test_program(program_id, NEW_SLOT, vec![4, 5, 6]);
@@ -2818,6 +2846,8 @@ async fn test_newer_program_clone_waits_then_replaces_older_slot() {
             fetch_cloner.clone_program_with_ownership(new_program).await
         })
     };
+    wait_for_pending_clone_waiter_count(&fetch_cloner, program_id, 1).await;
+    cloner.allow_clone_completion();
 
     old_task.await.unwrap().unwrap();
     new_task.await.unwrap().unwrap();
@@ -5593,10 +5623,8 @@ async fn test_fetch_subscription_race_duplicate_clone() {
     )
     .await;
 
-    // Clone delay ensures both paths enter clone_account_with_ownership
-    // before the owner finishes, so the second caller becomes a waiter.
     let cloner_stub = Arc::new(ClonerStub::new(accounts_bank.clone()));
-    cloner_stub.set_clone_delay(std::time::Duration::from_millis(200));
+    cloner_stub.block_clone_completion();
 
     let (subscription_tx, subscription_rx) = mpsc::channel(100);
     let fetch_cloner = FetchCloner::new(
@@ -5646,6 +5674,8 @@ async fn test_fetch_subscription_race_duplicate_clone() {
             .await
         })
     };
+    wait_for_pending_clone_waiter_count(&fetch_cloner, account_pubkey, 1).await;
+    cloner_stub.allow_clone_completion();
 
     let fetch_result = fetch_task.await.unwrap();
     assert!(
@@ -5725,7 +5755,7 @@ async fn test_newer_account_clone_waits_then_replaces_older_slot() {
     .await;
 
     let cloner_stub = Arc::new(ClonerStub::new(accounts_bank.clone()));
-    cloner_stub.set_clone_delay(Duration::from_millis(300));
+    cloner_stub.block_clone_completion();
 
     let (subscription_tx, subscription_rx) = mpsc::channel(100);
     let fetch_cloner = FetchCloner::new(
@@ -5776,6 +5806,8 @@ async fn test_newer_account_clone_waits_then_replaces_older_slot() {
                 .await
         })
     };
+    wait_for_pending_clone_waiter_count(&fetch_cloner, account_pubkey, 1).await;
+    cloner_stub.allow_clone_completion();
 
     let newer_result = newer_task.await.unwrap();
     assert!(

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -217,6 +217,21 @@ fn insert_plain_ata_in_bank(
     accounts_bank.insert(ata_pubkey, ata_account);
 }
 
+fn loaded_test_program(
+    program_id: Pubkey,
+    remote_slot: u64,
+    program_data: Vec<u8>,
+) -> crate::remote_account_provider::program_account::LoadedProgram {
+    crate::remote_account_provider::program_account::LoadedProgram {
+        program_id,
+        authority: random_pubkey(),
+        program_data,
+        loader: crate::remote_account_provider::program_account::RemoteProgramLoader::V4,
+        loader_status: solana_loader_v4_interface::state::LoaderV4Status::Deployed,
+        remote_slot,
+    }
+}
+
 fn create_non_raw_eata_owned_account(
     pubkey: Pubkey,
     data_len: usize,
@@ -2704,6 +2719,129 @@ async fn test_allowed_programs_empty_allows_all() {
         accounts_bank.get_account(&program_id2).is_some(),
         "Program 2 should be in the bank (empty allowed_programs allows all)"
     );
+}
+
+#[tokio::test]
+async fn test_concurrent_same_slot_program_clone_submits_once() {
+    init_logger();
+    let validator_keypair = Keypair::new();
+    let program_id = random_pubkey();
+    const CURRENT_SLOT: u64 = 100;
+
+    let FetcherTestCtx {
+        accounts_bank,
+        fetch_cloner,
+        cloner,
+        ..
+    } = setup(
+        std::iter::empty::<(Pubkey, Account)>(),
+        CURRENT_SLOT,
+        validator_keypair.insecure_clone(),
+    )
+    .await;
+    cloner.set_program_clone_delay(Duration::from_millis(200));
+
+    let program = loaded_test_program(program_id, CURRENT_SLOT, vec![1, 2, 3]);
+    let first_task = {
+        let fetch_cloner = fetch_cloner.clone();
+        let program = program.clone();
+        tokio::spawn(async move {
+            fetch_cloner.clone_program_with_ownership(program).await
+        })
+    };
+    cloner.wait_for_program_clone_count(1).await;
+
+    let second_task = {
+        let fetch_cloner = fetch_cloner.clone();
+        tokio::spawn(async move {
+            fetch_cloner.clone_program_with_ownership(program).await
+        })
+    };
+
+    first_task.await.unwrap().unwrap();
+    second_task.await.unwrap().unwrap();
+
+    assert_eq!(
+        cloner.program_clone_count(),
+        1,
+        "same-slot concurrent program clones should share the owner result"
+    );
+    assert_eq!(
+        cloner.max_active_program_clones(),
+        1,
+        "program clone submissions must not run concurrently"
+    );
+    assert_eq!(
+        accounts_bank
+            .get_account(&program_id)
+            .expect("program should be in bank")
+            .remote_slot(),
+        CURRENT_SLOT
+    );
+}
+
+#[tokio::test]
+async fn test_newer_program_clone_waits_then_replaces_older_slot() {
+    init_logger();
+    let validator_keypair = Keypair::new();
+    let program_id = random_pubkey();
+    const OLD_SLOT: u64 = 100;
+    const NEW_SLOT: u64 = 101;
+
+    let FetcherTestCtx {
+        accounts_bank,
+        fetch_cloner,
+        cloner,
+        ..
+    } = setup(
+        std::iter::empty::<(Pubkey, Account)>(),
+        NEW_SLOT,
+        validator_keypair.insecure_clone(),
+    )
+    .await;
+    cloner.set_program_clone_delay(Duration::from_millis(200));
+
+    let old_program = loaded_test_program(program_id, OLD_SLOT, vec![1, 2, 3]);
+    let new_program = loaded_test_program(program_id, NEW_SLOT, vec![4, 5, 6]);
+
+    let old_task = {
+        let fetch_cloner = fetch_cloner.clone();
+        tokio::spawn(async move {
+            fetch_cloner.clone_program_with_ownership(old_program).await
+        })
+    };
+    cloner.wait_for_program_clone_count(1).await;
+
+    let new_task = {
+        let fetch_cloner = fetch_cloner.clone();
+        tokio::spawn(async move {
+            fetch_cloner.clone_program_with_ownership(new_program).await
+        })
+    };
+
+    old_task.await.unwrap().unwrap();
+    new_task.await.unwrap().unwrap();
+
+    assert_eq!(
+        cloner.program_clone_count(),
+        2,
+        "newer program update should clone after the older owner finishes"
+    );
+    assert_eq!(
+        cloner.max_active_program_clones(),
+        1,
+        "program clone submissions must not run concurrently"
+    );
+
+    let in_bank = accounts_bank
+        .get_account(&program_id)
+        .expect("program should be in bank");
+    assert_eq!(in_bank.remote_slot(), NEW_SLOT);
+    let cloned_program = cloner
+        .get_cloned_program(&program_id)
+        .expect("program clone should be recorded");
+    assert_eq!(cloned_program.remote_slot, NEW_SLOT);
+    assert_eq!(cloned_program.program_data, vec![4, 5, 6]);
 }
 
 // -----------------
@@ -5471,6 +5609,12 @@ async fn test_fetch_subscription_race_duplicate_clone() {
         None,
     );
 
+    acquire_direct_subscription_for_update(
+        &remote_account_provider,
+        &account_pubkey,
+    )
+    .await;
+
     // Send subscription update (this will become the owner).
     let subscription_account =
         crate::remote_account_provider::RemoteAccount::from_fresh_account(
@@ -5487,8 +5631,7 @@ async fn test_fetch_subscription_race_duplicate_clone() {
         .await
         .unwrap();
 
-    // Let subscription listener pick up the update and start cloning.
-    tokio::time::sleep(Duration::from_millis(20)).await;
+    cloner_stub.wait_for_account_clone_count(1).await;
 
     // Trigger concurrent fetch (becomes a waiter via pending_clones).
     let fetch_task = {
@@ -5528,10 +5671,144 @@ async fn test_fetch_subscription_race_duplicate_clone() {
         same_account_clones, 1,
         "Expected 1 clone request (ownership should prevent duplicate)"
     );
+    assert_eq!(
+        cloner_stub.account_clone_count(),
+        1,
+        "same-slot concurrent account clones should submit once"
+    );
+    assert_eq!(
+        cloner_stub.max_active_account_clones(),
+        1,
+        "same-slot account clone submissions must not run concurrently"
+    );
 
     assert!(
         accounts_bank.get_account(&account_pubkey).is_some(),
         "Account should be present in bank"
+    );
+}
+
+#[tokio::test]
+async fn test_newer_account_clone_waits_then_replaces_older_slot() {
+    init_logger();
+    let validator_keypair = Keypair::new();
+    let account_owner = random_pubkey();
+    const OLD_SLOT: u64 = 100;
+    const NEW_SLOT: u64 = OLD_SLOT + 1;
+
+    let account_pubkey = random_pubkey();
+    let old_account = Account {
+        lamports: 1_000_000,
+        data: vec![1; 4096],
+        owner: account_owner,
+        executable: false,
+        rent_epoch: 0,
+    };
+    let new_account = Account {
+        lamports: 2_000_000,
+        data: vec![2, 3, 5],
+        owner: account_owner,
+        executable: false,
+        rent_epoch: 0,
+    };
+
+    let FetcherTestCtx {
+        accounts_bank,
+        remote_account_provider,
+        rpc_client,
+        ..
+    } = setup(
+        [(account_pubkey, old_account.clone())],
+        OLD_SLOT,
+        validator_keypair.insecure_clone(),
+    )
+    .await;
+
+    let cloner_stub = Arc::new(ClonerStub::new(accounts_bank.clone()));
+    cloner_stub.set_clone_delay(Duration::from_millis(300));
+
+    let (subscription_tx, subscription_rx) = mpsc::channel(100);
+    let fetch_cloner = FetchCloner::new(
+        &remote_account_provider,
+        &accounts_bank,
+        &cloner_stub,
+        validator_keypair.insecure_clone(),
+        subscription_rx,
+        None,
+        None,
+    );
+
+    acquire_direct_subscription_for_update(
+        &remote_account_provider,
+        &account_pubkey,
+    )
+    .await;
+
+    let old_subscription_account =
+        crate::remote_account_provider::RemoteAccount::from_fresh_account(
+            old_account.clone(),
+            OLD_SLOT,
+            crate::remote_account_provider::RemoteAccountUpdateSource::Subscription,
+        );
+    subscription_tx
+        .send(ForwardedSubscriptionUpdate {
+            pubkey: account_pubkey,
+            account: old_subscription_account,
+            source: SubscriptionSource::Account,
+        })
+        .await
+        .unwrap();
+    cloner_stub.wait_for_account_clone_count(1).await;
+
+    rpc_client.set_slot(NEW_SLOT);
+    rpc_client.add_account(account_pubkey, new_account.clone());
+
+    let newer_task = {
+        let fetch_cloner = fetch_cloner.clone();
+        tokio::spawn(async move {
+            fetch_cloner
+                .fetch_and_clone_accounts_with_dedup(
+                    &[account_pubkey],
+                    None,
+                    Some(NEW_SLOT),
+                    AccountFetchOrigin::GetAccount,
+                )
+                .await
+        })
+    };
+
+    let newer_result = newer_task.await.unwrap();
+    assert!(
+        newer_result.is_ok(),
+        "newer fetch should succeed, got: {:?}",
+        newer_result
+    );
+
+    assert_eq!(
+        cloner_stub.account_clone_count(),
+        2,
+        "newer account update should clone after the older owner finishes"
+    );
+    assert_eq!(
+        cloner_stub.max_active_account_clones(),
+        1,
+        "account clone submissions for one pubkey must not run concurrently"
+    );
+
+    let requests = cloner_stub.clone_requests();
+    assert_eq!(
+        requests
+            .iter()
+            .map(|request| request.account.remote_slot())
+            .collect::<Vec<_>>(),
+        vec![OLD_SLOT, NEW_SLOT]
+    );
+    assert_cloned_undelegated_account!(
+        accounts_bank,
+        account_pubkey,
+        new_account,
+        NEW_SLOT,
+        account_owner
     );
 }
 

--- a/magicblock-chainlink/src/testing/cloner_stub.rs
+++ b/magicblock-chainlink/src/testing/cloner_stub.rs
@@ -3,7 +3,7 @@ use std::{
     collections::HashMap,
     fmt,
     sync::{
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicU64, Ordering},
         Arc, Mutex,
     },
     time::Duration,
@@ -35,6 +35,15 @@ pub struct ClonerStub {
     cloned_programs: Arc<Mutex<HashMap<Pubkey, LoadedProgram>>>,
     clone_requests: Arc<Mutex<Vec<AccountCloneRequest>>>,
     clone_delay: Arc<Mutex<Option<Duration>>>,
+    account_clone_count: Arc<AtomicU64>,
+    active_account_clones: Arc<AtomicU64>,
+    max_active_account_clones: Arc<AtomicU64>,
+    account_clone_notify: Arc<Notify>,
+    program_clone_delay: Arc<Mutex<Option<Duration>>>,
+    program_clone_count: Arc<AtomicU64>,
+    active_program_clones: Arc<AtomicU64>,
+    max_active_program_clones: Arc<AtomicU64>,
+    program_clone_notify: Arc<Notify>,
     fail_next_clone: Arc<Mutex<bool>>,
     block_clone_completion: Arc<AtomicBool>,
     clone_completion_notify: Arc<Notify>,
@@ -49,6 +58,15 @@ impl ClonerStub {
                 Arc::<Mutex<HashMap<Pubkey, LoadedProgram>>>::default(),
             clone_requests: Arc::new(Mutex::new(Vec::new())),
             clone_delay: Arc::new(Mutex::new(None)),
+            account_clone_count: Arc::new(AtomicU64::new(0)),
+            active_account_clones: Arc::new(AtomicU64::new(0)),
+            max_active_account_clones: Arc::new(AtomicU64::new(0)),
+            account_clone_notify: Arc::new(Notify::new()),
+            program_clone_delay: Arc::new(Mutex::new(None)),
+            program_clone_count: Arc::new(AtomicU64::new(0)),
+            active_program_clones: Arc::new(AtomicU64::new(0)),
+            max_active_program_clones: Arc::new(AtomicU64::new(0)),
+            program_clone_notify: Arc::new(Notify::new()),
             fail_next_clone: Arc::new(Mutex::new(false)),
             block_clone_completion: Arc::new(AtomicBool::new(false)),
             clone_completion_notify: Arc::new(Notify::new()),
@@ -61,6 +79,10 @@ impl ClonerStub {
 
     pub fn set_clone_delay(&self, delay: Duration) {
         *self.clone_delay.lock().unwrap() = Some(delay);
+    }
+
+    pub fn set_program_clone_delay(&self, delay: Duration) {
+        *self.program_clone_delay.lock().unwrap() = Some(delay);
     }
 
     pub fn block_clone_completion(&self) {
@@ -94,6 +116,42 @@ impl ClonerStub {
         self.cloned_programs.lock().unwrap().len()
     }
 
+    pub fn account_clone_count(&self) -> u64 {
+        self.account_clone_count.load(Ordering::SeqCst)
+    }
+
+    pub fn max_active_account_clones(&self) -> u64 {
+        self.max_active_account_clones.load(Ordering::SeqCst)
+    }
+
+    pub async fn wait_for_account_clone_count(&self, expected: u64) {
+        loop {
+            let notified = self.account_clone_notify.notified();
+            if self.account_clone_count() >= expected {
+                break;
+            }
+            notified.await;
+        }
+    }
+
+    pub fn program_clone_count(&self) -> u64 {
+        self.program_clone_count.load(Ordering::SeqCst)
+    }
+
+    pub fn max_active_program_clones(&self) -> u64 {
+        self.max_active_program_clones.load(Ordering::SeqCst)
+    }
+
+    pub async fn wait_for_program_clone_count(&self, expected: u64) {
+        loop {
+            let notified = self.program_clone_notify.notified();
+            if self.program_clone_count() >= expected {
+                break;
+            }
+            notified.await;
+        }
+    }
+
     #[allow(dead_code)]
     pub fn dump_account_keys(&self, include_blacklisted: bool) -> String {
         self.accounts_bank.dump_account_keys(include_blacklisted)
@@ -118,6 +176,13 @@ impl Cloner for ClonerStub {
         &self,
         request: AccountCloneRequest,
     ) -> ClonerResult<Signature> {
+        let active =
+            self.active_account_clones.fetch_add(1, Ordering::SeqCst) + 1;
+        self.max_active_account_clones
+            .fetch_max(active, Ordering::SeqCst);
+        self.account_clone_count.fetch_add(1, Ordering::SeqCst);
+        self.account_clone_notify.notify_waiters();
+
         self.clone_requests.lock().unwrap().push(request.clone());
         let delay = *self.clone_delay.lock().unwrap();
         if let Some(delay) = delay {
@@ -127,6 +192,7 @@ impl Cloner for ClonerStub {
             let mut should_fail = self.fail_next_clone.lock().unwrap();
             if *should_fail {
                 *should_fail = false;
+                self.active_account_clones.fetch_sub(1, Ordering::SeqCst);
                 return Err(
                     crate::cloner::errors::ClonerError::CommittorServiceError(
                         "Injected test failure".to_string(),
@@ -142,6 +208,7 @@ impl Cloner for ClonerStub {
             notified.await;
         }
         self.accounts_bank.insert(request.pubkey, request.account);
+        self.active_account_clones.fetch_sub(1, Ordering::SeqCst);
         Ok(Signature::default())
     }
 
@@ -160,6 +227,18 @@ impl Cloner for ClonerStub {
         use solana_program::rent::Rent;
 
         use crate::remote_account_provider::program_account::LOADER_V4;
+
+        let active =
+            self.active_program_clones.fetch_add(1, Ordering::SeqCst) + 1;
+        self.max_active_program_clones
+            .fetch_max(active, Ordering::SeqCst);
+        self.program_clone_count.fetch_add(1, Ordering::SeqCst);
+        self.program_clone_notify.notify_waiters();
+
+        let delay = *self.program_clone_delay.lock().unwrap();
+        if let Some(delay) = delay {
+            tokio::time::sleep(delay).await;
+        }
 
         // 1. Add the program account to the bank
         {
@@ -202,6 +281,7 @@ impl Cloner for ClonerStub {
                 .unwrap()
                 .insert(program.program_id, program);
         }
+        self.active_program_clones.fetch_sub(1, Ordering::SeqCst);
         Ok(Signature::default())
     }
 }

--- a/magicblock-chainlink/src/testing/cloner_stub.rs
+++ b/magicblock-chainlink/src/testing/cloner_stub.rs
@@ -164,6 +164,16 @@ impl ClonerStub {
     pub fn clone_request_count(&self) -> usize {
         self.clone_requests.lock().unwrap().len()
     }
+
+    async fn wait_for_clone_completion_allowed(&self) {
+        loop {
+            let notified = self.clone_completion_notify.notified();
+            if !self.block_clone_completion.load(Ordering::SeqCst) {
+                break;
+            }
+            notified.await;
+        }
+    }
 }
 
 #[cfg(any(test, feature = "dev-context"))]
@@ -200,13 +210,7 @@ impl Cloner for ClonerStub {
                 );
             }
         }
-        loop {
-            let notified = self.clone_completion_notify.notified();
-            if !self.block_clone_completion.load(Ordering::SeqCst) {
-                break;
-            }
-            notified.await;
-        }
+        self.wait_for_clone_completion_allowed().await;
         self.accounts_bank.insert(request.pubkey, request.account);
         self.active_account_clones.fetch_sub(1, Ordering::SeqCst);
         Ok(Signature::default())
@@ -239,6 +243,7 @@ impl Cloner for ClonerStub {
         if let Some(delay) = delay {
             tokio::time::sleep(delay).await;
         }
+        self.wait_for_clone_completion_allowed().await;
 
         // 1. Add the program account to the bank
         {

--- a/programs/magicblock/src/clone_account/process_finalize_buffer.rs
+++ b/programs/magicblock/src/clone_account/process_finalize_buffer.rs
@@ -17,7 +17,7 @@ use super::{
     adjust_authority_lamports, close_buffer_account, get_deploy_slot,
     loader_v4_state_to_bytes, minimum_balance, validate_authority,
 };
-use crate::validator::validator_authority_id;
+use crate::validator::effective_validator_authority_id;
 
 /// Finalizes a LoaderV4 program from a buffer account.
 ///
@@ -68,7 +68,7 @@ pub(crate) fn process_finalize_program_from_buffer(
     // Build LoaderV4 account data: header + ELF
     let state = LoaderV4State {
         slot: deploy_slot,
-        authority_address_or_next_version: validator_authority_id(),
+        authority_address_or_next_version: effective_validator_authority_id(),
         status: LoaderV4Status::Retracted, // Deploy instruction will activate it
     };
     let program_data = build_loader_v4_data(&state, &buf_data);

--- a/programs/magicblock/src/schedule_task/mod.rs
+++ b/programs/magicblock/src/schedule_task/mod.rs
@@ -13,7 +13,7 @@ use solana_log_collector::ic_msg;
 use solana_program_runtime::invoke_context::InvokeContext;
 use solana_pubkey::Pubkey;
 
-use crate::validator::validator_authority_id;
+use crate::validator::effective_validator_authority_id;
 
 // Assert that the task instructions do not have signers aside from the crank signer
 // Assert they don't use the validator either
@@ -39,7 +39,7 @@ pub(crate) fn validate_cranks_instructions(
                     "Crank ERR: the crank signer PDA cannot be a writable account in cranks",
                 );
                 return Err(InstructionError::Immutable);
-            } else if account.pubkey.eq(&validator_authority_id()) {
+            } else if account.pubkey.eq(&effective_validator_authority_id()) {
                 ic_msg!(
                     invoke_context,
                     "Crank ERR: the validator authority cannot be used in cranks",

--- a/programs/magicblock/src/schedule_task/process_execute_task.rs
+++ b/programs/magicblock/src/schedule_task/process_execute_task.rs
@@ -9,7 +9,7 @@ use solana_pubkey::Pubkey;
 use crate::{
     schedule_task::validate_cranks_instructions,
     utils::accounts::get_instruction_pubkey_with_idx,
-    validator::validator_authority_id,
+    validator::effective_validator_authority_id,
 };
 
 pub(crate) fn process_execute_crank(
@@ -55,7 +55,8 @@ pub(crate) fn process_execute_crank(
             transaction_context,
             VALIDATOR_IDX,
         )?;
-        if validator_pubkey != &validator_authority_id() {
+        let validator_authority = effective_validator_authority_id();
+        if validator_pubkey != &validator_authority {
             ic_msg!(
                 invoke_context,
                 "ExecuteCrank ERR: validator pubkey {} is not the expected validator",
@@ -113,7 +114,7 @@ mod test {
     use crate::{
         test_utils::process_instruction,
         utils::instruction_utils::InstructionUtils,
-        validator::init_validator_authority,
+        validator::{init_validator_authority, validator_authority_id},
     };
 
     pub fn complex_ix(payer: Pubkey) -> Instruction {

--- a/programs/magicblock/src/schedule_transactions/mod.rs
+++ b/programs/magicblock/src/schedule_transactions/mod.rs
@@ -38,7 +38,7 @@ use crate::{
         get_instruction_account_with_idx, get_instruction_pubkey_with_idx,
         get_writable_with_idx, InstructionAccount,
     },
-    validator::validator_authority_id,
+    validator::effective_validator_authority_id,
 };
 
 pub(crate) const PAYER_IDX: u16 = 0;
@@ -243,7 +243,7 @@ pub(crate) fn validate_callback_accounts(
             return Err(InstructionError::IncorrectAuthority);
         }
 
-        if pubkey == &validator_authority_id() {
+        if pubkey == &effective_validator_authority_id() {
             ic_msg!(
                 invoke_context,
                 "{}: the validator authority cannot be used in callbacks",

--- a/programs/magicblock/src/schedule_transactions/process_execute_callback.rs
+++ b/programs/magicblock/src/schedule_transactions/process_execute_callback.rs
@@ -8,7 +8,7 @@ use solana_program_runtime::invoke_context::InvokeContext;
 use crate::{
     schedule_transactions::validate_callback_accounts,
     utils::accounts::get_instruction_pubkey_with_idx,
-    validator::validator_authority_id, Pubkey,
+    validator::effective_validator_authority_id, Pubkey,
 };
 
 const VALIDATOR_IDX: u16 = 0;
@@ -55,7 +55,8 @@ fn validate(
     // Only the validator can execute a callback
     let validator_pubkey =
         get_instruction_pubkey_with_idx(transaction_context, VALIDATOR_IDX)?;
-    if validator_pubkey != &validator_authority_id() {
+    let validator_authority = effective_validator_authority_id();
+    if validator_pubkey != &validator_authority {
         ic_msg!(
             invoke_context,
             "ExecuteCallback ERR: validator pubkey {} is not the expected validator",
@@ -97,13 +98,12 @@ mod tests {
     };
     use serial_test::serial;
     use solana_account::AccountSharedData;
-    use solana_instruction::{
-        error::InstructionError, AccountMeta, Instruction,
-    };
+    use solana_instruction::{error::InstructionError, AccountMeta};
     use solana_program_runtime::invoke_context::mock_process_instruction;
     use solana_pubkey::Pubkey;
 
     use crate::{
+        instruction_utils::InstructionUtils,
         magicblock_processor::CallbackEntrypoint,
         validator::{
             generate_validator_authority_if_needed, validator_authority_id,
@@ -111,12 +111,10 @@ mod tests {
     };
 
     fn make_data(inner_accounts: Vec<AccountMeta>) -> Vec<u8> {
+        let mut instruction = InstructionUtils::noop_instruction(0);
+        instruction.accounts = inner_accounts;
         bincode::serialize(&CallbackInstruction::ExecuteCallback {
-            instruction: Instruction {
-                program_id: Pubkey::new_unique(),
-                accounts: inner_accounts,
-                data: vec![],
-            },
+            instruction,
         })
         .unwrap()
     }


### PR DESCRIPTION
- bound the number on gSS request
- do not start slot ticker (actions drain) in non-primary mode
- apply replica authority override in all instruction processors
- limit websocket message size to 1MB
- serve duplicate signature subscritpions
- prevent race conditions cloning large accounts
- chainlink: prevent race conditions during cloning




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added a 1 MiB maximum WebSocket message size after upgrade.
* **Bug Fixes**
  * Enforced a limit of 256 signatures per signature-status request.
  * Improved WebSocket signature subscriptions for cached results and corrected cleanup of expired one-shot subscribers.
  * Prevented duplicate concurrent clone submissions by coordinating clone work per key and added additional cloning race coverage.
* **Chores**
  * Updated validator authority checks and related authorization/validation logic to use the effective validator authority.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->