### PR TITLE
Support newer sBPF v3 ELF layout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,8 +139,7 @@ dependencies = [
 [[package]]
 name = "agave-syscalls"
 version = "3.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5212f0b24fc37d4c844ae25b563d0cf5587d092912820c40f88d4b9b301148f8"
+source = "git+https://github.com/magicblock-labs/magicblock-svm.git?rev=05b75b685936f10ac482a16545a30b696f603350#05b75b685936f10ac482a16545a30b696f603350"
 dependencies = [
  "bincode",
  "libsecp256k1",
@@ -7553,7 +7552,7 @@ dependencies = [
 [[package]]
 name = "solana-account"
 version = "3.4.0"
-source = "git+https://github.com/magicblock-labs/magicblock-svm.git?rev=b501cdd#b501cdd58c187a167fcb19cc08f8f8e2688ecf1d"
+source = "git+https://github.com/magicblock-labs/magicblock-svm.git?rev=05b75b685936f10ac482a16545a30b696f603350#05b75b685936f10ac482a16545a30b696f603350"
 dependencies = [
  "bincode",
  "qualifier_attr",
@@ -7882,8 +7881,7 @@ dependencies = [
 [[package]]
 name = "solana-bpf-loader-program"
 version = "3.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "044a6c5327755992853454ea5ec495edd987dab53a6f9029e695bf0d43ab55dc"
+source = "git+https://github.com/magicblock-labs/magicblock-svm.git?rev=05b75b685936f10ac482a16545a30b696f603350#05b75b685936f10ac482a16545a30b696f603350"
 dependencies = [
  "agave-syscalls",
  "bincode",
@@ -8768,8 +8766,7 @@ dependencies = [
 [[package]]
 name = "solana-loader-v4-program"
 version = "3.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e88b98ba6b408fe6fcf180784fc378d07ae63100c7dd413ff97474b6de30c5d"
+source = "git+https://github.com/magicblock-labs/magicblock-svm.git?rev=05b75b685936f10ac482a16545a30b696f603350#05b75b685936f10ac482a16545a30b696f603350"
 dependencies = [
  "log",
  "solana-account 3.4.0",
@@ -9230,7 +9227,7 @@ dependencies = [
 [[package]]
 name = "solana-program-runtime"
 version = "3.1.12"
-source = "git+https://github.com/magicblock-labs/magicblock-svm.git?rev=b501cdd#b501cdd58c187a167fcb19cc08f8f8e2688ecf1d"
+source = "git+https://github.com/magicblock-labs/magicblock-svm.git?rev=05b75b685936f10ac482a16545a30b696f603350#05b75b685936f10ac482a16545a30b696f603350"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -9587,9 +9584,9 @@ checksum = "dcf09694a0fc14e5ffb18f9b7b7c0f15ecb6eac5b5610bf76a1853459d19daf9"
 
 [[package]]
 name = "solana-sbpf"
-version = "0.13.1"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15b079e08471a9dbfe1e48b2c7439c85aa2a055cbd54eddd8bd257b0a7dbb29"
+checksum = "733b3657a0fab205102b799dbe17f85d3972cf984232c1b0b108fa6ba438e382"
 dependencies = [
  "byteorder",
  "combine 3.8.1",
@@ -10065,7 +10062,7 @@ dependencies = [
 [[package]]
 name = "solana-svm"
 version = "3.1.12"
-source = "git+https://github.com/magicblock-labs/magicblock-svm.git?rev=b501cdd#b501cdd58c187a167fcb19cc08f8f8e2688ecf1d"
+source = "git+https://github.com/magicblock-labs/magicblock-svm.git?rev=05b75b685936f10ac482a16545a30b696f603350#05b75b685936f10ac482a16545a30b696f603350"
 dependencies = [
  "ahash 0.8.12",
  "log",
@@ -10435,7 +10432,7 @@ dependencies = [
 [[package]]
 name = "solana-transaction-context"
 version = "3.1.12"
-source = "git+https://github.com/magicblock-labs/magicblock-svm.git?rev=b501cdd#b501cdd58c187a167fcb19cc08f8f8e2688ecf1d"
+source = "git+https://github.com/magicblock-labs/magicblock-svm.git?rev=05b75b685936f10ac482a16545a30b696f603350#05b75b685936f10ac482a16545a30b696f603350"
 dependencies = [
  "bincode",
  "qualifier_attr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,7 +162,7 @@ serde_json = "1.0"
 serde_with = "3.16"
 serial_test = "3.2"
 sha3 = "0.10.8"
-solana-account = { git = "https://github.com/magicblock-labs/magicblock-svm.git", rev = "b501cdd" }
+solana-account = { git = "https://github.com/magicblock-labs/magicblock-svm.git", rev = "05b75b685936f10ac482a16545a30b696f603350" }
 solana-account-decoder = { version = "3.1" }
 solana-account-decoder-client-types = { version = "3.1" }
 solana-account-info = { version = "3.1" }
@@ -200,7 +200,7 @@ solana-program = "3.0"
 solana-program-error = { version = "3.0" }
 solana-program-option = { version = "3.0" }
 solana-program-pack = { version = "3.0" }
-solana-program-runtime = { git = "https://github.com/magicblock-labs/magicblock-svm.git", rev = "b501cdd" }
+solana-program-runtime = { git = "https://github.com/magicblock-labs/magicblock-svm.git", rev = "05b75b685936f10ac482a16545a30b696f603350" }
 solana-pubkey = { version = "3.0" }
 solana-pubsub-client = { version = "3.1" }
 solana-rent = { version = "3.0" }
@@ -222,7 +222,7 @@ solana-system-transaction = { version = "3.0" }
 solana-sysvar = { version = "3.0" }
 solana-timings = { package = "solana-svm-timings", version = "3.1" }
 solana-transaction = { version = "3.0" }
-solana-transaction-context = { git = "https://github.com/magicblock-labs/magicblock-svm.git", rev = "b501cdd", features = [
+solana-transaction-context = { git = "https://github.com/magicblock-labs/magicblock-svm.git", rev = "05b75b685936f10ac482a16545a30b696f603350", features = [
     "dev-context-only-utils"
 ] }
 solana-transaction-error = { version = "3.0" }
@@ -255,7 +255,7 @@ spl-token-2022 = { package = "spl-token-2022-interface", version = "2.1" }
 [workspace.dependencies.solana-svm]
 features = ["dev-context-only-utils"]
 git = "https://github.com/magicblock-labs/magicblock-svm.git"
-rev = "b501cdd"
+rev = "05b75b685936f10ac482a16545a30b696f603350"
 
 [workspace.dependencies.rocksdb]
 # Avoid the vendored bzip2 within rocksdb-sys that can cause linker conflicts
@@ -266,11 +266,14 @@ version = "0.22.0"
 # some solana dependencies have solana-storage-proto as dependency
 # we need to patch them with our version, because they use protobuf-src v1.1.0
 # and we use protobuf-src v2.1.1. Otherwise compilation fails
-solana-account = { git = "https://github.com/magicblock-labs/magicblock-svm.git", rev = "b501cdd" }
-solana-program-runtime = { git = "https://github.com/magicblock-labs/magicblock-svm.git", rev = "b501cdd" }
+agave-syscalls = { git = "https://github.com/magicblock-labs/magicblock-svm.git", rev = "05b75b685936f10ac482a16545a30b696f603350" }
+solana-account = { git = "https://github.com/magicblock-labs/magicblock-svm.git", rev = "05b75b685936f10ac482a16545a30b696f603350" }
+solana-bpf-loader-program = { git = "https://github.com/magicblock-labs/magicblock-svm.git", rev = "05b75b685936f10ac482a16545a30b696f603350" }
+solana-loader-v4-program = { git = "https://github.com/magicblock-labs/magicblock-svm.git", rev = "05b75b685936f10ac482a16545a30b696f603350" }
+solana-program-runtime = { git = "https://github.com/magicblock-labs/magicblock-svm.git", rev = "05b75b685936f10ac482a16545a30b696f603350" }
 solana-storage-proto = { path = "./storage-proto" }
-solana-svm = { git = "https://github.com/magicblock-labs/magicblock-svm.git", rev = "b501cdd" }
-solana-transaction-context = { git = "https://github.com/magicblock-labs/magicblock-svm.git", rev = "b501cdd" }
+solana-svm = { git = "https://github.com/magicblock-labs/magicblock-svm.git", rev = "05b75b685936f10ac482a16545a30b696f603350" }
+solana-transaction-context = { git = "https://github.com/magicblock-labs/magicblock-svm.git", rev = "05b75b685936f10ac482a16545a30b696f603350" }
 # Fork is used to enable `disable_manual_compaction` usage
 # Fork is based on commit d4e9e16 of rocksdb (parent commit of 0.23.0 release)
 # without patching update isn't possible due to conflict with solana deps

--- a/magicblock-processor/src/lib.rs
+++ b/magicblock-processor/src/lib.rs
@@ -111,6 +111,110 @@ pub fn build_svm_env(
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use solana_program_runtime::{
+        invoke_context::InvokeContext,
+        solana_sbpf::{ebpf, elf::Executable, program::SBPFVersion},
+    };
+
+    #[test]
+    fn loads_stripped_sbpf_v3_elf() {
+        let bytes = minimal_stripped_sbpf_v3_elf();
+        let runtime = BuiltinProgram::new_loader(Default::default());
+
+        let executable =
+            Executable::<InvokeContext>::load(&bytes, Arc::new(runtime))
+                .unwrap();
+        assert_eq!(executable.get_sbpf_version(), SBPFVersion::V3);
+    }
+
+    fn minimal_stripped_sbpf_v3_elf() -> Vec<u8> {
+        const ELF_HEADER_LEN: usize = 64;
+        const PROGRAM_HEADER_LEN: usize = 56;
+        const ET_DYN: u16 = 3;
+        const EM_BPF: u16 = 247;
+        const EV_CURRENT: u32 = 1;
+        const PT_LOAD: u32 = 1;
+        const PF_X: u32 = 1;
+        const PF_R: u32 = 4;
+
+        let text_offset = ELF_HEADER_LEN + PROGRAM_HEADER_LEN * 2;
+        let text_len = ebpf::INSN_SIZE as u64;
+        let mut bytes = Vec::with_capacity(text_offset + ebpf::INSN_SIZE);
+
+        bytes.extend_from_slice(&[
+            0x7f, b'E', b'L', b'F', 2, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ]);
+        push_u16(&mut bytes, ET_DYN);
+        push_u16(&mut bytes, EM_BPF);
+        push_u32(&mut bytes, EV_CURRENT);
+        push_u64(&mut bytes, ebpf::MM_BYTECODE_START);
+        push_u64(&mut bytes, ELF_HEADER_LEN as u64);
+        push_u64(&mut bytes, 0);
+        push_u32(&mut bytes, 3);
+        push_u16(&mut bytes, ELF_HEADER_LEN as u16);
+        push_u16(&mut bytes, PROGRAM_HEADER_LEN as u16);
+        push_u16(&mut bytes, 2);
+        push_u16(&mut bytes, 0);
+        push_u16(&mut bytes, 0);
+        push_u16(&mut bytes, 0);
+        assert_eq!(bytes.len(), ELF_HEADER_LEN);
+
+        push_program_header(
+            &mut bytes,
+            PT_LOAD,
+            PF_R,
+            text_offset as u64,
+            ebpf::MM_RODATA_START,
+            0,
+        );
+        push_program_header(
+            &mut bytes,
+            PT_LOAD,
+            PF_X,
+            text_offset as u64,
+            ebpf::MM_BYTECODE_START,
+            text_len,
+        );
+        assert_eq!(bytes.len(), text_offset);
+
+        bytes.extend_from_slice(&[ebpf::EXIT, 0, 0, 0, 0, 0, 0, 0]);
+        bytes
+    }
+
+    fn push_program_header(
+        bytes: &mut Vec<u8>,
+        p_type: u32,
+        p_flags: u32,
+        p_offset: u64,
+        p_vaddr: u64,
+        p_filesz: u64,
+    ) {
+        push_u32(bytes, p_type);
+        push_u32(bytes, p_flags);
+        push_u64(bytes, p_offset);
+        push_u64(bytes, p_vaddr);
+        push_u64(bytes, p_vaddr);
+        push_u64(bytes, p_filesz);
+        push_u64(bytes, p_filesz);
+        push_u64(bytes, ebpf::INSN_SIZE as u64);
+    }
+
+    fn push_u16(bytes: &mut Vec<u8>, value: u16) {
+        bytes.extend_from_slice(&value.to_le_bytes());
+    }
+
+    fn push_u32(bytes: &mut Vec<u8>, value: u32) {
+        bytes.extend_from_slice(&value.to_le_bytes());
+    }
+
+    fn push_u64(bytes: &mut Vec<u8>, value: u64) {
+        bytes.extend_from_slice(&value.to_le_bytes());
+    }
+}
+
 /// Helper to create and insert a feature account if it is missing.
 fn ensure_feature_account(
     accountsdb: &AccountsDb,

--- a/test-integration/Cargo.lock
+++ b/test-integration/Cargo.lock
@@ -217,8 +217,7 @@ dependencies = [
 [[package]]
 name = "agave-syscalls"
 version = "3.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5212f0b24fc37d4c844ae25b563d0cf5587d092912820c40f88d4b9b301148f8"
+source = "git+https://github.com/magicblock-labs/magicblock-svm.git?rev=05b75b685936f10ac482a16545a30b696f603350#05b75b685936f10ac482a16545a30b696f603350"
 dependencies = [
  "bincode",
  "libsecp256k1",
@@ -239,7 +238,7 @@ dependencies = [
  "solana-program-entrypoint 3.1.1",
  "solana-program-runtime",
  "solana-pubkey 3.0.0",
- "solana-sbpf",
+ "solana-sbpf 0.14.4",
  "solana-sdk-ids 3.1.0",
  "solana-secp256k1-recover 3.1.1",
  "solana-sha256-hasher 3.1.0",
@@ -1092,7 +1091,7 @@ dependencies = [
  "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "proc-macro2",
@@ -1112,7 +1111,7 @@ dependencies = [
  "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -2767,7 +2766,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75b8549488b4715defcb0d8a8a1c1c76a80661b5fa106b4ca0e7fce59d7d875"
 dependencies = [
- "five8_core 0.1.2",
+ "five8_core",
 ]
 
 [[package]]
@@ -2776,7 +2775,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23f76610e969fa1784327ded240f1e28a3fd9520c9cec93b636fcf62dd37f772"
 dependencies = [
- "five8_core 1.0.0",
+ "five8_core",
 ]
 
 [[package]]
@@ -2785,7 +2784,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26dec3da8bc3ef08f2c04f61eab298c3ab334523e55f076354d6d6f613799a7b"
 dependencies = [
- "five8_core 0.1.2",
+ "five8_core",
 ]
 
 [[package]]
@@ -2794,7 +2793,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a0f1728185f277989ca573a402716ae0beaaea3f76a8ff87ef9dd8fb19436c5"
 dependencies = [
- "five8_core 1.0.0",
+ "five8_core",
 ]
 
 [[package]]
@@ -2802,12 +2801,6 @@ name = "five8_core"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2551bf44bc5f776c15044b9b94153a00198be06743e262afaaa61f11ac7523a5"
-
-[[package]]
-name = "five8_core"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "059c31d7d36c43fe39d89e55711858b4da8be7eb6dabac23c7289b1a19489406"
 
 [[package]]
 name = "fixedbitset"
@@ -6978,7 +6971,7 @@ checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
  "heck 0.4.1",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -7019,7 +7012,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8587,7 +8580,7 @@ dependencies = [
 [[package]]
 name = "solana-account"
 version = "3.4.0"
-source = "git+https://github.com/magicblock-labs/magicblock-svm.git?rev=b501cdd#b501cdd58c187a167fcb19cc08f8f8e2688ecf1d"
+source = "git+https://github.com/magicblock-labs/magicblock-svm.git?rev=05b75b685936f10ac482a16545a30b696f603350#05b75b685936f10ac482a16545a30b696f603350"
 dependencies = [
  "bincode",
  "qualifier_attr",
@@ -9077,8 +9070,7 @@ dependencies = [
 [[package]]
 name = "solana-bpf-loader-program"
 version = "3.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "044a6c5327755992853454ea5ec495edd987dab53a6f9029e695bf0d43ab55dc"
+source = "git+https://github.com/magicblock-labs/magicblock-svm.git?rev=05b75b685936f10ac482a16545a30b696f603350#05b75b685936f10ac482a16545a30b696f603350"
 dependencies = [
  "agave-syscalls",
  "bincode",
@@ -9093,7 +9085,7 @@ dependencies = [
  "solana-program-entrypoint 3.1.1",
  "solana-program-runtime",
  "solana-pubkey 3.0.0",
- "solana-sbpf",
+ "solana-sbpf 0.14.4",
  "solana-sdk-ids 3.1.0",
  "solana-svm-feature-set 3.1.12",
  "solana-svm-log-collector",
@@ -10153,8 +10145,7 @@ dependencies = [
 [[package]]
 name = "solana-loader-v4-program"
 version = "3.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e88b98ba6b408fe6fcf180784fc378d07ae63100c7dd413ff97474b6de30c5d"
+source = "git+https://github.com/magicblock-labs/magicblock-svm.git?rev=05b75b685936f10ac482a16545a30b696f603350#05b75b685936f10ac482a16545a30b696f603350"
 dependencies = [
  "log",
  "solana-account 3.4.0",
@@ -10166,7 +10157,7 @@ dependencies = [
  "solana-packet",
  "solana-program-runtime",
  "solana-pubkey 3.0.0",
- "solana-sbpf",
+ "solana-sbpf 0.14.4",
  "solana-sdk-ids 3.1.0",
  "solana-svm-log-collector",
  "solana-svm-measure",
@@ -10724,7 +10715,7 @@ dependencies = [
 [[package]]
 name = "solana-program-runtime"
 version = "3.1.12"
-source = "git+https://github.com/magicblock-labs/magicblock-svm.git?rev=b501cdd#b501cdd58c187a167fcb19cc08f8f8e2688ecf1d"
+source = "git+https://github.com/magicblock-labs/magicblock-svm.git?rev=05b75b685936f10ac482a16545a30b696f603350#05b75b685936f10ac482a16545a30b696f603350"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -10746,7 +10737,7 @@ dependencies = [
  "solana-program-entrypoint 3.1.1",
  "solana-pubkey 3.0.0",
  "solana-rent 3.1.0",
- "solana-sbpf",
+ "solana-sbpf 0.14.4",
  "solana-sdk-ids 3.1.0",
  "solana-slot-hashes 3.0.2",
  "solana-stable-layout 3.0.1",
@@ -10810,7 +10801,7 @@ dependencies = [
  "solana-pubkey 3.0.0",
  "solana-rent 3.1.0",
  "solana-runtime",
- "solana-sbpf",
+ "solana-sbpf 0.13.1",
  "solana-sdk-ids 3.1.0",
  "solana-signer 3.0.0",
  "solana-stable-layout 3.0.1",
@@ -11378,6 +11369,20 @@ dependencies = [
  "byteorder",
  "combine 3.8.1",
  "hash32",
+ "log",
+ "rustc-demangle",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "solana-sbpf"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "733b3657a0fab205102b799dbe17f85d3972cf984232c1b0b108fa6ba438e382"
+dependencies = [
+ "byteorder",
+ "combine 3.8.1",
+ "hash32",
  "libc",
  "log",
  "rand 0.8.6",
@@ -11924,7 +11929,7 @@ dependencies = [
 [[package]]
 name = "solana-svm"
 version = "3.1.12"
-source = "git+https://github.com/magicblock-labs/magicblock-svm.git?rev=b501cdd#b501cdd58c187a167fcb19cc08f8f8e2688ecf1d"
+source = "git+https://github.com/magicblock-labs/magicblock-svm.git?rev=05b75b685936f10ac482a16545a30b696f603350#05b75b685936f10ac482a16545a30b696f603350"
 dependencies = [
  "ahash 0.8.12",
  "log",
@@ -12368,7 +12373,7 @@ dependencies = [
 [[package]]
 name = "solana-transaction-context"
 version = "3.1.12"
-source = "git+https://github.com/magicblock-labs/magicblock-svm.git?rev=b501cdd#b501cdd58c187a167fcb19cc08f8f8e2688ecf1d"
+source = "git+https://github.com/magicblock-labs/magicblock-svm.git?rev=05b75b685936f10ac482a16545a30b696f603350#05b75b685936f10ac482a16545a30b696f603350"
 dependencies = [
  "bincode",
  "qualifier_attr",
@@ -12378,7 +12383,7 @@ dependencies = [
  "solana-instructions-sysvar 3.0.1",
  "solana-pubkey 3.0.0",
  "solana-rent 3.1.0",
- "solana-sbpf",
+ "solana-sbpf 0.14.4",
  "solana-sdk-ids 3.1.0",
 ]
 

--- a/test-integration/Cargo.toml
+++ b/test-integration/Cargo.toml
@@ -80,7 +80,7 @@ schedulecommit-client = { path = "schedulecommit/client" }
 serde = "1.0.217"
 serial_test = "3.2.0"
 shlex = "1.3.0"
-solana-account = { git = "https://github.com/magicblock-labs/magicblock-svm.git", rev = "b501cdd" }
+solana-account = { git = "https://github.com/magicblock-labs/magicblock-svm.git", rev = "05b75b685936f10ac482a16545a30b696f603350" }
 solana-address-lookup-table-interface = "3.1"
 solana-commitment-config = "3.1.1"
 solana-compute-budget-interface = "3.0"
@@ -120,9 +120,12 @@ url = "2.5.0"
 solana-storage-proto = { path = "../storage-proto" }
 # same reason as above
 rocksdb = { git = "https://github.com/magicblock-labs/rust-rocksdb.git", rev = "6d975197" }
-solana-account = { git = "https://github.com/magicblock-labs/magicblock-svm.git", rev = "b501cdd" }
-solana-program-runtime = { git = "https://github.com/magicblock-labs/magicblock-svm.git", rev = "b501cdd" }
-solana-svm = { git = "https://github.com/magicblock-labs/magicblock-svm.git", rev = "b501cdd" }
-solana-transaction-context = { git = "https://github.com/magicblock-labs/magicblock-svm.git", rev = "b501cdd" }
+agave-syscalls = { git = "https://github.com/magicblock-labs/magicblock-svm.git", rev = "05b75b685936f10ac482a16545a30b696f603350" }
+solana-account = { git = "https://github.com/magicblock-labs/magicblock-svm.git", rev = "05b75b685936f10ac482a16545a30b696f603350" }
+solana-bpf-loader-program = { git = "https://github.com/magicblock-labs/magicblock-svm.git", rev = "05b75b685936f10ac482a16545a30b696f603350" }
+solana-loader-v4-program = { git = "https://github.com/magicblock-labs/magicblock-svm.git", rev = "05b75b685936f10ac482a16545a30b696f603350" }
+solana-program-runtime = { git = "https://github.com/magicblock-labs/magicblock-svm.git", rev = "05b75b685936f10ac482a16545a30b696f603350" }
+solana-svm = { git = "https://github.com/magicblock-labs/magicblock-svm.git", rev = "05b75b685936f10ac482a16545a30b696f603350" }
+solana-transaction-context = { git = "https://github.com/magicblock-labs/magicblock-svm.git", rev = "05b75b685936f10ac482a16545a30b696f603350" }
 # Fix libsodium for ARM builds - upstream crates.io version breaks Linux ARM binaries
 libsodium-rs = { git = "https://github.com/jedisct1/libsodium-rs.git", rev = "0397a6c5785233f9f2ac91f3eedc3cceb74e0060" }


### PR DESCRIPTION
Summary:
- Update the magicblock-svm fork revision so loader-v4 uses solana-sbpf 0.14.4 through the patched loader/syscall crates.
- Align the integration workspace SVM pins and lockfile with the root workspace.
- Add a regression test that builds a synthetic stripped sBPF v3 ELF in memory instead of using a dumped program binary.

Dependency:
- magicblock-labs/magicblock-svm#25