### PR TITLE
fix: improve ledger lockfile error

### DIFF
--- a/magicblock-aperture/src/requests/http/transaction_validation.rs
+++ b/magicblock-aperture/src/requests/http/transaction_validation.rs
@@ -10,7 +10,6 @@ use crate::{error::RpcError, RpcResult};
 // indices fit within a packet-bounded pubkey table (1232 / 32 = 38).
 const MAX_RUNTIME_PROGRAM_ID_INDEX_EXCLUSIVE: usize =
     1232 / size_of::<Pubkey>();
-const MAX_TX_ACCOUNT_LOCKS: usize = 1024;
 
 pub(super) fn validate_supported_transaction_shape(
     transaction: &VersionedTransaction,

--- a/magicblock-api/src/ledger.rs
+++ b/magicblock-api/src/ledger.rs
@@ -49,7 +49,7 @@ pub fn ledger_lockfile(ledger_path: &Path) -> RwLock<File> {
             .create(true)
             .truncate(false)
             .open(lockfile)
-            .unwrap(),
+            .expect(&format!("Unable to open ledger lockfile {}. Ensure proper permissions and disk space.", ledger_path.display())),
     )
 }
 

--- a/magicblock-api/src/ledger.rs
+++ b/magicblock-api/src/ledger.rs
@@ -49,7 +49,7 @@ pub fn ledger_lockfile(ledger_path: &Path) -> RwLock<File> {
             .create(true)
             .truncate(false)
             .open(lockfile)
-            .expect(&format!("Unable to open ledger lockfile {}. Ensure proper permissions and disk space.", ledger_path.display())),
+            .unwrap_or_else(|_| panic!("Unable to open ledger lockfile {}. Ensure proper permissions and disk space.", ledger_path.display())),
     )
 }
 


### PR DESCRIPTION
## Summary

Improves the ledger lockfile error message so failures to open the lockfile report the affected ledger path and point to likely causes such as permissions or disk space.

CLOSES: #1186


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved error messaging for lockfile operations, now providing clearer guidance including the lockfile path and suggestions for common issues like permissions or disk space problems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->