### PR TITLE
Add stripped sBPF v3 ELF regression test

### DIFF
--- a/magicblock-processor/src/lib.rs
+++ b/magicblock-processor/src/lib.rs
@@ -111,6 +111,116 @@ pub fn build_svm_env(
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use solana_program_runtime::{
+        invoke_context::InvokeContext,
+        solana_sbpf::{ebpf, elf::Executable, program::SBPFVersion},
+    };
+
+    use super::*;
+
+    #[test]
+    fn loads_stripped_sbpf_v3_elf() {
+        let bytes = minimal_stripped_sbpf_v3_elf();
+        let runtime = BuiltinProgram::new_loader(Default::default());
+
+        let executable =
+            Executable::<InvokeContext>::load(&bytes, Arc::new(runtime))
+                .unwrap();
+        assert_eq!(executable.get_sbpf_version(), SBPFVersion::V3);
+    }
+
+    fn minimal_stripped_sbpf_v3_elf() -> Vec<u8> {
+        const ELF_HEADER_LEN: usize = 64;
+        const PROGRAM_HEADER_LEN: usize = 56;
+        const ET_DYN: u16 = 3;
+        const EM_BPF: u16 = 247;
+        const EV_CURRENT: u32 = 1;
+        const PT_LOAD: u32 = 1;
+        const PF_X: u32 = 1;
+        const PF_R: u32 = 4;
+
+        let rodata_offset = ELF_HEADER_LEN + PROGRAM_HEADER_LEN * 3;
+        let rodata_len = ebpf::INSN_SIZE as u64;
+        let text_offset = rodata_offset + rodata_len as usize;
+        let text_len = ebpf::INSN_SIZE as u64;
+        let mut bytes = Vec::with_capacity(text_offset + text_len as usize);
+
+        bytes.extend_from_slice(&[
+            0x7f, b'E', b'L', b'F', 2, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ]);
+        push_u16(&mut bytes, ET_DYN);
+        push_u16(&mut bytes, EM_BPF);
+        push_u32(&mut bytes, EV_CURRENT);
+        push_u64(&mut bytes, ebpf::MM_BYTECODE_START);
+        push_u64(&mut bytes, ELF_HEADER_LEN as u64);
+        push_u64(&mut bytes, 0);
+        push_u32(&mut bytes, 3);
+        push_u16(&mut bytes, ELF_HEADER_LEN as u16);
+        push_u16(&mut bytes, PROGRAM_HEADER_LEN as u16);
+        push_u16(&mut bytes, 3);
+        push_u16(&mut bytes, 0);
+        push_u16(&mut bytes, 0);
+        push_u16(&mut bytes, 0);
+        assert_eq!(bytes.len(), ELF_HEADER_LEN);
+
+        push_program_header(
+            &mut bytes,
+            PT_LOAD,
+            PF_R,
+            rodata_offset as u64,
+            ebpf::MM_RODATA_START,
+            rodata_len,
+        );
+        push_program_header(
+            &mut bytes,
+            PT_LOAD,
+            PF_X,
+            text_offset as u64,
+            ebpf::MM_BYTECODE_START,
+            text_len,
+        );
+        push_program_header(&mut bytes, 0, 0, 0, 0, 0);
+        assert_eq!(bytes.len(), rodata_offset);
+
+        bytes.extend_from_slice(b"fake-ro\0");
+        assert_eq!(bytes.len(), text_offset);
+        bytes.extend_from_slice(&[ebpf::EXIT, 0, 0, 0, 0, 0, 0, 0]);
+        bytes
+    }
+
+    fn push_program_header(
+        bytes: &mut Vec<u8>,
+        p_type: u32,
+        p_flags: u32,
+        p_offset: u64,
+        p_vaddr: u64,
+        p_filesz: u64,
+    ) {
+        push_u32(bytes, p_type);
+        push_u32(bytes, p_flags);
+        push_u64(bytes, p_offset);
+        push_u64(bytes, p_vaddr);
+        push_u64(bytes, p_vaddr);
+        push_u64(bytes, p_filesz);
+        push_u64(bytes, p_filesz);
+        push_u64(bytes, ebpf::INSN_SIZE as u64);
+    }
+
+    fn push_u16(bytes: &mut Vec<u8>, value: u16) {
+        bytes.extend_from_slice(&value.to_le_bytes());
+    }
+
+    fn push_u32(bytes: &mut Vec<u8>, value: u32) {
+        bytes.extend_from_slice(&value.to_le_bytes());
+    }
+
+    fn push_u64(bytes: &mut Vec<u8>, value: u64) {
+        bytes.extend_from_slice(&value.to_le_bytes());
+    }
+}
+
 /// Helper to create and insert a feature account if it is missing.
 fn ensure_feature_account(
     accountsdb: &AccountsDb,


### PR DESCRIPTION
## Summary

- Add a processor unit test for loading a stripped sBPF v3 ELF.
- Build the ELF fixture in test code from a minimal fake program, avoiding any real program dump.
- Assert that the Solana 4 runtime stack recognizes the executable as `SBPFVersion::V3`.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p magicblock-processor loads_stripped_sbpf_v3_elf --locked`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit test coverage for SBPF v3 ELF file loading to verify correct behavior and enhance code reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->