### PR TITLE
Fix primary on-chain registration

### DIFF
--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -564,6 +564,15 @@ impl MagicValidator {
         matches!(replication_mode, ReplicationMode::Replica { .. })
     }
 
+    fn replication_mode_manages_onchain_registration(
+        replication_mode: &ReplicationMode,
+    ) -> bool {
+        matches!(
+            replication_mode,
+            ReplicationMode::Standalone | ReplicationMode::Primary(_)
+        )
+    }
+
     fn init_ledger(
         ledger_config: &LedgerConfig,
         storage: &Path,
@@ -688,7 +697,9 @@ impl MagicValidator {
             return;
         }
         if self.config.chain_operation.is_none()
-            || !self.is_standalone
+            || !Self::replication_mode_manages_onchain_registration(
+                &self.config.validator.replication_mode,
+            )
             || !matches!(self.config.lifecycle, LifecycleMode::Ephemeral)
             || !CoordinationMode::current().needs_onchain_interactions()
         {
@@ -991,6 +1002,12 @@ impl MagicValidator {
             }
         } else if let Some(replicator) = self.replication_service.take() {
             self.replication_handle.replace(replicator.spawn());
+            if Self::replication_mode_manages_onchain_registration(
+                &self.config.validator.replication_mode,
+            ) && matches!(self.config.lifecycle, LifecycleMode::Ephemeral)
+            {
+                self.spawn_primary_onchain_setup();
+            }
         }
 
         // Now we are ready to start all services and are ready to accept transactions
@@ -1237,5 +1254,35 @@ mod tests {
                 authority_override: SerdePubkey(Pubkey::new_unique()),
             },
         ));
+    }
+
+    #[test]
+    fn standalone_replication_mode_manages_onchain_registration() {
+        assert!(
+            MagicValidator::replication_mode_manages_onchain_registration(
+                &ReplicationMode::Standalone,
+            )
+        );
+    }
+
+    #[test]
+    fn primary_replication_mode_manages_onchain_registration() {
+        assert!(
+            MagicValidator::replication_mode_manages_onchain_registration(
+                &ReplicationMode::Primary(replication_config()),
+            )
+        );
+    }
+
+    #[test]
+    fn replica_replication_mode_does_not_manage_onchain_registration() {
+        assert!(
+            !MagicValidator::replication_mode_manages_onchain_registration(
+                &ReplicationMode::Replica {
+                    config: replication_config(),
+                    authority_override: SerdePubkey(Pubkey::new_unique()),
+                },
+            )
+        );
     }
 }

--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -564,6 +564,15 @@ impl MagicValidator {
         matches!(replication_mode, ReplicationMode::Replica { .. })
     }
 
+    fn replication_mode_manages_onchain_registration(
+        replication_mode: &ReplicationMode,
+    ) -> bool {
+        matches!(
+            replication_mode,
+            ReplicationMode::Standalone | ReplicationMode::Primary(_)
+        )
+    }
+
     fn init_ledger(
         ledger_config: &LedgerConfig,
         storage: &Path,
@@ -688,7 +697,9 @@ impl MagicValidator {
             return;
         }
         if self.config.chain_operation.is_none()
-            || !self.is_standalone
+            || !Self::replication_mode_manages_onchain_registration(
+                &self.config.validator.replication_mode,
+            )
             || !matches!(self.config.lifecycle, LifecycleMode::Ephemeral)
             || !CoordinationMode::current().needs_onchain_interactions()
         {
@@ -991,6 +1002,12 @@ impl MagicValidator {
             }
         } else if let Some(replicator) = self.replication_service.take() {
             self.replication_handle.replace(replicator.spawn());
+            if Self::replication_mode_manages_onchain_registration(
+                &self.config.validator.replication_mode,
+            ) && matches!(self.config.lifecycle, LifecycleMode::Ephemeral)
+            {
+                self.spawn_primary_onchain_setup();
+            }
         }
 
         // Now we are ready to start all services and are ready to accept transactions
@@ -998,7 +1015,11 @@ impl MagicValidator {
             .config
             .chain_operation
             .as_ref()
-            .filter(|_| self.is_standalone)
+            .filter(|_| {
+                Self::replication_mode_manages_onchain_registration(
+                    &self.config.validator.replication_mode,
+                )
+            })
             .filter(|co| !co.claim_fees_frequency.is_zero())
             .map(|co| co.claim_fees_frequency)
         {
@@ -1237,5 +1258,35 @@ mod tests {
                 authority_override: SerdePubkey(Pubkey::new_unique()),
             },
         ));
+    }
+
+    #[test]
+    fn standalone_replication_mode_manages_onchain_registration() {
+        assert!(
+            MagicValidator::replication_mode_manages_onchain_registration(
+                &ReplicationMode::Standalone,
+            )
+        );
+    }
+
+    #[test]
+    fn primary_replication_mode_manages_onchain_registration() {
+        assert!(
+            MagicValidator::replication_mode_manages_onchain_registration(
+                &ReplicationMode::Primary(replication_config()),
+            )
+        );
+    }
+
+    #[test]
+    fn replica_replication_mode_does_not_manage_onchain_registration() {
+        assert!(
+            !MagicValidator::replication_mode_manages_onchain_registration(
+                &ReplicationMode::Replica {
+                    config: replication_config(),
+                    authority_override: SerdePubkey(Pubkey::new_unique()),
+                },
+            )
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Treat standalone and primary replication modes as validators that manage on-chain registration.
- Spawn the existing primary on-chain setup for ephemeral primary nodes after replication starts.
- Start recurring fee claims for primary validators using the same primary/standalone eligibility predicate.
- Allow primary nodes through unregister eligibility while replicas remain excluded.

## Root cause
Primary replication mode started the replication service but skipped `spawn_primary_onchain_setup`, which was only called for standalone validators. After enabling primary registration, the recurring fee-claim task also needed to use the same primary/standalone eligibility instead of the older standalone-only gate.

## Validation
- `cargo test -p magicblock-api magic_validator::tests`
- `cargo check -p magicblock-api`