### PR TITLE
Add undelegation rescue for action clone failures

### DIFF
--- a/magicblock-account-cloner/src/lib.rs
+++ b/magicblock-account-cloner/src/lib.rs
@@ -198,6 +198,10 @@ impl ChainlinkCloner {
         )
     }
 
+    fn undelegation_rescue_ix(pubkey: Pubkey) -> Instruction {
+        InstructionUtils::schedule_undelegation_rescue_instruction(pubkey)
+    }
+
     fn finalize_program_ix(
         program: Pubkey,
         buffer: Pubkey,
@@ -651,6 +655,23 @@ impl Cloner for ChainlinkCloner {
         Ok(last_sig.unwrap_or_default())
     }
 
+    async fn schedule_undelegation_rescue(
+        &self,
+        pubkey: Pubkey,
+    ) -> ClonerResult<Signature> {
+        let blockhash = self.block.load().blockhash;
+        let tx = self.create_signed_tx(
+            &[Self::undelegation_rescue_ix(pubkey)],
+            blockhash,
+        );
+        self.send_tx(tx).await.map_err(|err| {
+            ClonerError::FailedToScheduleUndelegationRescue(
+                pubkey,
+                Box::new(err),
+            )
+        })
+    }
+
     async fn clone_program(
         &self,
         program: LoadedProgram,
@@ -809,6 +830,31 @@ mod tests {
                 assert_eq!(max_size, MAX_INLINE_TRANSACTION_SIZE);
             }
             err => panic!("unexpected error: {err:?}"),
+        }
+    }
+
+    #[test]
+    fn undelegation_rescue_ix_uses_specific_magic_instruction() {
+        magicblock_program::validator::generate_validator_authority_if_needed();
+        let pubkey = Pubkey::new_unique();
+        let ix = ChainlinkCloner::undelegation_rescue_ix(pubkey);
+
+        assert_eq!(ix.program_id, magicblock_program::ID);
+        assert_eq!(ix.accounts.len(), 3);
+        assert_eq!(
+            ix.accounts[0].pubkey,
+            magicblock_program::validator::validator_authority_id()
+        );
+        assert!(ix.accounts[0].is_signer);
+        assert!(ix.accounts[0].is_writable);
+        assert_eq!(ix.accounts[1].pubkey, MAGIC_CONTEXT_PUBKEY);
+        assert!(ix.accounts[1].is_writable);
+        assert_eq!(ix.accounts[2].pubkey, pubkey);
+        assert!(ix.accounts[2].is_writable);
+
+        match bincode::deserialize(&ix.data).unwrap() {
+            MagicBlockInstruction::ScheduleUndelegationRescue => {}
+            _ => panic!("expected schedule undelegation rescue instruction"),
         }
     }
 

--- a/magicblock-account-cloner/src/lib.rs
+++ b/magicblock-account-cloner/src/lib.rs
@@ -266,6 +266,23 @@ impl ChainlinkCloner {
         self.create_signed_tx(&ixs, blockhash)
     }
 
+    fn build_small_account_undelegation_rescue_tx(
+        &self,
+        request: &AccountCloneRequest,
+        blockhash: Hash,
+    ) -> Transaction {
+        let fields = Self::clone_fields(request);
+        let clone_ix = Self::clone_ix(
+            request.pubkey,
+            request.account.data().to_vec(),
+            fields,
+            Vec::new(),
+        );
+        let rescue_ix = Self::undelegation_rescue_ix(request.pubkey);
+
+        self.create_signed_tx(&[clone_ix, rescue_ix], blockhash)
+    }
+
     /// Builds crank commits instruction for periodic account commits.
     /// Currently disabled - see https://github.com/magicblock-labs/magicblock-validator/issues/625
     #[allow(dead_code)]
@@ -350,6 +367,67 @@ impl ChainlinkCloner {
                 Self::post_delegation_action_ix(request.pubkey, actions);
             txs.push(
                 self.create_signed_tx(&[continue_ix, action_ix], blockhash),
+            );
+        }
+
+        txs
+    }
+
+    fn build_large_account_undelegation_rescue_txs(
+        &self,
+        request: &AccountCloneRequest,
+        blockhash: Hash,
+    ) -> Vec<Transaction> {
+        let data = request.account.data();
+        let fields = Self::clone_fields(request);
+        let mut txs = Vec::new();
+
+        // Init tx with first chunk
+        let first_chunk = data[..MAX_INLINE_DATA_SIZE.min(data.len())].to_vec();
+        let init_ix = Self::clone_init_ix(
+            request.pubkey,
+            data.len() as u32,
+            first_chunk,
+            fields,
+        );
+        txs.push(self.create_signed_tx(&[init_ix], blockhash));
+
+        let rescue_ix = Self::undelegation_rescue_ix(request.pubkey);
+
+        // Continue txs for remaining chunks. The rescue schedule is attached
+        // only to the final continue, after the clone has completed.
+        let mut offset = MAX_INLINE_DATA_SIZE;
+        while offset < data.len() {
+            let end = (offset + MAX_INLINE_DATA_SIZE).min(data.len());
+            let chunk = data[offset..end].to_vec();
+            let is_last = end == data.len();
+
+            let continue_ix = Self::clone_continue_ix(
+                request.pubkey,
+                offset as u32,
+                chunk,
+                is_last,
+                Vec::new(),
+            );
+            let ixs = if is_last {
+                vec![continue_ix, rescue_ix.clone()]
+            } else {
+                vec![continue_ix]
+            };
+            txs.push(self.create_signed_tx(&ixs, blockhash));
+            offset = end;
+        }
+
+        if txs.len() == 1 {
+            let continue_ix = Self::clone_continue_ix(
+                request.pubkey,
+                data.len() as u32,
+                Vec::new(),
+                true,
+                Vec::new(),
+            );
+            txs.push(
+                self.create_signed_tx(&[continue_ix, rescue_ix], blockhash),
             );
         }
 
@@ -655,21 +733,60 @@ impl Cloner for ChainlinkCloner {
         Ok(last_sig.unwrap_or_default())
     }
 
-    async fn schedule_undelegation_rescue(
+    async fn clone_account_and_schedule_undelegation_rescue(
         &self,
-        pubkey: Pubkey,
+        request: AccountCloneRequest,
     ) -> ClonerResult<Signature> {
         let blockhash = self.block.load().blockhash;
-        let tx = self.create_signed_tx(
-            &[Self::undelegation_rescue_ix(pubkey)],
-            blockhash,
-        );
-        self.send_tx(tx).await.map_err(|err| {
-            ClonerError::FailedToScheduleUndelegationRescue(
-                pubkey,
-                Box::new(err),
-            )
-        })
+        let data_len = request.account.data().len();
+
+        if data_len <= MAX_INLINE_DATA_SIZE {
+            let tx = self.build_small_account_undelegation_rescue_tx(
+                &request, blockhash,
+            );
+            let tx_size = Self::transaction_size(&tx)?;
+            if tx_size <= MAX_INLINE_TRANSACTION_SIZE {
+                let signature = self.send_tx(tx).await.map_err(|err| {
+                    ClonerError::FailedToCloneAndScheduleUndelegationRescue(
+                        request.pubkey,
+                        Box::new(err),
+                    )
+                })?;
+
+                return Ok(signature);
+            }
+
+            debug!(
+                pubkey = %request.pubkey,
+                data_len,
+                tx_size,
+                "Small account clone and undelegation rescue transaction is too large, using chunked clone"
+            );
+        }
+
+        let txs = self
+            .build_large_account_undelegation_rescue_txs(&request, blockhash);
+        Self::ensure_transactions_fit(request.pubkey, &txs)?;
+
+        let mut last_sig = None;
+        for tx in txs {
+            match self.send_tx(tx).await {
+                Ok(sig) => {
+                    last_sig.replace(sig);
+                }
+                Err(e) => {
+                    self.send_cleanup(request.pubkey).await;
+                    return Err(
+                        ClonerError::FailedToCloneAndScheduleUndelegationRescue(
+                            request.pubkey,
+                            Box::new(e),
+                        ),
+                    );
+                }
+            }
+        }
+
+        Ok(last_sig.unwrap_or_default())
     }
 
     async fn clone_program(
@@ -853,6 +970,120 @@ mod tests {
         assert!(ix.accounts[2].is_writable);
 
         match bincode::deserialize(&ix.data).unwrap() {
+            MagicBlockInstruction::ScheduleUndelegationRescue => {}
+            _ => panic!("expected schedule undelegation rescue instruction"),
+        }
+    }
+
+    #[test]
+    fn small_undelegation_rescue_clone_schedules_in_same_tx_without_actions() {
+        let pubkey = Pubkey::new_unique();
+        let tx = cloner().build_small_account_undelegation_rescue_tx(
+            &request(pubkey, vec![1, 2, 3], vec![action()]),
+            Hash::default(),
+        );
+
+        assert_eq!(tx.message().instructions.len(), 2);
+        assert_eq!(instruction_program_id(&tx, 0), magicblock_program::ID);
+        assert_eq!(instruction_program_id(&tx, 1), magicblock_program::ID);
+
+        match bincode::deserialize(instruction_data(&tx, 0)).unwrap() {
+            MagicBlockInstruction::CloneAccount {
+                pubkey: clone_pubkey,
+                actions,
+                fields,
+                ..
+            } => {
+                assert_eq!(clone_pubkey, pubkey);
+                assert!(fields.delegated);
+                assert!(actions.is_empty());
+            }
+            _ => panic!("expected clone account instruction"),
+        }
+        match bincode::deserialize(instruction_data(&tx, 1)).unwrap() {
+            MagicBlockInstruction::ScheduleUndelegationRescue => {}
+            _ => panic!("expected schedule undelegation rescue instruction"),
+        }
+    }
+
+    #[test]
+    fn large_undelegation_rescue_clone_schedules_on_final_chunk_tx() {
+        let pubkey = Pubkey::new_unique();
+        let txs = cloner().build_large_account_undelegation_rescue_txs(
+            &request(pubkey, vec![7; MAX_INLINE_DATA_SIZE + 1], vec![action()]),
+            Hash::default(),
+        );
+
+        assert_eq!(txs.len(), 2);
+
+        let final_tx = txs.last().unwrap();
+        assert_eq!(final_tx.message().instructions.len(), 2);
+        assert_eq!(instruction_program_id(final_tx, 0), magicblock_program::ID);
+        assert_eq!(instruction_program_id(final_tx, 1), magicblock_program::ID);
+
+        match bincode::deserialize(instruction_data(final_tx, 0)).unwrap() {
+            MagicBlockInstruction::CloneAccountContinue {
+                pubkey: continue_pubkey,
+                offset,
+                data,
+                is_last,
+                actions,
+            } => {
+                assert_eq!(continue_pubkey, pubkey);
+                assert_eq!(offset, MAX_INLINE_DATA_SIZE as u32);
+                assert_eq!(data, vec![7]);
+                assert!(is_last);
+                assert!(actions.is_empty());
+            }
+            _ => panic!("expected clone account continue instruction"),
+        }
+        match bincode::deserialize(instruction_data(final_tx, 1)).unwrap() {
+            MagicBlockInstruction::ScheduleUndelegationRescue => {}
+            _ => panic!("expected schedule undelegation rescue instruction"),
+        }
+    }
+
+    #[test]
+    fn large_undelegation_rescue_max_final_chunk_fits() {
+        let pubkey = Pubkey::new_unique();
+        let txs = cloner().build_large_account_undelegation_rescue_txs(
+            &request(pubkey, vec![7; MAX_INLINE_DATA_SIZE * 2], vec![]),
+            Hash::default(),
+        );
+
+        ChainlinkCloner::ensure_transactions_fit(pubkey, &txs).unwrap();
+    }
+
+    #[test]
+    fn chunked_undelegation_rescue_short_data_uses_empty_final_continue() {
+        let pubkey = Pubkey::new_unique();
+        let data = vec![1, 2, 3];
+        let txs = cloner().build_large_account_undelegation_rescue_txs(
+            &request(pubkey, data.clone(), vec![action()]),
+            Hash::default(),
+        );
+
+        assert_eq!(txs.len(), 2);
+
+        let final_tx = txs.last().unwrap();
+        assert_eq!(final_tx.message().instructions.len(), 2);
+        match bincode::deserialize(instruction_data(final_tx, 0)).unwrap() {
+            MagicBlockInstruction::CloneAccountContinue {
+                pubkey: continue_pubkey,
+                offset,
+                data: continue_data,
+                is_last,
+                actions,
+            } => {
+                assert_eq!(continue_pubkey, pubkey);
+                assert_eq!(offset, data.len() as u32);
+                assert!(continue_data.is_empty());
+                assert!(is_last);
+                assert!(actions.is_empty());
+            }
+            _ => panic!("expected clone account continue instruction"),
+        }
+        match bincode::deserialize(instruction_data(final_tx, 1)).unwrap() {
             MagicBlockInstruction::ScheduleUndelegationRescue => {}
             _ => panic!("expected schedule undelegation rescue instruction"),
         }

--- a/magicblock-account-cloner/src/lib.rs
+++ b/magicblock-account-cloner/src/lib.rs
@@ -392,10 +392,8 @@ impl ChainlinkCloner {
         );
         txs.push(self.create_signed_tx(&[init_ix], blockhash));
 
-        let rescue_ix = Self::undelegation_rescue_ix(request.pubkey);
-
-        // Continue txs for remaining chunks. The rescue schedule is attached
-        // only to the final continue, after the clone has completed.
+        // Continue txs for remaining chunks. Rescue scheduling is sent as a
+        // separate final transaction once the chunked clone has completed.
         let mut offset = MAX_INLINE_DATA_SIZE;
         while offset < data.len() {
             let end = (offset + MAX_INLINE_DATA_SIZE).min(data.len());
@@ -409,12 +407,7 @@ impl ChainlinkCloner {
                 is_last,
                 Vec::new(),
             );
-            let ixs = if is_last {
-                vec![continue_ix, rescue_ix.clone()]
-            } else {
-                vec![continue_ix]
-            };
-            txs.push(self.create_signed_tx(&ixs, blockhash));
+            txs.push(self.create_signed_tx(&[continue_ix], blockhash));
             offset = end;
         }
 
@@ -426,10 +419,13 @@ impl ChainlinkCloner {
                 true,
                 Vec::new(),
             );
-            txs.push(
-                self.create_signed_tx(&[continue_ix, rescue_ix], blockhash),
-            );
+            txs.push(self.create_signed_tx(&[continue_ix], blockhash));
         }
+
+        txs.push(self.create_signed_tx(
+            &[Self::undelegation_rescue_ix(request.pubkey)],
+            blockhash,
+        ));
 
         txs
     }
@@ -769,13 +765,16 @@ impl Cloner for ChainlinkCloner {
         Self::ensure_transactions_fit(request.pubkey, &txs)?;
 
         let mut last_sig = None;
-        for tx in txs {
+        let rescue_tx_idx = txs.len().saturating_sub(1);
+        for (idx, tx) in txs.into_iter().enumerate() {
             match self.send_tx(tx).await {
                 Ok(sig) => {
                     last_sig.replace(sig);
                 }
                 Err(e) => {
-                    self.send_cleanup(request.pubkey).await;
+                    if idx < rescue_tx_idx {
+                        self.send_cleanup(request.pubkey).await;
+                    }
                     return Err(
                         ClonerError::FailedToCloneAndScheduleUndelegationRescue(
                             request.pubkey,
@@ -1007,21 +1006,24 @@ mod tests {
     }
 
     #[test]
-    fn large_undelegation_rescue_clone_schedules_on_final_chunk_tx() {
+    fn large_undelegation_rescue_clone_schedules_after_final_chunk_tx() {
         let pubkey = Pubkey::new_unique();
         let txs = cloner().build_large_account_undelegation_rescue_txs(
             &request(pubkey, vec![7; MAX_INLINE_DATA_SIZE + 1], vec![action()]),
             Hash::default(),
         );
 
-        assert_eq!(txs.len(), 2);
+        assert_eq!(txs.len(), 3);
 
-        let final_tx = txs.last().unwrap();
-        assert_eq!(final_tx.message().instructions.len(), 2);
-        assert_eq!(instruction_program_id(final_tx, 0), magicblock_program::ID);
-        assert_eq!(instruction_program_id(final_tx, 1), magicblock_program::ID);
+        let final_clone_tx = &txs[1];
+        assert_eq!(final_clone_tx.message().instructions.len(), 1);
+        assert_eq!(
+            instruction_program_id(final_clone_tx, 0),
+            magicblock_program::ID
+        );
 
-        match bincode::deserialize(instruction_data(final_tx, 0)).unwrap() {
+        match bincode::deserialize(instruction_data(final_clone_tx, 0)).unwrap()
+        {
             MagicBlockInstruction::CloneAccountContinue {
                 pubkey: continue_pubkey,
                 offset,
@@ -1037,7 +1039,14 @@ mod tests {
             }
             _ => panic!("expected clone account continue instruction"),
         }
-        match bincode::deserialize(instruction_data(final_tx, 1)).unwrap() {
+
+        let rescue_tx = txs.last().unwrap();
+        assert_eq!(rescue_tx.message().instructions.len(), 1);
+        assert_eq!(
+            instruction_program_id(rescue_tx, 0),
+            magicblock_program::ID
+        );
+        match bincode::deserialize(instruction_data(rescue_tx, 0)).unwrap() {
             MagicBlockInstruction::ScheduleUndelegationRescue => {}
             _ => panic!("expected schedule undelegation rescue instruction"),
         }
@@ -1063,11 +1072,12 @@ mod tests {
             Hash::default(),
         );
 
-        assert_eq!(txs.len(), 2);
+        assert_eq!(txs.len(), 3);
 
-        let final_tx = txs.last().unwrap();
-        assert_eq!(final_tx.message().instructions.len(), 2);
-        match bincode::deserialize(instruction_data(final_tx, 0)).unwrap() {
+        let final_clone_tx = &txs[1];
+        assert_eq!(final_clone_tx.message().instructions.len(), 1);
+        match bincode::deserialize(instruction_data(final_clone_tx, 0)).unwrap()
+        {
             MagicBlockInstruction::CloneAccountContinue {
                 pubkey: continue_pubkey,
                 offset,
@@ -1083,7 +1093,10 @@ mod tests {
             }
             _ => panic!("expected clone account continue instruction"),
         }
-        match bincode::deserialize(instruction_data(final_tx, 1)).unwrap() {
+
+        let rescue_tx = txs.last().unwrap();
+        assert_eq!(rescue_tx.message().instructions.len(), 1);
+        match bincode::deserialize(instruction_data(rescue_tx, 0)).unwrap() {
             MagicBlockInstruction::ScheduleUndelegationRescue => {}
             _ => panic!("expected schedule undelegation rescue instruction"),
         }

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -715,12 +715,27 @@ where
                         Arc::clone(&self.pending_clones),
                         pubkey,
                     );
+                    let Some(owned_request) = request.take() else {
+                        let err = ClonerError::CommittorServiceError(
+                            "owner missing request for undelegation rescue clone"
+                                .to_string(),
+                        );
+                        self.finish_pending_clone(
+                            pubkey,
+                            CloneCompletion::Failed,
+                        );
+                        guard.dismiss();
+                        return Err(
+                            ClonerError::FailedToCloneAndScheduleUndelegationRescue(
+                                pubkey,
+                                Box::new(err),
+                            ),
+                        );
+                    };
                     let result = self
                         .cloner
                         .clone_account_and_schedule_undelegation_rescue(
-                            request
-                                .take()
-                                .expect("owner must still have request"),
+                            owned_request,
                         )
                         .await;
                     let completion = if result.is_ok() {

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -146,10 +146,9 @@ struct PendingUndelegationRescueGuard {
 
 impl Drop for PendingUndelegationRescueGuard {
     fn drop(&mut self) {
-        self.pending_rescues
-            .lock()
-            .expect("pending undelegation rescues lock poisoned")
-            .remove(&self.pubkey);
+        if let Ok(mut pending_rescues) = self.pending_rescues.lock() {
+            pending_rescues.remove(&self.pubkey);
+        }
     }
 }
 
@@ -697,10 +696,8 @@ where
         &self,
         pubkey: Pubkey,
     ) -> Option<PendingUndelegationRescueGuard> {
-        let mut pending_rescues = self
-            .pending_undelegation_rescues
-            .lock()
-            .expect("pending undelegation rescues lock poisoned");
+        let mut pending_rescues =
+            self.pending_undelegation_rescues.lock().ok()?;
         if !pending_rescues.insert(pubkey) {
             return None;
         }

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -671,7 +671,7 @@ where
 
     async fn rescue_undelegation_after_post_delegation_failure(
         &self,
-        mut request: AccountCloneRequest,
+        request: AccountCloneRequest,
     ) -> ChainlinkResult<()> {
         let pubkey = request.pubkey;
         if self
@@ -686,10 +686,73 @@ where
             return Ok(());
         };
 
-        request.delegation_actions = DelegationActions::default();
-        self.clone_account_with_ownership(request).await?;
-        self.cloner.schedule_undelegation_rescue(pubkey).await?;
+        self.clone_account_and_schedule_undelegation_rescue_with_ownership(
+            request,
+        )
+        .await?;
         Ok(())
+    }
+
+    async fn clone_account_and_schedule_undelegation_rescue_with_ownership(
+        &self,
+        request: AccountCloneRequest,
+    ) -> ClonerResult<Signature> {
+        let pubkey = request.pubkey;
+        let mut request = Some(request);
+
+        loop {
+            if self
+                .accounts_bank
+                .get_account(&pubkey)
+                .is_some_and(|account| account.undelegating())
+            {
+                return Ok(Signature::default());
+            }
+
+            match self.claim_pending_clone(pubkey) {
+                CloneClaim::Owner => {
+                    let mut guard = PendingCloneGuard::new(
+                        Arc::clone(&self.pending_clones),
+                        pubkey,
+                    );
+                    let result = self
+                        .cloner
+                        .clone_account_and_schedule_undelegation_rescue(
+                            request
+                                .take()
+                                .expect("owner must still have request"),
+                        )
+                        .await;
+                    let completion = if result.is_ok() {
+                        CloneCompletion::Success
+                    } else {
+                        CloneCompletion::Failed
+                    };
+                    self.finish_pending_clone(pubkey, completion);
+                    guard.dismiss();
+                    return result;
+                }
+                CloneClaim::Waiter(rx) => match rx.await {
+                    Ok(CloneCompletion::Success) => continue,
+                    Ok(CloneCompletion::Failed) => {
+                        return Err(ClonerError::FailedToCloneRegularAccount(
+                            pubkey,
+                            Box::new(ClonerError::CommittorServiceError(
+                                "Clone owner failed".to_string(),
+                            )),
+                        ));
+                    }
+                    Err(_) => {
+                        return Err(ClonerError::FailedToCloneRegularAccount(
+                            pubkey,
+                            Box::new(ClonerError::CommittorServiceError(
+                                "Clone owner dropped".to_string(),
+                            )),
+                        ));
+                    }
+                },
+            }
+        }
     }
 
     fn claim_undelegation_rescue(

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -131,11 +131,26 @@ where
     pending_clones: Arc<
         Mutex<hash_map::HashMap<Pubkey, Vec<oneshot::Sender<CloneCompletion>>>>,
     >,
+    pending_undelegation_rescues: Arc<Mutex<HashSet<Pubkey>>>,
 
     pending_operation_timeout_ms: Arc<AtomicU64>,
 
     /// Risk checker for post-delegation action addresses.
     risk_service: Option<Arc<RiskService>>,
+}
+
+struct PendingUndelegationRescueGuard {
+    pending_rescues: Arc<Mutex<HashSet<Pubkey>>>,
+    pubkey: Pubkey,
+}
+
+impl Drop for PendingUndelegationRescueGuard {
+    fn drop(&mut self) {
+        self.pending_rescues
+            .lock()
+            .expect("pending undelegation rescues lock poisoned")
+            .remove(&self.pubkey);
+    }
 }
 
 /// Negative-cache capacity for known-empty eATAs.
@@ -171,6 +186,9 @@ where
             programs_not_to_subscribe: self.programs_not_to_subscribe.clone(),
             known_empty_eatas: self.known_empty_eatas.clone(),
             pending_clones: self.pending_clones.clone(),
+            pending_undelegation_rescues: self
+                .pending_undelegation_rescues
+                .clone(),
             pending_operation_timeout_ms: self
                 .pending_operation_timeout_ms
                 .clone(),
@@ -219,6 +237,7 @@ where
                 KNOWN_EMPTY_EATAS_CAPACITY,
             ))),
             pending_clones: Arc::new(Mutex::new(hash_map::HashMap::new())),
+            pending_undelegation_rescues: Arc::new(Mutex::new(HashSet::new())),
             pending_operation_timeout_ms: Arc::new(AtomicU64::new(
                 FETCH_CLONE_OPERATION_TIMEOUT.as_millis() as u64,
             )),
@@ -619,14 +638,76 @@ where
             ));
         }
 
-        self.ensure_delegation_action_dependencies(
-            request.pubkey,
-            request.account.remote_slot(),
-            &request.delegation_actions,
-        )
-        .await?;
+        let result = async {
+            self.ensure_delegation_action_dependencies(
+                request.pubkey,
+                request.account.remote_slot(),
+                &request.delegation_actions,
+            )
+            .await?;
 
-        Ok(self.clone_account_with_ownership(request).await?)
+            Ok(self.clone_account_with_ownership(request.clone()).await?)
+        }
+        .await;
+
+        match result {
+            Ok(signature) => Ok(signature),
+            Err(err) => {
+                let pubkey = request.pubkey;
+                if let Err(rescue_err) = self
+                    .rescue_undelegation_after_post_delegation_failure(request)
+                    .await
+                {
+                    warn!(
+                        pubkey = %pubkey,
+                        error = ?err,
+                        rescue_error = ?rescue_err,
+                        "Failed to schedule undelegation rescue after post-delegation action clone failure"
+                    );
+                }
+                Err(err)
+            }
+        }
+    }
+
+    async fn rescue_undelegation_after_post_delegation_failure(
+        &self,
+        mut request: AccountCloneRequest,
+    ) -> ChainlinkResult<()> {
+        let pubkey = request.pubkey;
+        if self
+            .accounts_bank
+            .get_account(&pubkey)
+            .is_some_and(|account| account.undelegating())
+        {
+            return Ok(());
+        }
+
+        let Some(_guard) = self.claim_undelegation_rescue(pubkey) else {
+            return Ok(());
+        };
+
+        request.delegation_actions = DelegationActions::default();
+        self.clone_account_with_ownership(request).await?;
+        self.cloner.schedule_undelegation_rescue(pubkey).await?;
+        Ok(())
+    }
+
+    fn claim_undelegation_rescue(
+        &self,
+        pubkey: Pubkey,
+    ) -> Option<PendingUndelegationRescueGuard> {
+        let mut pending_rescues = self
+            .pending_undelegation_rescues
+            .lock()
+            .expect("pending undelegation rescues lock poisoned");
+        if !pending_rescues.insert(pubkey) {
+            return None;
+        }
+        Some(PendingUndelegationRescueGuard {
+            pending_rescues: Arc::clone(&self.pending_undelegation_rescues),
+            pubkey,
+        })
     }
 
     fn normalize_unresolved_dlp_clone_request(

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -4909,6 +4909,69 @@ async fn test_post_delegation_actions_execute_once_across_remote_slots() {
 }
 
 #[tokio::test]
+async fn test_post_delegation_action_clone_failure_schedules_undelegation_rescue(
+) {
+    init_logger();
+    let validator_keypair = Keypair::new();
+    const CURRENT_SLOT: u64 = 100;
+
+    let FetcherTestCtx {
+        cloner,
+        fetch_cloner,
+        ..
+    } = setup(
+        std::iter::empty::<(Pubkey, Account)>(),
+        CURRENT_SLOT,
+        validator_keypair.insecure_clone(),
+    )
+    .await;
+
+    let target_pubkey = random_pubkey();
+    let mut target_account = AccountSharedData::from(Account {
+        lamports: 1_000_000,
+        data: vec![1, 2, 3, 4],
+        owner: system_program::id(),
+        executable: false,
+        rent_epoch: 0,
+    });
+    target_account.set_remote_slot(CURRENT_SLOT);
+    target_account.set_delegated(true);
+
+    let actions = DelegationActions::from(vec![Instruction::new_with_bytes(
+        target_pubkey,
+        &[1],
+        vec![],
+    )]);
+
+    cloner.set_fail_next_clone(true);
+    let err = fetch_cloner
+        .clone_account_with_post_delegation_action_invariants(
+            AccountCloneRequest {
+                pubkey: target_pubkey,
+                account: target_account,
+                commit_frequency_ms: None,
+                delegation_actions: actions,
+                delegated_to_other: None,
+            },
+        )
+        .await
+        .expect_err("action-bearing clone failure must be returned");
+
+    assert!(matches!(err, ChainlinkError::ClonerError(_)));
+    let clone_requests = cloner.clone_requests();
+    assert_eq!(clone_requests.len(), 2);
+    assert!(
+        !clone_requests[0].delegation_actions.is_empty(),
+        "first clone attempt should carry post-delegation actions"
+    );
+    assert!(
+        clone_requests[1].delegation_actions.is_empty(),
+        "rescue clone retry must not carry post-delegation actions"
+    );
+    assert_eq!(cloner.undelegation_rescue_requests(), vec![target_pubkey]);
+}
+
+#[tokio::test]
 async fn test_delegated_clone_does_not_override_active_local_target() {
     init_logger();
     let validator_keypair = Keypair::new();

--- a/magicblock-chainlink/src/cloner/errors.rs
+++ b/magicblock-chainlink/src/cloner/errors.rs
@@ -38,8 +38,10 @@ pub enum ClonerError {
     #[error("Failed to clone program {0} : {1:?}")]
     FailedToCloneProgram(Pubkey, Box<ClonerError>),
 
-    #[error("Failed to schedule undelegation rescue for account {0} : {1:?}")]
-    FailedToScheduleUndelegationRescue(Pubkey, Box<ClonerError>),
+    #[error(
+        "Failed to clone and schedule undelegation rescue for account {0} : {1:?}"
+    )]
+    FailedToCloneAndScheduleUndelegationRescue(Pubkey, Box<ClonerError>),
 
     #[error("Failed to evict account {0} : {1:?}")]
     FailedToEvictAccount(Pubkey, Box<ClonerError>),

--- a/magicblock-chainlink/src/cloner/errors.rs
+++ b/magicblock-chainlink/src/cloner/errors.rs
@@ -38,6 +38,9 @@ pub enum ClonerError {
     #[error("Failed to clone program {0} : {1:?}")]
     FailedToCloneProgram(Pubkey, Box<ClonerError>),
 
+    #[error("Failed to schedule undelegation rescue for account {0} : {1:?}")]
+    FailedToScheduleUndelegationRescue(Pubkey, Box<ClonerError>),
+
     #[error("Failed to evict account {0} : {1:?}")]
     FailedToEvictAccount(Pubkey, Box<ClonerError>),
 }

--- a/magicblock-chainlink/src/cloner/mod.rs
+++ b/magicblock-chainlink/src/cloner/mod.rs
@@ -80,6 +80,13 @@ pub trait Cloner: Send + Sync + 'static {
         program: LoadedProgram,
     ) -> ClonerResult<Signature>;
 
+    /// Schedules a validator-initiated undelegation rescue for a delegated
+    /// account whose post-delegation actions could not be applied locally.
+    async fn schedule_undelegation_rescue(
+        &self,
+        pubkey: Pubkey,
+    ) -> ClonerResult<Signature>;
+
     /// Evicts an account from the ephemeral validator by submitting an
     /// EvictAccount transaction through the transaction pipeline.
     async fn evict_account(&self, pubkey: Pubkey) -> ClonerResult<()>;

--- a/magicblock-chainlink/src/cloner/mod.rs
+++ b/magicblock-chainlink/src/cloner/mod.rs
@@ -73,18 +73,18 @@ pub trait Cloner: Send + Sync + 'static {
         request: AccountCloneRequest,
     ) -> ClonerResult<Signature>;
 
+    /// Clones a delegated account without post-delegation actions and schedules
+    /// validator-initiated undelegation rescue in the same final transaction.
+    async fn clone_account_and_schedule_undelegation_rescue(
+        &self,
+        request: AccountCloneRequest,
+    ) -> ClonerResult<Signature>;
+
     // Overrides the accounts in the bank to make sure the program is usable normally (and upgraded)
     // We make sure all accounts involved in the program are present in the bank with latest state
     async fn clone_program(
         &self,
         program: LoadedProgram,
-    ) -> ClonerResult<Signature>;
-
-    /// Schedules a validator-initiated undelegation rescue for a delegated
-    /// account whose post-delegation actions could not be applied locally.
-    async fn schedule_undelegation_rescue(
-        &self,
-        pubkey: Pubkey,
     ) -> ClonerResult<Signature>;
 
     /// Evicts an account from the ephemeral validator by submitting an

--- a/magicblock-chainlink/src/testing/cloner_stub.rs
+++ b/magicblock-chainlink/src/testing/cloner_stub.rs
@@ -34,6 +34,7 @@ pub struct ClonerStub {
     accounts_bank: Arc<AccountsBankStub>,
     cloned_programs: Arc<Mutex<HashMap<Pubkey, LoadedProgram>>>,
     clone_requests: Arc<Mutex<Vec<AccountCloneRequest>>>,
+    undelegation_rescue_requests: Arc<Mutex<Vec<Pubkey>>>,
     clone_delay: Arc<Mutex<Option<Duration>>>,
     account_clone_count: Arc<AtomicU64>,
     active_account_clones: Arc<AtomicU64>,
@@ -57,6 +58,7 @@ impl ClonerStub {
             cloned_programs:
                 Arc::<Mutex<HashMap<Pubkey, LoadedProgram>>>::default(),
             clone_requests: Arc::new(Mutex::new(Vec::new())),
+            undelegation_rescue_requests: Arc::new(Mutex::new(Vec::new())),
             clone_delay: Arc::new(Mutex::new(None)),
             account_clone_count: Arc::new(AtomicU64::new(0)),
             active_account_clones: Arc::new(AtomicU64::new(0)),
@@ -165,6 +167,10 @@ impl ClonerStub {
         self.clone_requests.lock().unwrap().len()
     }
 
+    pub fn undelegation_rescue_requests(&self) -> Vec<Pubkey> {
+        self.undelegation_rescue_requests.lock().unwrap().clone()
+    }
+
     async fn wait_for_clone_completion_allowed(&self) {
         loop {
             let notified = self.clone_completion_notify.notified();
@@ -213,6 +219,17 @@ impl Cloner for ClonerStub {
         self.wait_for_clone_completion_allowed().await;
         self.accounts_bank.insert(request.pubkey, request.account);
         self.active_account_clones.fetch_sub(1, Ordering::SeqCst);
+        Ok(Signature::default())
+    }
+
+    async fn schedule_undelegation_rescue(
+        &self,
+        pubkey: Pubkey,
+    ) -> ClonerResult<Signature> {
+        self.undelegation_rescue_requests
+            .lock()
+            .unwrap()
+            .push(pubkey);
         Ok(Signature::default())
     }
 

--- a/magicblock-chainlink/src/testing/cloner_stub.rs
+++ b/magicblock-chainlink/src/testing/cloner_stub.rs
@@ -222,10 +222,13 @@ impl Cloner for ClonerStub {
         Ok(Signature::default())
     }
 
-    async fn schedule_undelegation_rescue(
+    async fn clone_account_and_schedule_undelegation_rescue(
         &self,
-        pubkey: Pubkey,
+        mut request: AccountCloneRequest,
     ) -> ClonerResult<Signature> {
+        let pubkey = request.pubkey;
+        request.delegation_actions = Default::default();
+        self.clone_account(request).await?;
         self.undelegation_rescue_requests
             .lock()
             .unwrap()

--- a/magicblock-magic-program-api/src/instruction.rs
+++ b/magicblock-magic-program-api/src/instruction.rs
@@ -310,6 +310,17 @@ pub enum MagicBlockInstruction {
         authority: Pubkey,
         instructions: Vec<Instruction>,
     },
+
+    /// Schedules an undelegation rescue after a post-delegation action clone
+    /// failure. This uses the same underlying commit-finalize-and-undelegate
+    /// flow as `ScheduleCommitAndUndelegate`, but is reserved for validator
+    /// initiated cleanup.
+    ///
+    /// # Account references
+    /// - **0.** `[WRITE, SIGNER]` Validator authority
+    /// - **1.** `[WRITE]`         Magic Context Account
+    /// - **2.** `[WRITE]`         Account to commit and undelegate
+    ScheduleUndelegationRescue,
 }
 
 impl MagicBlockInstruction {

--- a/programs/magicblock/src/magicblock_processor.rs
+++ b/programs/magicblock/src/magicblock_processor.rs
@@ -76,6 +76,7 @@ declare_process_instruction!(
                 invoke_context,
                 ProcessScheduleCommitOptions {
                     request_undelegation: false,
+                    ..Default::default()
                 },
             ),
             ScheduleCommitAndUndelegate => process_schedule_commit(
@@ -83,6 +84,15 @@ declare_process_instruction!(
                 invoke_context,
                 ProcessScheduleCommitOptions {
                     request_undelegation: true,
+                    ..Default::default()
+                },
+            ),
+            ScheduleUndelegationRescue => process_schedule_commit(
+                signers,
+                invoke_context,
+                ProcessScheduleCommitOptions {
+                    request_undelegation: true,
+                    require_validator_authority_payer: true,
                 },
             ),
             Unused => {

--- a/programs/magicblock/src/schedule_transactions/process_schedule_commit.rs
+++ b/programs/magicblock/src/schedule_transactions/process_schedule_commit.rs
@@ -26,12 +26,14 @@ use crate::{
         },
         instruction_utils::InstructionUtils,
     },
+    validator::effective_validator_authority_id,
     MagicContext,
 };
 
 #[derive(Default)]
 pub(crate) struct ProcessScheduleCommitOptions {
     pub request_undelegation: bool,
+    pub require_validator_authority_payer: bool,
 }
 
 pub(crate) fn process_schedule_commit(
@@ -71,6 +73,18 @@ pub(crate) fn process_schedule_commit(
             payer_pubkey
         );
         return Err(InstructionError::MissingRequiredSignature);
+    }
+    if opts.require_validator_authority_payer {
+        let validator_authority = effective_validator_authority_id();
+        if payer_pubkey != &validator_authority {
+            ic_msg!(
+                invoke_context,
+                "ScheduleCommit ERR: payer pubkey {} is not validator authority {}",
+                payer_pubkey,
+                validator_authority
+            );
+            return Err(InstructionError::IncorrectAuthority);
+        }
     }
 
     let payer_account =

--- a/programs/magicblock/src/schedule_transactions/process_schedule_commit_tests.rs
+++ b/programs/magicblock/src/schedule_transactions/process_schedule_commit_tests.rs
@@ -816,6 +816,53 @@ mod tests {
 
     #[test]
     #[serial]
+    fn test_schedule_undelegation_rescue_success() {
+        init_logger!();
+
+        validator::generate_validator_authority_if_needed();
+        let payer = validator::validator_authority();
+        let program = Pubkey::new_unique();
+        let committee = Pubkey::new_unique();
+
+        let (mut account_data, mut transaction_accounts) =
+            prepare_transaction_with_single_committee(
+                &payer, program, committee,
+            );
+
+        let ix = InstructionUtils::schedule_undelegation_rescue_instruction(
+            committee,
+        );
+        extend_transaction_accounts_from_ix(
+            &ix,
+            &mut account_data,
+            &mut transaction_accounts,
+        );
+
+        let processed_scheduled = process_instruction(
+            ix.data.as_slice(),
+            transaction_accounts,
+            ix.accounts,
+            Ok(()),
+        );
+
+        let magic_context_acc = assert_non_accepted_actions(
+            &processed_scheduled,
+            &payer.pubkey(),
+            1,
+        );
+        let magic_context =
+            bincode::deserialize::<MagicContext>(magic_context_acc.data())
+                .unwrap();
+        assert_first_commit(
+            &magic_context.scheduled_base_intents,
+            &payer.pubkey(),
+            &[committee],
+            true,
+        );
+    }
+
+    #[test]
+    #[serial]
     fn test_schedule_commit_three_accounts_success() {
         init_logger!();
 
@@ -1158,6 +1205,47 @@ mod tests {
             transaction_accounts.clone(),
             ix.accounts,
             Err(InstructionError::ReadonlyDataModified),
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_schedule_undelegation_rescue_rejects_non_validator_payer() {
+        init_logger!();
+
+        let payer = Keypair::new();
+        let program = Pubkey::new_unique();
+        let committee = Pubkey::new_unique();
+
+        let (mut account_data, mut transaction_accounts) =
+            prepare_transaction_with_single_committee(
+                &payer, program, committee,
+            );
+
+        let ix = {
+            let account_metas = vec![
+                AccountMeta::new(payer.pubkey(), true),
+                AccountMeta::new(MAGIC_CONTEXT_PUBKEY, false),
+                AccountMeta::new(committee, false),
+            ];
+            Instruction::new_with_bincode(
+                crate::id(),
+                &MagicBlockInstruction::ScheduleUndelegationRescue,
+                account_metas,
+            )
+        };
+
+        extend_transaction_accounts_from_ix(
+            &ix,
+            &mut account_data,
+            &mut transaction_accounts,
+        );
+
+        process_instruction(
+            ix.data.as_slice(),
+            transaction_accounts,
+            ix.accounts,
+            Err(InstructionError::IncorrectAuthority),
         );
     }
 

--- a/programs/magicblock/src/utils/instruction_utils.rs
+++ b/programs/magicblock/src/utils/instruction_utils.rs
@@ -112,6 +112,20 @@ impl InstructionUtils {
         )
     }
 
+    pub fn schedule_undelegation_rescue_instruction(
+        pubkey: Pubkey,
+    ) -> Instruction {
+        Instruction::new_with_bincode(
+            crate::id(),
+            &MagicBlockInstruction::ScheduleUndelegationRescue,
+            vec![
+                AccountMeta::new(validator_authority_id(), true),
+                AccountMeta::new(MAGIC_CONTEXT_PUBKEY, false),
+                AccountMeta::new(pubkey, false),
+            ],
+        )
+    }
+
     // -----------------
     // Scheduled Commit Sent
     // -----------------


### PR DESCRIPTION
## Summary
- Add a dedicated `ScheduleUndelegationRescue` Magic instruction for validator-initiated cleanup.
- On post-delegation action clone failure, retry the clone without actions and schedule undelegation rescue best-effort while returning the original failure.
- Cover the instruction builder, Magic processor authorization, and fetch-cloner rescue path with focused tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validator-authority–initiated undelegation rescue scheduling triggered after post-delegation clone failures, including new on-chain instruction support and validator-authority payer enforcement.
  * Cloning now automatically schedules undelegation rescue with handling for small vs. large clone transaction flows, including post-processing for larger flows.
* **Bug Fixes**
  * Improved reliability with best-effort rescue retry and prevention of duplicate rescue scheduling.
  * Clearer error reporting when cloning plus rescue scheduling can’t be completed.
* **Tests**
  * Added coverage for scheduling success, rejection for non-validator payers, small/large clone behavior, and failure-path rescue retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->