### PR TITLE
fix: skip ephemeral account evictions

### DIFF
--- a/magicblock-chainlink/src/chainlink/mod.rs
+++ b/magicblock-chainlink/src/chainlink/mod.rs
@@ -288,19 +288,24 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
 
         task::spawn(async move {
             while let Some(pubkey) = removed_accounts_rx.recv().await {
-                // Pre-flight check: skip if delegated/undelegating
+                // Pre-flight check: skip if delegated/undelegating/ephemeral
                 // (the processor enforces this too, but this avoids
-                // the overhead of building and submitting a doomed tx)
+                // the overhead of building and submitting an incorrect tx).
+                // Ephemeral accounts are local-validator state and must not update on
+                // base chain, so losing the remote subscription cannot make the local
+                // ephemeral bank state stale.
                 let should_evict = match accounts_bank.get_account(&pubkey) {
                     Some(account) => {
                         let undelegating = account.undelegating();
                         let delegated = account.delegated();
-                        let evict = !undelegating && !delegated;
+                        let ephemeral = account.ephemeral();
+                        let evict = !undelegating && !delegated && !ephemeral;
                         if !evict {
                             trace!(
                                 pubkey = %pubkey,
                                 undelegating,
                                 delegated,
+                                ephemeral,
                                 owner = %account.owner(),
                                 "Ignoring removal notification because bank \
                                  state is protected; no EvictAccount \
@@ -311,7 +316,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
                     }
                     None => false,
                 };
-                // Skipping a delegated/undelegating LRU candidate is not a
+                // Skipping a delegated/undelegating/ephemeral LRU candidate is not a
                 // removal event; protected bank state must not be translated
                 // into a downstream bank eviction.
                 if !should_evict {

--- a/magicblock-chainlink/src/chainlink/mod.rs
+++ b/magicblock-chainlink/src/chainlink/mod.rs
@@ -737,6 +737,7 @@ mod tests {
 
         let delegated_pubkey = Pubkey::new_unique();
         let undelegating_pubkey = Pubkey::new_unique();
+        let ephemeral_pubkey = Pubkey::new_unique();
         let normal_pubkey = Pubkey::new_unique();
         let owner = Pubkey::new_unique();
 
@@ -749,6 +750,11 @@ mod tests {
             AccountSharedData::new(1_000_000, 0, &owner);
         undelegating_account.set_undelegating(true);
         accounts_bank.insert(undelegating_pubkey, undelegating_account);
+
+        let mut ephemeral_account =
+            AccountSharedData::new(1_000_000, 0, &owner);
+        ephemeral_account.set_ephemeral(true);
+        accounts_bank.insert(ephemeral_pubkey, ephemeral_account);
 
         let normal_account = AccountSharedData::new(1_000_000, 0, &owner);
         accounts_bank.insert(normal_pubkey, normal_account);
@@ -767,6 +773,7 @@ mod tests {
 
         removed_tx.send(delegated_pubkey).await.unwrap();
         removed_tx.send(undelegating_pubkey).await.unwrap();
+        removed_tx.send(ephemeral_pubkey).await.unwrap();
         removed_tx.send(normal_pubkey).await.unwrap();
 
         tokio::time::timeout(Duration::from_secs(1), async {
@@ -782,6 +789,10 @@ mod tests {
 
         assert!(accounts_bank.get_account(&delegated_pubkey).is_some());
         assert!(accounts_bank.get_account(&undelegating_pubkey).is_some());
+        let ephemeral_account = accounts_bank
+            .get_account(&ephemeral_pubkey)
+            .expect("ephemeral account should not be evicted");
+        assert!(ephemeral_account.ephemeral());
         assert!(accounts_bank.get_account(&normal_pubkey).is_none());
 
         drop(removed_tx);


### PR DESCRIPTION
## Summary

Prevent chainlink from submitting `EvictAccount` for local ephemeral accounts when account-removal notifications are processed.

CLOSES: #1302

## Details

### magicblock-chainlink

- Extends the removal preflight to treat ephemeral bank accounts as protected state, alongside delegated and undelegating accounts.
- Documents the key invariant directly in the code: ephemeral accounts are local-validator state and must not update on base chain, so dropping the remote subscription cannot make the local ephemeral bank state stale.
- Adds regression coverage for delegated, undelegating, ephemeral, and normal account-removal behavior so only normal accounts are evicted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ephemeral bank accounts are now protected from eviction, ensuring proper account lifecycle management alongside delegated accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->