### PR TITLE
fix: prevent subscription reconcile race

### DIFF
--- a/magicblock-chainlink/src/remote_account_provider/chain_pubsub_client.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_pubsub_client.rs
@@ -319,6 +319,10 @@ pub mod mock {
         pending_program_subscribe_failures: Arc<Mutex<usize>>,
         reconnectable: Arc<Mutex<bool>>,
         subscribe_blocked: Arc<Mutex<bool>>,
+        subscribe_pause_after_insert: Arc<Mutex<bool>>,
+        subscribe_insertions: Arc<AtomicU64>,
+        subscribe_insert_notify: Arc<Notify>,
+        subscribe_continue_notify: Arc<Notify>,
         subscribe_attempts: Arc<AtomicU64>,
         program_subscribe_attempts: Arc<AtomicU64>,
         subscribe_notify: Arc<Notify>,
@@ -344,6 +348,10 @@ pub mod mock {
                 pending_program_subscribe_failures: Arc::new(Mutex::new(0)),
                 reconnectable: Arc::new(Mutex::new(true)),
                 subscribe_blocked: Arc::new(Mutex::new(false)),
+                subscribe_pause_after_insert: Arc::new(Mutex::new(false)),
+                subscribe_insertions: Arc::new(AtomicU64::new(0)),
+                subscribe_insert_notify: Arc::new(Notify::new()),
+                subscribe_continue_notify: Arc::new(Notify::new()),
                 subscribe_attempts: Arc::new(AtomicU64::new(0)),
                 program_subscribe_attempts: Arc::new(AtomicU64::new(0)),
                 subscribe_notify: Arc::new(Notify::new()),
@@ -436,6 +444,35 @@ pub mod mock {
             self.subscribe_notify.notify_waiters();
         }
 
+        /// Pause subscribe() after it has inserted the pubkey into the mock
+        /// pubsub set but before subscribe() returns to the caller.
+        pub fn pause_after_subscribe_insert(&self) {
+            *self.subscribe_pause_after_insert.lock() = true;
+        }
+
+        /// Resume subscribe() calls paused by pause_after_subscribe_insert().
+        pub fn resume_after_subscribe_insert(&self) {
+            *self.subscribe_pause_after_insert.lock() = false;
+            self.subscribe_continue_notify.notify_waiters();
+        }
+
+        pub fn subscribe_insertions(&self) -> u64 {
+            self.subscribe_insertions.load(AtomicOrdering::SeqCst)
+        }
+
+        pub async fn wait_for_subscribe_insertions(&self, min_insertions: u64) {
+            loop {
+                let notified = self.subscribe_insert_notify.notified();
+                tokio::pin!(notified);
+                let current =
+                    self.subscribe_insertions.load(AtomicOrdering::SeqCst);
+                if current >= min_insertions {
+                    break;
+                }
+                notified.await;
+            }
+        }
+
         /// Wait until at least `min_attempts` subscribe attempts have been made.
         /// Used for testing to ensure subscribes are being called.
         pub async fn wait_for_subscribe_attempts(&self, min_attempts: u64) {
@@ -515,8 +552,23 @@ pub mod mock {
                     ),
                 );
             }
-            let mut subscribed_pubkeys = self.subscribed_pubkeys.lock();
-            subscribed_pubkeys.insert(pubkey);
+            {
+                let mut subscribed_pubkeys = self.subscribed_pubkeys.lock();
+                subscribed_pubkeys.insert(pubkey);
+            }
+            self.subscribe_insertions
+                .fetch_add(1, AtomicOrdering::SeqCst);
+            self.subscribe_insert_notify.notify_waiters();
+
+            loop {
+                let notified = self.subscribe_continue_notify.notified();
+                tokio::pin!(notified);
+                if !*self.subscribe_pause_after_insert.lock() {
+                    break;
+                }
+                notified.await;
+            }
+
             Ok(())
         }
 

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -87,6 +87,34 @@ use crate::{
 const ACTIVE_SUBSCRIPTIONS_UPDATE_INTERVAL_MS: u64 = 60_000;
 pub(crate) const DEFAULT_SUBSCRIPTION_RETRIES: usize = 5;
 
+type SubscriptionKeyLocks =
+    Arc<AsyncMutex<HashMap<Pubkey, Weak<AsyncMutex<()>>>>>;
+
+pub(crate) async fn subscription_key_lock_from_map(
+    subscription_key_locks: &SubscriptionKeyLocks,
+    pubkey: &Pubkey,
+) -> Arc<AsyncMutex<()>> {
+    let mut locks = subscription_key_locks.lock().await;
+    locks.retain(|_, lock| lock.strong_count() > 0);
+
+    if let Some(lock) = locks.get(pubkey).and_then(Weak::upgrade) {
+        return lock;
+    }
+
+    let lock = Arc::new(AsyncMutex::new(()));
+    locks.insert(*pubkey, Arc::downgrade(&lock));
+    lock
+}
+
+pub(crate) async fn subscription_key_owned_guard_from_map(
+    subscription_key_locks: &SubscriptionKeyLocks,
+    pubkey: Pubkey,
+) -> tokio::sync::OwnedMutexGuard<()> {
+    let lock =
+        subscription_key_lock_from_map(subscription_key_locks, &pubkey).await;
+    lock.lock_owned().await
+}
+
 type ChainUpdatesPubsub = (Arc<ChainUpdatesClient>, mpsc::Receiver<()>);
 
 async fn connect_pubsub_client(
@@ -398,8 +426,7 @@ pub struct RemoteAccountProvider<T: ChainRpcClient, U: ChainPubsubClient> {
     ///
     /// Values are weak references so pubkeys do not accumulate forever after
     /// their transient transition lock is no longer in use.
-    subscription_key_locks:
-        Arc<AsyncMutex<HashMap<Pubkey, Weak<AsyncMutex<()>>>>>,
+    subscription_key_locks: SubscriptionKeyLocks,
     /// The current slot on chain.
     ///
     /// This value is updated from two sources and always stores the maximum
@@ -566,6 +593,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
         subscribed_accounts: Arc<AccountsLruCache>,
         pubsub_client: Arc<PubsubClient>,
         removed_account_tx: mpsc::Sender<Pubkey>,
+        subscription_key_locks: SubscriptionKeyLocks,
     ) -> task::JoinHandle<()> {
         task::spawn(async move {
             let mut interval = time::interval(Duration::from_millis(
@@ -576,11 +604,12 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
             loop {
                 interval.tick().await;
                 let pubsub_total =
-                    subscription_reconciler::reconcile_subscriptions(
+                    subscription_reconciler::reconcile_subscriptions_with_key_locks(
                         &subscribed_accounts,
                         pubsub_client.as_ref(),
                         &never_evicted,
                         &removed_account_tx,
+                        Some(&subscription_key_locks),
                     )
                     .await;
 
@@ -603,6 +632,8 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
     ) -> RemoteAccountProviderResult<Self> {
         let (removed_account_tx, removed_account_rx) =
             tokio::sync::mpsc::channel(100);
+        let subscription_key_locks: SubscriptionKeyLocks =
+            Arc::new(AsyncMutex::new(HashMap::new()));
 
         let active_subscriptions_updater =
             if config.enable_subscription_metrics() {
@@ -610,6 +641,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                     lrucache_subscribed_accounts.clone(),
                     Arc::new(pubsub_client.clone()),
                     removed_account_tx.clone(),
+                    subscription_key_locks.clone(),
                 ))
             } else {
                 None
@@ -620,7 +652,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
             next_fetching_account_generation: AtomicU64::default(),
             subscription_ownership: Arc::new(AsyncMutex::new(HashMap::new())),
             subscription_transition_lock: Arc::new(AsyncMutex::new(())),
-            subscription_key_locks: Arc::new(AsyncMutex::new(HashMap::new())),
+            subscription_key_locks,
             rpc_client,
             pubsub_client,
             chain_slot,
@@ -1602,11 +1634,12 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
     pub(crate) async fn reconcile_subscriptions_once_for_test(&self) -> usize {
         let never_evicted =
             self.lrucache_subscribed_accounts.never_evicted_accounts();
-        subscription_reconciler::reconcile_subscriptions(
+        subscription_reconciler::reconcile_subscriptions_with_key_locks(
             &self.lrucache_subscribed_accounts,
             &self.pubsub_client,
             &never_evicted,
             &self.removed_account_tx,
+            Some(&self.subscription_key_locks),
         )
         .await
     }
@@ -1641,16 +1674,8 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
         &self,
         pubkey: &Pubkey,
     ) -> Arc<AsyncMutex<()>> {
-        let mut locks = self.subscription_key_locks.lock().await;
-        locks.retain(|_, lock| lock.strong_count() > 0);
-
-        if let Some(lock) = locks.get(pubkey).and_then(Weak::upgrade) {
-            return lock;
-        }
-
-        let lock = Arc::new(AsyncMutex::new(()));
-        locks.insert(*pubkey, Arc::downgrade(&lock));
-        lock
+        subscription_key_lock_from_map(&self.subscription_key_locks, pubkey)
+            .await
     }
 
     pub async fn acquire_subscription(

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -1598,6 +1598,19 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
         self.lrucache_subscribed_accounts.contains(pubkey)
     }
 
+    #[cfg(test)]
+    pub(crate) async fn reconcile_subscriptions_once_for_test(&self) -> usize {
+        let never_evicted =
+            self.lrucache_subscribed_accounts.never_evicted_accounts();
+        subscription_reconciler::reconcile_subscriptions(
+            &self.lrucache_subscribed_accounts,
+            &self.pubsub_client,
+            &never_evicted,
+            &self.removed_account_tx,
+        )
+        .await
+    }
+
     pub(crate) async fn evict_unwatched_with_subscription_lock<F, Fut>(
         &self,
         pubkey: &Pubkey,

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -108,6 +108,12 @@ pub(crate) async fn subscription_key_owned_guard_from_map(
     subscription_key_locks: &SubscriptionKeyLocks,
     pubkey: Pubkey,
 ) -> tokio::sync::OwnedMutexGuard<()> {
+    // The reconciler uses this to serialize repair work with normal
+    // acquire/release/unsubscribe transitions for the same pubkey. Creating the
+    // lock when it is missing is intentional: if reconciliation only looked up
+    // existing locks, a new same-pubkey transition could start immediately after
+    // the lookup and race the repair. Reconciliation only calls this for drifted
+    // pubkeys it is about to repair, not for every subscribed account.
     let lock =
         subscription_key_lock_from_map(subscription_key_locks, &pubkey).await;
     lock.lock_owned().await

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -28,8 +28,6 @@ use solana_account::Account;
 use solana_account_decoder_client_types::UiAccountEncoding;
 use solana_commitment_config::CommitmentConfig;
 use solana_pubkey::Pubkey;
-#[cfg(any(test, feature = "dev-context"))]
-use solana_rpc_client::nonblocking::rpc_client::RpcClient;
 use solana_rpc_client_api::{
     client_error::ErrorKind, config::RpcAccountInfoConfig,
     custom_error::JSON_RPC_SERVER_ERROR_MIN_CONTEXT_SLOT_NOT_REACHED,
@@ -604,7 +602,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
             loop {
                 interval.tick().await;
                 let pubsub_total =
-                    subscription_reconciler::reconcile_subscriptions_with_key_locks(
+                    subscription_reconciler::reconcile_subscriptions(
                         &subscribed_accounts,
                         pubsub_client.as_ref(),
                         &never_evicted,
@@ -1630,20 +1628,6 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
         self.lrucache_subscribed_accounts.contains(pubkey)
     }
 
-    #[cfg(test)]
-    pub(crate) async fn reconcile_subscriptions_once_for_test(&self) -> usize {
-        let never_evicted =
-            self.lrucache_subscribed_accounts.never_evicted_accounts();
-        subscription_reconciler::reconcile_subscriptions_with_key_locks(
-            &self.lrucache_subscribed_accounts,
-            &self.pubsub_client,
-            &never_evicted,
-            &self.removed_account_tx,
-            Some(&self.subscription_key_locks),
-        )
-        .await
-    }
-
     pub(crate) async fn evict_unwatched_with_subscription_lock<F, Fut>(
         &self,
         pubkey: &Pubkey,
@@ -1662,12 +1646,6 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
 
         evict().await;
         true
-    }
-
-    /// Check if an account is currently pending (being fetched)
-    pub fn is_pending(&self, pubkey: &Pubkey) -> bool {
-        let fetching = self.fetching_accounts.lock().unwrap();
-        fetching.contains_key(pubkey)
     }
 
     async fn subscription_key_lock(
@@ -1694,19 +1672,6 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
     ) -> RemoteAccountProviderResult<()> {
         self.acquire_subscription_with_mode(pubkey, reason, true)
             .await
-    }
-
-    #[cfg(test)]
-    pub(crate) async fn has_subscription_reason(
-        &self,
-        pubkey: &Pubkey,
-        reason: SubscriptionReason,
-    ) -> bool {
-        self.subscription_ownership
-            .lock()
-            .await
-            .get(pubkey)
-            .is_some_and(|ownership| ownership.contains(reason))
     }
 
     async fn acquire_subscription_with_mode(
@@ -1910,12 +1875,6 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
         program_id: Pubkey,
     ) -> RemoteAccountProviderResult<()> {
         self.pubsub_client.subscribe_program(program_id).await
-    }
-
-    /// Get a reference to the pubsub client (for testing)
-    #[cfg(any(test, feature = "dev-context"))]
-    pub fn pubsub_client(&self) -> &U {
-        &self.pubsub_client
     }
 
     /// Unsubscribe from an account
@@ -2285,34 +2244,6 @@ fn remove_fetching_account_if_generation_matches(
     }
 }
 
-impl RemoteAccountProvider<ChainRpcClientImpl, ChainPubsubClientImpl> {
-    #[cfg(any(test, feature = "dev-context"))]
-    pub fn rpc_client(&self) -> &RpcClient {
-        &self.rpc_client.rpc_client
-    }
-}
-
-impl
-    RemoteAccountProvider<
-        ChainRpcClientImpl,
-        SubMuxClient<ChainPubsubClientImpl>,
-    >
-{
-    #[cfg(any(test, feature = "dev-context"))]
-    pub fn rpc_client(&self) -> &RpcClient {
-        &self.rpc_client.rpc_client
-    }
-}
-
-impl
-    RemoteAccountProvider<ChainRpcClientImpl, SubMuxClient<ChainUpdatesClient>>
-{
-    #[cfg(any(test, feature = "dev-context"))]
-    pub fn rpc_client(&self) -> &RpcClient {
-        &self.rpc_client.rpc_client
-    }
-}
-
 fn all_slots_match(accs: &[RemoteAccount]) -> bool {
     if accs.is_empty() {
         return true;
@@ -2359,4 +2290,67 @@ fn pubkeys_str(pubkeys: &[Pubkey]) -> String {
         .map(|pk| pk.to_string())
         .collect::<Vec<_>>()
         .join(", ")
+}
+
+#[cfg(any(test, feature = "dev-context"))]
+impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
+    /// Get a reference to the pubsub client for tests and dev tooling.
+    pub fn pubsub_client(&self) -> &U {
+        &self.pubsub_client
+    }
+}
+
+#[cfg(test)]
+impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
+    /// Check if an account is currently pending (being fetched).
+    pub(crate) fn is_pending(&self, pubkey: &Pubkey) -> bool {
+        let fetching = self.fetching_accounts.lock().unwrap();
+        fetching.contains_key(pubkey)
+    }
+
+    pub(crate) async fn has_subscription_reason(
+        &self,
+        pubkey: &Pubkey,
+        reason: SubscriptionReason,
+    ) -> bool {
+        self.subscription_ownership
+            .lock()
+            .await
+            .get(pubkey)
+            .is_some_and(|ownership| ownership.contains(reason))
+    }
+}
+
+#[cfg(any(test, feature = "dev-context"))]
+impl RemoteAccountProvider<ChainRpcClientImpl, ChainPubsubClientImpl> {
+    pub fn rpc_client(
+        &self,
+    ) -> &solana_rpc_client::nonblocking::rpc_client::RpcClient {
+        &self.rpc_client.rpc_client
+    }
+}
+
+#[cfg(any(test, feature = "dev-context"))]
+impl
+    RemoteAccountProvider<
+        ChainRpcClientImpl,
+        SubMuxClient<ChainPubsubClientImpl>,
+    >
+{
+    pub fn rpc_client(
+        &self,
+    ) -> &solana_rpc_client::nonblocking::rpc_client::RpcClient {
+        &self.rpc_client.rpc_client
+    }
+}
+
+#[cfg(any(test, feature = "dev-context"))]
+impl
+    RemoteAccountProvider<ChainRpcClientImpl, SubMuxClient<ChainUpdatesClient>>
+{
+    pub fn rpc_client(
+        &self,
+    ) -> &solana_rpc_client::nonblocking::rpc_client::RpcClient {
+        &self.rpc_client.rpc_client
+    }
 }

--- a/magicblock-chainlink/src/remote_account_provider/subscription_reconciler.rs
+++ b/magicblock-chainlink/src/remote_account_provider/subscription_reconciler.rs
@@ -46,61 +46,7 @@ pub(crate) async fn unsubscribe_and_notify_removal<T: ChainPubsubClient>(
     }
 }
 
-/// Reconciles subscription state between the LRU cache and the pubsub client.
-///
-/// This function is called when a mismatch is detected between the accounts
-/// tracked in the LRU cache and the actual subscriptions held by the pubsub
-/// client. It ensures both are in sync by:
-///
-/// - **Resubscribing**: Accounts present in the LRU cache but missing from the
-///   pubsub client are resubscribed. This can happen if subscriptions were
-///   dropped due to network issues or reconnections.
-///
-/// - **Unsubscribing**: Accounts present in the pubsub client but missing from
-///   the LRU cache are unsubscribed. This can happen if the LRU evicted an
-///   account but the unsubscribe request failed or was lost.
-///
-/// # Parameters
-///
-/// - `subscribed_accounts`: The LRU cache that tracks which accounts should be
-///   subscribed. This is the source of truth for user-requested subscriptions.
-///
-/// - `pubsub_client`: The client managing actual WebSocket/gRPC subscriptions
-///   to the chain. Provides the current set of active subscriptions.
-///
-/// - `never_evicted`: A list of system accounts (e.g., sysvar::clock) that are
-///   always subscribed but are **not** tracked in the LRU cache. These accounts
-///   are excluded from reconciliation because:
-///   1. They are subscribed directly without going through the LRU.
-///   2. They should never be unsubscribed regardless of LRU state.
-///   3. Their presence in pubsub but absence from LRU is expected and correct.
-///
-///   Without filtering these out, the reconciler would incorrectly attempt to
-///   unsubscribe them since they appear in pubsub but not in the LRU cache.
-///
-/// - `removed_account_tx`: Channel to notify upstream that an account was
-///   unsubscribed and should be removed from the bank.
-/// - Returns: The number of accounts that are subscribed
-#[cfg(test)]
-pub async fn reconcile_subscriptions<PubsubClient: ChainPubsubClient>(
-    subscribed_accounts: &AccountsLruCache,
-    pubsub_client: &PubsubClient,
-    never_evicted: &[Pubkey],
-    removed_account_tx: &mpsc::Sender<Pubkey>,
-) -> usize {
-    reconcile_subscriptions_with_key_locks(
-        subscribed_accounts,
-        pubsub_client,
-        never_evicted,
-        removed_account_tx,
-        None,
-    )
-    .await
-}
-
-pub(crate) async fn reconcile_subscriptions_with_key_locks<
-    PubsubClient: ChainPubsubClient,
->(
+pub(crate) async fn reconcile_subscriptions<PubsubClient: ChainPubsubClient>(
     subscribed_accounts: &AccountsLruCache,
     pubsub_client: &PubsubClient,
     never_evicted: &[Pubkey],
@@ -294,7 +240,8 @@ mod tests {
         let (removed_tx, _removed_rx) = mpsc::channel::<Pubkey>(10);
 
         // Reconcile
-        reconcile_subscriptions(&lru, &mock_client, &[], &removed_tx).await;
+        reconcile_subscriptions_local(&lru, &mock_client, &[], &removed_tx)
+            .await;
 
         // Verify subscriptions are unchanged
         let subs = mock_client.subscriptions_union();
@@ -328,7 +275,8 @@ mod tests {
         let (removed_tx, _removed_rx) = mpsc::channel::<Pubkey>(10);
 
         // Reconcile
-        reconcile_subscriptions(&lru, &mock_client, &[], &removed_tx).await;
+        reconcile_subscriptions_local(&lru, &mock_client, &[], &removed_tx)
+            .await;
 
         // Verify pk3 was resubscribed
         let subs = mock_client.subscriptions_union();
@@ -364,7 +312,7 @@ mod tests {
         let never_evicted = vec![never_evict_pk];
 
         // Reconcile
-        reconcile_subscriptions(
+        reconcile_subscriptions_local(
             &lru,
             &mock_client,
             &never_evicted,
@@ -408,7 +356,8 @@ mod tests {
         let (removed_tx, _removed_rx) = mpsc::channel::<Pubkey>(10);
 
         // Reconcile
-        reconcile_subscriptions(&lru, &mock_client, &[], &removed_tx).await;
+        reconcile_subscriptions_local(&lru, &mock_client, &[], &removed_tx)
+            .await;
 
         // Verify pk3 was resubscribed
         let subs = mock_client.subscriptions_union();
@@ -435,7 +384,8 @@ mod tests {
         let (removed_tx, _removed_rx) = mpsc::channel::<Pubkey>(10);
 
         // Reconcile
-        reconcile_subscriptions(&lru, &mock_client, &[], &removed_tx).await;
+        reconcile_subscriptions_local(&lru, &mock_client, &[], &removed_tx)
+            .await;
 
         // Verify state unchanged (both empty)
         let subs = mock_client.subscriptions_union();
@@ -464,7 +414,8 @@ mod tests {
         let (removed_tx, _removed_rx) = mpsc::channel::<Pubkey>(10);
 
         // Reconcile
-        reconcile_subscriptions(&lru, &mock_client, &[], &removed_tx).await;
+        reconcile_subscriptions_local(&lru, &mock_client, &[], &removed_tx)
+            .await;
 
         // Verify all subscriptions added
         let subs = mock_client.subscriptions_union();
@@ -502,7 +453,8 @@ mod tests {
         let (removed_tx, _removed_rx) = mpsc::channel::<Pubkey>(10);
 
         // Reconcile
-        reconcile_subscriptions(&lru, &mock_client, &[], &removed_tx).await;
+        reconcile_subscriptions_local(&lru, &mock_client, &[], &removed_tx)
+            .await;
 
         // Verify all accounts are now subscribed
         let subs = mock_client.subscriptions_union();
@@ -539,7 +491,7 @@ mod tests {
         let never_evicted: Vec<Pubkey> = vec![];
 
         // Reconcile should resubscribe pubkey2 and pubkey3
-        reconcile_subscriptions(
+        reconcile_subscriptions_local(
             &lru_cache,
             &pubsub_client,
             &never_evicted,
@@ -591,7 +543,7 @@ mod tests {
         let never_evicted: Vec<Pubkey> = vec![];
 
         // Reconcile should unsubscribe pubkey2 and pubkey3
-        reconcile_subscriptions(
+        reconcile_subscriptions_local(
             &lru_cache,
             &pubsub_client,
             &never_evicted,
@@ -640,7 +592,7 @@ mod tests {
         // preserved even though it's not in the LRU cache
         let never_evicted = vec![never_evicted_pubkey];
 
-        reconcile_subscriptions(
+        reconcile_subscriptions_local(
             &lru_cache,
             &pubsub_client,
             &never_evicted,
@@ -670,5 +622,21 @@ mod tests {
         let removed = drain_removed_account_rx(&mut removed_rx);
         assert_eq!(removed.len(), 1);
         assert!(removed.contains(&stale_pubkey));
+    }
+
+    async fn reconcile_subscriptions_local<PubsubClient: ChainPubsubClient>(
+        subscribed_accounts: &AccountsLruCache,
+        pubsub_client: &PubsubClient,
+        never_evicted: &[Pubkey],
+        removed_account_tx: &mpsc::Sender<Pubkey>,
+    ) -> usize {
+        reconcile_subscriptions(
+            subscribed_accounts,
+            pubsub_client,
+            never_evicted,
+            removed_account_tx,
+            None,
+        )
+        .await
     }
 }

--- a/magicblock-chainlink/src/remote_account_provider/subscription_reconciler.rs
+++ b/magicblock-chainlink/src/remote_account_provider/subscription_reconciler.rs
@@ -46,6 +46,34 @@ pub(crate) async fn unsubscribe_and_notify_removal<T: ChainPubsubClient>(
     }
 }
 
+/// Reconciles subscription state between the LRU cache and the pubsub client.
+///
+/// This function is called when a mismatch is detected between the accounts
+/// tracked in the LRU cache and the actual subscriptions held by the pubsub
+/// client. It repairs drift by:
+///
+/// - **Resubscribing**: Accounts present in the LRU cache but missing from the
+///   pubsub client are resubscribed. This can happen if subscriptions were
+///   dropped due to network issues or reconnects.
+///
+/// - **Unsubscribing**: Accounts present in the pubsub client but missing from
+///   the LRU cache are unsubscribed and reported through `removed_account_tx`.
+///   This can happen if the LRU evicted an account but the unsubscribe request
+///   failed or was lost.
+///
+/// `never_evicted` contains system accounts, such as sysvars, that are expected
+/// to be present in pubsub without being tracked in the LRU. These are excluded
+/// so reconciliation does not incorrectly unsubscribe them.
+///
+/// When `subscription_key_locks` is provided, reconciliation serializes each
+/// per-pubkey repair with normal subscription transitions and rechecks the live
+/// LRU/pubsub state after acquiring the lock. This prevents a stale snapshot
+/// from unsubscribing an account that is in the middle of being registered, while
+/// still allowing tests to exercise the unlocked reconciliation path by passing
+/// `None`.
+///
+/// Returns the expected total number of monitored accounts: LRU-tracked accounts
+/// plus never-evicted accounts.
 pub(crate) async fn reconcile_subscriptions<PubsubClient: ChainPubsubClient>(
     subscribed_accounts: &AccountsLruCache,
     pubsub_client: &PubsubClient,

--- a/magicblock-chainlink/src/remote_account_provider/subscription_reconciler.rs
+++ b/magicblock-chainlink/src/remote_account_provider/subscription_reconciler.rs
@@ -5,7 +5,10 @@ use solana_pubkey::Pubkey;
 use tokio::sync::mpsc;
 use tracing::*;
 
-use super::{AccountsLruCache, ChainPubsubClient};
+use super::{
+    subscription_key_owned_guard_from_map, AccountsLruCache, ChainPubsubClient,
+    SubscriptionKeyLocks,
+};
 use crate::remote_account_provider::RemoteAccountProviderError;
 
 /// Unsubscribes from pubsub and sends a removal notification to trigger bank
@@ -78,11 +81,31 @@ pub(crate) async fn unsubscribe_and_notify_removal<T: ChainPubsubClient>(
 /// - `removed_account_tx`: Channel to notify upstream that an account was
 ///   unsubscribed and should be removed from the bank.
 /// - Returns: The number of accounts that are subscribed
+#[cfg(test)]
 pub async fn reconcile_subscriptions<PubsubClient: ChainPubsubClient>(
     subscribed_accounts: &AccountsLruCache,
     pubsub_client: &PubsubClient,
     never_evicted: &[Pubkey],
     removed_account_tx: &mpsc::Sender<Pubkey>,
+) -> usize {
+    reconcile_subscriptions_with_key_locks(
+        subscribed_accounts,
+        pubsub_client,
+        never_evicted,
+        removed_account_tx,
+        None,
+    )
+    .await
+}
+
+pub(crate) async fn reconcile_subscriptions_with_key_locks<
+    PubsubClient: ChainPubsubClient,
+>(
+    subscribed_accounts: &AccountsLruCache,
+    pubsub_client: &PubsubClient,
+    never_evicted: &[Pubkey],
+    removed_account_tx: &mpsc::Sender<Pubkey>,
+    subscription_key_locks: Option<&SubscriptionKeyLocks>,
 ) -> usize {
     let pubsub_union = pubsub_client.subscriptions_union();
     let pubsub_intersection = pubsub_client.subscriptions_intersection();
@@ -137,7 +160,28 @@ pub async fn reconcile_subscriptions<PubsubClient: ChainPubsubClient>(
         );
         trace!(pubkeys = ?extra_in_lru, "Resubscribing missing accounts");
         for pubkey in extra_in_lru {
-            if let Err(e) = pubsub_client.subscribe(*pubkey, None).await {
+            let pubkey = *pubkey;
+            let _subscription_guard =
+                acquire_subscription_key_guard(subscription_key_locks, pubkey)
+                    .await;
+
+            if !subscribed_accounts.contains(&pubkey) {
+                trace!(
+                    pubkey = %pubkey,
+                    "Skipping resubscribe because pubkey left LRU after reconciliation snapshot"
+                );
+                continue;
+            }
+
+            if pubsub_client.subscriptions_intersection().contains(&pubkey) {
+                trace!(
+                    pubkey = %pubkey,
+                    "Skipping resubscribe because pubkey is already ensured after reconciliation snapshot"
+                );
+                continue;
+            }
+
+            if let Err(e) = pubsub_client.subscribe(pubkey, None).await {
                 warn!(pubkey = %pubkey, error = ?e, "Failed to resubscribe account");
             }
         }
@@ -154,8 +198,29 @@ pub async fn reconcile_subscriptions<PubsubClient: ChainPubsubClient>(
         );
         trace!(pubkeys = ?extra_in_pubsub, "Unsubscribing stale accounts");
         for pubkey in extra_in_pubsub {
+            let pubkey = *pubkey;
+            let _subscription_guard =
+                acquire_subscription_key_guard(subscription_key_locks, pubkey)
+                    .await;
+
+            if subscribed_accounts.contains(&pubkey) {
+                trace!(
+                    pubkey = %pubkey,
+                    "Skipping stale unsubscribe because pubkey entered LRU after reconciliation snapshot"
+                );
+                continue;
+            }
+
+            if !pubsub_client.subscriptions_union().contains(&pubkey) {
+                trace!(
+                    pubkey = %pubkey,
+                    "Skipping stale unsubscribe because pubkey left pubsub after reconciliation snapshot"
+                );
+                continue;
+            }
+
             unsubscribe_and_notify_removal(
-                *pubkey,
+                pubkey,
                 pubsub_client,
                 removed_account_tx,
             )
@@ -166,6 +231,22 @@ pub async fn reconcile_subscriptions<PubsubClient: ChainPubsubClient>(
     // Pubsubs should be subscribed to all accounts in LRU accounts and accounts that
     // are never evicted (not tracked in LRU)
     lru_count + never_evicted.len()
+}
+
+async fn acquire_subscription_key_guard(
+    subscription_key_locks: Option<&SubscriptionKeyLocks>,
+    pubkey: Pubkey,
+) -> Option<tokio::sync::OwnedMutexGuard<()>> {
+    match subscription_key_locks {
+        Some(subscription_key_locks) => Some(
+            subscription_key_owned_guard_from_map(
+                subscription_key_locks,
+                pubkey,
+            )
+            .await,
+        ),
+        None => None,
+    }
 }
 
 #[cfg(test)]

--- a/magicblock-chainlink/src/remote_account_provider/tests.rs
+++ b/magicblock-chainlink/src/remote_account_provider/tests.rs
@@ -1808,3 +1808,18 @@ fn test_removed_stuck_pubkey_symbols_are_absent_from_production_code() {
         hits.join("\n")
     );
 }
+
+impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
+    async fn reconcile_subscriptions_once_for_test(&self) -> usize {
+        let never_evicted =
+            self.lrucache_subscribed_accounts.never_evicted_accounts();
+        subscription_reconciler::reconcile_subscriptions(
+            &self.lrucache_subscribed_accounts,
+            &self.pubsub_client,
+            &never_evicted,
+            &self.removed_account_tx,
+            Some(&self.subscription_key_locks),
+        )
+        .await
+    }
+}

--- a/magicblock-chainlink/src/remote_account_provider/tests.rs
+++ b/magicblock-chainlink/src/remote_account_provider/tests.rs
@@ -26,7 +26,7 @@ struct ProviderTestCtx {
     provider:
         Arc<RemoteAccountProvider<ChainRpcClientMock, ChainPubsubClientMock>>,
     rpc_client: ChainRpcClientMock,
-    _pubsub_client: ChainPubsubClientMock,
+    pubsub_client: ChainPubsubClientMock,
     _forward_rx: mpsc::Receiver<ForwardedSubscriptionUpdate>,
 }
 
@@ -72,7 +72,7 @@ async fn setup_provider_with_lru_capacity(
     ProviderTestCtx {
         provider,
         rpc_client,
-        _pubsub_client: pubsub_client,
+        pubsub_client,
         _forward_rx: forward_rx,
     }
 }
@@ -217,12 +217,12 @@ async fn test_try_get_multi_setup_subscriptions_failure_cleans_up_pending_entry(
 
     let ProviderTestCtx {
         provider,
-        _pubsub_client,
+        pubsub_client,
         _forward_rx,
         ..
     } = setup_provider(pubkey, account).await;
 
-    _pubsub_client.block_subscribe();
+    pubsub_client.block_subscribe();
 
     let task_handle = tokio::spawn({
         let provider = provider.clone();
@@ -238,12 +238,12 @@ async fn test_try_get_multi_setup_subscriptions_failure_cleans_up_pending_entry(
         }
     });
 
-    _pubsub_client.wait_for_subscribe_attempts(1).await;
+    pubsub_client.wait_for_subscribe_attempts(1).await;
     tokio::time::sleep(Duration::from_millis(50)).await;
     assert!(provider.is_pending(&pubkey));
 
-    _pubsub_client.simulate_disconnect();
-    _pubsub_client.release_subscribe();
+    pubsub_client.simulate_disconnect();
+    pubsub_client.release_subscribe();
 
     let result = tokio::time::timeout(Duration::from_secs(2), task_handle)
         .await
@@ -253,7 +253,7 @@ async fn test_try_get_multi_setup_subscriptions_failure_cleans_up_pending_entry(
     assert!(err.to_string().contains("subscription(s) failed"));
     assert!(!provider.is_pending(&pubkey));
 
-    _pubsub_client.try_reconnect().await.unwrap();
+    pubsub_client.try_reconnect().await.unwrap();
     let retry = provider
         .try_get_multi(&[pubkey], None, AccountFetchOrigin::GetAccount, None)
         .await
@@ -274,12 +274,12 @@ async fn test_try_get_multi_waiter_receives_setup_subscriptions_failure() {
 
     let ProviderTestCtx {
         provider,
-        _pubsub_client,
+        pubsub_client,
         _forward_rx,
         ..
     } = setup_provider(pubkey, account).await;
 
-    _pubsub_client.block_subscribe();
+    pubsub_client.block_subscribe();
 
     let first_task_handle = tokio::spawn({
         let provider = provider.clone();
@@ -295,7 +295,7 @@ async fn test_try_get_multi_waiter_receives_setup_subscriptions_failure() {
         }
     });
 
-    _pubsub_client.wait_for_subscribe_attempts(1).await;
+    pubsub_client.wait_for_subscribe_attempts(1).await;
     tokio::time::sleep(Duration::from_millis(50)).await;
 
     let second_task_handle = tokio::spawn({
@@ -331,8 +331,8 @@ async fn test_try_get_multi_waiter_receives_setup_subscriptions_failure() {
         tokio::time::sleep(Duration::from_millis(10)).await;
     }
 
-    _pubsub_client.simulate_disconnect();
-    _pubsub_client.release_subscribe();
+    pubsub_client.simulate_disconnect();
+    pubsub_client.release_subscribe();
 
     let first_result =
         tokio::time::timeout(Duration::from_secs(2), first_task_handle)
@@ -397,7 +397,7 @@ async fn test_release_subscription_reason_keeps_watching_until_last_direct_refco
 
     let ProviderTestCtx {
         provider,
-        _pubsub_client,
+        pubsub_client,
         _forward_rx,
         ..
     } = setup_provider(pubkey, account).await;
@@ -418,7 +418,7 @@ async fn test_release_subscription_reason_keeps_watching_until_last_direct_refco
 
     assert!(!unsubscribed);
     assert!(provider.is_watching(&pubkey));
-    assert!(_pubsub_client.subscriptions_union().contains(&pubkey));
+    assert!(pubsub_client.subscriptions_union().contains(&pubkey));
 
     let unsubscribed = provider
         .release_single_subscription(&pubkey, SubscriptionReason::DirectAccount)
@@ -427,7 +427,7 @@ async fn test_release_subscription_reason_keeps_watching_until_last_direct_refco
 
     assert!(unsubscribed);
     assert!(!provider.is_watching(&pubkey));
-    assert!(!_pubsub_client.subscriptions_union().contains(&pubkey));
+    assert!(!pubsub_client.subscriptions_union().contains(&pubkey));
 }
 
 #[tokio::test]
@@ -443,7 +443,6 @@ async fn test_release_subscription_reason_all_clears_duplicate_reason_counts() {
 
     let ProviderTestCtx {
         provider,
-        _pubsub_client,
         _forward_rx,
         ..
     } = setup_provider(pubkey, account).await;
@@ -501,7 +500,7 @@ async fn test_release_subscription_reason_unsubscribes_after_final_release() {
 
     let ProviderTestCtx {
         provider,
-        _pubsub_client,
+        pubsub_client,
         _forward_rx,
         ..
     } = setup_provider(pubkey, account).await;
@@ -518,7 +517,7 @@ async fn test_release_subscription_reason_unsubscribes_after_final_release() {
 
     assert!(unsubscribed);
     assert!(!provider.is_watching(&pubkey));
-    assert!(!_pubsub_client.subscriptions_union().contains(&pubkey));
+    assert!(!pubsub_client.subscriptions_union().contains(&pubkey));
 }
 
 #[tokio::test]
@@ -535,7 +534,7 @@ async fn test_delegated_direct_cleanup_removes_final_direct_reason_without_notif
 
     let ProviderTestCtx {
         provider,
-        _pubsub_client,
+        pubsub_client,
         _forward_rx,
         ..
     } = setup_provider(pubkey, account).await;
@@ -556,7 +555,7 @@ async fn test_delegated_direct_cleanup_removes_final_direct_reason_without_notif
 
     assert!(unsubscribed);
     assert!(!provider.is_watching(&pubkey));
-    assert!(!_pubsub_client.subscriptions_union().contains(&pubkey));
+    assert!(!pubsub_client.subscriptions_union().contains(&pubkey));
     assert!(matches!(
         removed_rx.try_recv(),
         Err(tokio::sync::mpsc::error::TryRecvError::Empty)
@@ -576,7 +575,7 @@ async fn test_delegated_direct_cleanup_keeps_undelegation_tracking() {
 
     let ProviderTestCtx {
         provider,
-        _pubsub_client,
+        pubsub_client,
         _forward_rx,
         ..
     } = setup_provider(pubkey, account).await;
@@ -600,7 +599,7 @@ async fn test_delegated_direct_cleanup_keeps_undelegation_tracking() {
 
     assert!(!unsubscribed);
     assert!(provider.is_watching(&pubkey));
-    assert!(_pubsub_client.subscriptions_union().contains(&pubkey));
+    assert!(pubsub_client.subscriptions_union().contains(&pubkey));
 
     let unsubscribed = provider
         .release_subscription_with_mode(
@@ -613,7 +612,7 @@ async fn test_delegated_direct_cleanup_keeps_undelegation_tracking() {
 
     assert!(unsubscribed);
     assert!(!provider.is_watching(&pubkey));
-    assert!(!_pubsub_client.subscriptions_union().contains(&pubkey));
+    assert!(!pubsub_client.subscriptions_union().contains(&pubkey));
 }
 
 #[tokio::test]
@@ -629,7 +628,7 @@ async fn test_subscription_reasons_do_not_release_each_other() {
 
     let ProviderTestCtx {
         provider,
-        _pubsub_client,
+        pubsub_client,
         _forward_rx,
         ..
     } = setup_provider(pubkey, account).await;
@@ -650,7 +649,7 @@ async fn test_subscription_reasons_do_not_release_each_other() {
 
     assert!(!unsubscribed);
     assert!(provider.is_watching(&pubkey));
-    assert!(_pubsub_client.subscriptions_union().contains(&pubkey));
+    assert!(pubsub_client.subscriptions_union().contains(&pubkey));
 
     let unsubscribed = provider
         .release_single_subscription(
@@ -662,7 +661,7 @@ async fn test_subscription_reasons_do_not_release_each_other() {
 
     assert!(unsubscribed);
     assert!(!provider.is_watching(&pubkey));
-    assert!(!_pubsub_client.subscriptions_union().contains(&pubkey));
+    assert!(!pubsub_client.subscriptions_union().contains(&pubkey));
 }
 
 #[tokio::test]
@@ -679,7 +678,7 @@ async fn test_concurrent_reason_changes_do_not_unsubscribe_until_final_release()
 
     let ProviderTestCtx {
         provider,
-        _pubsub_client,
+        pubsub_client,
         _forward_rx,
         ..
     } = setup_provider(pubkey, account).await;
@@ -704,7 +703,7 @@ async fn test_concurrent_reason_changes_do_not_unsubscribe_until_final_release()
 
     assert!(!unsubscribed);
     assert!(provider.is_watching(&pubkey));
-    assert!(_pubsub_client.subscriptions_union().contains(&pubkey));
+    assert!(pubsub_client.subscriptions_union().contains(&pubkey));
 
     let unsubscribed = provider
         .release_single_subscription(
@@ -716,7 +715,7 @@ async fn test_concurrent_reason_changes_do_not_unsubscribe_until_final_release()
 
     assert!(unsubscribed);
     assert!(!provider.is_watching(&pubkey));
-    assert!(!_pubsub_client.subscriptions_union().contains(&pubkey));
+    assert!(!pubsub_client.subscriptions_union().contains(&pubkey));
 }
 
 #[tokio::test]
@@ -733,13 +732,13 @@ async fn test_reconciler_does_not_unsubscribe_registration_between_pubsub_and_lr
 
     let ProviderTestCtx {
         provider,
-        _pubsub_client,
+        pubsub_client,
         _forward_rx,
         ..
     } = setup_provider(pubkey, account).await;
 
-    _pubsub_client.pause_after_subscribe_insert();
-    let insertions_before = _pubsub_client.subscribe_insertions();
+    pubsub_client.pause_after_subscribe_insert();
+    let insertions_before = pubsub_client.subscribe_insertions();
 
     let provider_for_acquire = provider.clone();
     let acquire = tokio::spawn(async move {
@@ -748,11 +747,11 @@ async fn test_reconciler_does_not_unsubscribe_registration_between_pubsub_and_lr
             .await
     });
 
-    _pubsub_client
+    pubsub_client
         .wait_for_subscribe_insertions(insertions_before + 1)
         .await;
 
-    assert!(_pubsub_client.subscriptions_union().contains(&pubkey));
+    assert!(pubsub_client.subscriptions_union().contains(&pubkey));
     assert!(!provider.is_watching(&pubkey));
 
     let provider_for_reconcile = provider.clone();
@@ -765,11 +764,11 @@ async fn test_reconciler_does_not_unsubscribe_registration_between_pubsub_and_lr
     tokio::time::sleep(Duration::from_millis(50)).await;
 
     assert!(
-        _pubsub_client.subscriptions_union().contains(&pubkey),
+        pubsub_client.subscriptions_union().contains(&pubkey),
         "reconciler must not unsubscribe a registration that is in pubsub but not yet in the LRU"
     );
 
-    _pubsub_client.resume_after_subscribe_insert();
+    pubsub_client.resume_after_subscribe_insert();
     acquire
         .await
         .expect("acquire task should not panic")
@@ -777,7 +776,7 @@ async fn test_reconciler_does_not_unsubscribe_registration_between_pubsub_and_lr
     reconcile.await.expect("reconcile task should not panic");
 
     assert!(provider.is_watching(&pubkey));
-    assert!(_pubsub_client.subscriptions_union().contains(&pubkey));
+    assert!(pubsub_client.subscriptions_union().contains(&pubkey));
 }
 
 #[tokio::test]
@@ -795,18 +794,18 @@ async fn test_lock_aware_reconciler_still_removes_truly_stale_pubsub_only_subscr
 
     let ProviderTestCtx {
         provider,
-        _pubsub_client,
+        pubsub_client,
         _forward_rx,
         ..
     } = setup_provider(setup_pubkey, account).await;
 
-    _pubsub_client.insert_subscription(stale_pubkey);
-    assert!(_pubsub_client.subscriptions_union().contains(&stale_pubkey));
+    pubsub_client.insert_subscription(stale_pubkey);
+    assert!(pubsub_client.subscriptions_union().contains(&stale_pubkey));
     assert!(!provider.is_watching(&stale_pubkey));
 
     provider.reconcile_subscriptions_once_for_test().await;
 
-    assert!(!_pubsub_client.subscriptions_union().contains(&stale_pubkey));
+    assert!(!pubsub_client.subscriptions_union().contains(&stale_pubkey));
 }
 
 #[tokio::test]
@@ -823,7 +822,7 @@ async fn test_lock_aware_reconciler_still_resubscribes_lru_owned_missing_pubsub(
 
     let ProviderTestCtx {
         provider,
-        _pubsub_client,
+        pubsub_client,
         _forward_rx,
         ..
     } = setup_provider(pubkey, account).await;
@@ -833,19 +832,19 @@ async fn test_lock_aware_reconciler_still_resubscribes_lru_owned_missing_pubsub(
         .await
         .unwrap();
     assert!(provider.is_watching(&pubkey));
-    assert!(_pubsub_client.subscriptions_union().contains(&pubkey));
+    assert!(pubsub_client.subscriptions_union().contains(&pubkey));
 
-    _pubsub_client
+    pubsub_client
         .unsubscribe(pubkey)
         .await
         .expect("mock unsubscribe should remove pubsub state");
     assert!(provider.is_watching(&pubkey));
-    assert!(!_pubsub_client.subscriptions_union().contains(&pubkey));
+    assert!(!pubsub_client.subscriptions_union().contains(&pubkey));
 
     provider.reconcile_subscriptions_once_for_test().await;
 
     assert!(provider.is_watching(&pubkey));
-    assert!(_pubsub_client.subscriptions_union().contains(&pubkey));
+    assert!(pubsub_client.subscriptions_union().contains(&pubkey));
 }
 
 #[tokio::test]
@@ -863,7 +862,7 @@ async fn test_lru_eviction_clears_all_subscription_reasons_for_evicted_pubkey()
 
     let ProviderTestCtx {
         provider,
-        _pubsub_client,
+        pubsub_client,
         _forward_rx,
         ..
     } = setup_provider_with_lru_capacity(pubkey1, account, 1).await;
@@ -882,7 +881,7 @@ async fn test_lru_eviction_clears_all_subscription_reasons_for_evicted_pubkey()
         .unwrap();
 
     assert!(provider.is_watching(&pubkey1));
-    assert!(_pubsub_client.subscriptions_union().contains(&pubkey1));
+    assert!(pubsub_client.subscriptions_union().contains(&pubkey1));
     assert!(provider
         .subscription_ownership
         .lock()
@@ -896,8 +895,8 @@ async fn test_lru_eviction_clears_all_subscription_reasons_for_evicted_pubkey()
 
     assert!(!provider.is_watching(&pubkey1));
     assert!(provider.is_watching(&pubkey2));
-    assert!(!_pubsub_client.subscriptions_union().contains(&pubkey1));
-    assert!(_pubsub_client.subscriptions_union().contains(&pubkey2));
+    assert!(!pubsub_client.subscriptions_union().contains(&pubkey1));
+    assert!(pubsub_client.subscriptions_union().contains(&pubkey2));
     assert!(!provider
         .subscription_ownership
         .lock()
@@ -924,7 +923,7 @@ async fn test_lru_eviction_and_reason_release_are_serialized() {
 
     let ProviderTestCtx {
         provider,
-        _pubsub_client,
+        pubsub_client,
         _forward_rx,
         ..
     } = setup_provider_with_lru_capacity(pubkey1, account, 1).await;
@@ -952,8 +951,8 @@ async fn test_lru_eviction_and_reason_release_are_serialized() {
 
     assert!(!provider.is_watching(&pubkey1));
     assert!(provider.is_watching(&pubkey2));
-    assert!(!_pubsub_client.subscriptions_union().contains(&pubkey1));
-    assert!(_pubsub_client.subscriptions_union().contains(&pubkey2));
+    assert!(!pubsub_client.subscriptions_union().contains(&pubkey1));
+    assert!(pubsub_client.subscriptions_union().contains(&pubkey2));
     assert!(!provider
         .subscription_ownership
         .lock()

--- a/magicblock-chainlink/src/remote_account_provider/tests.rs
+++ b/magicblock-chainlink/src/remote_account_provider/tests.rs
@@ -781,6 +781,74 @@ async fn test_reconciler_does_not_unsubscribe_registration_between_pubsub_and_lr
 }
 
 #[tokio::test]
+async fn test_lock_aware_reconciler_still_removes_truly_stale_pubsub_only_subscription(
+) {
+    let setup_pubkey = solana_pubkey::Pubkey::new_unique();
+    let stale_pubkey = solana_pubkey::Pubkey::new_unique();
+    let account = Account {
+        lamports: 1_000_000,
+        data: vec![1, 2, 3, 4],
+        owner: solana_pubkey::Pubkey::new_unique(),
+        executable: false,
+        rent_epoch: 0,
+    };
+
+    let ProviderTestCtx {
+        provider,
+        _pubsub_client,
+        _forward_rx,
+        ..
+    } = setup_provider(setup_pubkey, account).await;
+
+    _pubsub_client.insert_subscription(stale_pubkey);
+    assert!(_pubsub_client.subscriptions_union().contains(&stale_pubkey));
+    assert!(!provider.is_watching(&stale_pubkey));
+
+    provider.reconcile_subscriptions_once_for_test().await;
+
+    assert!(!_pubsub_client.subscriptions_union().contains(&stale_pubkey));
+}
+
+#[tokio::test]
+async fn test_lock_aware_reconciler_still_resubscribes_lru_owned_missing_pubsub(
+) {
+    let pubkey = solana_pubkey::Pubkey::new_unique();
+    let account = Account {
+        lamports: 1_000_000,
+        data: vec![1, 2, 3, 4],
+        owner: solana_pubkey::Pubkey::new_unique(),
+        executable: false,
+        rent_epoch: 0,
+    };
+
+    let ProviderTestCtx {
+        provider,
+        _pubsub_client,
+        _forward_rx,
+        ..
+    } = setup_provider(pubkey, account).await;
+
+    provider
+        .acquire_subscription(&pubkey, SubscriptionReason::DirectAccount)
+        .await
+        .unwrap();
+    assert!(provider.is_watching(&pubkey));
+    assert!(_pubsub_client.subscriptions_union().contains(&pubkey));
+
+    _pubsub_client
+        .unsubscribe(pubkey)
+        .await
+        .expect("mock unsubscribe should remove pubsub state");
+    assert!(provider.is_watching(&pubkey));
+    assert!(!_pubsub_client.subscriptions_union().contains(&pubkey));
+
+    provider.reconcile_subscriptions_once_for_test().await;
+
+    assert!(provider.is_watching(&pubkey));
+    assert!(_pubsub_client.subscriptions_union().contains(&pubkey));
+}
+
+#[tokio::test]
 async fn test_lru_eviction_clears_all_subscription_reasons_for_evicted_pubkey()
 {
     let pubkey1 = solana_pubkey::Pubkey::new_unique();

--- a/magicblock-chainlink/src/remote_account_provider/tests.rs
+++ b/magicblock-chainlink/src/remote_account_provider/tests.rs
@@ -720,6 +720,67 @@ async fn test_concurrent_reason_changes_do_not_unsubscribe_until_final_release()
 }
 
 #[tokio::test]
+async fn test_reconciler_does_not_unsubscribe_registration_between_pubsub_and_lru(
+) {
+    let pubkey = solana_pubkey::Pubkey::new_unique();
+    let account = Account {
+        lamports: 1_000_000,
+        data: vec![1, 2, 3, 4],
+        owner: solana_pubkey::Pubkey::new_unique(),
+        executable: false,
+        rent_epoch: 0,
+    };
+
+    let ProviderTestCtx {
+        provider,
+        _pubsub_client,
+        _forward_rx,
+        ..
+    } = setup_provider(pubkey, account).await;
+
+    _pubsub_client.pause_after_subscribe_insert();
+    let insertions_before = _pubsub_client.subscribe_insertions();
+
+    let provider_for_acquire = provider.clone();
+    let acquire = tokio::spawn(async move {
+        provider_for_acquire
+            .acquire_subscription(&pubkey, SubscriptionReason::DirectAccount)
+            .await
+    });
+
+    _pubsub_client
+        .wait_for_subscribe_insertions(insertions_before + 1)
+        .await;
+
+    assert!(_pubsub_client.subscriptions_union().contains(&pubkey));
+    assert!(!provider.is_watching(&pubkey));
+
+    let provider_for_reconcile = provider.clone();
+    let reconcile = tokio::spawn(async move {
+        provider_for_reconcile
+            .reconcile_subscriptions_once_for_test()
+            .await
+    });
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    assert!(
+        _pubsub_client.subscriptions_union().contains(&pubkey),
+        "reconciler must not unsubscribe a registration that is in pubsub but not yet in the LRU"
+    );
+
+    _pubsub_client.resume_after_subscribe_insert();
+    acquire
+        .await
+        .expect("acquire task should not panic")
+        .expect("subscription acquire should succeed");
+    reconcile.await.expect("reconcile task should not panic");
+
+    assert!(provider.is_watching(&pubkey));
+    assert!(_pubsub_client.subscriptions_union().contains(&pubkey));
+}
+
+#[tokio::test]
 async fn test_lru_eviction_clears_all_subscription_reasons_for_evicted_pubkey()
 {
     let pubkey1 = solana_pubkey::Pubkey::new_unique();


### PR DESCRIPTION
## Summary

Fix a race where subscription reconciliation could unsubscribe an account while a normal subscription registration was between the pubsub subscribe and LRU tracking steps.

CLOSES: #1015

## Details

### magicblock-chainlink

The subscription reconciler now coordinates with the existing per-pubkey subscription transition locks. When reconciliation detects drift, it locks the affected pubkey, rechecks the current LRU/pubsub state, and only then performs a repair. This prevents stale reconciliation snapshots from undoing an in-progress registration while preserving the reconciler's ability to clean up real pubsub-only drift and resubscribe LRU-owned accounts missing from pubsub.

Added regression coverage for the pubsub-before-LRU race by pausing the mock pubsub client after insertion but before subscription acquisition completes. Added follow-up coverage proving lock-aware reconciliation still removes truly stale pubsub subscriptions and restores missing pubsub subscriptions for accounts still owned by the LRU.

Test/dev-only helpers were kept out of the main provider implementation flow, and the lock helper documents why creating a missing per-pubkey lock during reconciliation is intentional.
