### PR TITLE
fix: finalize the block on shutdown when primary

### DIFF
--- a/magicblock-processor/src/scheduler/mod.rs
+++ b/magicblock-processor/src/scheduler/mod.rs
@@ -301,6 +301,10 @@ impl TransactionScheduler {
                 else => break,
             }
         }
+        if self.coordinator.is_primary() {
+            let slot = self.transition_to_new_slot(None).await;
+            self.handle_superblock(slot).await;
+        }
         // Shutdown: drop executor channels to signal workers to stop,
         // then drain remaining ready notifications
         drop(self.executors);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced scheduler shutdown process in primary mode to properly finalize and complete all necessary operations during termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->