### PR TITLE
fix: omit reconnecting pubsub clients from reconciliation

### DIFF
--- a/.agents/context/crates/magicblock-chainlink.md
+++ b/.agents/context/crates/magicblock-chainlink.md
@@ -321,6 +321,8 @@ Removal handling is serialized with same-pubkey subscription transitions via `ev
 
 If subscription metrics are enabled, a background task periodically runs `subscription_reconciler::reconcile_subscriptions` to compare the LRU with actual pubsub-client subscriptions, update metrics, and notify removal for subscriptions that vanished.
 
+When the pubsub client is `SubMuxClient`, reconciliation snapshots are intentionally based only on currently connected inner clients. Disconnected/reconnecting clients are ignored by `subscriptions_union()` and `subscriptions_intersection()` until the reconnect path has reconnected them, resubscribed programs/accounts from the authoritative trackers, performed its catch-up pass, and marked them connected again. Reconciler-triggered SubMux subscribe/unsubscribe repair operations also fan out only to connected clients; reconnecting clients catch up through the reconnect path instead. If no inner pubsub client is connected, reconciliation skips repair/noisy LRU-vs-pubsub mismatch reporting for that tick because there is no live client to inspect or repair.
+
 ## SubMuxClient internals
 
 `SubMuxClient<T>` wraps multiple pubsub clients and implements `ChainPubsubClient`.

--- a/magicblock-chainlink/src/remote_account_provider/chain_pubsub_client.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_pubsub_client.rs
@@ -64,25 +64,17 @@ pub trait ChainPubsubClient: Send + Sync + Clone + 'static {
         self.subscriptions_union()
     }
 
-    /// Returns whether subscription reconciliation has at least one live
-    /// subscription client it can meaningfully inspect and repair.
-    ///
-    /// Single-client implementations default to available. Multi-client
-    /// implementations such as SubMuxClient should override this when all
-    /// inner clients are disconnected/reconnecting.
-    fn reconciliation_available(&self) -> bool {
-        true
-    }
-
     /// Returns an atomic reconciliation snapshot. `None` means no live
     /// subscription client is available to inspect or repair.
+    ///
+    /// Default single-client implementations are always inspectable and derive
+    /// both snapshot sets from one `subscriptions_union()` call. Implementers
+    /// with connection availability state, such as `SubMuxClient`, must override
+    /// this method and decide availability from the same state snapshot used to
+    /// build the returned sets.
     fn subscription_reconciliation_snapshot(
         &self,
     ) -> Option<SubscriptionReconciliationSnapshot> {
-        if !self.reconciliation_available() {
-            return None;
-        }
-
         let union = self.subscriptions_union();
         Some(SubscriptionReconciliationSnapshot {
             intersection: union.clone(),

--- a/magicblock-chainlink/src/remote_account_provider/chain_pubsub_client.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_pubsub_client.rs
@@ -22,6 +22,12 @@ use super::{
 
 const MAX_RESUB_DELAY_MS: u64 = 800;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SubscriptionReconciliationSnapshot {
+    pub union: HashSet<Pubkey>,
+    pub intersection: HashSet<Pubkey>,
+}
+
 // -----------------
 // Trait
 // -----------------
@@ -66,6 +72,22 @@ pub trait ChainPubsubClient: Send + Sync + Clone + 'static {
     /// inner clients are disconnected/reconnecting.
     fn reconciliation_available(&self) -> bool {
         true
+    }
+
+    /// Returns an atomic reconciliation snapshot. `None` means no live
+    /// subscription client is available to inspect or repair.
+    fn subscription_reconciliation_snapshot(
+        &self,
+    ) -> Option<SubscriptionReconciliationSnapshot> {
+        if !self.reconciliation_available() {
+            return None;
+        }
+
+        let union = self.subscriptions_union();
+        Some(SubscriptionReconciliationSnapshot {
+            intersection: union.clone(),
+            union,
+        })
     }
 
     fn subs_immediately(&self) -> bool;

--- a/magicblock-chainlink/src/remote_account_provider/chain_pubsub_client.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_pubsub_client.rs
@@ -58,6 +58,16 @@ pub trait ChainPubsubClient: Send + Sync + Clone + 'static {
         self.subscriptions_union()
     }
 
+    /// Returns whether subscription reconciliation has at least one live
+    /// subscription client it can meaningfully inspect and repair.
+    ///
+    /// Single-client implementations default to available. Multi-client
+    /// implementations such as SubMuxClient should override this when all
+    /// inner clients are disconnected/reconnecting.
+    fn reconciliation_available(&self) -> bool {
+        true
+    }
+
     fn subs_immediately(&self) -> bool;
 
     fn id(&self) -> &str;

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -57,9 +57,6 @@ pub mod pubsub_common;
 pub mod pubsub_connection;
 pub mod pubsub_connection_pool;
 mod remote_account;
-#[cfg(not(test))]
-mod subscription_reconciler;
-#[cfg(test)]
 pub(crate) mod subscription_reconciler;
 
 #[cfg(test)]

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -57,7 +57,10 @@ pub mod pubsub_common;
 pub mod pubsub_connection;
 pub mod pubsub_connection_pool;
 mod remote_account;
+#[cfg(not(test))]
 mod subscription_reconciler;
+#[cfg(test)]
+pub(crate) mod subscription_reconciler;
 
 #[cfg(test)]
 mod tests;

--- a/magicblock-chainlink/src/remote_account_provider/subscription_reconciler.rs
+++ b/magicblock-chainlink/src/remote_account_provider/subscription_reconciler.rs
@@ -81,10 +81,20 @@ pub(crate) async fn reconcile_subscriptions<PubsubClient: ChainPubsubClient>(
     removed_account_tx: &mpsc::Sender<Pubkey>,
     subscription_key_locks: Option<&SubscriptionKeyLocks>,
 ) -> usize {
-    let pubsub_union = pubsub_client.subscriptions_union();
-    let pubsub_intersection = pubsub_client.subscriptions_intersection();
     let lru_pubkeys = subscribed_accounts.pubkeys();
     let lru_count = lru_pubkeys.len();
+
+    if !pubsub_client.reconciliation_available() {
+        debug!(
+            lru_count = lru_count,
+            never_evicted_count = never_evicted.len(),
+            "Skipping subscription reconciliation because no connected pubsub client is available"
+        );
+        return lru_count + never_evicted.len();
+    }
+
+    let pubsub_union = pubsub_client.subscriptions_union();
+    let pubsub_intersection = pubsub_client.subscriptions_intersection();
 
     let ensured_subs_without_never_evict: HashSet<_> = pubsub_intersection
         .into_iter()

--- a/magicblock-chainlink/src/remote_account_provider/subscription_reconciler.rs
+++ b/magicblock-chainlink/src/remote_account_provider/subscription_reconciler.rs
@@ -84,23 +84,24 @@ pub(crate) async fn reconcile_subscriptions<PubsubClient: ChainPubsubClient>(
     let lru_pubkeys = subscribed_accounts.pubkeys();
     let lru_count = lru_pubkeys.len();
 
-    if !pubsub_client.reconciliation_available() {
+    let Some(pubsub_snapshot) =
+        pubsub_client.subscription_reconciliation_snapshot()
+    else {
         debug!(
             lru_count = lru_count,
             never_evicted_count = never_evicted.len(),
             "Skipping subscription reconciliation because no connected pubsub client is available"
         );
         return lru_count + never_evicted.len();
-    }
+    };
 
-    let pubsub_union = pubsub_client.subscriptions_union();
-    let pubsub_intersection = pubsub_client.subscriptions_intersection();
-
-    let ensured_subs_without_never_evict: HashSet<_> = pubsub_intersection
+    let ensured_subs_without_never_evict: HashSet<_> = pubsub_snapshot
+        .intersection
         .into_iter()
         .filter(|pk| !never_evicted.contains(pk))
         .collect();
-    let partial_subs_without_never_evict: HashSet<_> = pubsub_union
+    let partial_subs_without_never_evict: HashSet<_> = pubsub_snapshot
+        .union
         .into_iter()
         .filter(|pk| !never_evicted.contains(pk))
         .collect();
@@ -157,7 +158,17 @@ pub(crate) async fn reconcile_subscriptions<PubsubClient: ChainPubsubClient>(
                 continue;
             }
 
-            if pubsub_client.subscriptions_intersection().contains(&pubkey) {
+            let Some(pubsub_snapshot) =
+                pubsub_client.subscription_reconciliation_snapshot()
+            else {
+                trace!(
+                    pubkey = %pubkey,
+                    "Skipping resubscribe because no connected pubsub client is available after reconciliation snapshot"
+                );
+                continue;
+            };
+
+            if pubsub_snapshot.intersection.contains(&pubkey) {
                 trace!(
                     pubkey = %pubkey,
                     "Skipping resubscribe because pubkey is already ensured after reconciliation snapshot"
@@ -195,7 +206,17 @@ pub(crate) async fn reconcile_subscriptions<PubsubClient: ChainPubsubClient>(
                 continue;
             }
 
-            if !pubsub_client.subscriptions_union().contains(&pubkey) {
+            let Some(pubsub_snapshot) =
+                pubsub_client.subscription_reconciliation_snapshot()
+            else {
+                trace!(
+                    pubkey = %pubkey,
+                    "Skipping stale unsubscribe because no connected pubsub client is available after reconciliation snapshot"
+                );
+                continue;
+            };
+
+            if !pubsub_snapshot.union.contains(&pubkey) {
                 trace!(
                     pubkey = %pubkey,
                     "Skipping stale unsubscribe because pubkey left pubsub after reconciliation snapshot"

--- a/magicblock-chainlink/src/submux/mod.rs
+++ b/magicblock-chainlink/src/submux/mod.rs
@@ -1162,10 +1162,6 @@ where
             .collect()
     }
 
-    fn reconciliation_available(&self) -> bool {
-        !self.connected_clients_snapshot().is_empty()
-    }
-
     fn subscription_reconciliation_snapshot(
         &self,
     ) -> Option<SubscriptionReconciliationSnapshot> {
@@ -2226,7 +2222,7 @@ mod tests {
         wait_for_connected_clients(&mux, 0).await;
 
         assert_eq!(mux.connected_clients.load(Ordering::SeqCst), 0);
-        assert!(!mux.reconciliation_available());
+        assert!(mux.subscription_reconciliation_snapshot().is_none());
 
         let before_client1_attempts = client1.subscribe_attempts();
         let before_client2_attempts = client2.subscribe_attempts();

--- a/magicblock-chainlink/src/submux/mod.rs
+++ b/magicblock-chainlink/src/submux/mod.rs
@@ -1159,6 +1159,10 @@ where
             .collect()
     }
 
+    fn reconciliation_available(&self) -> bool {
+        !self.connected_clients_snapshot().is_empty()
+    }
+
     /// Returns true if any inner client subscribes immediately
     fn subs_immediately(&self) -> bool {
         self.clients_snapshot().iter().any(|c| c.subs_immediately())
@@ -1171,12 +1175,17 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::num::NonZeroUsize;
+
     use solana_account::Account;
     use tokio::sync::mpsc;
 
     use super::*;
     use crate::{
-        remote_account_provider::chain_pubsub_client::mock::ChainPubsubClientMock,
+        remote_account_provider::{
+            chain_pubsub_client::mock::ChainPubsubClientMock,
+            subscription_reconciler::reconcile_subscriptions, AccountsLruCache,
+        },
         submux::subscribed_accounts_tracker::mock::MockSubscribedAccountsTracker,
         testing::{init_logger, utils::sleep_ms},
     };
@@ -2118,6 +2127,53 @@ mod tests {
             !union.contains(&reconnecting_only_pk),
             "reconnecting-only subscriptions must not affect union"
         );
+
+        mux.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_reconcile_skips_repair_when_no_submux_clients_connected() {
+        init_logger();
+
+        let (tx1, rx1) = mpsc::channel(10_000);
+        let (tx2, rx2) = mpsc::channel(10_000);
+        let client1 = Arc::new(ChainPubsubClientMock::new(tx1, rx1));
+        let client2 = Arc::new(ChainPubsubClientMock::new(tx2, rx2));
+
+        let pk = Pubkey::new_unique();
+        let (mux, aborts) = new_submux_with_abort(
+            vec![client1.clone(), client2.clone()],
+            vec![pk],
+            Some(100),
+        );
+
+        mux.subscribe(pk, None).await.unwrap();
+
+        client1.disable_reconnect();
+        client2.disable_reconnect();
+        client1.simulate_disconnect();
+        client2.simulate_disconnect();
+        aborts[0].send(()).await.expect("abort send 1");
+        aborts[1].send(()).await.expect("abort send 2");
+        sleep_ms(100).await;
+
+        assert_eq!(mux.connected_clients.load(Ordering::SeqCst), 0);
+        assert!(!mux.reconciliation_available());
+
+        let before_client1_attempts = client1.subscribe_attempts();
+        let before_client2_attempts = client2.subscribe_attempts();
+
+        let lru = AccountsLruCache::new(NonZeroUsize::new(10).unwrap());
+        lru.add(pk);
+        let (removed_tx, mut removed_rx) = mpsc::channel::<Pubkey>(10);
+
+        let count =
+            reconcile_subscriptions(&lru, &mux, &[], &removed_tx, None).await;
+
+        assert_eq!(count, 1);
+        assert_eq!(client1.subscribe_attempts(), before_client1_attempts);
+        assert_eq!(client2.subscribe_attempts(), before_client2_attempts);
+        assert!(removed_rx.try_recv().is_err());
 
         mux.shutdown().await.unwrap();
     }

--- a/magicblock-chainlink/src/submux/mod.rs
+++ b/magicblock-chainlink/src/submux/mod.rs
@@ -1128,7 +1128,7 @@ where
 
     fn subscriptions_union(&self) -> HashSet<Pubkey> {
         let mut union = HashSet::new();
-        for client in self.clients_snapshot() {
+        for client in self.connected_clients_snapshot() {
             let subs = client.subscriptions_union();
             union.extend(subs);
         }
@@ -1137,7 +1137,7 @@ where
 
     fn subscriptions_intersection(&self) -> HashSet<Pubkey> {
         let sets: Vec<HashSet<Pubkey>> = self
-            .clients_snapshot()
+            .connected_clients_snapshot()
             .iter()
             .map(|c| c.subscriptions_intersection())
             .collect();

--- a/magicblock-chainlink/src/submux/mod.rs
+++ b/magicblock-chainlink/src/submux/mod.rs
@@ -2067,6 +2067,62 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_reconciliation_snapshots_ignore_reconnecting_clients() {
+        init_logger();
+
+        let (tx1, rx1) = mpsc::channel(10_000);
+        let (tx2, rx2) = mpsc::channel(10_000);
+        let (tx3, rx3) = mpsc::channel(10_000);
+        let client1 = Arc::new(ChainPubsubClientMock::new(tx1, rx1));
+        let client2 = Arc::new(ChainPubsubClientMock::new(tx2, rx2));
+        let client3 = Arc::new(ChainPubsubClientMock::new(tx3, rx3));
+
+        let shared_pk = Pubkey::new_unique();
+        let reconnecting_only_pk = Pubkey::new_unique();
+        let (mux, aborts) = new_submux_with_abort(
+            vec![client1.clone(), client2.clone(), client3.clone()],
+            vec![shared_pk],
+            Some(100),
+        );
+
+        mux.subscribe(shared_pk, None).await.unwrap();
+        assert!(client1.subscriptions_union().contains(&shared_pk));
+        assert!(client2.subscriptions_union().contains(&shared_pk));
+        assert!(client3.subscriptions_union().contains(&shared_pk));
+
+        client3.disable_reconnect();
+        client3.simulate_disconnect();
+        client3.insert_subscription(reconnecting_only_pk);
+        aborts[2].send(()).await.expect("abort send");
+        sleep_ms(100).await;
+
+        assert_eq!(mux.connected_clients.load(Ordering::SeqCst), 2);
+        assert_eq!(mux.connected_clients_snapshot().len(), 2);
+
+        let intersection = mux.subscriptions_intersection();
+        assert!(
+            intersection.contains(&shared_pk),
+            "connected clients still agree on the shared subscription"
+        );
+        assert!(
+            !intersection.contains(&reconnecting_only_pk),
+            "reconnecting-only subscriptions must not affect intersection"
+        );
+
+        let union = mux.subscriptions_union();
+        assert!(
+            union.contains(&shared_pk),
+            "connected-client union should include shared subscriptions"
+        );
+        assert!(
+            !union.contains(&reconnecting_only_pk),
+            "reconnecting-only subscriptions must not affect union"
+        );
+
+        mux.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
     async fn test_subscribe_skips_disconnected_client_during_reconnect() {
         init_logger();
 

--- a/magicblock-chainlink/src/submux/mod.rs
+++ b/magicblock-chainlink/src/submux/mod.rs
@@ -18,7 +18,10 @@ use tokio_util::sync::CancellationToken;
 use tracing::*;
 
 use crate::remote_account_provider::{
-    chain_pubsub_client::{ChainPubsubClient, ReconnectableClient},
+    chain_pubsub_client::{
+        ChainPubsubClient, ReconnectableClient,
+        SubscriptionReconciliationSnapshot,
+    },
     errors::RemoteAccountProviderResult,
     pubsub_common::SubscriptionUpdate,
 };
@@ -1161,6 +1164,51 @@ where
 
     fn reconciliation_available(&self) -> bool {
         !self.connected_clients_snapshot().is_empty()
+    }
+
+    fn subscription_reconciliation_snapshot(
+        &self,
+    ) -> Option<SubscriptionReconciliationSnapshot> {
+        let connected_clients = self.connected_clients_snapshot();
+        if connected_clients.is_empty() {
+            return None;
+        }
+
+        let mut union = HashSet::new();
+        let mut intersection_sets = Vec::with_capacity(connected_clients.len());
+        for client in connected_clients {
+            let snapshot = match client.subscription_reconciliation_snapshot() {
+                Some(snapshot) => snapshot,
+                None => continue,
+            };
+            union.extend(snapshot.union);
+            intersection_sets.push(snapshot.intersection);
+        }
+
+        if intersection_sets.is_empty() {
+            return None;
+        }
+
+        // Find the smallest set to iterate over, then check membership
+        // in all others — no intermediate cloning/collecting.
+        // SAFETY: we return above if the set is empty, so unwrap is safe here.
+        let smallest =
+            intersection_sets.iter().min_by_key(|s| s.len()).unwrap();
+        let intersection = smallest
+            .iter()
+            .filter(|pk| {
+                intersection_sets
+                    .iter()
+                    .filter(|s| !std::ptr::eq(*s, smallest))
+                    .all(|s| s.contains(pk))
+            })
+            .copied()
+            .collect();
+
+        Some(SubscriptionReconciliationSnapshot {
+            union,
+            intersection,
+        })
     }
 
     /// Returns true if any inner client subscribes immediately

--- a/magicblock-chainlink/src/submux/mod.rs
+++ b/magicblock-chainlink/src/submux/mod.rs
@@ -1303,6 +1303,26 @@ mod tests {
         )
     }
 
+    async fn wait_for_connected_clients(
+        mux: &SubMuxClient<ChainPubsubClientMock>,
+        expected: u16,
+    ) {
+        let deadline = Instant::now() + Duration::from_secs(1);
+        loop {
+            let connected = mux.connected_clients.load(Ordering::SeqCst);
+            let snapshot_len = mux.connected_clients_snapshot().len();
+            if connected == expected && snapshot_len == expected as usize {
+                return;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "timed out waiting for {expected} connected clients; \
+                 connected_clients={connected}, snapshot_len={snapshot_len}"
+            );
+            sleep_ms(10).await;
+        }
+    }
+
     // -----------------
     // Subscribe/Unsubscribe
     // -----------------
@@ -2151,7 +2171,7 @@ mod tests {
         client3.simulate_disconnect();
         client3.insert_subscription(reconnecting_only_pk);
         aborts[2].send(()).await.expect("abort send");
-        sleep_ms(100).await;
+        wait_for_connected_clients(&mux, 2).await;
 
         assert_eq!(mux.connected_clients.load(Ordering::SeqCst), 2);
         assert_eq!(mux.connected_clients_snapshot().len(), 2);
@@ -2203,7 +2223,7 @@ mod tests {
         client2.simulate_disconnect();
         aborts[0].send(()).await.expect("abort send 1");
         aborts[1].send(()).await.expect("abort send 2");
-        sleep_ms(100).await;
+        wait_for_connected_clients(&mux, 0).await;
 
         assert_eq!(mux.connected_clients.load(Ordering::SeqCst), 0);
         assert!(!mux.reconciliation_available());
@@ -2247,7 +2267,7 @@ mod tests {
         client1.disable_reconnect();
         client1.simulate_disconnect();
         aborts[0].send(()).await.expect("abort send");
-        sleep_ms(100).await;
+        wait_for_connected_clients(&mux, 1).await;
 
         assert_eq!(mux.connected_clients.load(Ordering::SeqCst), 1);
         let client1_attempts = client1.subscribe_attempts();


### PR DESCRIPTION
## Summary

Fix subscription reconciliation while pubsub clients are reconnecting:

- Make SubMux reconciliation snapshots consider only currently connected inner clients.
- Skip noisy reconciliation repair when no pubsub clients are connected.
- Add regression coverage for reconnecting clients and the all-disconnected reconciliation window.
- Document the Chainlink/SubMux reconciliation behavior for future agents.

## Details

### magicblock-chainlink

SubMux now reports subscription union/intersection based on connected clients only. Reconnecting clients no longer make the reconciler think healthy subscriptions are missing, and reconciler-triggered repair continues to fan out only to connected clients.

The pubsub client abstraction now exposes whether reconciliation is meaningful. SubMux uses this to report that reconciliation should be skipped when every inner client is disconnected or reconnecting, preventing full-LRU false positives while reconnect loops resubscribe from the authoritative trackers.

The subscription reconciler now checks that availability before taking pubsub snapshots. If no connected client is available, it leaves repair to reconnect handling for that tick instead of logging or attempting to resubscribe every LRU account.

### Tests and docs

Added unit coverage for:

- ignoring reconnecting clients in SubMux reconciliation snapshots;
- skipping reconciler repair when no SubMux clients are connected.

Updated the Chainlink agent documentation to capture the connected-client-only reconciliation behavior and the reconnect catch-up responsibility.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subscription reconciliation to only account for subscriptions from currently connected clients.
  * Reconciliation now avoids union/intersection noise when no live reconciliation snapshot is available, skipping repair/noisy reporting for that cycle.
  * Reconnecting/disconnected clients no longer affect reconciliation until they complete reconnect and rejoin the connected set.
* **Tests**
  * Added reconciliation tests covering reconnecting-only clients and the no-connected-clients scenario, plus updated timing assertions for connection-state transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->