### PR TITLE
feat: Establish nats connection in the background

### DIFF
--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -58,7 +58,7 @@ use magicblock_program::{
     validator::{self, validator_authority},
     TransactionScheduler as ActionTransactionScheduler,
 };
-use magicblock_replicator::{nats::Broker, ReplicationService};
+use magicblock_replicator::{nats::Broker, BrokerSource, ReplicationService};
 use magicblock_services::actions_callback_service::ActionsCallbackService;
 use magicblock_task_scheduler::{SchedulerDatabase, TaskSchedulerService};
 use magicblock_validator_admin::claim_fees::{claim_fees, ClaimFeesTask};
@@ -184,11 +184,14 @@ impl MagicValidator {
         let broker = if let Some(conf) =
             config.validator.replication_mode.config()
         {
-            let step_start = Instant::now();
-            let mut broker = Broker::connect(conf.url, conf.secret).await?;
             let is_fresh_start = accountsdb.slot() == 0;
-            // Fetch snapshot from primary if starting fresh
-            if is_fresh_start {
+            // A fresh node must fetch the bootstrap snapshot before ledger
+            // replay, so it connects synchronously here. Otherwise the connect
+            // (and producer-lock acquisition) is deferred to the replication
+            // service thread
+            let source = if is_fresh_start {
+                let step_start = Instant::now();
+                let mut broker = Broker::connect(conf.url, conf.secret).await?;
                 info!(
                     "accountsdb is not initialized, trying to fetch snapshot"
                 );
@@ -205,9 +208,15 @@ impl MagicValidator {
                 } else {
                     warn!("no snapshot is found in replication stream");
                 }
-            }
-            log_timing("startup", "replication broker init", step_start);
-            Some((broker, is_fresh_start))
+                log_timing("startup", "replication broker init", step_start);
+                BrokerSource::Connected(broker)
+            } else {
+                BrokerSource::Pending {
+                    url: conf.url,
+                    secret: conf.secret,
+                }
+            };
+            Some((source, is_fresh_start))
         } else {
             None
         };
@@ -245,12 +254,12 @@ impl MagicValidator {
         log_timing("startup", "chainlink_init", step_start);
 
         let replication_service =
-            if let Some((broker, is_fresh_start)) = broker {
+            if let Some((broker_source, is_fresh_start)) = broker {
                 let messages_rx = dispatch.replication_messages.take().expect(
                     "replication channel should always exist after init",
                 );
-                ReplicationService::new(
-                    broker,
+                Some(ReplicationService::new(
+                    broker_source,
                     mode_tx.clone(),
                     accountsdb.clone(),
                     ledger.clone(),
@@ -258,10 +267,9 @@ impl MagicValidator {
                     messages_rx,
                     token.clone(),
                     is_fresh_start,
-                    &config.validator.replication_mode,
+                    config.validator.replication_mode.clone(),
                     validator_pubkey,
-                )
-                .await?
+                ))
             } else {
                 None
             };

--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -255,9 +255,12 @@ impl MagicValidator {
 
         let replication_service =
             if let Some((broker_source, is_fresh_start)) = broker {
-                let messages_rx = dispatch.replication_messages.take().expect(
-                    "replication channel should always exist after init",
-                );
+                let messages_rx =
+                    dispatch.replication_messages.take().ok_or_else(|| {
+                        ApiError::FailedToSendModeSwitch(
+                            "replication channel missing after init".to_owned(),
+                        )
+                    })?;
                 Some(ReplicationService::new(
                     broker_source,
                     mode_tx.clone(),

--- a/magicblock-core/src/link/replication.rs
+++ b/magicblock-core/src/link/replication.rs
@@ -53,6 +53,10 @@ impl Message {
             Self::Reset(slot) => (*slot, RESET_INDEX),
         }
     }
+
+    pub fn requires_ack(&self) -> bool {
+        matches!(self, Self::SuperBlock(_) | Self::Reset(_))
+    }
 }
 
 /// Transaction with slot context for ordered replay.

--- a/magicblock-replicator/src/lib.rs
+++ b/magicblock-replicator/src/lib.rs
@@ -21,4 +21,4 @@ pub mod watcher;
 mod tests;
 
 pub use error::{Error, Result};
-pub use service::Service as ReplicationService;
+pub use service::{BrokerSource, Service as ReplicationService};

--- a/magicblock-replicator/src/service/mod.rs
+++ b/magicblock-replicator/src/service/mod.rs
@@ -41,8 +41,10 @@ use tokio::{
     sync::mpsc::{Receiver, Sender},
 };
 use tokio_util::sync::CancellationToken;
+use tracing::error;
+use url::Url;
 
-use crate::{nats::Broker, Error, Result};
+use crate::{nats::Broker, Result};
 
 // =============================================================================
 // Constants
@@ -53,13 +55,29 @@ pub(crate) const LEADER_TIMEOUT: Duration = Duration::from_secs(15);
 const CONSUMER_RETRY_DELAY: Duration = Duration::from_secs(1);
 
 // =============================================================================
+// Broker source
+// =============================================================================
+
+pub enum BrokerSource {
+    Connected(Broker),
+    Pending { url: Url, secret: String },
+}
+
+// =============================================================================
 // Service
 // =============================================================================
 
-/// Replication service for the selected replication role.
-pub enum Service {
-    Primary(Primary),
-    Replica(Replica),
+pub struct Service {
+    broker: BrokerSource,
+    mode_tx: Sender<SchedulerMode>,
+    accountsdb: Arc<AccountsDb>,
+    ledger: Arc<Ledger>,
+    scheduler: TransactionSchedulerHandle,
+    messages: Receiver<Message>,
+    cancel: CancellationToken,
+    reset: bool,
+    mode: ReplicationMode,
+    validator_identity: Pubkey,
 }
 
 impl Service {
@@ -68,8 +86,8 @@ impl Service {
     /// When `can_promote` is false (ReplicaOnly mode), skips lock acquisition
     /// and goes directly to Replica mode.
     #[allow(clippy::too_many_arguments)]
-    pub async fn new(
-        broker: Broker,
+    pub fn new(
+        broker: BrokerSource,
         mode_tx: Sender<SchedulerMode>,
         accountsdb: Arc<AccountsDb>,
         ledger: Arc<Ledger>,
@@ -77,10 +95,56 @@ impl Service {
         messages: Receiver<Message>,
         cancel: CancellationToken,
         reset: bool,
-        mode: &ReplicationMode,
+        mode: ReplicationMode,
         validator_identity: Pubkey,
-    ) -> crate::Result<Option<Self>> {
-        let ctx = ReplicationContext::new(
+    ) -> Self {
+        Self {
+            broker,
+            mode_tx,
+            accountsdb,
+            ledger,
+            scheduler,
+            messages,
+            cancel,
+            reset,
+            mode,
+            validator_identity,
+        }
+    }
+
+    /// Connects, enters the configured role, and runs until shutdown.
+    ///
+    /// Failing to connect or acquire the producer lock is fatal: it is logged
+    /// and the process exits, since a primary cannot run without them.
+    pub async fn run(self) {
+        let Self {
+            broker,
+            mode_tx,
+            accountsdb,
+            ledger,
+            scheduler,
+            messages,
+            cancel,
+            reset,
+            mode,
+            validator_identity,
+        } = self;
+
+        // Connect once (for `Pending`, this runs connect + init_resources here).
+        let broker = match broker {
+            BrokerSource::Connected(broker) => broker,
+            BrokerSource::Pending { url, secret } => {
+                match Broker::connect(url, secret).await {
+                    Ok(broker) => broker,
+                    Err(e) => {
+                        error!(%e, "replication broker connect failed");
+                        std::process::exit(1);
+                    }
+                }
+            }
+        };
+
+        let ctx = match ReplicationContext::new(
             broker,
             mode_tx,
             accountsdb,
@@ -89,40 +153,52 @@ impl Service {
             cancel,
             validator_identity,
         )
-        .await?;
-
-        if let ReplicationMode::Primary(_) = mode {
-            // Try to become primary
-            match ctx.try_acquire_producer().await? {
-                Some(producer) => Ok(Some(Self::Primary(
-                    ctx.into_primary(producer, messages).await?,
-                ))),
-                None => Err(Error::Internal(
-                    "Failed to acquire producer lock".into(),
-                )),
+        .await
+        {
+            Ok(ctx) => ctx,
+            Err(e) => {
+                error!(%e, "failed to initialize replication context");
+                std::process::exit(1);
             }
-        } else {
-            // Replica mode: skip lock acquisition, go directly to Replica
-            let Some(replica) = ctx.into_replica(reset).await? else {
-                // Shutdown during consumer creation
-                return Ok(None);
-            };
-            Ok(Some(Self::Replica(replica)))
+        };
+
+        match mode {
+            ReplicationMode::Primary(_) => {
+                let producer = match ctx.try_acquire_producer().await {
+                    Ok(Some(producer)) => producer,
+                    Ok(None) => {
+                        error!("failed to acquire producer lock");
+                        std::process::exit(1);
+                    }
+                    Err(e) => {
+                        error!(%e, "producer lock acquisition failed");
+                        std::process::exit(1);
+                    }
+                };
+                match ctx.into_primary(producer, messages).await {
+                    Ok(primary) => primary.run().await,
+                    Err(e) => {
+                        error!(%e, "failed to enter primary mode");
+                        std::process::exit(1);
+                    }
+                }
+            }
+            ReplicationMode::Replica { .. } => {
+                match ctx.into_replica(reset).await {
+                    Ok(Some(replica)) => replica.run().await,
+                    // Shutdown was signalled during consumer creation.
+                    Ok(None) => {}
+                    Err(e) => {
+                        error!(%e, "failed to enter replica mode");
+                        std::process::exit(1);
+                    }
+                }
+            }
+            ReplicationMode::Standalone => {}
         }
     }
 
-    /// Runs the configured replication role until it exits.
-    pub async fn run(self) {
-        match self {
-            Service::Primary(p) => p.run().await,
-            Service::Replica(s) => s.run().await,
-        }
-    }
-
-    /// Spawns the service in a dedicated OS thread with a single-threaded runtime.
-    ///
-    /// Returns a `JoinHandle` that yields startup/runtime errors from the
-    /// service thread.
+    /// Spawns the service on a dedicated OS thread with a single-threaded runtime.
     pub fn spawn(self) -> JoinHandle<Result<()>> {
         std::thread::spawn(move || {
             let runtime = Builder::new_current_thread()

--- a/magicblock-replicator/src/service/primary.rs
+++ b/magicblock-replicator/src/service/primary.rs
@@ -176,21 +176,27 @@ impl Primary {
             warn!("primary lock is not held, skipping replication drain");
             return;
         }
+        let _timing = ShutdownTiming::new("replication_service_drain");
 
         let deadline = Instant::now() + SHUTDOWN_DRAIN_TIMEOUT;
         let mut drained = 0_u64;
+        let mut acked = 0_u64;
 
         if let Some(msg) = pending.take() {
             if !self.publish_with_retry_until(&msg, Some(deadline)).await {
-                warn!(drained, "failed to drain pending replication message");
+                warn!(
+                    drained,
+                    acked, "failed to drain pending replication message"
+                );
                 return;
             }
             drained += 1;
+            acked += msg.requires_ack() as u64;
         }
 
         loop {
             if Instant::now() >= deadline {
-                warn!(drained, "replication shutdown drain timed out");
+                warn!(drained, acked, "replication shutdown drain timed out");
                 return;
             }
 
@@ -202,19 +208,24 @@ impl Primary {
                     {
                         warn!(
                             drained,
-                            "failed to drain queued replication message"
+                            acked, "failed to drain queued replication message"
                         );
                         return;
                     }
                     drained += 1;
+                    acked += msg.requires_ack() as u64;
                 }
                 Err(TryRecvError::Empty) => {
-                    info!(drained, "replication shutdown drain complete");
+                    info!(
+                        drained,
+                        acked, "replication shutdown drain complete"
+                    );
                     return;
                 }
                 Err(TryRecvError::Disconnected) => {
                     info!(
                         drained,
+                        acked,
                         "replication channel closed during shutdown drain"
                     );
                     return;
@@ -227,6 +238,7 @@ impl Primary {
         if !lock_state.can_publish() {
             return;
         }
+        let _timing = ShutdownTiming::new("replication_service_lock_release");
         if let Err(error) = self.producer.release().await {
             warn!(%error, "failed to release the lock");
         }
@@ -243,7 +255,7 @@ impl Primary {
         let subject = Subjects::from_message(msg);
         let (slot, index) = msg.slot_and_index();
         let msg_id = message_id(slot, index);
-        let ack = matches!(msg, Message::SuperBlock(_) | Message::Reset(_));
+        let ack = msg.requires_ack();
 
         self.ctx
             .broker
@@ -315,6 +327,31 @@ impl Primary {
         }
 
         false
+    }
+}
+
+struct ShutdownTiming {
+    step: &'static str,
+    start: Instant,
+}
+
+impl ShutdownTiming {
+    fn new(step: &'static str) -> Self {
+        Self {
+            step,
+            start: Instant::now(),
+        }
+    }
+}
+
+impl Drop for ShutdownTiming {
+    fn drop(&mut self) {
+        info!(
+            phase = "shutdown",
+            step = self.step,
+            duration_ms = self.start.elapsed().as_millis() as u64,
+            "Validator timing"
+        );
     }
 }
 


### PR DESCRIPTION
## Summary
In case of warm restart - nats connection is establish by replicator in the background (separate thread). If preserves the same terminating behaviour in case of failure. When there's an empty account db it performs blocking connect on main thread as it needs to pull the snapshot anyway before moving forward.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replication startup now supports both immediate and deferred broker connection, improving bootstrap handling for fresh and already-running nodes.
  * Message handling now consistently tracks whether acknowledgements are required for different replication events.

* **Bug Fixes**
  * Shutdown draining now reports both drained and acknowledged messages, giving clearer visibility into replication cleanup.
  * Added more detailed timing logs for key replication startup and shutdown steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->