### PR TITLE
Harden projected ATA cloning

### DIFF
--- a/.agents/context/crates/magicblock-chainlink.md
+++ b/.agents/context/crates/magicblock-chainlink.md
@@ -233,6 +233,8 @@ Chainlink has special handling for associated token accounts and ephemeral ATAs:
 Pitfalls:
 
 - Do not rebuild Token-2022 accounts as legacy SPL Token accounts; use the projection helpers that preserve layout.
+- Native-token normalization is safe only after Chainlink has proved the cloned account is a canonical ATA/eATA projection target. Non-canonical delegated wrapped-SOL token accounts must be preserved because commit settlement will not remap them to eATA.
+- Projected ATAs are virtual eATA views and should be uncloseable locally; do not preserve base close authority on the projected clone.
 - Same-slot delegated refreshes are a narrow ordering exception for allowing a delegated update over plain/undelegating local state at the same `remote_slot`. They do not mean same-slot re-delegation to the same validator is fully supported; without a delegation generation/index, `account_still_undelegating_on_chain` cannot distinguish `delegation_slot == remote_slot_in_bank` from a still-pending undelegation, and `magicblock-chainlink/tests/07_redeleg_us_same_slot.rs` remains ignored for that reason.
 - Undelegating ATAs may remain in bank while a companion eATA is still delegated to this validator.
 

--- a/.agents/context/crates/magicblock-chainlink.md
+++ b/.agents/context/crates/magicblock-chainlink.md
@@ -234,6 +234,7 @@ Pitfalls:
 
 - Do not rebuild Token-2022 accounts as legacy SPL Token accounts; use the projection helpers that preserve layout.
 - Native-token normalization is safe only after Chainlink has proved the cloned account is a canonical ATA/eATA projection target. Non-canonical delegated wrapped-SOL token accounts must be preserved because commit settlement will not remap them to eATA.
+- If canonical delegated ATA normalization reports malformed token-program data, reject the clone request instead of forwarding the unnormalized account to the cloner.
 - Projected ATAs are virtual eATA views and should be uncloseable locally; do not preserve base close authority on the projected clone.
 - Same-slot delegated refreshes are a narrow ordering exception for allowing a delegated update over plain/undelegating local state at the same `remote_slot`. They do not mean same-slot re-delegation to the same validator is fully supported; without a delegation generation/index, `account_still_undelegating_on_chain` cannot distinguish `delegation_slot == remote_slot_in_bank` from a still-pending undelegation, and `magicblock-chainlink/tests/07_redeleg_us_same_slot.rs` remains ignored for that reason.
 - Undelegating ATAs may remain in bank while a companion eATA is still delegated to this validator.

--- a/.agents/context/crates/magicblock-core.md
+++ b/.agents/context/crates/magicblock-core.md
@@ -146,7 +146,9 @@ Use `CoordinationMode::current()`, `needs_validator_signer()`, `should_schedule_
 - ATA derivation: `derive_ata`, `derive_ata_with_token_program`, `try_derive_supported_ata_pubkeys`.
 - eATA derivation: `derive_eata`, `try_derive_eata_address_and_bump`.
 - ATA detection/remapping: `is_ata`, `try_remap_ata_to_eata`.
-- eATA projection: `MaybeIntoAta<AccountSharedData>` and `EphemeralAta` conversion/projection helpers.
+- eATA projection: `EphemeralAta` projection helpers require a real base ATA layout and do not synthesize legacy SPL Token accounts from raw eATA data.
+- Native-token local projection: `normalize_native_token_account_for_local_clone` strips `is_native` and claimable lamports only for canonical delegated ATA clones, and supports both legacy SPL Token native mint and Token-2022 native mint while preserving Token-2022 account layout/extensions.
+- Projected ATA local safety: `normalize_projected_token_account_for_local_clone` makes virtual projected ATAs uncloseable with `close_authority = Some(Pubkey::default())`; closure/materialization belongs in settlement, not local projection.
 
 ## Runtime flows
 
@@ -241,6 +243,8 @@ Keep these types serializable and stable enough for persistence and cross-crate 
 ### Token and eATA helpers are protocol-sensitive
 
 `try_remap_ata_to_eata` only remaps delegated token accounts whose pubkey matches the derived ATA for their owner/mint/token program. `EphemeralAta::try_from_account_data` supports both `EPHEMERAL_ATA_LEN` and `LEGACY_EPHEMERAL_ATA_LEN`. Changes here can affect cloning, post-delegation token transfer tests, commit account payloads, and chainlink blacklisting/ATA projection.
+
+Native-token projection is intentionally limited to local ATA/eATA projection semantics. Do not turn arbitrary delegated wrapped-SOL token accounts into non-native accounts or strip their lamports unless the surrounding caller has proved the account is a canonical ATA that will remap to eATA on settlement.
 
 ### Logging initialization is process-global
 

--- a/magicblock-chainlink/src/chainlink/errors.rs
+++ b/magicblock-chainlink/src/chainlink/errors.rs
@@ -25,6 +25,9 @@ pub enum ChainlinkError {
     #[error("Delegation actions could not be decoded: {0} ({1})")]
     InvalidDelegationActions(Pubkey, String),
 
+    #[error("Token account could not be decoded while cloning: {0} ({1})")]
+    InvalidTokenAccount(Pubkey, String),
+
     #[error("Failed to resolve one or more accounts {0} when getting delegation records")]
     DelegatedAccountResolutionsFailed(String),
 

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/ata_projection.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/ata_projection.rs
@@ -5,7 +5,7 @@ use futures_util::future::join_all;
 use magicblock_accounts_db::traits::AccountsBank;
 use magicblock_core::token_programs::{
     is_ata, try_derive_eata_address_and_bump, try_derive_supported_ata_pubkeys,
-    AtaInfo, EphemeralAta, MaybeIntoAta, EATA_PROGRAM_ID,
+    AtaInfo, EphemeralAta, EATA_PROGRAM_ID,
 };
 use magicblock_metrics::metrics;
 use solana_account::{AccountSharedData, ReadableAccount};
@@ -185,8 +185,10 @@ where
         if let Some(candidate_account) =
             this.accounts_bank.get_account(&candidate_pubkey)
         {
-            base_ata = Some((candidate_pubkey, candidate_account));
-            break;
+            if is_ata(&candidate_pubkey, &candidate_account).is_some() {
+                base_ata = Some((candidate_pubkey, candidate_account));
+                break;
+            }
         }
     }
     let (ata_pubkey, base_ata) = match base_ata {
@@ -399,9 +401,7 @@ where
         None
     };
 
-    let mut projected_ata = match projected_from_base_ata
-        .or_else(|| eata_account.maybe_into_ata(deleg_record.owner))
-    {
+    let mut projected_ata = match projected_from_base_ata {
         Some(projected_ata) => projected_ata,
         None => {
             return None;

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -16,6 +16,7 @@ use magicblock_accounts_db::traits::AccountsBank;
 use magicblock_aml::RiskService;
 use magicblock_config::config::AllowedProgram;
 use magicblock_core::token_programs::{
+    normalize_native_token_account_for_local_clone,
     try_derive_supported_ata_pubkeys, EATA_PROGRAM_ID,
 };
 use magicblock_metrics::metrics::{self, AccountFetchOrigin};
@@ -698,6 +699,11 @@ where
         &self,
         mut request: AccountCloneRequest,
     ) -> ChainlinkResult<Signature> {
+        if request.account.delegated() {
+            normalize_native_token_account_for_local_clone(
+                &mut request.account,
+            );
+        }
         self.normalize_unresolved_dlp_clone_request(&mut request)?;
 
         if request.account.delegated()

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -701,10 +701,14 @@ where
     ) -> ChainlinkResult<Signature> {
         if request.account.delegated()
             && is_ata(&request.pubkey, &request.account).is_some()
-        {
-            normalize_native_token_account_for_local_clone(
+            && !normalize_native_token_account_for_local_clone(
                 &mut request.account,
-            );
+            )
+        {
+            return Err(ChainlinkError::InvalidTokenAccount(
+                request.pubkey,
+                "delegated ATA token data is malformed".to_string(),
+            ));
         }
         self.normalize_unresolved_dlp_clone_request(&mut request)?;
 

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -16,7 +16,7 @@ use magicblock_accounts_db::traits::AccountsBank;
 use magicblock_aml::RiskService;
 use magicblock_config::config::AllowedProgram;
 use magicblock_core::token_programs::{
-    normalize_native_token_account_for_local_clone,
+    is_ata, normalize_native_token_account_for_local_clone,
     try_derive_supported_ata_pubkeys, EATA_PROGRAM_ID,
 };
 use magicblock_metrics::metrics::{self, AccountFetchOrigin};
@@ -699,7 +699,9 @@ where
         &self,
         mut request: AccountCloneRequest,
     ) -> ChainlinkResult<Signature> {
-        if request.account.delegated() {
+        if request.account.delegated()
+            && is_ata(&request.pubkey, &request.account).is_some()
+        {
             normalize_native_token_account_for_local_clone(
                 &mut request.account,
             );

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -14,7 +14,7 @@ use spl_token::state::{Account as SplAccount, AccountState};
 use spl_token_2022::{
     extension::{
         immutable_owner::ImmutableOwner, BaseStateWithExtensions,
-        StateWithExtensions,
+        StateWithExtensions, StateWithExtensionsMut,
     },
     state::Account as Token2022Account,
 };
@@ -5109,6 +5109,12 @@ async fn test_delegated_eata_subscription_update_clones_raw_eata_and_projects_at
     assert_eq!(projected_mint, mint);
     assert_eq!(projected_owner, wallet_owner);
     assert_eq!(projected_amount, AMOUNT);
+    let projected_token =
+        SplAccount::unpack(ata_data).expect("unpack projected ATA");
+    assert_eq!(
+        projected_token.close_authority,
+        COption::Some(Pubkey::default())
+    );
 }
 
 #[tokio::test]
@@ -5812,6 +5818,7 @@ async fn test_delegated_native_token_clone_uses_data_only_amount() {
                 commit_frequency_ms: None,
                 delegation_actions: DelegationActions::default(),
                 delegated_to_other: None,
+                needs_undelegation: false,
             },
         )
         .await
@@ -5830,6 +5837,65 @@ async fn test_delegated_native_token_clone_uses_data_only_amount() {
         token_account.close_authority,
         COption::Some(Pubkey::default())
     );
+}
+
+#[tokio::test]
+async fn test_delegated_non_ata_native_token_clone_preserves_wrapped_sol_layout(
+) {
+    init_logger();
+    let validator_keypair = Keypair::new();
+    const CURRENT_SLOT: u64 = 100;
+    const AMOUNT: u64 = 100_000_000;
+
+    let FetcherTestCtx {
+        cloner,
+        fetch_cloner,
+        ..
+    } = setup(
+        std::iter::empty::<(Pubkey, Account)>(),
+        CURRENT_SLOT,
+        validator_keypair.insecure_clone(),
+    )
+    .await;
+
+    let wallet_owner = random_pubkey();
+    let account_pubkey = loop {
+        let candidate = random_pubkey();
+        if candidate != derive_ata(&wallet_owner, &spl_token::native_mint::id())
+        {
+            break candidate;
+        }
+    };
+    let (native_account, rent_exempt_reserve) =
+        create_native_ata_account(&wallet_owner, AMOUNT);
+    let mut account = AccountSharedData::from(native_account);
+    account.set_remote_slot(CURRENT_SLOT);
+    account.set_delegated(true);
+
+    fetch_cloner
+        .clone_account_with_post_delegation_action_invariants(
+            AccountCloneRequest {
+                pubkey: account_pubkey,
+                account,
+                commit_frequency_ms: None,
+                delegation_actions: DelegationActions::default(),
+                delegated_to_other: None,
+                needs_undelegation: false,
+            },
+        )
+        .await
+        .expect("non-ATA native token clone should be preserved");
+
+    let clone_requests = cloner.clone_requests();
+    assert_eq!(clone_requests.len(), 1);
+    let cloned_account = &clone_requests[0].account;
+    assert_eq!(cloned_account.lamports(), rent_exempt_reserve + AMOUNT);
+
+    let token_account = SplAccount::unpack(cloned_account.data())
+        .expect("unpack non-ATA native token account");
+    assert_eq!(token_account.amount, AMOUNT);
+    assert_eq!(token_account.is_native, COption::Some(rent_exempt_reserve));
+    assert_eq!(token_account.close_authority, COption::None);
 }
 
 #[tokio::test]
@@ -5865,6 +5931,7 @@ async fn test_plain_native_token_clone_preserves_wrapped_sol_layout() {
                 commit_frequency_ms: None,
                 delegation_actions: DelegationActions::default(),
                 delegated_to_other: None,
+                needs_undelegation: false,
             },
         )
         .await
@@ -6782,6 +6849,13 @@ async fn test_greedy_delegated_eata_update_projects_remote_token_2022_ata() {
     assert_eq!(projected_mint, mint);
     assert_eq!(projected_owner, wallet_owner);
     assert_eq!(projected_amount, EATA_AMOUNT);
+    let projected_token_account =
+        StateWithExtensions::<Token2022Account>::unpack(ata_data)
+            .expect("unpack projected Token-2022 ATA");
+    assert_eq!(
+        projected_token_account.base.close_authority,
+        COption::Some(Pubkey::default())
+    );
 
     assert!(
         accounts_bank.get_account(&legacy_ata_pubkey).is_none(),
@@ -7348,12 +7422,13 @@ async fn test_ata_projection_releases_ata_direct_ref_after_fetch() {
 }
 
 #[tokio::test]
-async fn test_token_2022_ata_projection_preserves_token_program_and_layout() {
+async fn test_token_2022_native_ata_projection_normalizes_and_preserves_layout()
+{
     init_logger();
     let validator_keypair = Keypair::new();
     let validator_pubkey = validator_keypair.pubkey();
     let wallet_owner = random_pubkey();
-    let mint = random_pubkey();
+    let mint = spl_token_2022::native_mint::id();
     const CURRENT_SLOT: u64 = 100;
     const AMOUNT: u64 = 777;
 
@@ -7363,9 +7438,20 @@ async fn test_token_2022_ata_projection_preserves_token_program_and_layout() {
         &TOKEN_2022_PROGRAM_ID,
     );
     let eata_pubkey = derive_eata(&wallet_owner, &mint);
-    let ata_account = create_token_2022_ata_account(&wallet_owner, &mint);
+    let mut ata_account = create_token_2022_ata_account(&wallet_owner, &mint);
     let eata_account = create_eata_account(&wallet_owner, &mint, AMOUNT, true);
     let expected_len = ata_account.data.len();
+    let rent_exempt_reserve = Rent::default().minimum_balance(expected_len);
+    {
+        let mut token_account =
+            StateWithExtensionsMut::<Token2022Account>::unpack(
+                &mut ata_account.data,
+            )
+            .expect("unpack Token-2022 native ATA");
+        token_account.base.is_native = COption::Some(rent_exempt_reserve);
+        token_account.pack_base();
+    }
+    ata_account.lamports = rent_exempt_reserve + AMOUNT;
 
     let FetcherTestCtx {
         accounts_bank,
@@ -7403,19 +7489,25 @@ async fn test_token_2022_ata_projection_preserves_token_program_and_layout() {
         .expect("Token-2022 ATA should be projected");
     assert!(projected_ata.delegated());
     assert_eq!(*projected_ata.owner(), TOKEN_2022_PROGRAM_ID);
+    assert_eq!(projected_ata.lamports(), rent_exempt_reserve);
     assert_eq!(projected_ata.data().len(), expected_len);
     assert_eq!(projected_ata.remote_slot(), CURRENT_SLOT);
 
     let ata_data = projected_ata.data();
-    let projected_mint =
-        Pubkey::new_from_array(ata_data[0..32].try_into().unwrap());
-    let projected_owner =
-        Pubkey::new_from_array(ata_data[32..64].try_into().unwrap());
-    let projected_amount =
-        u64::from_le_bytes(ata_data[64..72].try_into().unwrap());
-    assert_eq!(projected_mint, mint);
-    assert_eq!(projected_owner, wallet_owner);
-    assert_eq!(projected_amount, AMOUNT);
+    let projected_token_account =
+        StateWithExtensions::<Token2022Account>::unpack(ata_data)
+            .expect("unpack projected Token-2022 ATA");
+    assert_eq!(projected_token_account.base.mint, mint);
+    assert_eq!(projected_token_account.base.owner, wallet_owner);
+    assert_eq!(projected_token_account.base.amount, AMOUNT);
+    assert_eq!(projected_token_account.base.is_native, COption::None);
+    assert_eq!(
+        projected_token_account.base.close_authority,
+        COption::Some(Pubkey::default())
+    );
+    projected_token_account
+        .get_extension::<ImmutableOwner>()
+        .expect("projected Token-2022 ATA preserves ImmutableOwner");
 }
 
 #[tokio::test]

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -6,8 +6,11 @@ use solana_account::{
 };
 use solana_instruction::{AccountMeta, Instruction};
 use solana_keypair::Keypair;
+use solana_program::{program_option::COption, program_pack::Pack};
+use solana_rent::Rent;
 use solana_sdk_ids::system_program;
 use solana_signer::Signer;
+use spl_token::state::{Account as SplAccount, AccountState};
 use spl_token_2022::{
     extension::{
         immutable_owner::ImmutableOwner, BaseStateWithExtensions,
@@ -230,6 +233,38 @@ fn loaded_test_program(
         loader_status: solana_loader_v4_interface::state::LoaderV4Status::Deployed,
         remote_slot,
     }
+}
+
+fn create_native_ata_account(
+    wallet_owner: &Pubkey,
+    amount: u64,
+) -> (Account, u64) {
+    let rent_exempt_reserve = Rent::default().minimum_balance(SplAccount::LEN);
+    let token_account = SplAccount {
+        mint: spl_token::native_mint::id(),
+        owner: *wallet_owner,
+        amount,
+        delegate: COption::None,
+        state: AccountState::Initialized,
+        is_native: COption::Some(rent_exempt_reserve),
+        delegated_amount: 0,
+        close_authority: COption::None,
+    };
+
+    let mut data = vec![0u8; SplAccount::LEN];
+    SplAccount::pack(token_account, &mut data)
+        .expect("pack native token account");
+
+    (
+        Account {
+            lamports: rent_exempt_reserve + amount,
+            data,
+            owner: spl_token::id(),
+            executable: false,
+            ..Default::default()
+        },
+        rent_exempt_reserve,
+    )
 }
 
 fn create_non_raw_eata_owned_account(
@@ -5741,6 +5776,110 @@ async fn test_dlp_owned_magic_fee_vault_without_actions_remains_delegated() {
     assert_eq!(cloned_account.owner(), &dlp_api::id());
     assert!(cloned_account.delegated());
     assert!(!cloned_account.confined());
+}
+
+#[tokio::test]
+async fn test_delegated_native_token_clone_uses_data_only_amount() {
+    init_logger();
+    let validator_keypair = Keypair::new();
+    const CURRENT_SLOT: u64 = 100;
+    const AMOUNT: u64 = 100_000_000;
+
+    let FetcherTestCtx {
+        cloner,
+        fetch_cloner,
+        ..
+    } = setup(
+        std::iter::empty::<(Pubkey, Account)>(),
+        CURRENT_SLOT,
+        validator_keypair.insecure_clone(),
+    )
+    .await;
+
+    let wallet_owner = random_pubkey();
+    let ata_pubkey = derive_ata(&wallet_owner, &spl_token::native_mint::id());
+    let (native_ata, rent_exempt_reserve) =
+        create_native_ata_account(&wallet_owner, AMOUNT);
+    let mut account = AccountSharedData::from(native_ata);
+    account.set_remote_slot(CURRENT_SLOT);
+    account.set_delegated(true);
+
+    fetch_cloner
+        .clone_account_with_post_delegation_action_invariants(
+            AccountCloneRequest {
+                pubkey: ata_pubkey,
+                account,
+                commit_frequency_ms: None,
+                delegation_actions: DelegationActions::default(),
+                delegated_to_other: None,
+            },
+        )
+        .await
+        .expect("native token clone should be normalized");
+
+    let clone_requests = cloner.clone_requests();
+    assert_eq!(clone_requests.len(), 1);
+    let cloned_account = &clone_requests[0].account;
+    assert_eq!(cloned_account.lamports(), rent_exempt_reserve);
+
+    let token_account =
+        SplAccount::unpack(cloned_account.data()).expect("unpack native ATA");
+    assert_eq!(token_account.amount, AMOUNT);
+    assert_eq!(token_account.is_native, COption::None);
+    assert_eq!(
+        token_account.close_authority,
+        COption::Some(Pubkey::default())
+    );
+}
+
+#[tokio::test]
+async fn test_plain_native_token_clone_preserves_wrapped_sol_layout() {
+    init_logger();
+    let validator_keypair = Keypair::new();
+    const CURRENT_SLOT: u64 = 100;
+    const AMOUNT: u64 = 100_000_000;
+
+    let FetcherTestCtx {
+        cloner,
+        fetch_cloner,
+        ..
+    } = setup(
+        std::iter::empty::<(Pubkey, Account)>(),
+        CURRENT_SLOT,
+        validator_keypair.insecure_clone(),
+    )
+    .await;
+
+    let wallet_owner = random_pubkey();
+    let ata_pubkey = derive_ata(&wallet_owner, &spl_token::native_mint::id());
+    let (native_ata, rent_exempt_reserve) =
+        create_native_ata_account(&wallet_owner, AMOUNT);
+    let mut account = AccountSharedData::from(native_ata);
+    account.set_remote_slot(CURRENT_SLOT);
+
+    fetch_cloner
+        .clone_account_with_post_delegation_action_invariants(
+            AccountCloneRequest {
+                pubkey: ata_pubkey,
+                account,
+                commit_frequency_ms: None,
+                delegation_actions: DelegationActions::default(),
+                delegated_to_other: None,
+            },
+        )
+        .await
+        .expect("plain native token clone should be preserved");
+
+    let clone_requests = cloner.clone_requests();
+    assert_eq!(clone_requests.len(), 1);
+    let cloned_account = &clone_requests[0].account;
+    assert_eq!(cloned_account.lamports(), rent_exempt_reserve + AMOUNT);
+
+    let token_account =
+        SplAccount::unpack(cloned_account.data()).expect("unpack native ATA");
+    assert_eq!(token_account.amount, AMOUNT);
+    assert_eq!(token_account.is_native, COption::Some(rent_exempt_reserve));
+    assert_eq!(token_account.close_authority, COption::None);
 }
 
 #[tokio::test]

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -5840,6 +5840,62 @@ async fn test_delegated_native_token_clone_uses_data_only_amount() {
 }
 
 #[tokio::test]
+async fn test_delegated_malformed_ata_clone_is_rejected() {
+    init_logger();
+    let validator_keypair = Keypair::new();
+    const CURRENT_SLOT: u64 = 100;
+
+    let FetcherTestCtx {
+        cloner,
+        fetch_cloner,
+        ..
+    } = setup(
+        std::iter::empty::<(Pubkey, Account)>(),
+        CURRENT_SLOT,
+        validator_keypair.insecure_clone(),
+    )
+    .await;
+
+    let wallet_owner = random_pubkey();
+    let mint = spl_token::native_mint::id();
+    let ata_pubkey = derive_ata(&wallet_owner, &mint);
+    let mut data = vec![0u8; 72];
+    data[0..32].copy_from_slice(mint.as_ref());
+    data[32..64].copy_from_slice(wallet_owner.as_ref());
+    let mut account = AccountSharedData::from(Account {
+        lamports: Rent::default().minimum_balance(SplAccount::LEN),
+        data,
+        owner: spl_token::id(),
+        executable: false,
+        rent_epoch: 0,
+    });
+    account.set_remote_slot(CURRENT_SLOT);
+    account.set_delegated(true);
+
+    let err = fetch_cloner
+        .clone_account_with_post_delegation_action_invariants(
+            AccountCloneRequest {
+                pubkey: ata_pubkey,
+                account,
+                commit_frequency_ms: None,
+                delegation_actions: DelegationActions::default(),
+                delegated_to_other: None,
+                needs_undelegation: false,
+            },
+        )
+        .await
+        .expect_err("malformed delegated ATA clone should be rejected");
+
+    assert!(
+        matches!(err, ChainlinkError::InvalidTokenAccount(pubkey, _) if pubkey == ata_pubkey)
+    );
+    assert!(
+        cloner.clone_requests().is_empty(),
+        "malformed delegated ATA must not be cloned"
+    );
+}
+
+#[tokio::test]
 async fn test_delegated_non_ata_native_token_clone_preserves_wrapped_sol_layout(
 ) {
     init_logger();

--- a/magicblock-core/src/token_programs.rs
+++ b/magicblock-core/src/token_programs.rs
@@ -481,8 +481,9 @@ impl From<EphemeralAta> for Account {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use spl_token::state::AccountState;
+
+    use super::*;
 
     #[test]
     fn project_non_native_ata_is_uncloseable() {

--- a/magicblock-core/src/token_programs.rs
+++ b/magicblock-core/src/token_programs.rs
@@ -29,6 +29,36 @@ pub const EATA_PROGRAM_ID: Pubkey =
 pub const EPHEMERAL_ATA_LEN: usize = 80;
 const LEGACY_EPHEMERAL_ATA_LEN: usize = 72;
 
+/// Private WSOL is represented locally by the token amount that maps to eATA,
+/// not by claimable lamports on the projected ATA.
+pub fn normalize_native_token_account_for_local_clone(
+    account: &mut AccountSharedData,
+) {
+    if account.owner() != &TOKEN_PROGRAM_ID {
+        return;
+    }
+
+    let Ok(token_account) = SplAccount::unpack(account.data()) else {
+        return;
+    };
+    if token_account.mint != spl_token::native_mint::id() {
+        return;
+    }
+
+    let COption::Some(rent_exempt_reserve) = token_account.is_native else {
+        return;
+    };
+
+    let mut token_account = token_account;
+    token_account.is_native = COption::None;
+    token_account.close_authority = COption::Some(Pubkey::default());
+    if SplAccount::pack(token_account, account.data_as_mut_slice()).is_err() {
+        return;
+    }
+
+    account.set_lamports(rent_exempt_reserve);
+}
+
 /// Derives the standard Associated Token Account (ATA) address for the given wallet owner and token mint.
 ///
 /// # Arguments
@@ -327,6 +357,7 @@ impl EphemeralAta {
         let mut projected = ata_account.clone();
         projected.data_as_mut_slice()[64..72]
             .copy_from_slice(&self.amount.to_le_bytes());
+        normalize_native_token_account_for_local_clone(&mut projected);
         Some(projected)
     }
 }
@@ -393,5 +424,60 @@ impl MaybeIntoAta<AccountSharedData> for AccountSharedData {
 
         let eata = EphemeralAta::try_from_account_data(self.data())?;
         eata.try_into().ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn project_native_ata_uses_data_only_local_amount() {
+        let wallet_owner = Pubkey::new_unique();
+        let mint = spl_token::native_mint::id();
+        let amount = 100_000_000;
+        let rent_exempt_reserve =
+            Rent::default().minimum_balance(SplAccount::LEN);
+        let token_account = SplAccount {
+            mint,
+            owner: wallet_owner,
+            amount: 0,
+            delegate: COption::None,
+            state: AccountState::Initialized,
+            is_native: COption::Some(rent_exempt_reserve),
+            delegated_amount: 0,
+            close_authority: COption::None,
+        };
+
+        let mut data = vec![0u8; SplAccount::LEN];
+        SplAccount::pack(token_account, &mut data).unwrap();
+        let base_ata = AccountSharedData::from(Account {
+            owner: TOKEN_PROGRAM_ID,
+            data,
+            lamports: rent_exempt_reserve,
+            executable: false,
+            ..Default::default()
+        });
+
+        let eata = EphemeralAta {
+            owner: wallet_owner,
+            mint,
+            amount,
+            bump: 0,
+        };
+
+        let projected = eata
+            .project_into_ata_account(&base_ata)
+            .expect("native ATA should project");
+        assert_eq!(projected.lamports(), rent_exempt_reserve);
+
+        let projected_token =
+            SplAccount::unpack(projected.data()).expect("unpack projected");
+        assert_eq!(projected_token.amount, amount);
+        assert_eq!(projected_token.is_native, COption::None);
+        assert_eq!(
+            projected_token.close_authority,
+            COption::Some(Pubkey::default())
+        );
     }
 }

--- a/magicblock-core/src/token_programs.rs
+++ b/magicblock-core/src/token_programs.rs
@@ -1,12 +1,12 @@
 use solana_account::{
     Account, AccountSharedData, ReadableAccount, WritableAccount,
 };
-use solana_program::{
-    program_error::ProgramError, program_option::COption, program_pack::Pack,
-    rent::Rent,
-};
+use solana_program::{program_option::COption, program_pack::Pack, rent::Rent};
 use solana_pubkey::{pubkey, Pubkey};
-use spl_token::state::{Account as SplAccount, AccountState};
+use spl_token::state::Account as SplAccount;
+use spl_token_2022::{
+    extension::StateWithExtensionsMut, state::Account as Token2022Account,
+};
 
 // Shared program IDs and helper functions for SPL Token, Associated Token, and eATA programs.
 
@@ -31,32 +31,138 @@ const LEGACY_EPHEMERAL_ATA_LEN: usize = 72;
 
 /// Private WSOL is represented locally by the token amount that maps to eATA,
 /// not by claimable lamports on the projected ATA.
+/// Returns false when token-program data is malformed and a caller that already
+/// rewrote projected token data should reject the clone.
 pub fn normalize_native_token_account_for_local_clone(
     account: &mut AccountSharedData,
-) {
-    if account.owner() != &TOKEN_PROGRAM_ID {
-        return;
-    }
+) -> bool {
+    let normalized = if account.owner() == &TOKEN_PROGRAM_ID {
+        normalize_legacy_native_token_account(account)
+    } else if account.owner() == &TOKEN_2022_PROGRAM_ID {
+        normalize_token_2022_native_token_account(account)
+    } else {
+        NativeTokenNormalization::NotNative
+    };
 
-    let Ok(token_account) = SplAccount::unpack(account.data()) else {
-        return;
+    match normalized {
+        NativeTokenNormalization::NotNative => true,
+        NativeTokenNormalization::Invalid => false,
+        NativeTokenNormalization::Normalized(rent_exempt_reserve) => {
+            account.set_lamports(rent_exempt_reserve);
+            true
+        }
+    }
+}
+
+/// Projected ATAs are virtual views over eATA state. They must not be locally
+/// closeable; settlement owns materialization and closure on the base layer.
+pub fn normalize_projected_token_account_for_local_clone(
+    account: &mut AccountSharedData,
+) -> bool {
+    if account.owner() == &TOKEN_PROGRAM_ID {
+        normalize_legacy_projected_token_account(account)
+    } else if account.owner() == &TOKEN_2022_PROGRAM_ID {
+        normalize_token_2022_projected_token_account(account)
+    } else {
+        true
+    }
+}
+
+enum NativeTokenNormalization {
+    NotNative,
+    Normalized(u64),
+    Invalid,
+}
+
+fn normalize_legacy_native_token_account(
+    account: &mut AccountSharedData,
+) -> NativeTokenNormalization {
+    let Ok(mut token_account) = SplAccount::unpack(account.data()) else {
+        return NativeTokenNormalization::Invalid;
     };
     if token_account.mint != spl_token::native_mint::id() {
-        return;
+        return NativeTokenNormalization::NotNative;
     }
 
     let COption::Some(rent_exempt_reserve) = token_account.is_native else {
-        return;
+        return NativeTokenNormalization::NotNative;
     };
 
-    let mut token_account = token_account;
     token_account.is_native = COption::None;
     token_account.close_authority = COption::Some(Pubkey::default());
     if SplAccount::pack(token_account, account.data_as_mut_slice()).is_err() {
-        return;
+        return NativeTokenNormalization::Invalid;
+    }
+    NativeTokenNormalization::Normalized(rent_exempt_reserve)
+}
+
+fn normalize_legacy_projected_token_account(
+    account: &mut AccountSharedData,
+) -> bool {
+    let Ok(mut token_account) = SplAccount::unpack(account.data()) else {
+        return false;
+    };
+    if token_account.mint == spl_token::native_mint::id() {
+        if let COption::Some(rent_exempt_reserve) = token_account.is_native {
+            token_account.is_native = COption::None;
+            account.set_lamports(rent_exempt_reserve);
+        }
+    }
+    token_account.close_authority = COption::Some(Pubkey::default());
+    SplAccount::pack(token_account, account.data_as_mut_slice()).is_ok()
+}
+
+fn normalize_token_2022_native_token_account(
+    account: &mut AccountSharedData,
+) -> NativeTokenNormalization {
+    let Ok(mut state) = StateWithExtensionsMut::<Token2022Account>::unpack(
+        account.data_as_mut_slice(),
+    ) else {
+        return NativeTokenNormalization::Invalid;
+    };
+    if state.base.mint != spl_token_2022::native_mint::id() {
+        return NativeTokenNormalization::NotNative;
     }
 
-    account.set_lamports(rent_exempt_reserve);
+    let COption::Some(rent_exempt_reserve) = state.base.is_native else {
+        return NativeTokenNormalization::NotNative;
+    };
+
+    state.base.is_native = COption::None;
+    state.base.close_authority = COption::Some(Pubkey::default());
+    state.pack_base();
+    NativeTokenNormalization::Normalized(rent_exempt_reserve)
+}
+
+fn normalize_token_2022_projected_token_account(
+    account: &mut AccountSharedData,
+) -> bool {
+    let rent_exempt_reserve = {
+        let Ok(mut state) = StateWithExtensionsMut::<Token2022Account>::unpack(
+            account.data_as_mut_slice(),
+        ) else {
+            return false;
+        };
+        let rent_exempt_reserve =
+            if state.base.mint == spl_token_2022::native_mint::id() {
+                match state.base.is_native {
+                    COption::Some(rent_exempt_reserve) => {
+                        state.base.is_native = COption::None;
+                        Some(rent_exempt_reserve)
+                    }
+                    COption::None => None,
+                }
+            } else {
+                None
+            };
+        state.base.close_authority = COption::Some(Pubkey::default());
+        state.pack_base();
+        rent_exempt_reserve
+    };
+    if let Some(rent_exempt_reserve) = rent_exempt_reserve {
+        account.set_lamports(rent_exempt_reserve);
+    }
+    true
 }
 
 /// Derives the standard Associated Token Account (ATA) address for the given wallet owner and token mint.
@@ -285,16 +391,6 @@ pub fn try_remap_ata_to_eata(
 
 // ---------------- eATA -> ATA projection helpers ----------------
 
-/// Try to convert an eATA account data buffer into a concrete SPL Token
-/// ATA account (AccountSharedData) when the owning program matches the
-/// expected eATA program. This is an extension trait implemented for
-/// AccountSharedData.
-pub trait MaybeIntoAta<T> {
-    /// Attempts to convert `self` to an ATA form if `owner_program` equals
-    /// the eATA program id. Returns None if not an eATA or parsing fails.
-    fn maybe_into_ata(&self, owner_program: Pubkey) -> Option<T>;
-}
-
 /// Minimal ephemeral representation of an SPL token account used to build
 /// a real AccountSharedData with correct layout and rent.
 #[repr(C)]
@@ -357,40 +453,10 @@ impl EphemeralAta {
         let mut projected = ata_account.clone();
         projected.data_as_mut_slice()[64..72]
             .copy_from_slice(&self.amount.to_le_bytes());
-        normalize_native_token_account_for_local_clone(&mut projected);
+        if !normalize_projected_token_account_for_local_clone(&mut projected) {
+            return None;
+        }
         Some(projected)
-    }
-}
-
-impl TryFrom<EphemeralAta> for AccountSharedData {
-    type Error = ProgramError;
-
-    fn try_from(val: EphemeralAta) -> Result<Self, Self::Error> {
-        let token_account = SplAccount {
-            mint: val.mint,
-            owner: val.owner,
-            amount: val.amount,
-            delegate: COption::None,
-            state: AccountState::Initialized,
-            is_native: COption::None,
-            delegated_amount: 0,
-            close_authority: COption::None,
-        };
-
-        let mut data = vec![0u8; SplAccount::LEN];
-        SplAccount::pack(token_account, &mut data)?;
-
-        let lamports = Rent::default().minimum_balance(data.len());
-
-        let account = Account {
-            owner: spl_token::id(),
-            data,
-            lamports,
-            executable: false,
-            ..Default::default()
-        };
-
-        Ok(AccountSharedData::from(account))
     }
 }
 
@@ -413,23 +479,61 @@ impl From<EphemeralAta> for Account {
     }
 }
 
-impl MaybeIntoAta<AccountSharedData> for AccountSharedData {
-    fn maybe_into_ata(
-        &self,
-        owner_program: Pubkey,
-    ) -> Option<AccountSharedData> {
-        if owner_program != EATA_PROGRAM_ID {
-            return None;
-        }
-
-        let eata = EphemeralAta::try_from_account_data(self.data())?;
-        eata.try_into().ok()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use spl_token::state::AccountState;
+
+    #[test]
+    fn project_non_native_ata_is_uncloseable() {
+        let wallet_owner = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let close_authority = Pubkey::new_unique();
+        let amount = 100_000_000;
+        let rent_exempt_reserve =
+            Rent::default().minimum_balance(SplAccount::LEN);
+        let token_account = SplAccount {
+            mint,
+            owner: wallet_owner,
+            amount: 0,
+            delegate: COption::None,
+            state: AccountState::Initialized,
+            is_native: COption::None,
+            delegated_amount: 0,
+            close_authority: COption::Some(close_authority),
+        };
+
+        let mut data = vec![0u8; SplAccount::LEN];
+        SplAccount::pack(token_account, &mut data).unwrap();
+        let base_ata = AccountSharedData::from(Account {
+            owner: TOKEN_PROGRAM_ID,
+            data,
+            lamports: rent_exempt_reserve,
+            executable: false,
+            ..Default::default()
+        });
+
+        let eata = EphemeralAta {
+            owner: wallet_owner,
+            mint,
+            amount,
+            bump: 0,
+        };
+
+        let projected = eata
+            .project_into_ata_account(&base_ata)
+            .expect("ATA should project");
+        assert_eq!(projected.lamports(), rent_exempt_reserve);
+
+        let projected_token =
+            SplAccount::unpack(projected.data()).expect("unpack projected");
+        assert_eq!(projected_token.amount, amount);
+        assert_eq!(projected_token.is_native, COption::None);
+        assert_eq!(
+            projected_token.close_authority,
+            COption::Some(Pubkey::default())
+        );
+    }
 
     #[test]
     fn project_native_ata_uses_data_only_local_amount() {
@@ -473,6 +577,59 @@ mod tests {
 
         let projected_token =
             SplAccount::unpack(projected.data()).expect("unpack projected");
+        assert_eq!(projected_token.amount, amount);
+        assert_eq!(projected_token.is_native, COption::None);
+        assert_eq!(
+            projected_token.close_authority,
+            COption::Some(Pubkey::default())
+        );
+    }
+
+    #[test]
+    fn project_token_2022_non_native_ata_is_uncloseable() {
+        let wallet_owner = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let close_authority = Pubkey::new_unique();
+        let amount = 100_000_000;
+        let rent_exempt_reserve =
+            Rent::default().minimum_balance(Token2022Account::LEN);
+        let token_account = Token2022Account {
+            mint,
+            owner: wallet_owner,
+            amount: 0,
+            delegate: COption::None,
+            state: spl_token_2022::state::AccountState::Initialized,
+            is_native: COption::None,
+            delegated_amount: 0,
+            close_authority: COption::Some(close_authority),
+        };
+
+        let mut data = vec![0u8; Token2022Account::LEN];
+        Token2022Account::pack(token_account, &mut data).unwrap();
+        let base_ata = AccountSharedData::from(Account {
+            owner: TOKEN_2022_PROGRAM_ID,
+            data,
+            lamports: rent_exempt_reserve,
+            executable: false,
+            ..Default::default()
+        });
+
+        let eata = EphemeralAta {
+            owner: wallet_owner,
+            mint,
+            amount,
+            bump: 0,
+        };
+
+        let projected = eata
+            .project_into_ata_account(&base_ata)
+            .expect("Token-2022 ATA should project");
+        assert_eq!(projected.owner(), &TOKEN_2022_PROGRAM_ID);
+        assert_eq!(projected.lamports(), rent_exempt_reserve);
+        assert_eq!(projected.data().len(), Token2022Account::LEN);
+
+        let projected_token = Token2022Account::unpack(projected.data())
+            .expect("unpack projected Token-2022 ATA");
         assert_eq!(projected_token.amount, amount);
         assert_eq!(projected_token.is_native, COption::None);
         assert_eq!(

--- a/test-integration/test-chainlink/tests/ix_ata_eata_replace.rs
+++ b/test-integration/test-chainlink/tests/ix_ata_eata_replace.rs
@@ -12,6 +12,7 @@ use magicblock_chainlink::{
 use solana_account::ReadableAccount;
 use solana_pubkey::{pubkey, Pubkey};
 use solana_sdk::{
+    program_option::COption,
     program_pack::Pack,
     signature::{Keypair, Signer},
 };
@@ -71,7 +72,10 @@ async fn ixtest_ata_eata_replace_when_delegated_to_us() {
     assert_eq!(spl_token_account.mint, mint);
     assert_eq!(spl_token_account.amount, amount);
     assert_eq!(spl_token_account.owner, wallet_owner);
-    assert!(spl_token_account.close_authority.is_none());
+    assert_eq!(
+        spl_token_account.close_authority,
+        COption::Some(Pubkey::default())
+    );
     assert_eq!(spl_token_account.state, AccountState::Initialized);
     assert_eq!(spl_token_account.delegated_amount, 0);
     assert!(spl_token_account.is_native.is_none());


### PR DESCRIPTION
## Summary

- Normalize delegated native ATA clones only after canonical ATA detection, preserving non-ATA wrapped SOL token accounts.
- Project eATA balances through a real base ATA layout and remove the synthetic raw eATA-to-legacy-token fallback.
- Make projected ATA views locally uncloseable by setting their close authority to the default pubkey, and cover legacy SPL Token and Token-2022 projections in tests.

## Notes

Making projected ata unclosable is required for implementing #1330 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token account cloning for wrapped SOL and Token-2022 so balance, native-token flags, and `close_authority` are normalized consistently.
  * Strengthened ATA/eATA projection by validating canonical ATA targets, rejecting malformed delegated ATA clones, and removing unsafe fallback conversions.
  * Ensured projected (“virtual”) ATAs are uncloseable locally while preserving key Token-2022 extensions; updated delegation clone behavior to the expected `close_authority`.

* **Tests**
  * Expanded unit and integration coverage for native-token and Token-2022 ATA/eATA projection and cloning invariants, including layout assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->