### PR TITLE
hotfix: load failed intents on restart & reschedule

### DIFF
--- a/magicblock-committor-service/src/committor_processor.rs
+++ b/magicblock-committor-service/src/committor_processor.rs
@@ -154,11 +154,11 @@ impl CommittorProcessor {
         Ok(signatures)
     }
 
-    /// Fetches pending bundles from DB
-    pub async fn pending_intent_bundles(
+    /// Fetches pending and failed bundles from DB for recovery
+    pub async fn load_recovery_intent_bundles(
         &self,
     ) -> CommittorServiceResult<Vec<ScheduledIntentBundle>> {
-        // Extract pending bundles satisfying predicate
+        // Extract pending and failed bundles satisfying predicate
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
@@ -180,7 +180,7 @@ impl CommittorProcessor {
             info!(
                 intent_count = bundles.len(),
                 accounts_count,
-                "Loaded pending commit intents from persistence for recovery"
+                "Loaded commit intents from persistence for recovery"
             );
         }
 

--- a/magicblock-committor-service/src/persist/commit_persister.rs
+++ b/magicblock-committor-service/src/persist/commit_persister.rs
@@ -254,7 +254,7 @@ impl IntentPersister for IntentPersisterImpl {
             .get_commit_statuses_by_id(message_id)
     }
 
-    /// Returns pending bundles created at or after `min_created_at`.
+    /// Returns pending and failed bundles created at or after `min_created_at`.
     /// NOTE: this constructs `ScheduleIntentBundle` only from existing information.
     /// As persister doesn't save `ScheduleIntentBundle::payer` info, Pubkey::default is used.
     /// `CommittedAccount` information like slot may also be outdated.
@@ -263,11 +263,11 @@ impl IntentPersister for IntentPersisterImpl {
         &self,
         min_created_at: u64,
     ) -> CommitPersistResult<Vec<ScheduledIntentBundle>> {
-        let rows = self
-            .commits_db
-            .lock()
-            .expect(POISONED_MUTEX_MSG)
-            .get_pending_commit_statuses(min_created_at)?;
+        let commits_db = self.commits_db.lock().expect(POISONED_MUTEX_MSG);
+        let mut rows =
+            commits_db.get_pending_commit_statuses(min_created_at)?;
+        rows.extend(commits_db.get_failed_commit_statuses(min_created_at)?);
+        drop(commits_db);
 
         Ok(pending_rows_to_scheduled_intent_bundles(
             rows,

--- a/magicblock-committor-service/src/persist/db.rs
+++ b/magicblock-committor-service/src/persist/db.rs
@@ -585,6 +585,35 @@ impl CommittsDb {
         extract_committor_rows(&mut rows)
     }
 
+    pub(crate) fn get_failed_commit_statuses(
+        &self,
+        min_created_at: u64,
+    ) -> CommitPersistResult<Vec<CommitStatusRow>> {
+        let query = format!(
+            "WITH eligible_messages AS (
+                 SELECT message_id
+                 FROM commit_status
+                 WHERE commit_status IN (?1, ?2)
+                 GROUP BY message_id
+                 HAVING MIN(created_at) >= ?3
+             )
+             {SELECT_ALL_COMMIT_STATUS_COLUMNS}
+             WHERE commit_status IN (?1, ?2)
+               AND message_id IN (
+                   SELECT message_id FROM eligible_messages
+               )
+             ORDER BY message_id, created_at, pubkey"
+        );
+        let stmt = &mut self.conn.prepare(&query)?;
+        let mut rows = stmt.query(params![
+            "FailedFinalize",
+            "FailedProcess",
+            u64_into_i64(min_created_at)
+        ])?;
+
+        extract_committor_rows(&mut rows)
+    }
+
     pub(crate) fn get_commit_status(
         &self,
         message_id: u64,
@@ -915,6 +944,105 @@ mod tests {
                 too_recent,
                 partially_eligible,
                 partially_too_recent
+            ]
+        );
+    }
+
+    #[test]
+    fn test_get_failed_commit_statuses() {
+        let (mut db, _file) = setup_test_db();
+        let pending = create_test_row(1, 0);
+        let mut failed_finalize = create_test_row(2, 0);
+        failed_finalize.commit_status =
+            CommitStatus::FailedFinalize(CommitStatusSignatures {
+                commit_stage_signature: Signature::new_unique(),
+                finalize_stage_signature: None,
+            });
+        let mut failed_process = create_test_row(3, 0);
+        failed_process.commit_status = CommitStatus::FailedProcess(None);
+        let mut succeeded = create_test_row(4, 0);
+        succeeded.commit_status =
+            CommitStatus::Succeeded(CommitStatusSignatures {
+                commit_stage_signature: Signature::new_unique(),
+                finalize_stage_signature: Some(Signature::new_unique()),
+            });
+
+        db.insert_commit_status_rows(&[
+            pending,
+            failed_finalize.clone(),
+            failed_process.clone(),
+            succeeded,
+        ])
+        .unwrap();
+
+        let rows = db.get_failed_commit_statuses(0).unwrap();
+        assert_eq!(rows, vec![failed_finalize, failed_process]);
+    }
+
+    #[test]
+    fn test_get_failed_commit_statuses_filters_recovery_window() {
+        let (mut db, _file) = setup_test_db();
+        let mut failed = create_test_row(1, 0);
+        failed.created_at = 10;
+        failed.last_retried_at = 19;
+        failed.commit_status =
+            CommitStatus::FailedFinalize(CommitStatusSignatures {
+                commit_stage_signature: Signature::new_unique(),
+                finalize_stage_signature: None,
+            });
+        let mut failed_same_message = create_test_row(1, 0);
+        failed_same_message.created_at = 11;
+        failed_same_message.last_retried_at = 18;
+        failed_same_message.commit_status = CommitStatus::FailedProcess(None);
+        let mut too_old = create_test_row(2, 0);
+        too_old.created_at = 9;
+        too_old.last_retried_at = 9;
+        too_old.commit_status =
+            CommitStatus::FailedFinalize(CommitStatusSignatures {
+                commit_stage_signature: Signature::new_unique(),
+                finalize_stage_signature: None,
+            });
+        let mut too_recent = create_test_row(3, 0);
+        too_recent.created_at = 20;
+        too_recent.last_retried_at = 20;
+        too_recent.commit_status =
+            CommitStatus::FailedFinalize(CommitStatusSignatures {
+                commit_stage_signature: Signature::new_unique(),
+                finalize_stage_signature: None,
+            });
+        let mut partially_eligible = create_test_row(4, 0);
+        partially_eligible.created_at = 10;
+        partially_eligible.last_retried_at = 19;
+        partially_eligible.commit_status =
+            CommitStatus::FailedFinalize(CommitStatusSignatures {
+                commit_stage_signature: Signature::new_unique(),
+                finalize_stage_signature: None,
+            });
+        let mut partially_failed_process = create_test_row(4, 0);
+        partially_failed_process.created_at = 11;
+        partially_failed_process.last_retried_at = 20;
+        partially_failed_process.commit_status =
+            CommitStatus::FailedProcess(None);
+
+        db.insert_commit_status_rows(&[
+            failed.clone(),
+            failed_same_message.clone(),
+            too_old,
+            too_recent.clone(),
+            partially_eligible.clone(),
+            partially_failed_process.clone(),
+        ])
+        .unwrap();
+
+        let rows = db.get_failed_commit_statuses(10).unwrap();
+        assert_eq!(
+            rows,
+            vec![
+                failed,
+                failed_same_message,
+                too_recent,
+                partially_eligible,
+                partially_failed_process,
             ]
         );
     }

--- a/magicblock-committor-service/src/service.rs
+++ b/magicblock-committor-service/src/service.rs
@@ -180,9 +180,12 @@ where
     }
 
     async fn reschedule_pending_bundles(&self) -> CommittorServiceResult<()> {
-        // Fetch pending bundles from DB
-        let mut bundles =
-            self.processor.pending_intent_bundles().await.inspect_err(|err| {
+        // Fetch pending and failed bundles from DB
+        let mut bundles = self
+            .processor
+            .load_recovery_intent_bundles()
+            .await
+            .inspect_err(|err| {
                 error!(error = ?err, "Failed to load pending intent bundles for recovery");
             })?;
         if bundles.is_empty() {


### PR DESCRIPTION
<!--
PR title must match: type(scope): summary
Types: feat|fix|docs|chore|refactor|test|perf|ci|build
Examples:
  fix: avoid panic on empty slot
  feat(rpc): add getFoo endpoint
-->

## Summary
<!-- One sentence. Link to issue if applicable. -->
Loads failed intents on restart and reschedules them. Proper recovery is coming with introducion of outbox accounts following MIMD-0025

## Breaking Changes
- [ ] None
- [ ] Yes — migration path described below


## Test Plan
<!-- How you verified this works. e.g., "unit tests", "ran locally against testnet", "existing tests pass" -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recovery now loads and schedules eligible commit intents from persistence, including both pending and previously failed attempts.
  * Recovery scheduling uses a dedicated “recovery intent” loading flow and improved persistence coverage for failed commits.

* **Bug Fixes**
  * Recently failed commits are retried when they fall within the recovery window.
  * Updated recovery intent selection and logging to better reflect which intents are eligible for scheduling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->