### PR TITLE
feat: added extra non-delegated to us metric

### DIFF
--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -1431,6 +1431,7 @@ where
             == self.validator_pubkey
             || deleg_record.authority == Pubkey::default();
         if !is_delegated_to_us {
+            metrics::inc_discovered_dlp_update_delegated_elsewhere();
             trace!(
                 pubkey = %pubkey,
                 authority = %deleg_record.authority,

--- a/magicblock-metrics/src/metrics/mod.rs
+++ b/magicblock-metrics/src/metrics/mod.rs
@@ -172,8 +172,8 @@ lazy_static::lazy_static! {
         "evicted_accounts_count", "Total cumulative number of accounts forcefully removed from monitored list and database (monotonically increasing)",
     ).unwrap();
 
-    static ref DISCOVERED_DLP_UPDATE_DELEGATED_ELSEWHERE_COUNT: IntCounter = IntCounter::new(
-        "discovered_dlp_update_delegated_elsewhere_count", "DLP-owned subscription updates that, after fetching the delegation record, were found delegated to another validator and dropped",
+    static ref PROGRAM_SUBSCRIPTION_DISCOVERED_DLP_UPDATE_DELEGATED_ELSEWHERE_COUNT: IntCounter = IntCounter::new(
+        "program_subscription_discovered_dlp_update_delegated_elsewhere_count", "DLP-owned subscription updates that, after fetching the delegation record, were found delegated to another validator and dropped",
     ).unwrap();
 
     static ref PROGRAM_SUBSCRIPTION_ACCOUNT_UPDATES_COUNT: IntCounterVec =
@@ -612,7 +612,7 @@ pub(crate) fn register() {
         register!(MONITORED_ACCOUNTS_GAUGE);
         register!(INFLIGHT_SUBSCRIPTION_UPDATES_GAUGE);
         register!(EVICTED_ACCOUNTS_COUNT);
-        register!(DISCOVERED_DLP_UPDATE_DELEGATED_ELSEWHERE_COUNT);
+        register!(PROGRAM_SUBSCRIPTION_DISCOVERED_DLP_UPDATE_DELEGATED_ELSEWHERE_COUNT);
         register!(PROGRAM_SUBSCRIPTION_ACCOUNT_UPDATES_COUNT);
         register!(ACCOUNT_SUBSCRIPTION_ACCOUNT_UPDATES_COUNT);
         register!(ACCOUNT_SUBSCRIPTION_ACTIVATIONS_COUNT);
@@ -787,7 +787,7 @@ pub fn inc_evicted_accounts_count() {
 }
 
 pub fn inc_discovered_dlp_update_delegated_elsewhere() {
-    DISCOVERED_DLP_UPDATE_DELEGATED_ELSEWHERE_COUNT.inc();
+    PROGRAM_SUBSCRIPTION_DISCOVERED_DLP_UPDATE_DELEGATED_ELSEWHERE_COUNT.inc();
 }
 
 pub fn inc_committor_intents_count() {

--- a/magicblock-metrics/src/metrics/mod.rs
+++ b/magicblock-metrics/src/metrics/mod.rs
@@ -172,6 +172,10 @@ lazy_static::lazy_static! {
         "evicted_accounts_count", "Total cumulative number of accounts forcefully removed from monitored list and database (monotonically increasing)",
     ).unwrap();
 
+    static ref DISCOVERED_DLP_UPDATE_DELEGATED_ELSEWHERE_COUNT: IntCounter = IntCounter::new(
+        "discovered_dlp_update_delegated_elsewhere_count", "DLP-owned subscription updates that, after fetching the delegation record, were found delegated to another validator and dropped",
+    ).unwrap();
+
     static ref PROGRAM_SUBSCRIPTION_ACCOUNT_UPDATES_COUNT: IntCounterVec =
         IntCounterVec::new(
             Opts::new(
@@ -608,6 +612,7 @@ pub(crate) fn register() {
         register!(MONITORED_ACCOUNTS_GAUGE);
         register!(INFLIGHT_SUBSCRIPTION_UPDATES_GAUGE);
         register!(EVICTED_ACCOUNTS_COUNT);
+        register!(DISCOVERED_DLP_UPDATE_DELEGATED_ELSEWHERE_COUNT);
         register!(PROGRAM_SUBSCRIPTION_ACCOUNT_UPDATES_COUNT);
         register!(ACCOUNT_SUBSCRIPTION_ACCOUNT_UPDATES_COUNT);
         register!(ACCOUNT_SUBSCRIPTION_ACTIVATIONS_COUNT);
@@ -779,6 +784,10 @@ pub fn set_monitored_accounts_count(count: usize) {
 }
 pub fn inc_evicted_accounts_count() {
     EVICTED_ACCOUNTS_COUNT.inc();
+}
+
+pub fn inc_discovered_dlp_update_delegated_elsewhere() {
+    DISCOVERED_DLP_UPDATE_DELEGATED_ELSEWHERE_COUNT.inc();
 }
 
 pub fn inc_committor_intents_count() {


### PR DESCRIPTION
Adding extra metrics for accounts fetched but not delegated to myself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of updates that are delegated to a different validator, so they are now consistently ignored during processing.
* **Chores**
  * Added a new monitoring counter to track these skipped updates, improving visibility into system behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->