### PR TITLE
feat: add metrics to see how many alts are typically used by intents

### DIFF
--- a/magicblock-committor-service/src/transaction_preparator/mod.rs
+++ b/magicblock-committor-service/src/transaction_preparator/mod.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use magicblock_metrics::metrics;
 use magicblock_rpc_client::MagicblockRpcClient;
 use magicblock_table_mania::TableMania;
 use solana_keypair::Keypair;
@@ -100,6 +101,7 @@ impl TransactionPreparator for TransactionPreparatorImpl {
             .delivery_preparator
             .prepare_for_delivery(authority, tx_strategy, intent_persister)
             .await?;
+        metrics::observe_committor_intent_alt_count(lookup_tables.len());
 
         let message =
             TransactionUtils::assemble_tasks_tx_with_standalone_action_nonce(

--- a/magicblock-metrics/src/metrics/mod.rs
+++ b/magicblock-metrics/src/metrics/mod.rs
@@ -451,6 +451,14 @@ lazy_static::lazy_static! {
         ),
     ).unwrap();
 
+    static ref COMMITTOR_INTENT_ALT_COUNT: Histogram = Histogram::with_opts(
+        HistogramOpts::new(
+            "committor_intent_alt_count",
+            "Number of address lookup tables used per intent transaction (only recorded when ALTs are present)"
+        )
+        .buckets(vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 10.0])
+    ).unwrap();
+
     static ref COMMITTOR_FETCH_COMMIT_NONCES_WAIT_TIME: Histogram = Histogram::with_opts(
         HistogramOpts::new(
             "committor_fetch_commit_nonces_wait_time_second",
@@ -624,6 +632,7 @@ pub(crate) fn register() {
         register!(COMMITTOR_INTENT_CU_USAGE);
         register!(COMMITTOR_INTENT_TASK_PREPARATION_TIME);
         register!(COMMITTOR_INTENT_ALT_PREPARATION_TIME);
+        register!(COMMITTOR_INTENT_ALT_COUNT);
         register!(COMMITTOR_FETCH_COMMIT_NONCES_WAIT_TIME);
         register!(ENSURE_ACCOUNTS_TIME);
         register!(RPC_REQUEST_HANDLING_TIME);
@@ -841,6 +850,10 @@ pub fn observe_committor_intent_task_preparation_time<
 
 pub fn observe_committor_intent_alt_preparation_time() -> HistogramTimer {
     COMMITTOR_INTENT_ALT_PREPARATION_TIME.start_timer()
+}
+
+pub fn observe_committor_intent_alt_count(count: usize) {
+    COMMITTOR_INTENT_ALT_COUNT.observe(count as f64);
 }
 
 pub fn start_fetch_commit_nonces_wait_timer() -> HistogramTimer {


### PR DESCRIPTION
<!--
PR title must match: type(scope): summary
Types: feat|fix|docs|chore|refactor|test|perf|ci|build
Examples:
  fix: avoid panic on empty slot
  feat(rpc): add getFoo endpoint
-->

## Summary
<!-- One sentence. Link to issue if applicable. -->
Have a suspicion that intent may use a lot of ALTs, adding metric to track

## Breaking Changes
- [ ] None
- [ ] Yes — migration path described below


## Test Plan
<!-- How you verified this works. e.g., "unit tests", "ran locally against testnet", "existing tests pass" -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new metric that tracks how many address lookup table entries are used per intent transaction.
  * Intent transaction preparation now records this count automatically, improving observability and monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->