### PR TITLE
Fix committor cleanup ordering

### DIFF
--- a/.agents/context/crates/magicblock-committor-service.md
+++ b/.agents/context/crates/magicblock-committor-service.md
@@ -200,7 +200,7 @@ IntentExecutorImpl::execute
   -> TransactionPreparator prepares buffers/ALTs and assembles VersionedMessage
   -> SingleStageExecutor or TwoStageExecutor sends base-layer transactions
   -> persist final status/signatures and schedule callbacks
-  -> reset nonce cache on errors or undelegation
+  -> reset nonce cache for all committed pubkeys on errors, or only undelegated pubkeys on successful undelegation
 ```
 
 For committed accounts with `data.len() > COMMIT_STATE_SIZE_THRESHOLD` (`256`), the task builder fetches the base account and may use diff-in-args delivery. If the base-account fetch fails, it falls back to full state args and logs a warning. This can increase transaction size and trigger buffer/ALT strategy later.
@@ -221,7 +221,9 @@ Cleanup closes prepared buffers and releases TableMania pubkeys. `IntentExecutio
 
 ### Commit nonce cache
 
-`CacheTaskInfoFetcher` caches commit nonces in a 1,000-entry LRU. It uses per-pubkey async mutexes acquired in sorted order to avoid A→B / B→A deadlocks, and a `retiring` map to keep evicted locks alive while in-flight requests still hold them. `fetch_next_commit_nonces` increments cached values and reserves the next nonce; `fetch_current_commit_nonces` reads/stores the current value without incrementing. After a failed commit or undelegation, `IntentExecutorImpl` resets the cache for affected pubkeys.
+`CacheTaskInfoFetcher` caches commit nonces in a 10,000-entry LRU. It uses per-pubkey async mutexes acquired in sorted order to avoid A->B / B->A deadlocks, and a `retiring` map to keep evicted locks alive while in-flight requests still hold them. `fetch_next_commit_nonces` increments cached values and reserves the next nonce; `fetch_current_commit_nonces` reads/stores the current value without incrementing.
+
+`IntentExecutorImpl` resets cached nonces according to execution certainty. On any execution error, it resets all committed pubkeys because it cannot know what landed on chain. On successful undelegation paths, it resets only the pubkeys returned by `get_undelegate_intent_pubkeys()` and `get_commit_finalize_and_undelegate_intent_pubkeys()`. Other successfully committed pubkeys keep their incremented cached nonce, which avoids a chain re-fetch racing the just-landed finalize and reusing a stale nonce/buffer PDA.
 
 Do not remove sorted lock acquisition or the retiring map without replacing the deadlock/race prevention. Commit nonce races can cause base-layer commit failures and stuck undelegations.
 
@@ -251,7 +253,7 @@ The public service API uses nonblocking `try_send`. If the service channel is fu
 2. Preserve FIFO blocking semantics across indirectly blocked intents; later intents must not bypass an earlier blocked intent sharing any key.
 3. Do not schedule duplicate intent ids in the same scheduler/execution-extension context.
 4. Commit nonces must be fetched with base-layer freshness (`min_context_slot`) and incremented atomically per account.
-5. A failed or undelegating intent must reset cached nonces for affected accounts.
+5. Execution errors must reset cached nonces for all committed pubkeys; successful undelegation must reset only the undelegated pubkeys and preserve other committed-account cache entries.
 6. Fresh intent scheduling must persist rows before execution when possible; recovered scheduling must not reinsert rows.
 7. Pending-intent recovery must reconstruct only rows inside the recovery window and skip inconsistent or incomplete persisted groups.
 8. Buffer accounts and ALTs must be prepared before transaction assembly uses them, and released/closed only when safe.

--- a/.agents/context/crates/magicblock-committor-service.md
+++ b/.agents/context/crates/magicblock-committor-service.md
@@ -47,7 +47,7 @@ For the general documentation-update rule, see .agents/memory/agent-memory-and-d
 | `src/config.rs` and `src/compute_budget.rs` | Chain/RPC configuration, default action timeout, and per-task compute-budget helpers. |
 | `src/committor_processor.rs` | Constructs `MagicblockRpcClient`, `TableMania`, `IntentPersisterImpl`, `IntentExecutionManager`, and `CacheTaskInfoFetcher`; exposes persistence queries and recovery helpers. |
 | `src/intent_execution_manager.rs` | Backpressure boundary between service and execution engine; enqueues bundles and falls back to an internal DB when the channel is full. |
-| `src/intent_execution_manager/intent_execution_engine.rs` | Main scheduler loop, executor semaphore (`MAX_EXECUTORS = 50`), result broadcasting, metrics, and successful-cleanup spawning. |
+| `src/intent_execution_manager/intent_execution_engine.rs` | Main scheduler loop, executor semaphore (`MAX_EXECUTORS = 50`), result broadcasting, metrics, and awaited cleanup before scheduler completion. |
 | `src/intent_execution_manager/intent_scheduler.rs` | Pubkey conflict scheduler for committed accounts. Maintains FIFO blocking queues and prevents duplicate/concurrent conflicting intents. |
 | `src/intent_executor/` | Intent execution state machine, transaction client, factory, single-stage/two-stage executors, timeout helpers, and commit nonce fetcher/cache. |
 | `src/tasks/` | Atomic base-layer task types and task builders/strategist for commit, commit-finalize, undelegate, actions, buffers, ALTs, and compute budgets. |
@@ -179,7 +179,9 @@ Preserve the no-repersist path for recovered intents. Re-inserting rows can viol
 3. asks `IntentScheduler` whether it can run now;
 4. waits for one of `MAX_EXECUTORS = 50` semaphore permits;
 5. creates an executor and spawns intent execution;
-6. broadcasts the result, completes the scheduler entry, and cleans buffers/ALTs only after successful execution.
+6. broadcasts the result, awaits executor cleanup, completes the scheduler entry, and releases the executor permit.
+
+Results are broadcast before cleanup, so subscribers can observe completion while conflicting intents remain blocked. Cleanup must finish before scheduler completion unblocks a conflicting intent, because nonce reuse can target the same buffer PDAs and a detached cleanup could close buffers a next intent just re-initialized.
 
 The scheduler blocks on the union of `ScheduledIntentBundle::get_all_committed_pubkeys()`, including commit and commit-and-undelegate accounts in the same bundle. Standalone base actions with no committed pubkeys do not block on account keys.
 
@@ -215,7 +217,7 @@ For committed accounts with `data.len() > COMMIT_STATE_SIZE_THRESHOLD` (`256`), 
 4. reserve ALTs in TableMania and wait for finalized lookup table accounts;
 5. assemble the final versioned message with real lookup table accounts.
 
-Cleanup closes prepared buffers and releases TableMania pubkeys. `IntentExecutionEngine` intentionally runs cleanup only after successful execution because failed intent cleanup can race with a retried or concurrent intent using the same buffer PDA set.
+Cleanup closes prepared buffers and releases TableMania pubkeys. `IntentExecutionEngine` awaits cleanup after broadcasting the result and before completing the scheduler entry, so conflicting intents with the same committed pubkeys cannot start until the previous intent's cleanup has finished. The executor closes buffers only after successful execution; after a failure, cleanup releases ALT reservations without closing buffer PDAs, because failed intent buffer cleanup can race with a retry or later intent using the same PDA set.
 
 ## Important internals and caveats
 
@@ -255,12 +257,13 @@ The public service API uses nonblocking `try_send`. If the service channel is fu
 6. Fresh intent scheduling must persist rows before execution when possible; recovered scheduling must not reinsert rows.
 7. Pending-intent recovery must reconstruct only rows inside the recovery window and skip inconsistent or incomplete persisted groups.
 8. Buffer accounts and ALTs must be prepared before transaction assembly uses them, and released/closed only when safe.
-9. Failed intent cleanup must not race with retries using the same buffer PDAs; current cleanup is success-only for that reason.
-10. Transaction-size and compute-budget choices must keep produced transactions under Solana wire limits.
-11. Base-layer sends must preserve explicit processed/committed confirmation semantics from `magicblock-rpc-client`.
-12. Signer/authority requirements for validator-signed commits, committor-program buffers, ALTs, callbacks, and base-layer instructions must not be relaxed.
-13. Persistence status/signature updates must continue to expose enough information for diagnostics, retries, and recovery.
-14. Avoid adding blocking I/O or unbounded work to service actor, scheduler, executor, task-preparation, or RPC hot paths.
+9. Failed intent cleanup must not close buffer PDAs that retries or later intents can reuse; release ALT reservations without closing those buffers.
+10. Successful intent cleanup must finish before scheduler completion unblocks conflicting intents that can reuse the same buffer PDAs.
+11. Transaction-size and compute-budget choices must keep produced transactions under Solana wire limits.
+12. Base-layer sends must preserve explicit processed/committed confirmation semantics from `magicblock-rpc-client`.
+13. Signer/authority requirements for validator-signed commits, committor-program buffers, ALTs, callbacks, and base-layer instructions must not be relaxed.
+14. Persistence status/signature updates must continue to expose enough information for diagnostics, retries, and recovery.
+15. Avoid adding blocking I/O or unbounded work to service actor, scheduler, executor, task-preparation, or RPC hot paths.
 
 ## Common change areas and what to inspect
 
@@ -282,7 +285,7 @@ Start with `src/tasks/task_builder.rs`, `src/tasks/task_strategist.rs`, `src/tas
 
 ### Changing delivery preparation or cleanup
 
-Start with `src/transaction_preparator/mod.rs` and `delivery_preparator.rs`, then inspect `.agents/context/crates/magicblock-committor-program.md`, `.agents/context/crates/magicblock-table-mania.md`, and `.agents/context/crates/magicblock-rpc-client.md`. Check buffer init/realloc/write chunking, retry handling for already-initialized buffers, cached blockhash invalidation, ALT finalized waits, cleanup-on-success only, and release of TableMania refs.
+Start with `src/transaction_preparator/mod.rs` and `delivery_preparator.rs`, then inspect `.agents/context/crates/magicblock-committor-program.md`, `.agents/context/crates/magicblock-table-mania.md`, and `.agents/context/crates/magicblock-rpc-client.md`. Check buffer init/realloc/write chunking, retry handling for already-initialized buffers, cached blockhash invalidation, ALT finalized waits, success-only buffer closing, release of TableMania refs, and cleanup-before-scheduler-completion ordering for conflicting intents.
 
 ### Changing persistence or recovery
 

--- a/.agents/context/crates/magicblock-committor-service.md
+++ b/.agents/context/crates/magicblock-committor-service.md
@@ -47,7 +47,7 @@ For the general documentation-update rule, see .agents/memory/agent-memory-and-d
 | `src/config.rs` and `src/compute_budget.rs` | Chain/RPC configuration, default action timeout, and per-task compute-budget helpers. |
 | `src/committor_processor.rs` | Constructs `MagicblockRpcClient`, `TableMania`, `IntentPersisterImpl`, `IntentExecutionManager`, and `CacheTaskInfoFetcher`; exposes persistence queries and recovery helpers. |
 | `src/intent_execution_manager.rs` | Backpressure boundary between service and execution engine; enqueues bundles and falls back to an internal DB when the channel is full. |
-| `src/intent_execution_manager/intent_execution_engine.rs` | Main scheduler loop, executor semaphore (`MAX_EXECUTORS = 50`), result broadcasting, metrics, and awaited cleanup before scheduler completion. |
+| `src/intent_execution_manager/intent_execution_engine.rs` | Main scheduler loop, executor semaphore (`MAX_EXECUTORS = 50`), result broadcasting, metrics, and successful-cleanup spawning. |
 | `src/intent_execution_manager/intent_scheduler.rs` | Pubkey conflict scheduler for committed accounts. Maintains FIFO blocking queues and prevents duplicate/concurrent conflicting intents. |
 | `src/intent_executor/` | Intent execution state machine, transaction client, factory, single-stage/two-stage executors, timeout helpers, and commit nonce fetcher/cache. |
 | `src/tasks/` | Atomic base-layer task types and task builders/strategist for commit, commit-finalize, undelegate, actions, buffers, ALTs, and compute budgets. |
@@ -179,9 +179,7 @@ Preserve the no-repersist path for recovered intents. Re-inserting rows can viol
 3. asks `IntentScheduler` whether it can run now;
 4. waits for one of `MAX_EXECUTORS = 50` semaphore permits;
 5. creates an executor and spawns intent execution;
-6. broadcasts the result, awaits executor cleanup, completes the scheduler entry, and releases the executor permit.
-
-Results are broadcast before cleanup, so subscribers can observe completion while conflicting intents remain blocked. Cleanup must finish before scheduler completion unblocks a conflicting intent, because nonce reuse can target the same buffer PDAs and a detached cleanup could close buffers a next intent just re-initialized.
+6. broadcasts the result, completes the scheduler entry, and cleans buffers/ALTs only after successful execution.
 
 The scheduler blocks on the union of `ScheduledIntentBundle::get_all_committed_pubkeys()`, including commit and commit-and-undelegate accounts in the same bundle. Standalone base actions with no committed pubkeys do not block on account keys.
 
@@ -217,7 +215,7 @@ For committed accounts with `data.len() > COMMIT_STATE_SIZE_THRESHOLD` (`256`), 
 4. reserve ALTs in TableMania and wait for finalized lookup table accounts;
 5. assemble the final versioned message with real lookup table accounts.
 
-Cleanup closes prepared buffers and releases TableMania pubkeys. `IntentExecutionEngine` awaits cleanup after broadcasting the result and before completing the scheduler entry, so conflicting intents with the same committed pubkeys cannot start until the previous intent's cleanup has finished. The executor closes buffers only after successful execution; after a failure, cleanup releases ALT reservations without closing buffer PDAs, because failed intent buffer cleanup can race with a retry or later intent using the same PDA set.
+Cleanup closes prepared buffers and releases TableMania pubkeys. `IntentExecutionEngine` intentionally runs cleanup only after successful execution because failed intent cleanup can race with a retried or concurrent intent using the same buffer PDA set.
 
 ## Important internals and caveats
 
@@ -257,13 +255,12 @@ The public service API uses nonblocking `try_send`. If the service channel is fu
 6. Fresh intent scheduling must persist rows before execution when possible; recovered scheduling must not reinsert rows.
 7. Pending-intent recovery must reconstruct only rows inside the recovery window and skip inconsistent or incomplete persisted groups.
 8. Buffer accounts and ALTs must be prepared before transaction assembly uses them, and released/closed only when safe.
-9. Failed intent cleanup must not close buffer PDAs that retries or later intents can reuse; release ALT reservations without closing those buffers.
-10. Successful intent cleanup must finish before scheduler completion unblocks conflicting intents that can reuse the same buffer PDAs.
-11. Transaction-size and compute-budget choices must keep produced transactions under Solana wire limits.
-12. Base-layer sends must preserve explicit processed/committed confirmation semantics from `magicblock-rpc-client`.
-13. Signer/authority requirements for validator-signed commits, committor-program buffers, ALTs, callbacks, and base-layer instructions must not be relaxed.
-14. Persistence status/signature updates must continue to expose enough information for diagnostics, retries, and recovery.
-15. Avoid adding blocking I/O or unbounded work to service actor, scheduler, executor, task-preparation, or RPC hot paths.
+9. Failed intent cleanup must not race with retries using the same buffer PDAs; current cleanup is success-only for that reason.
+10. Transaction-size and compute-budget choices must keep produced transactions under Solana wire limits.
+11. Base-layer sends must preserve explicit processed/committed confirmation semantics from `magicblock-rpc-client`.
+12. Signer/authority requirements for validator-signed commits, committor-program buffers, ALTs, callbacks, and base-layer instructions must not be relaxed.
+13. Persistence status/signature updates must continue to expose enough information for diagnostics, retries, and recovery.
+14. Avoid adding blocking I/O or unbounded work to service actor, scheduler, executor, task-preparation, or RPC hot paths.
 
 ## Common change areas and what to inspect
 
@@ -285,7 +282,7 @@ Start with `src/tasks/task_builder.rs`, `src/tasks/task_strategist.rs`, `src/tas
 
 ### Changing delivery preparation or cleanup
 
-Start with `src/transaction_preparator/mod.rs` and `delivery_preparator.rs`, then inspect `.agents/context/crates/magicblock-committor-program.md`, `.agents/context/crates/magicblock-table-mania.md`, and `.agents/context/crates/magicblock-rpc-client.md`. Check buffer init/realloc/write chunking, retry handling for already-initialized buffers, cached blockhash invalidation, ALT finalized waits, success-only buffer closing, release of TableMania refs, and cleanup-before-scheduler-completion ordering for conflicting intents.
+Start with `src/transaction_preparator/mod.rs` and `delivery_preparator.rs`, then inspect `.agents/context/crates/magicblock-committor-program.md`, `.agents/context/crates/magicblock-table-mania.md`, and `.agents/context/crates/magicblock-rpc-client.md`. Check buffer init/realloc/write chunking, retry handling for already-initialized buffers, cached blockhash invalidation, ALT finalized waits, cleanup-on-success only, and release of TableMania refs.
 
 ### Changing persistence or recovery
 

--- a/magicblock-committor-service/src/intent_execution_manager/intent_execution_engine.rs
+++ b/magicblock-committor-service/src/intent_execution_manager/intent_execution_engine.rs
@@ -297,6 +297,14 @@ where
             warn!(error = ?err, "No result listeners");
         }
 
+        // Cleanup BEFORE unblocking conflicting intents: a detached cleanup
+        // can close buffers a next intent just re-initialized (same PDAs on
+        // nonce reuse). The result is already broadcast, so this only delays
+        // intents blocked on the same accounts.
+        if let Err(err) = executor.cleanup().await {
+            error!(error = ?err, "Failed to cleanup after intent");
+        }
+
         // Remove executed task from Scheduler to unblock other intents
         // SAFETY: Self::execute is called ONLY after IntentScheduler
         // successfully is able to schedule execution of some Intent
@@ -306,12 +314,6 @@ where
             .expect(POISONED_INNER_MSG)
             .complete(&intent)
             .expect("Valid completion of previously scheduled message");
-
-        tokio::spawn(async move {
-            if let Err(err) = executor.cleanup().await {
-                error!(error = ?err, "Failed to cleanup after intent");
-            }
-        });
 
         // Free worker
         drop(execution_permit);
@@ -665,6 +667,38 @@ mod tests {
         );
     }
 
+    /// A conflicting intent must not start before the previous intent's
+    /// cleanup closed its buffers (nonce reuse maps to the same buffer PDAs).
+    #[tokio::test]
+    async fn test_cleanup_completes_before_conflicting_intent() {
+        const NUM_MESSAGES: u64 = 3;
+
+        let (sender, mut worker) = setup_engine(false);
+        let tracking = Arc::new(CleanupTracking::default());
+        worker.executor_factory.with_cleanup_tracking(&tracking);
+
+        let result_subscriber = worker.spawn();
+        let mut result_receiver = result_subscriber.subscribe();
+
+        // Same pubkey: intents conflict and execute strictly sequentially
+        let key = pubkey!("1111111111111111111111111111111111111111111");
+        for i in 0..NUM_MESSAGES {
+            let msg = create_test_intent(i, &[key], false);
+            sender.send(msg).await.unwrap();
+        }
+
+        for _ in 0..NUM_MESSAGES {
+            let result = result_receiver.recv().await.unwrap();
+            assert!(result.is_ok());
+        }
+
+        assert_eq!(
+            tracking.violations.load(Ordering::SeqCst),
+            0,
+            "conflicting intent started before previous cleanup finished"
+        );
+    }
+
     #[tokio::test]
     async fn test_mixed_blocking_non_blocking() {
         const NUM_MESSAGES: usize = 100;
@@ -716,10 +750,19 @@ mod tests {
     }
 
     // Mock implementations for testing
+    /// Tracks execute/cleanup ordering across executor instances.
+    #[derive(Default)]
+    pub struct CleanupTracking {
+        executions: AtomicUsize,
+        cleanups: AtomicUsize,
+        violations: AtomicUsize,
+    }
+
     pub struct MockIntentExecutorFactory {
         should_fail: bool,
         active_tasks: Option<Arc<AtomicUsize>>,
         max_concurrent: Option<Arc<AtomicUsize>>,
+        cleanup_tracking: Option<Arc<CleanupTracking>>,
     }
 
     impl MockIntentExecutorFactory {
@@ -728,6 +771,7 @@ mod tests {
                 should_fail: false,
                 active_tasks: None,
                 max_concurrent: None,
+                cleanup_tracking: None,
             }
         }
 
@@ -736,6 +780,7 @@ mod tests {
                 should_fail: true,
                 active_tasks: None,
                 max_concurrent: None,
+                cleanup_tracking: None,
             }
         }
 
@@ -747,6 +792,13 @@ mod tests {
             self.active_tasks = Some(active_tasks.clone());
             self.max_concurrent = Some(max_concurrent.clone());
         }
+
+        pub fn with_cleanup_tracking(
+            &mut self,
+            tracking: &Arc<CleanupTracking>,
+        ) {
+            self.cleanup_tracking = Some(tracking.clone());
+        }
     }
 
     impl IntentExecutorFactory for MockIntentExecutorFactory {
@@ -757,6 +809,7 @@ mod tests {
                 should_fail: self.should_fail,
                 active_tasks: self.active_tasks.clone(),
                 max_concurrent: self.max_concurrent.clone(),
+                cleanup_tracking: self.cleanup_tracking.clone(),
             }
         }
     }
@@ -765,6 +818,7 @@ mod tests {
         should_fail: bool,
         active_tasks: Option<Arc<AtomicUsize>>,
         max_concurrent: Option<Arc<AtomicUsize>>,
+        cleanup_tracking: Option<Arc<CleanupTracking>>,
     }
 
     impl MockIntentExecutor {
@@ -806,6 +860,14 @@ mod tests {
             _persister: Option<P>,
         ) -> IntentExecutionResult {
             self.on_task_started();
+            if let Some(tracking) = &self.cleanup_tracking {
+                // All previously started executions must have cleaned up
+                let started =
+                    tracking.executions.fetch_add(1, Ordering::SeqCst);
+                if tracking.cleanups.load(Ordering::SeqCst) < started {
+                    tracking.violations.fetch_add(1, Ordering::SeqCst);
+                }
+            }
 
             // Simulate some work
             sleep(Duration::from_millis(50)).await;
@@ -845,6 +907,10 @@ mod tests {
         }
 
         async fn cleanup(self) -> Result<(), BufferExecutionError> {
+            if let Some(tracking) = &self.cleanup_tracking {
+                sleep(Duration::from_millis(100)).await;
+                tracking.cleanups.fetch_add(1, Ordering::SeqCst);
+            }
             Ok(())
         }
     }

--- a/magicblock-committor-service/src/intent_execution_manager/intent_execution_engine.rs
+++ b/magicblock-committor-service/src/intent_execution_manager/intent_execution_engine.rs
@@ -297,14 +297,6 @@ where
             warn!(error = ?err, "No result listeners");
         }
 
-        // Cleanup BEFORE unblocking conflicting intents: a detached cleanup
-        // can close buffers a next intent just re-initialized (same PDAs on
-        // nonce reuse). The result is already broadcast, so this only delays
-        // intents blocked on the same accounts.
-        if let Err(err) = executor.cleanup().await {
-            error!(error = ?err, "Failed to cleanup after intent");
-        }
-
         // Remove executed task from Scheduler to unblock other intents
         // SAFETY: Self::execute is called ONLY after IntentScheduler
         // successfully is able to schedule execution of some Intent
@@ -314,6 +306,12 @@ where
             .expect(POISONED_INNER_MSG)
             .complete(&intent)
             .expect("Valid completion of previously scheduled message");
+
+        tokio::spawn(async move {
+            if let Err(err) = executor.cleanup().await {
+                error!(error = ?err, "Failed to cleanup after intent");
+            }
+        });
 
         // Free worker
         drop(execution_permit);
@@ -667,38 +665,6 @@ mod tests {
         );
     }
 
-    /// A conflicting intent must not start before the previous intent's
-    /// cleanup closed its buffers (nonce reuse maps to the same buffer PDAs).
-    #[tokio::test]
-    async fn test_cleanup_completes_before_conflicting_intent() {
-        const NUM_MESSAGES: u64 = 3;
-
-        let (sender, mut worker) = setup_engine(false);
-        let tracking = Arc::new(CleanupTracking::default());
-        worker.executor_factory.with_cleanup_tracking(&tracking);
-
-        let result_subscriber = worker.spawn();
-        let mut result_receiver = result_subscriber.subscribe();
-
-        // Same pubkey: intents conflict and execute strictly sequentially
-        let key = pubkey!("1111111111111111111111111111111111111111111");
-        for i in 0..NUM_MESSAGES {
-            let msg = create_test_intent(i, &[key], false);
-            sender.send(msg).await.unwrap();
-        }
-
-        for _ in 0..NUM_MESSAGES {
-            let result = result_receiver.recv().await.unwrap();
-            assert!(result.is_ok());
-        }
-
-        assert_eq!(
-            tracking.violations.load(Ordering::SeqCst),
-            0,
-            "conflicting intent started before previous cleanup finished"
-        );
-    }
-
     #[tokio::test]
     async fn test_mixed_blocking_non_blocking() {
         const NUM_MESSAGES: usize = 100;
@@ -750,19 +716,10 @@ mod tests {
     }
 
     // Mock implementations for testing
-    /// Tracks execute/cleanup ordering across executor instances.
-    #[derive(Default)]
-    pub struct CleanupTracking {
-        executions: AtomicUsize,
-        cleanups: AtomicUsize,
-        violations: AtomicUsize,
-    }
-
     pub struct MockIntentExecutorFactory {
         should_fail: bool,
         active_tasks: Option<Arc<AtomicUsize>>,
         max_concurrent: Option<Arc<AtomicUsize>>,
-        cleanup_tracking: Option<Arc<CleanupTracking>>,
     }
 
     impl MockIntentExecutorFactory {
@@ -771,7 +728,6 @@ mod tests {
                 should_fail: false,
                 active_tasks: None,
                 max_concurrent: None,
-                cleanup_tracking: None,
             }
         }
 
@@ -780,7 +736,6 @@ mod tests {
                 should_fail: true,
                 active_tasks: None,
                 max_concurrent: None,
-                cleanup_tracking: None,
             }
         }
 
@@ -792,13 +747,6 @@ mod tests {
             self.active_tasks = Some(active_tasks.clone());
             self.max_concurrent = Some(max_concurrent.clone());
         }
-
-        pub fn with_cleanup_tracking(
-            &mut self,
-            tracking: &Arc<CleanupTracking>,
-        ) {
-            self.cleanup_tracking = Some(tracking.clone());
-        }
     }
 
     impl IntentExecutorFactory for MockIntentExecutorFactory {
@@ -809,7 +757,6 @@ mod tests {
                 should_fail: self.should_fail,
                 active_tasks: self.active_tasks.clone(),
                 max_concurrent: self.max_concurrent.clone(),
-                cleanup_tracking: self.cleanup_tracking.clone(),
             }
         }
     }
@@ -818,7 +765,6 @@ mod tests {
         should_fail: bool,
         active_tasks: Option<Arc<AtomicUsize>>,
         max_concurrent: Option<Arc<AtomicUsize>>,
-        cleanup_tracking: Option<Arc<CleanupTracking>>,
     }
 
     impl MockIntentExecutor {
@@ -860,14 +806,6 @@ mod tests {
             _persister: Option<P>,
         ) -> IntentExecutionResult {
             self.on_task_started();
-            if let Some(tracking) = &self.cleanup_tracking {
-                // All previously started executions must have cleaned up
-                let started =
-                    tracking.executions.fetch_add(1, Ordering::SeqCst);
-                if tracking.cleanups.load(Ordering::SeqCst) < started {
-                    tracking.violations.fetch_add(1, Ordering::SeqCst);
-                }
-            }
 
             // Simulate some work
             sleep(Duration::from_millis(50)).await;
@@ -907,10 +845,6 @@ mod tests {
         }
 
         async fn cleanup(self) -> Result<(), BufferExecutionError> {
-            if let Some(tracking) = &self.cleanup_tracking {
-                sleep(Duration::from_millis(100)).await;
-                tracking.cleanups.fetch_add(1, Ordering::SeqCst);
-            }
             Ok(())
         }
     }

--- a/magicblock-committor-service/src/intent_executor/mod.rs
+++ b/magicblock-committor-service/src/intent_executor/mod.rs
@@ -544,8 +544,18 @@ where
     ) -> IntentExecutionResult {
         self.started_at = Instant::now();
         let message_id = base_intent.id;
-        let is_undelegate = base_intent.has_undelegate_intent();
         let pubkeys = base_intent.get_all_committed_pubkeys();
+        let undelegated_pubkeys: Vec<Pubkey> = base_intent
+            .intent_bundle
+            .get_undelegate_intent_pubkeys()
+            .into_iter()
+            .chain(
+                base_intent
+                    .intent_bundle
+                    .get_commit_finalize_and_undelegate_intent_pubkeys(),
+            )
+            .flatten()
+            .collect();
 
         let mut execution_report = IntentExecutionReport::default();
         let result = self
@@ -553,10 +563,17 @@ where
             .await;
         if !pubkeys.is_empty() {
             // Reset TaskInfoFetcher, as cache could become invalid
-            // NOTE: if undelegation was removed - we still reset
-            // We assume its safe since all consecutive commits will fail
-            if result.is_err() || is_undelegate {
+            if result.is_err() {
+                // We can't know what landed on chain, resync everything
                 self.task_info_fetcher.reset(ResetType::Specific(&pubkeys));
+            } else if !undelegated_pubkeys.is_empty() {
+                // Only undelegated accounts' nonces become stale. Keep the
+                // rest cached: a chain re-fetch can race the just-landed
+                // finalize and reuse a nonce (buffer PDA collision).
+                // NOTE: if undelegation was removed - we still reset
+                // We assume its safe since all consecutive commits will fail
+                self.task_info_fetcher
+                    .reset(ResetType::Specific(&undelegated_pubkeys));
             }
 
             // Write result of intent into Persister

--- a/magicblock-committor-service/src/intent_executor/task_info_fetcher.rs
+++ b/magicblock-committor-service/src/intent_executor/task_info_fetcher.rs
@@ -372,7 +372,7 @@ pub struct CacheTaskInfoFetcher<T> {
 
 impl<T: TaskInfoFetcher> CacheTaskInfoFetcher<T> {
     pub fn new(inner: T) -> Self {
-        const CACHE_SIZE: NonZeroUsize = NonZeroUsize::new(1000).unwrap();
+        const CACHE_SIZE: NonZeroUsize = NonZeroUsize::new(10_000).unwrap();
 
         Self {
             inner,


### PR DESCRIPTION
## Summary
- run committor cleanup before unblocking conflicting intents so reused buffer PDAs cannot be closed by a previous detached cleanup
- narrow successful undelegation cache resets to the accounts actually undelegated while still resetting all committed accounts on execution errors
- add coverage for cleanup-before-next-conflicting-intent ordering

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache refresh behavior so only the affected undelegation-related entries are cleared during successful execution, while broader resets still occur on failures.
  * Increased the default cache capacity, allowing more recent entries to stay available before older ones are evicted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->