### PR TITLE
Add program transaction purge before ledger truncation

### DIFF
--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -42,7 +42,9 @@ use magicblock_core::{
 };
 use magicblock_ledger::{
     blockstore_processor::process_ledger,
-    ledger_truncator::{LedgerTruncator, DEFAULT_TRUNCATION_TIME_INTERVAL},
+    ledger_truncator::{
+        LedgerTruncator, ProgramPurgeConfig, DEFAULT_TRUNCATION_TIME_INTERVAL,
+    },
     LatestBlock, Ledger,
 };
 use magicblock_metrics::{metrics::TRANSACTION_COUNT, MetricsService};
@@ -300,6 +302,15 @@ impl MagicValidator {
             ledger.clone(),
             DEFAULT_TRUNCATION_TIME_INTERVAL,
             config.ledger.size,
+            ProgramPurgeConfig::new(
+                config
+                    .ledger
+                    .truncate_first_programs
+                    .iter()
+                    .map(|program| program.0)
+                    .collect(),
+                config.ledger.block_time_ms(),
+            ),
         );
 
         init_validator_identity(&accountsdb, &validator_pubkey);

--- a/magicblock-config/src/config/ledger.rs
+++ b/magicblock-config/src/config/ledger.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 
-use crate::consts;
+use crate::{consts, types::SerdePubkey};
 
 /// Configuration for the ledger database and block production.
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -29,6 +29,11 @@ pub struct LedgerConfig {
     /// ledger truncation logic kicks in, when the disk space
     /// used by the ledger approaches this number.
     pub size: u64,
+
+    /// Programs whose transactions are purged first (oldest first) when
+    /// the ledger approaches its max size. Transactions from the recent
+    /// protected window are never purged.
+    pub truncate_first_programs: Vec<SerdePubkey>,
 }
 
 impl Default for LedgerConfig {
@@ -42,6 +47,7 @@ impl Default for LedgerConfig {
             reset: false,
             verify_keypair: true,
             size: consts::DEFAULT_LEDGER_SIZE,
+            truncate_first_programs: Vec::new(),
         }
     }
 }

--- a/magicblock-config/src/tests.rs
+++ b/magicblock-config/src/tests.rs
@@ -344,6 +344,7 @@ fn test_ledger_and_commit_settings() {
         [ledger]
         block-time = "800ms"
         verify-keypair = false
+        truncate-first-programs = ["MyProgram1111111111111111111111111111111111"]
 
         [commit]
         compute-unit-price = 123456
@@ -354,6 +355,11 @@ fn test_ledger_and_commit_settings() {
 
     assert_eq!(config.ledger.block_time.as_millis(), 800);
     assert!(!config.ledger.verify_keypair);
+    assert_eq!(config.ledger.truncate_first_programs.len(), 1);
+    assert_eq!(
+        config.ledger.truncate_first_programs[0].0.to_string(),
+        "MyProgram1111111111111111111111111111111111"
+    );
     assert_eq!(config.commit.compute_unit_price, 123456);
 }
 

--- a/magicblock-ledger/src/ledger_truncator.rs
+++ b/magicblock-ledger/src/ledger_truncator.rs
@@ -10,6 +10,7 @@ use magicblock_metrics::metrics::{
     HistogramTimer,
 };
 use solana_measure::measure::Measure;
+use solana_pubkey::Pubkey;
 use tokio::{runtime::Builder, time::interval};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, instrument, warn};
@@ -31,11 +32,34 @@ pub const DEFAULT_TRUNCATION_TIME_INTERVAL: Duration =
     Duration::from_secs(2 * 60);
 const PERCENTAGE_TO_TRUNCATE: u8 = 10;
 const FILLED_PERCENTAGE_LIMIT: u8 = 100 - PERCENTAGE_TO_TRUNCATE;
+/// Bounds purge work per truncation cycle
+const MAX_PURGED_TXS_PER_CYCLE: usize = 100_000;
+
+/// Programs whose transactions are purged (oldest first) before generic
+/// slot truncation kicks in, sparing the rest of the ledger.
+#[derive(Debug, Clone, Default)]
+pub struct ProgramPurgeConfig {
+    pub programs: Vec<Pubkey>,
+    /// Number of most recent slots whose transactions are never purged
+    pub protected_slots: u64,
+}
+
+impl ProgramPurgeConfig {
+    /// Protects the most recent 12 hours worth of slots from purging
+    pub fn new(programs: Vec<Pubkey>, block_time_ms: u64) -> Self {
+        const PROTECTED_WINDOW_MS: u64 = 12 * 60 * 60 * 1000;
+        Self {
+            programs,
+            protected_slots: PROTECTED_WINDOW_MS / block_time_ms.max(1),
+        }
+    }
+}
 
 struct LedgerTrunctationWorker {
     ledger: Arc<Ledger>,
     truncation_time_interval: Duration,
     ledger_size: u64,
+    purge_config: ProgramPurgeConfig,
     cancellation_token: CancellationToken,
 }
 
@@ -44,12 +68,14 @@ impl LedgerTrunctationWorker {
         ledger: Arc<Ledger>,
         truncation_time_interval: Duration,
         ledger_size: u64,
+        purge_config: ProgramPurgeConfig,
         cancellation_token: CancellationToken,
     ) -> Self {
         Self {
             ledger,
             truncation_time_interval,
             ledger_size,
+            purge_config,
             cancellation_token,
         }
     }
@@ -65,7 +91,7 @@ impl LedgerTrunctationWorker {
                 _ = interval.tick() => {
                     // Note: since we clean 10%, tomstones will take around 10% as well
 
-                    let current_size = match self.ledger.storage_size() {
+                    let mut current_size = match self.ledger.storage_size() {
                         Ok(value) => value,
                         Err(err) => {
                             error!(error = ?err, "Truncation check failed");
@@ -74,18 +100,123 @@ impl LedgerTrunctationWorker {
                     };
 
                     // Check if we should truncate
-                    if current_size < (self.ledger_size / 100) * FILLED_PERCENTAGE_LIMIT as u64 {
+                    let size_limit = (self.ledger_size / 100) * FILLED_PERCENTAGE_LIMIT as u64;
+                    if current_size < size_limit {
                         debug!(current_size, "Skipping truncation");
                         continue;
                     }
 
                     info!(current_size, "Checking ledger size");
+
+                    // Purge configured programs' transactions first; skip slot
+                    // truncation entirely when that frees enough space
+                    if self.purge_first_programs() {
+                        match self.ledger.storage_size() {
+                            Ok(size) if size < size_limit => {
+                                info!(size, "Program purge freed enough space");
+                                continue;
+                            }
+                            Ok(size) => current_size = size,
+                            Err(err) => {
+                                error!(error = ?err, "Size check after purge failed")
+                            }
+                        }
+                    }
+
                     if let Err(err) = self.truncate(current_size) {
                         error!(error = ?err, "Truncation failed");
                     }
                 }
             }
         }
+    }
+
+    /// Purges transactions of the configured programs outside the protected
+    /// window. Returns whether anything was purged and compacted.
+    fn purge_first_programs(&self) -> bool {
+        if self.purge_config.programs.is_empty() {
+            return false;
+        }
+        let (from_slot, latest_slot) = match self.available_truncation_range() {
+            Some(range) => range,
+            None => return false,
+        };
+        let to_slot =
+            latest_slot.saturating_sub(self.purge_config.protected_slots);
+        if to_slot < from_slot {
+            return false;
+        }
+
+        let mut purged = 0;
+        for program in &self.purge_config.programs {
+            match self.ledger.purge_program_transactions(
+                program,
+                from_slot,
+                to_slot,
+                MAX_PURGED_TXS_PER_CYCLE - purged,
+            ) {
+                Ok(count) => purged += count,
+                Err(err) => {
+                    error!(%program, error = ?err, "Program purge failed")
+                }
+            }
+            if purged >= MAX_PURGED_TXS_PER_CYCLE {
+                break;
+            }
+        }
+        if purged == 0 {
+            return false;
+        }
+
+        info!(purged, from_slot, to_slot, "Purged truncate-first programs");
+        if let Err(err) = self.ledger.flush() {
+            // We will still compact
+            error!(error = ?err, "Flush failed");
+        }
+        Self::compact_purged_columns(
+            &self.ledger,
+            self.cancellation_token.clone(),
+        );
+        true
+    }
+
+    /// Compacts the transaction columns touched by a program purge
+    fn compact_purged_columns(
+        ledger: &Arc<Ledger>,
+        cancellation_token: CancellationToken,
+    ) {
+        use crate::compact_cf_or_return;
+
+        compact_cf_or_return!(
+            ledger,
+            cancellation_token,
+            (None, None),
+            SlotSignatures
+        );
+        compact_cf_or_return!(
+            ledger,
+            cancellation_token,
+            (None, None),
+            TransactionStatus
+        );
+        compact_cf_or_return!(
+            ledger,
+            cancellation_token,
+            (None, None),
+            Transaction
+        );
+        compact_cf_or_return!(
+            ledger,
+            cancellation_token,
+            (None, None),
+            TransactionMemos
+        );
+        compact_cf_or_return!(
+            ledger,
+            cancellation_token,
+            (None, None),
+            AddressSignatures
+        );
     }
 
     pub fn truncate(&self, current_ledger_size: u64) -> LedgerResult<()> {
@@ -409,6 +540,7 @@ pub struct LedgerTruncator {
     ledger: Arc<Ledger>,
     ledger_size: u64,
     truncation_time_interval: Duration,
+    purge_config: ProgramPurgeConfig,
     state: ServiceState,
 }
 
@@ -417,11 +549,13 @@ impl LedgerTruncator {
         ledger: Arc<Ledger>,
         truncation_time_interval: Duration,
         ledger_size: u64,
+        purge_config: ProgramPurgeConfig,
     ) -> Self {
         Self {
             ledger,
             truncation_time_interval,
             ledger_size,
+            purge_config,
             state: ServiceState::Created,
         }
     }
@@ -433,6 +567,7 @@ impl LedgerTruncator {
                 self.ledger.clone(),
                 self.truncation_time_interval,
                 self.ledger_size,
+                self.purge_config.clone(),
                 cancellation_token.clone(),
             );
             let worker_handle = thread::spawn(move || {

--- a/magicblock-ledger/src/store/api.rs
+++ b/magicblock-ledger/src/store/api.rs
@@ -988,6 +988,72 @@ impl Ledger {
         }
     }
 
+    /// Deletes transactions referencing `program` in slots
+    /// [from_slot, to_slot], up to `max_txs`. Returns the number purged.
+    /// AddressSignatures entries of other accounts in purged transactions
+    /// are left behind; regular slot truncation removes them later.
+    pub fn purge_program_transactions(
+        &self,
+        program: &Pubkey,
+        from_slot: Slot,
+        to_slot: Slot,
+        max_txs: usize,
+    ) -> LedgerResult<usize> {
+        const WRITES_PER_BATCH: usize = 1_000;
+
+        let mut purged = 0;
+        let mut batch = self.db.batch();
+        let iter = self.address_signatures_cf.iter_current_index_filtered(
+            IteratorMode::From(
+                (*program, from_slot, 0, Signature::default()),
+                IteratorDirection::Forward,
+            ),
+        );
+        for ((address, slot, tx_idx, signature), _) in iter {
+            if address != *program || slot > to_slot || purged >= max_txs {
+                break;
+            }
+            batch.delete::<cf::Transaction>((signature, slot));
+            batch.delete::<cf::TransactionStatus>((signature, slot));
+            batch.delete::<cf::TransactionMemos>((signature, slot));
+            batch.delete::<cf::SlotSignatures>((slot, tx_idx));
+            batch.delete::<cf::AddressSignatures>((
+                address, slot, tx_idx, signature,
+            ));
+            purged += 1;
+            if purged.is_multiple_of(WRITES_PER_BATCH) {
+                let full = std::mem::replace(&mut batch, self.db.batch());
+                self.db.write(full)?;
+            }
+        }
+        self.db.write(batch)?;
+
+        if purged > 0 {
+            // Exact per-column deletion counts are unknowable
+            // (e.g. not every transaction has memos), mark counters dirty
+            self.transaction_cf
+                .entry_counter
+                .store(DIRTY_COUNT, Ordering::Relaxed);
+            self.transaction_status_cf
+                .entry_counter
+                .store(DIRTY_COUNT, Ordering::Relaxed);
+            self.transaction_memos_cf
+                .entry_counter
+                .store(DIRTY_COUNT, Ordering::Relaxed);
+            self.slot_signatures_cf
+                .entry_counter
+                .store(DIRTY_COUNT, Ordering::Relaxed);
+            self.address_signatures_cf
+                .entry_counter
+                .store(DIRTY_COUNT, Ordering::Relaxed);
+            self.transaction_successful_status_count
+                .store(DIRTY_COUNT, Ordering::Relaxed);
+            self.transaction_failed_status_count
+                .store(DIRTY_COUNT, Ordering::Relaxed);
+        }
+        Ok(purged)
+    }
+
     /// Verifies the signature of a transaction stored in the ledger.
     ///
     /// Returns:

--- a/magicblock-ledger/tests/common.rs
+++ b/magicblock-ledger/tests/common.rs
@@ -21,6 +21,18 @@ pub fn write_dummy_transaction(
     slot: Slot,
     index: u32,
 ) -> (Hash, Signature) {
+    write_dummy_transaction_with_readonly(ledger, slot, index, &[])
+}
+
+/// Writes a dummy transaction referencing `readonly_keys` in addition
+/// to its own random accounts, e.g. to simulate a program invocation
+#[allow(dead_code)]
+pub fn write_dummy_transaction_with_readonly(
+    ledger: &Ledger,
+    slot: Slot,
+    index: u32,
+    readonly_keys: &[Pubkey],
+) -> (Hash, Signature) {
     let from = Keypair::new();
     let to = Pubkey::new_unique();
     let tx =
@@ -32,13 +44,14 @@ pub fn write_dummy_transaction(
     let versioned = transaction.to_versioned_transaction();
     let encoded = bincode::serialize(&versioned).unwrap();
     let locks = transaction.get_account_locks_unchecked();
+    let readonly = [locks.readonly, readonly_keys.iter().collect()].concat();
     ledger
         .write_transaction(
             signature,
             slot,
             index,
             locks.writable,
-            locks.readonly,
+            readonly,
             &encoded,
             status,
         )

--- a/magicblock-ledger/tests/test_ledger_truncator.rs
+++ b/magicblock-ledger/tests/test_ledger_truncator.rs
@@ -2,13 +2,17 @@ mod common;
 use std::{sync::Arc, time::Duration};
 
 use magicblock_ledger::{
-    ledger_truncator::LedgerTruncator, LatestBlockInner, Ledger,
+    ledger_truncator::{LedgerTruncator, ProgramPurgeConfig},
+    LatestBlockInner, Ledger,
 };
 use solana_hash::Hash;
+use solana_pubkey::Pubkey;
 use solana_signature::Signature;
 use test_kit::init_logger;
 
-use crate::common::{setup, write_dummy_transaction};
+use crate::common::{
+    setup, write_dummy_transaction, write_dummy_transaction_with_readonly,
+};
 
 const TEST_TRUNCATION_TIME_INTERVAL: Duration = Duration::from_millis(50);
 
@@ -90,6 +94,7 @@ async fn test_truncator_not_purged_size() {
         ledger.clone(),
         TEST_TRUNCATION_TIME_INTERVAL,
         1 << 30, // 1 GB
+        ProgramPurgeConfig::default(),
     );
 
     for i in 0..NUM_TRANSACTIONS {
@@ -136,8 +141,12 @@ async fn test_truncator_non_empty_ledger() {
 
     ledger.flush().unwrap();
     ledger.set_lowest_cleanup_slot(FINAL_SLOT);
-    let mut ledger_truncator =
-        LedgerTruncator::new(ledger.clone(), TEST_TRUNCATION_TIME_INTERVAL, 0);
+    let mut ledger_truncator = LedgerTruncator::new(
+        ledger.clone(),
+        TEST_TRUNCATION_TIME_INTERVAL,
+        0,
+        ProgramPurgeConfig::default(),
+    );
 
     ledger_truncator.start();
     tokio::time::sleep(TEST_TRUNCATION_TIME_INTERVAL * 2).await;
@@ -190,8 +199,12 @@ async fn test_truncator_with_tx_spammer() {
     init_logger!();
     let ledger = Arc::new(setup());
 
-    let mut ledger_truncator =
-        LedgerTruncator::new(ledger.clone(), TEST_TRUNCATION_TIME_INTERVAL, 0);
+    let mut ledger_truncator = LedgerTruncator::new(
+        ledger.clone(),
+        TEST_TRUNCATION_TIME_INTERVAL,
+        0,
+        ProgramPurgeConfig::default(),
+    );
 
     ledger_truncator.start();
     let handle = tokio::spawn(transaction_spammer(ledger.clone(), 10, 20));
@@ -215,6 +228,110 @@ async fn test_truncator_with_tx_spammer() {
 
     assert!(ledger.get_lowest_cleanup_slot() >= last_signature_slot);
     verify_transactions_state(&ledger, 0, &signatures, false);
+}
+
+// Writes one transaction per slot in [0, num_slots);
+// even slots reference `program`, odd slots don't
+fn write_program_and_plain_transactions(
+    ledger: &Ledger,
+    program: &Pubkey,
+    num_slots: u64,
+) -> Vec<Signature> {
+    (0..num_slots)
+        .map(|slot| {
+            let readonly = if slot.is_multiple_of(2) {
+                std::slice::from_ref(program)
+            } else {
+                &[]
+            };
+            let (_, signature) = write_dummy_transaction_with_readonly(
+                ledger, slot, 0, readonly,
+            );
+            ledger
+                .write_block(LatestBlockInner::new(slot, Hash::new_unique(), 0))
+                .unwrap();
+            signature
+        })
+        .collect()
+}
+
+// Tests that program purge removes only the targeted program's transactions
+// within the requested slot range
+#[test]
+fn test_purge_program_transactions() {
+    init_logger!();
+    const NUM_SLOTS: u64 = 100;
+    const PURGE_TO_SLOT: u64 = 79;
+
+    let ledger = setup();
+    let program = Pubkey::new_unique();
+    let signatures =
+        write_program_and_plain_transactions(&ledger, &program, NUM_SLOTS);
+
+    let purged = ledger
+        .purge_program_transactions(&program, 0, PURGE_TO_SLOT, usize::MAX)
+        .unwrap();
+    assert_eq!(purged, 40);
+
+    for (slot, signature) in signatures.iter().enumerate() {
+        let slot = slot as u64;
+        let is_purged = slot.is_multiple_of(2) && slot <= PURGE_TO_SLOT;
+        assert_eq!(
+            ledger
+                .read_transaction((*signature, slot))
+                .unwrap()
+                .is_some(),
+            !is_purged
+        );
+        assert_eq!(
+            ledger
+                .read_transaction_status((*signature, slot))
+                .unwrap()
+                .is_some(),
+            !is_purged
+        );
+        assert_eq!(
+            ledger.read_slot_signature((slot, 0)).unwrap().is_some(),
+            !is_purged
+        );
+    }
+
+    // Blocks of purged slots remain readable, just without the transactions
+    let block = ledger.get_block(0).unwrap().unwrap();
+    assert!(block.transactions.is_empty());
+    let block = ledger.get_block(1).unwrap().unwrap();
+    assert_eq!(block.transactions.len(), 1);
+}
+
+// Tests that max_txs caps the purge at the oldest transactions
+#[test]
+fn test_purge_program_transactions_max_txs() {
+    init_logger!();
+    const NUM_SLOTS: u64 = 100;
+    const MAX_TXS: usize = 10;
+
+    let ledger = setup();
+    let program = Pubkey::new_unique();
+    let signatures =
+        write_program_and_plain_transactions(&ledger, &program, NUM_SLOTS);
+
+    let purged = ledger
+        .purge_program_transactions(&program, 0, NUM_SLOTS, MAX_TXS)
+        .unwrap();
+    assert_eq!(purged, MAX_TXS);
+
+    // Only the oldest MAX_TXS program transactions (even slots 0..=18) purged
+    for (slot, signature) in signatures.iter().enumerate() {
+        let slot = slot as u64;
+        let is_purged = slot.is_multiple_of(2) && slot < (MAX_TXS as u64) * 2;
+        assert_eq!(
+            ledger
+                .read_transaction((*signature, slot))
+                .unwrap()
+                .is_some(),
+            !is_purged
+        );
+    }
 }
 
 #[ignore = "Long running test"]
@@ -244,6 +361,7 @@ async fn test_with_1gb_db() {
         ledger.clone(),
         TEST_TRUNCATION_TIME_INTERVAL,
         DB_SIZE,
+        ProgramPurgeConfig::default(),
     );
 
     ledger_truncator.start();


### PR DESCRIPTION
## Summary
- add `truncate-first-programs` ledger config for targeted program transaction purging
- purge old transactions for configured programs before full slot truncation
- cover config parsing, purge limits, and targeted transaction removal in tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for prioritizing transaction cleanup for selected programs when ledger space needs to be reduced.
  * Introduced a new ledger setting to configure which programs are handled first during truncation.
* **Bug Fixes**
  * Ledger cleanup now preserves a recent protected window while removing older eligible transactions.
  * Improved consistency of related transaction data when entries are removed.
* **Tests**
  * Expanded coverage for the new configuration and program-priority cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->