### PR TITLE
Configure ledger RocksDB caching and compression

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -223,6 +223,13 @@ superblock-size = 72000
 # Env: MBV_LEDGER__SIZE
 size = 536_870_912
 
+# Capacity in bytes of the RocksDB block cache shared by all ledger columns.
+# This is the only read caching layer (the ledger bypasses the OS page cache),
+# so production nodes should set 16 GB or more.
+# Default: 536_870_912 (512 MB)
+# Env: MBV_LEDGER__BLOCK_CACHE_SIZE
+block-cache-size = 536_870_912
+
 # Whether to verify that the ledger on disk belongs to the configured keypair.
 # Default: true
 # Env: MBV_LEDGER__VERIFY_KEYPAIR

--- a/magicblock-api/src/ledger.rs
+++ b/magicblock-api/src/ledger.rs
@@ -6,7 +6,9 @@ use std::{
 
 use fd_lock::{RwLock, RwLockWriteGuard};
 use magicblock_config::config::LedgerConfig;
-use magicblock_ledger::{Ledger, BLOCKSTORE_DIRECTORY_ROCKS_LEVEL};
+use magicblock_ledger::{
+    Ledger, LedgerOptions, BLOCKSTORE_DIRECTORY_ROCKS_LEVEL,
+};
 use solana_keypair::Keypair;
 use solana_program::clock::Slot;
 use solana_signer::EncodableKey;
@@ -27,7 +29,11 @@ pub(crate) fn init(
             ApiError::UnableToCleanLedgerDirectory(path.display().to_string())
         })?;
     };
-    let ledger = Ledger::open(path)?;
+    let options = LedgerOptions {
+        block_cache_size: config.block_cache_size as usize,
+        ..Default::default()
+    };
+    let ledger = Ledger::open_with_options(path, options)?;
     let slot = if config.reset {
         // If the ledger was reset, then we use whatever
         // current slot is available in the AccountsDB

--- a/magicblock-config/src/config/ledger.rs
+++ b/magicblock-config/src/config/ledger.rs
@@ -29,6 +29,12 @@ pub struct LedgerConfig {
     /// ledger truncation logic kicks in, when the disk space
     /// used by the ledger approaches this number.
     pub size: u64,
+
+    /// Capacity in bytes of the RocksDB block cache shared by all ledger
+    /// columns. This is the only read caching layer since the ledger
+    /// bypasses the OS page cache, so production nodes should set 16 GB
+    /// or more. Default: 512 MB.
+    pub block_cache_size: u64,
 }
 
 impl Default for LedgerConfig {
@@ -42,6 +48,7 @@ impl Default for LedgerConfig {
             reset: false,
             verify_keypair: true,
             size: consts::DEFAULT_LEDGER_SIZE,
+            block_cache_size: consts::DEFAULT_LEDGER_BLOCK_CACHE_SIZE,
         }
     }
 }

--- a/magicblock-config/src/consts.rs
+++ b/magicblock-config/src/consts.rs
@@ -57,6 +57,10 @@ pub const DEFAULT_LEDGER_SIZE: u64 = 100 * 1024 * 1024 * 1024;
 /// Default superblock size (72K ~ 1 hour with 50ms block time)
 pub const DEFAULT_SUPERBLOCK_SIZE: u64 = 3600 * 20;
 
+/// Default ledger block cache size (512 MB, suits local dev;
+/// production nodes should configure 16 GB or more)
+pub const DEFAULT_LEDGER_BLOCK_CACHE_SIZE: u64 = 512 * 1024 * 1024;
+
 /// Metrics Defaults
 /// Default address for the metrics endpoint (Prometheus format)
 pub const DEFAULT_METRICS_ADDR: &str = "0.0.0.0:9000";

--- a/magicblock-ledger/src/database/cf_descriptors.rs
+++ b/magicblock-ledger/src/database/cf_descriptors.rs
@@ -4,11 +4,14 @@ use std::{
     sync::{atomic::AtomicU64, Arc},
 };
 
-use rocksdb::{ColumnFamilyDescriptor, DBCompressionType, Options, DB};
+use rocksdb::{
+    BlockBasedOptions, Cache, ColumnFamilyDescriptor, DBCompressionType,
+    Options, DB,
+};
 use tracing::*;
 
 use super::{
-    columns::{should_enable_compression, Column, ColumnName},
+    columns::{Column, ColumnName},
     consts,
     options::{LedgerColumnOptions, LedgerOptions},
     rocksdb_options::should_disable_auto_compactions,
@@ -33,15 +36,28 @@ pub fn cf_descriptors(
 ) -> Vec<ColumnFamilyDescriptor> {
     use columns::*;
 
+    let block_cache = Cache::new_lru_cache(options.block_cache_size);
     let mut cf_descriptors = vec![
-        new_cf_descriptor::<TransactionStatus>(options, oldest_slot),
-        new_cf_descriptor::<AddressSignatures>(options, oldest_slot),
-        new_cf_descriptor::<SlotSignatures>(options, oldest_slot),
-        new_cf_descriptor::<Blocktime>(options, oldest_slot),
-        new_cf_descriptor::<Blockhash>(options, oldest_slot),
-        new_cf_descriptor::<Transaction>(options, oldest_slot),
-        new_cf_descriptor::<TransactionMemos>(options, oldest_slot),
-        new_cf_descriptor::<PerfSamples>(options, oldest_slot),
+        new_cf_descriptor::<TransactionStatus>(
+            options,
+            oldest_slot,
+            &block_cache,
+        ),
+        new_cf_descriptor::<AddressSignatures>(
+            options,
+            oldest_slot,
+            &block_cache,
+        ),
+        new_cf_descriptor::<SlotSignatures>(options, oldest_slot, &block_cache),
+        new_cf_descriptor::<Blocktime>(options, oldest_slot, &block_cache),
+        new_cf_descriptor::<Blockhash>(options, oldest_slot, &block_cache),
+        new_cf_descriptor::<Transaction>(options, oldest_slot, &block_cache),
+        new_cf_descriptor::<TransactionMemos>(
+            options,
+            oldest_slot,
+            &block_cache,
+        ),
+        new_cf_descriptor::<PerfSamples>(options, oldest_slot, &block_cache),
     ];
 
     // If the access type is Secondary, we don't need to open all of the
@@ -94,10 +110,11 @@ pub fn cf_descriptors(
 fn new_cf_descriptor<C: 'static + Column + ColumnName>(
     options: &LedgerOptions,
     oldest_slot: &Arc<AtomicU64>,
+    block_cache: &Cache,
 ) -> ColumnFamilyDescriptor {
     ColumnFamilyDescriptor::new(
         C::NAME,
-        get_cf_options::<C>(options, oldest_slot),
+        get_cf_options::<C>(options, oldest_slot, block_cache),
     )
 }
 
@@ -105,8 +122,19 @@ fn new_cf_descriptor<C: 'static + Column + ColumnName>(
 fn get_cf_options<C: 'static + Column + ColumnName>(
     options: &LedgerOptions,
     oldest_slot: &Arc<AtomicU64>,
+    block_cache: &Cache,
 ) -> Options {
     let mut cf_options = Options::default();
+
+    // With direct reads enabled the block cache is the only read caching
+    // layer, so use a large shared cache instead of the 32MiB per-CF default.
+    // Bloom filters spare disk reads for point lookups of absent keys.
+    let mut table_options = BlockBasedOptions::default();
+    table_options.set_block_cache(block_cache);
+    table_options.set_bloom_filter(10.0, false);
+    table_options.set_cache_index_and_filter_blocks(true);
+    table_options.set_pin_l0_filter_and_index_blocks_in_cache(true);
+    cf_options.set_block_based_table_factory(&table_options);
     // 256 * 8 = 2GB. 6 of these columns should take at most 12GB of RAM
     cf_options.set_max_write_buffer_number(8);
     cf_options.set_write_buffer_size(consts::MAX_WRITE_BUFFER_SIZE as usize);
@@ -152,17 +180,12 @@ fn get_cf_options<C: 'static + Column + ColumnName>(
 
 fn process_cf_options_advanced<C: 'static + Column + ColumnName>(
     cf_options: &mut Options,
-    column_options: &LedgerColumnOptions,
+    _column_options: &LedgerColumnOptions,
 ) {
-    // Explicitly disable compression on all columns by default
-    // See https://docs.rs/rocksdb/0.21.0/rocksdb/struct.Options.html#method.set_compression_type
-    cf_options.set_compression_type(DBCompressionType::None);
-
-    if should_enable_compression::<C>() {
-        cf_options.set_compression_type(
-            column_options
-                .compression_type
-                .to_rocksdb_compression_type(),
-        );
-    }
+    // Cheap LZ4 for fresh data on upper levels; higher-ratio Zstd for the
+    // bottommost level, where the bulk of the cold data lives. Compression is
+    // applied per block as SSTs are (re)written, so existing uncompressed
+    // ledgers remain readable and converge without migration.
+    cf_options.set_compression_type(DBCompressionType::Lz4);
+    cf_options.set_bottommost_compression_type(DBCompressionType::Zstd);
 }

--- a/magicblock-ledger/src/database/columns.rs
+++ b/magicblock-ledger/src/database/columns.rs
@@ -622,15 +622,6 @@ impl ColumnName for PerfSamples {
 }
 
 // -----------------
-// Column Configuration
-// -----------------
-
-// Returns true if the column family enables compression.
-pub fn should_enable_compression<C: 'static + Column + ColumnName>() -> bool {
-    C::NAME == TransactionStatus::NAME
-}
-
-// -----------------
 // Column Queries
 // -----------------
 pub(crate) const DIRTY_COUNT: i64 = -1;

--- a/magicblock-ledger/src/database/consts.rs
+++ b/magicblock-ledger/src/database/consts.rs
@@ -1,1 +1,7 @@
 pub const MAX_WRITE_BUFFER_SIZE: u64 = 256 * 1024 * 1024; // 256MB
+
+// Default capacity of the block cache shared by all column families, sized
+// for local development; production nodes should configure much more via
+// the `ledger.block-cache-size` setting. With direct reads enabled the OS
+// page cache is bypassed, so this is the only read caching layer.
+pub const BLOCK_CACHE_CAPACITY: usize = 512 * 1024 * 1024; // 512MB

--- a/magicblock-ledger/src/database/options.rs
+++ b/magicblock-ledger/src/database/options.rs
@@ -1,5 +1,3 @@
-use rocksdb::DBCompressionType as RocksCompressionType;
-
 // -----------------
 // AccessType
 // -----------------
@@ -27,6 +25,10 @@ pub struct LedgerOptions {
     // desired open file descriptor limit cannot be configured. Default: true.
     pub enforce_ulimit_nofile: bool,
     pub column_options: LedgerColumnOptions,
+    // Capacity in bytes of the block cache shared by all column families.
+    // The only read caching layer since direct reads bypass the OS page
+    // cache. Default: 512MB, production nodes should configure much more.
+    pub block_cache_size: usize,
 }
 
 impl Default for LedgerOptions {
@@ -38,6 +40,7 @@ impl Default for LedgerOptions {
             access_type: AccessType::Primary,
             enforce_ulimit_nofile: true,
             column_options: LedgerColumnOptions::default(),
+            block_cache_size: crate::database::consts::BLOCK_CACHE_CAPACITY,
         }
     }
 }
@@ -122,15 +125,4 @@ pub enum LedgerCompressionType {
     Snappy,
     Lz4,
     Zlib,
-}
-
-impl LedgerCompressionType {
-    pub(crate) fn to_rocksdb_compression_type(&self) -> RocksCompressionType {
-        match self {
-            Self::None => RocksCompressionType::None,
-            Self::Snappy => RocksCompressionType::Snappy,
-            Self::Lz4 => RocksCompressionType::Lz4,
-            Self::Zlib => RocksCompressionType::Zlib,
-        }
-    }
 }

--- a/magicblock-ledger/src/lib.rs
+++ b/magicblock-ledger/src/lib.rs
@@ -2,7 +2,8 @@ use std::sync::Arc;
 
 use arc_swap::{ArcSwapAny, Guard};
 pub use database::{
-    meta::PerfSample, options::BLOCKSTORE_DIRECTORY_ROCKS_LEVEL,
+    meta::PerfSample,
+    options::{LedgerOptions, BLOCKSTORE_DIRECTORY_ROCKS_LEVEL},
 };
 use magicblock_core::traits::LatestBlockProvider;
 use solana_clock::Clock;


### PR DESCRIPTION
## Summary
- add a configurable `ledger.block-cache-size` setting and pass it into ledger opening
- configure a shared RocksDB block cache with Bloom filters for ledger column families
- use LZ4 compression for fresh data and Zstd for bottommost ledger data
