### PR TITLE
fix: prevent transaction pipeline stall when gRPC streams wedge silently

### DIFF
--- a/magicblock-aperture/src/requests/http/mod.rs
+++ b/magicblock-aperture/src/requests/http/mod.rs
@@ -8,6 +8,7 @@ use hyper::{
     Request, Response,
 };
 use magicblock_accounts_db::traits::AccountsBank;
+use magicblock_chainlink::errors::ChainlinkError;
 use magicblock_core::{
     coordination_mode::CoordinationMode,
     link::transactions::{SanitizeableTransaction, WithEncoded},
@@ -285,7 +286,7 @@ impl HttpDispatcher {
         )
         .await
         .unwrap_or_else(|_elapsed| {
-            Err(magicblock_chainlink::errors::ChainlinkError::EnsureAccountsTimeout(
+            Err(ChainlinkError::EnsureAccountsTimeout(
                 ENSURE_ACCOUNTS_TIMEOUT.as_secs(),
             ))
         }) {

--- a/magicblock-aperture/src/requests/http/mod.rs
+++ b/magicblock-aperture/src/requests/http/mod.rs
@@ -1,5 +1,5 @@
 use core::str;
-use std::{mem::size_of, ops::Range};
+use std::{mem::size_of, ops::Range, time::Duration};
 
 use base64::{prelude::BASE64_STANDARD, Engine};
 use http_body_util::BodyExt;
@@ -269,16 +269,26 @@ impl HttpDispatcher {
         &self,
         transaction: &SanitizedTransaction,
     ) -> RpcResult<()> {
+        // Hard bound on account preparation: if the cloning pipeline is
+        // degraded the transaction must fail with an error instead of
+        // holding the request (and the client) hostage indefinitely.
+        const ENSURE_ACCOUNTS_TIMEOUT: Duration = Duration::from_secs(30);
+
         self.require_primary_rpc_method("transaction")?;
 
         let _timer = ENSURE_ACCOUNTS_TIME
             .with_label_values(&["transaction"])
             .start_timer();
-        match self
-            .chainlink
-            .ensure_transaction_accounts(transaction)
-            .await
-        {
+        match tokio::time::timeout(
+            ENSURE_ACCOUNTS_TIMEOUT,
+            self.chainlink.ensure_transaction_accounts(transaction),
+        )
+        .await
+        .unwrap_or_else(|_elapsed| {
+            Err(magicblock_chainlink::errors::ChainlinkError::EnsureAccountsTimeout(
+                ENSURE_ACCOUNTS_TIMEOUT.as_secs(),
+            ))
+        }) {
             Ok(res) if res.is_ok() => Ok(()),
             Ok(res) => {
                 debug!(%res, "Transaction account resolution encountered issues");

--- a/magicblock-chainlink/src/chainlink/errors.rs
+++ b/magicblock-chainlink/src/chainlink/errors.rs
@@ -19,6 +19,9 @@ pub enum ChainlinkError {
     #[error("Cloner error: {0}")]
     ClonerError(#[from] crate::cloner::errors::ClonerError),
 
+    #[error("Timed out ensuring accounts after {0}s")]
+    EnsureAccountsTimeout(u64),
+
     #[error("Delegation record could not be decoded: {0} ({1:?})")]
     InvalidDelegationRecord(Pubkey, ProgramError),
 

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -458,14 +458,31 @@ where
             let mark_empty_ref = (!mark_empty_list.is_empty())
                 .then_some(mark_empty_list.as_slice());
 
-            // One shared wire call for the whole claim set.
-            let accs = match this
-                .fetch_accounts(&pubkeys, mark_empty_ref, slot, fetch_origin)
-                .await
+            // One shared wire call for the whole claim set, bounded by the
+            // earliest claim deadline so a hung fetch cannot leave the
+            // waiters of these operations blocked past their timeout.
+            let fetch_deadline = claimed
+                .iter()
+                .map(|op| op.deadline)
+                .min()
+                .expect("claimed is non-empty");
+            let fetch_result = match tokio::time::timeout_at(
+                fetch_deadline,
+                this.fetch_accounts(
+                    &pubkeys,
+                    mark_empty_ref,
+                    slot,
+                    fetch_origin,
+                ),
+            )
+            .await
             {
+                Ok(result) => result.map_err(|err| err.to_string()),
+                Err(_) => Err("account fetch deadline exceeded".to_string()),
+            };
+            let accs = match fetch_result {
                 Ok(accs) => accs,
-                Err(err) => {
-                    let owner_msg = err.to_string();
+                Err(owner_msg) => {
                     let now = tokio::time::Instant::now();
                     for mut op in claimed {
                         let failure = if op.deadline <= now {

--- a/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/actor.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/actor.rs
@@ -247,6 +247,14 @@ impl<H: StreamHandle, S: StreamFactory<H>> ChainLaserActor<H, S> {
 
     #[instrument(skip(self), fields(client_id = %self.client_id))]
     pub async fn run(mut self) {
+        // Every account stream carries a slot-update filter, so a healthy
+        // connection delivers updates several times per second. Prolonged
+        // silence while subscriptions exist means the connection died
+        // without erroring (e.g. an h2 half-open wedge) and the error-driven
+        // recovery will never fire - force a reconnect instead.
+        const STREAM_LIVENESS_TIMEOUT: Duration = Duration::from_secs(30);
+        const LIVENESS_CHECK_INTERVAL: Duration = Duration::from_secs(10);
+
         let mut optimization_interval =
             tokio::time::interval(self.optimization_interval_duration);
         optimization_interval
@@ -254,6 +262,13 @@ impl<H: StreamHandle, S: StreamFactory<H>> ChainLaserActor<H, S> {
         // The first tick completes immediately; consume it so
         // the timer starts counting from now.
         optimization_interval.tick().await;
+
+        let mut liveness_interval =
+            tokio::time::interval(LIVENESS_CHECK_INTERVAL);
+        liveness_interval
+            .set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        liveness_interval.tick().await;
+        let mut last_stream_activity = tokio::time::Instant::now();
 
         loop {
             tokio::select! {
@@ -271,6 +286,7 @@ impl<H: StreamHandle, S: StreamFactory<H>> ChainLaserActor<H, S> {
                     }
                 },
                 update = self.stream_manager.next_update(), if self.stream_manager.has_any_subscriptions() => {
+                    last_stream_activity = tokio::time::Instant::now();
                     match update {
                         Some((src, result)) => {
                             self.handle_stream_result(
@@ -288,6 +304,28 @@ impl<H: StreamHandle, S: StreamFactory<H>> ChainLaserActor<H, S> {
                             )
                             .await;
                         }
+                    }
+                },
+                _ = liveness_interval.tick() => {
+                    if !self.stream_manager.has_any_subscriptions() {
+                        last_stream_activity = tokio::time::Instant::now();
+                    } else if last_stream_activity.elapsed()
+                        >= STREAM_LIVENESS_TIMEOUT
+                    {
+                        warn!(
+                            client_id = %self.client_id,
+                            silent_for = ?last_stream_activity.elapsed(),
+                            slots = ?self.slots,
+                            "No stream updates within liveness window, \
+                             forcing reconnect"
+                        );
+                        Self::signal_connection_issue(
+                            &mut self.stream_manager,
+                            &self.abort_sender,
+                            &self.client_id,
+                        )
+                        .await;
+                        last_stream_activity = tokio::time::Instant::now();
                     }
                 },
                 _ = optimization_interval.tick() => {

--- a/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/actor.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/actor.rs
@@ -23,7 +23,10 @@ use solana_account::Account;
 use solana_commitment_config::CommitmentLevel as SolanaCommitmentLevel;
 use solana_pubkey::Pubkey;
 use solana_sdk_ids::sysvar::clock;
-use tokio::sync::{mpsc, oneshot};
+use tokio::{
+    sync::{mpsc, oneshot},
+    time::{interval, Instant, MissedTickBehavior},
+};
 use tonic::Code;
 use tracing::*;
 
@@ -247,28 +250,26 @@ impl<H: StreamHandle, S: StreamFactory<H>> ChainLaserActor<H, S> {
 
     #[instrument(skip(self), fields(client_id = %self.client_id))]
     pub async fn run(mut self) {
-        // Every account stream carries a slot-update filter, so a healthy
-        // connection delivers updates several times per second. Prolonged
-        // silence while subscriptions exist means the connection died
-        // without erroring (e.g. an h2 half-open wedge) and the error-driven
-        // recovery will never fire - force a reconnect instead.
-        const STREAM_LIVENESS_TIMEOUT: Duration = Duration::from_secs(30);
-        const LIVENESS_CHECK_INTERVAL: Duration = Duration::from_secs(10);
+        // Every stream carries a slot-update filter, so a healthy connection
+        // delivers updates every chain slot (~400ms). Prolonged silence while
+        // subscriptions exist means the connection died without erroring
+        // (e.g. an h2 half-open wedge) and the error-driven recovery will
+        // never fire - force a reconnect instead.
+        const STREAM_LIVENESS_TIMEOUT: Duration = Duration::from_secs(5);
+        const LIVENESS_CHECK_INTERVAL: Duration = Duration::from_secs(2);
 
         let mut optimization_interval =
-            tokio::time::interval(self.optimization_interval_duration);
+            interval(self.optimization_interval_duration);
         optimization_interval
-            .set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            .set_missed_tick_behavior(MissedTickBehavior::Delay);
         // The first tick completes immediately; consume it so
         // the timer starts counting from now.
         optimization_interval.tick().await;
 
-        let mut liveness_interval =
-            tokio::time::interval(LIVENESS_CHECK_INTERVAL);
-        liveness_interval
-            .set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        let mut liveness_interval = interval(LIVENESS_CHECK_INTERVAL);
+        liveness_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
         liveness_interval.tick().await;
-        let mut last_stream_activity = tokio::time::Instant::now();
+        let mut last_stream_activity = Instant::now();
 
         loop {
             tokio::select! {
@@ -286,7 +287,7 @@ impl<H: StreamHandle, S: StreamFactory<H>> ChainLaserActor<H, S> {
                     }
                 },
                 update = self.stream_manager.next_update(), if self.stream_manager.has_any_subscriptions() => {
-                    last_stream_activity = tokio::time::Instant::now();
+                    last_stream_activity = Instant::now();
                     match update {
                         Some((src, result)) => {
                             self.handle_stream_result(
@@ -308,7 +309,7 @@ impl<H: StreamHandle, S: StreamFactory<H>> ChainLaserActor<H, S> {
                 },
                 _ = liveness_interval.tick() => {
                     if !self.stream_manager.has_any_subscriptions() {
-                        last_stream_activity = tokio::time::Instant::now();
+                        last_stream_activity = Instant::now();
                     } else if last_stream_activity.elapsed()
                         >= STREAM_LIVENESS_TIMEOUT
                     {
@@ -325,7 +326,7 @@ impl<H: StreamHandle, S: StreamFactory<H>> ChainLaserActor<H, S> {
                             &self.client_id,
                         )
                         .await;
-                        last_stream_activity = tokio::time::Instant::now();
+                        last_stream_activity = Instant::now();
                     }
                 },
                 _ = optimization_interval.tick() => {

--- a/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/mod.rs
@@ -40,28 +40,37 @@ pub(crate) async fn write_with_retry<S: StreamHandle>(
     request: SubscribeRequest,
 ) -> RemoteAccountProviderResult<()> {
     const MAX_RETRIES: usize = 5;
+    // A healthy write flushes in milliseconds. A write into a dead/frozen
+    // gRPC connection hangs without erroring once the sink backpressures,
+    // which would wedge the single actor loop forever - bound it instead.
+    const WRITE_TIMEOUT: Duration = Duration::from_secs(10);
     let mut retries = MAX_RETRIES;
     let initial_retries = retries;
 
     loop {
-        match handle.write(request.clone()).await {
-            Ok(()) => return Ok(()),
-            Err(err) => {
-                if retries > 0 {
-                    retries -= 1;
-                    let backoff_ms = 50u64 * (initial_retries - retries) as u64;
-                    tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
-                    continue;
-                }
-                return Err(
-                    RemoteAccountProviderError::GrpcSubscriptionUpdateFailed(
-                        task.to_string(),
-                        MAX_RETRIES,
-                        format!("{err} ({err:?})"),
-                    ),
-                );
+        let err_msg = match tokio::time::timeout(
+            WRITE_TIMEOUT,
+            handle.write(request.clone()),
+        )
+        .await
+        {
+            Ok(Ok(())) => return Ok(()),
+            Ok(Err(err)) => format!("{err} ({err:?})"),
+            Err(_) => {
+                format!("stream write timed out after {WRITE_TIMEOUT:?}")
             }
+        };
+        if retries > 0 {
+            retries -= 1;
+            let backoff_ms = 50u64 * (initial_retries - retries) as u64;
+            tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
+            continue;
         }
+        return Err(RemoteAccountProviderError::GrpcSubscriptionUpdateFailed(
+            task.to_string(),
+            MAX_RETRIES,
+            err_msg,
+        ));
     }
 }
 

--- a/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/mod.rs
@@ -31,19 +31,17 @@ mod stream_manager;
 
 /// Retry a `handle.write(request)` call with linear backoff.
 ///
-/// Tries up to `MAX_RETRIES` (5) times with 50 ms × attempt
-/// backoff. Returns the original error after all retries are
-/// exhausted.
+/// Retries up to `MAX_RETRIES` (5) times with 50 ms × attempt
+/// backoff. Returns the original error after all retries are exhausted.
 pub(crate) async fn write_with_retry<S: StreamHandle>(
     handle: &S,
     task: &str,
     request: SubscribeRequest,
 ) -> RemoteAccountProviderResult<()> {
     const MAX_RETRIES: usize = 5;
-    // A healthy write flushes in milliseconds. A write into a dead/frozen
-    // gRPC connection hangs without erroring once the sink backpressures,
-    // which would wedge the single actor loop forever - bound it instead.
-    const WRITE_TIMEOUT: Duration = Duration::from_secs(10);
+    // A healthy write flushes in milliseconds. Keep the full retry sequence
+    // below the caller's 30s actor response timeout.
+    const WRITE_TIMEOUT: Duration = Duration::from_secs(4);
     let mut retries = MAX_RETRIES;
     let initial_retries = retries;
 

--- a/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/stream_manager.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/stream_manager.rs
@@ -583,9 +583,22 @@ impl<S: StreamHandle, SF: StreamFactory<S>> StreamManager<S, SF> {
     // Internal helpers
     // ---------------------------------------------------------
 
+    /// Slot subscription filter attached to every stream. It provides chain
+    /// slot synchronisation and serves as a liveness heartbeat: a healthy
+    /// stream delivers a slot update every chain slot.
+    fn slot_updates_filter() -> HashMap<String, SubscribeRequestFilterSlots> {
+        let mut slots = HashMap::new();
+        slots.insert(
+            "slot_updates".to_string(),
+            SubscribeRequestFilterSlots {
+                filter_by_commitment: Some(true),
+                ..Default::default()
+            },
+        );
+        slots
+    }
+
     /// Build a `SubscribeRequest` for the given account pubkeys.
-    /// Includes a slot subscription for chain slot
-    /// synchronisation.
     fn build_account_request(
         pubkeys: &[&Pubkey],
         commitment: &CommitmentLevel,
@@ -600,18 +613,9 @@ impl<S: StreamHandle, SF: StreamFactory<S>> StreamManager<S, SF> {
             },
         );
 
-        let mut slots = HashMap::new();
-        slots.insert(
-            "slot_updates".to_string(),
-            SubscribeRequestFilterSlots {
-                filter_by_commitment: Some(true),
-                ..Default::default()
-            },
-        );
-
         SubscribeRequest {
             accounts,
-            slots,
+            slots: Self::slot_updates_filter(),
             commitment: Some((*commitment).into()),
             from_slot: Some(from_slot),
             ..Default::default()
@@ -718,6 +722,7 @@ impl<S: StreamHandle, SF: StreamFactory<S>> StreamManager<S, SF> {
 
         SubscribeRequest {
             accounts,
+            slots: Self::slot_updates_filter(),
             commitment: Some((*commitment).into()),
             from_slot: Some(from_slot),
             ..Default::default()

--- a/magicblock-chainlink/src/remote_account_provider/chain_laser_client.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_laser_client.rs
@@ -58,7 +58,7 @@ async fn await_actor_response<T>(
 ) -> RemoteAccountProviderResult<T> {
     match tokio::time::timeout(ACTOR_RESPONSE_TIMEOUT, rx).await {
         Ok(response) => response?,
-        Err(_) => Err(RemoteAccountProviderError::ChainPubsubActorTimeout(
+        Err(_) => Err(RemoteAccountProviderError::ChainLaserActorTimeout(
             op.to_string(),
         )),
     }
@@ -158,7 +158,7 @@ impl ChainLaserClientImpl {
                     format!("{err:#?}"),
                 )
             }),
-            Err(_) => Err(RemoteAccountProviderError::ChainPubsubActorTimeout(
+            Err(_) => Err(RemoteAccountProviderError::ChainLaserActorTimeout(
                 "send_msg".to_string(),
             )),
         }

--- a/magicblock-chainlink/src/remote_account_provider/chain_laser_client.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_laser_client.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::HashSet,
     sync::{Arc, Mutex},
+    time::Duration,
 };
 
 use async_trait::async_trait;
@@ -42,6 +43,26 @@ use crate::remote_account_provider::{
 /// data. It exists purely for accounting purposes.
 static SLOT_SUBSCRIPTION_DUMMY: Pubkey =
     pubkey!("FAKESUB111111111111111111111111111111111111");
+
+/// Upper bound on any round-trip to the actor. Normally these complete in
+/// milliseconds; if the actor is wedged (e.g. on a dead gRPC connection) this
+/// converts an indefinite hang of every caller into an error, which the
+/// fetch/subscription layers handle and retry.
+const ACTOR_RESPONSE_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Awaits the actor's oneshot response, bounded by
+/// [`ACTOR_RESPONSE_TIMEOUT`].
+async fn await_actor_response<T>(
+    rx: oneshot::Receiver<RemoteAccountProviderResult<T>>,
+    op: &str,
+) -> RemoteAccountProviderResult<T> {
+    match tokio::time::timeout(ACTOR_RESPONSE_TIMEOUT, rx).await {
+        Ok(response) => response?,
+        Err(_) => Err(RemoteAccountProviderError::ChainPubsubActorTimeout(
+            op.to_string(),
+        )),
+    }
+}
 
 #[derive(Clone)]
 pub struct ChainLaserClientImpl {
@@ -115,7 +136,7 @@ impl ChainLaserClientImpl {
         })
         .await?;
 
-        rx.await?
+        await_actor_response(rx, "subscribe_multiple").await
     }
 
     #[instrument(skip(self, msg), fields(client_id = %self.client_id))]
@@ -123,12 +144,24 @@ impl ChainLaserClientImpl {
         &self,
         msg: ChainPubsubActorMessage,
     ) -> RemoteAccountProviderResult<()> {
-        self.messages.send(msg).await.map_err(|err| {
-            RemoteAccountProviderError::ChainLaserActorSendError(
-                err.to_string(),
-                format!("{err:#?}"),
-            )
-        })
+        // The message channel only backs up when the actor stopped draining
+        // it; bound the send so callers fail instead of hanging with it.
+        match tokio::time::timeout(
+            ACTOR_RESPONSE_TIMEOUT,
+            self.messages.send(msg),
+        )
+        .await
+        {
+            Ok(sent) => sent.map_err(|err| {
+                RemoteAccountProviderError::ChainLaserActorSendError(
+                    err.to_string(),
+                    format!("{err:#?}"),
+                )
+            }),
+            Err(_) => Err(RemoteAccountProviderError::ChainPubsubActorTimeout(
+                "send_msg".to_string(),
+            )),
+        }
     }
 }
 
@@ -161,7 +194,7 @@ impl ChainPubsubClient for ChainLaserClientImpl {
         })
         .await?;
 
-        rx.await?
+        await_actor_response(rx, "subscribe").await
     }
 
     async fn subscribe_program(
@@ -175,7 +208,7 @@ impl ChainPubsubClient for ChainLaserClientImpl {
         })
         .await?;
 
-        rx.await?
+        await_actor_response(rx, "subscribe_program").await
     }
 
     async fn unsubscribe(
@@ -189,7 +222,7 @@ impl ChainPubsubClient for ChainLaserClientImpl {
         })
         .await?;
 
-        rx.await?
+        await_actor_response(rx, "unsubscribe").await
     }
 
     async fn shutdown(&self) -> RemoteAccountProviderResult<()> {
@@ -197,12 +230,7 @@ impl ChainPubsubClient for ChainLaserClientImpl {
         self.send_msg(ChainPubsubActorMessage::Shutdown { response: tx })
             .await?;
 
-        rx.await.map_err(|err| {
-            RemoteAccountProviderError::ChainLaserActorSendError(
-                err.to_string(),
-                format!("{err:#?}"),
-            )
-        })?
+        await_actor_response(rx, "shutdown").await
     }
 
     fn take_updates(&self) -> mpsc::Receiver<SubscriptionUpdate> {
@@ -234,9 +262,11 @@ impl ReconnectableClient for ChainLaserClientImpl {
         self.send_msg(ChainPubsubActorMessage::Reconnect { response: tx })
             .await?;
 
-        rx.await.inspect_err(|err| {
-            warn!(error = ?err, "RecvError while awaiting reconnect response");
-        })?
+        await_actor_response(rx, "reconnect")
+            .await
+            .inspect_err(|err| {
+                warn!(error = ?err, "Error while awaiting reconnect response");
+            })
     }
 
     async fn resub_multiple(

--- a/magicblock-chainlink/src/remote_account_provider/errors.rs
+++ b/magicblock-chainlink/src/remote_account_provider/errors.rs
@@ -41,8 +41,8 @@ pub enum RemoteAccountProviderError {
     #[error("Failed to send message to laser actor: {0} ({1})")]
     ChainLaserActorSendError(String, String),
 
-    #[error("Timed out waiting for pubsub actor during {0}")]
-    ChainPubsubActorTimeout(String),
+    #[error("Timed out waiting for laser actor during {0}")]
+    ChainLaserActorTimeout(String),
 
     #[error("Missing API key for: {0}")]
     MissingApiKey(String),

--- a/magicblock-chainlink/src/remote_account_provider/errors.rs
+++ b/magicblock-chainlink/src/remote_account_provider/errors.rs
@@ -41,6 +41,9 @@ pub enum RemoteAccountProviderError {
     #[error("Failed to send message to laser actor: {0} ({1})")]
     ChainLaserActorSendError(String, String),
 
+    #[error("Timed out waiting for pubsub actor during {0}")]
+    ChainPubsubActorTimeout(String),
+
     #[error("Missing API key for: {0}")]
     MissingApiKey(String),
 


### PR DESCRIPTION
## Problem

gRPC laserstream connection can wedge half-open after an h2 protocol error: they stop delivering updates but never return an error. Recovery is error-driven, so nothing ever recover in this scenario. Is this happen, every `sendTransaction`/`simulateTransaction` hung indefinitely in `ensure_transaction_accounts` (blocks kept being produced with zero transactions, read RPCs stayed healthy) until a manual restart.

## Fix

- **Liveness watchdog** (`chain_laser_actor/actor.rs`): every account stream carries a slot-update filter, so a healthy connection delivers updates several times per second. If no stream update arrives for 30s while subscriptions exist, force the reconnect path. This covers connections that die without erroring.
- **Bounded stream writes** (`write_with_retry`): 10s timeout per write attempt, treated as a retryable error. A frozen sink can no longer wedge the single-threaded actor loop — this was the exact blocking point in the incident.
- **Bounded actor round-trips** (`chain_laser_client.rs`): all subscribe/unsubscribe/reconnect/shutdown calls and channel sends time out after 30s with a new `ChainPubsubActorTimeout` error instead of awaiting a wedged actor forever.
- **Fetch phase under deadline** (`fetch_cloner`): the batched wire fetch is now wrapped in `timeout_at` with the earliest claim deadline. Previously only the clone phase was deadline-bounded, so a hung fetch stranded all dedup waiters past their 60s budget.
- **Fail-fast at the RPC layer** (`aperture`): `ensure_transaction_accounts` is hard-bounded at 30s (new `EnsureAccountsTimeout` error), so even an unforeseen hang in the pipeline surfaces as transaction errors rather than silently hung requests.