### PR TITLE
fix: make websocket pubsub reconnection converge instead of self-destructing

### DIFF
--- a/magicblock-chainlink/src/remote_account_provider/chain_pubsub_actor.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_pubsub_actor.rs
@@ -17,6 +17,7 @@ use magicblock_metrics::metrics::{
 use solana_account_decoder_client_types::UiAccountEncoding;
 use solana_commitment_config::CommitmentConfig;
 use solana_pubkey::Pubkey;
+use solana_pubsub_client::nonblocking::pubsub_client::PubsubClientError;
 use solana_rpc_client_api::{
     config::{RpcAccountInfoConfig, RpcProgramAccountsConfig},
     response::Response as RpcResponse,
@@ -46,6 +47,18 @@ use crate::remote_account_provider::{
 
 // Log every 10 secs (given chain slot time is 400ms)
 const CLOCK_LOG_SLOT_FREQ: u64 = 25;
+
+/// Errors that indicate the websocket connection itself is broken, as
+/// opposed to the server rejecting an individual request over a healthy
+/// connection.
+fn is_connection_level_error(err: &PubsubClientError) -> bool {
+    matches!(
+        err,
+        PubsubClientError::ConnectionError(_)
+            | PubsubClientError::WsError(_)
+            | PubsubClientError::ConnectionClosed(_)
+    )
+}
 #[cfg(not(test))]
 const SUBSCRIPTION_COMPLETION_TIMEOUT: Duration = Duration::from_secs(5);
 
@@ -650,12 +663,27 @@ impl ChainPubsubActor {
                             "Failed to subscribe to account after retrying multiple times",
                         );
                     }
-                    // Fail only this subscription. Tearing the connection
-                    // down here would cancel every other (healthy)
-                    // subscription, which made mass resubscription after a
-                    // reconnect self-destruct on the first failed key.
-                    // Genuine connection loss is detected by the listener
-                    // tasks when their streams end.
+                    // A server-side rejection fails only this subscription.
+                    // Tearing the connection down for it would cancel every
+                    // other (healthy) subscription, which made mass
+                    // resubscription after a reconnect self-destruct on the
+                    // first failed key. A broken connection however must be
+                    // signaled here: with no live listener yet (e.g. right
+                    // after a reconnect) nothing else would detect it and
+                    // the client would stay attached but dead forever.
+                    if is_connection_level_error(&err) {
+                        Self::abort_and_signal_connection_issue(
+                            client_id,
+                            subs.clone(),
+                            program_subs.clone(),
+                            abort_sender,
+                            is_connected.clone(),
+                            &format!(
+                                "Connection error subscribing to \
+                                 account {pubkey}"
+                            ),
+                        );
+                    }
                     subs.lock()
                         .expect("subscriptions lock poisoned")
                         .remove(&pubkey);
@@ -844,8 +872,21 @@ impl ChainPubsubActor {
                     100,
                     &SUBSCRIPTION_FAILURE_COUNT,
                 );
-                // Fail only this subscription; see the account subscribe
-                // failure path for why we don't tear the connection down.
+                // Server-side rejections fail only this subscription;
+                // see the account subscribe failure path for details.
+                if is_connection_level_error(&err) {
+                    Self::abort_and_signal_connection_issue(
+                        client_id,
+                        subs.clone(),
+                        program_subs.clone(),
+                        abort_sender,
+                        is_connected.clone(),
+                        &format!(
+                            "Connection error subscribing to \
+                             program {program_pubkey}"
+                        ),
+                    );
+                }
                 program_subs
                     .lock()
                     .expect("program_subs lock poisoned")

--- a/magicblock-chainlink/src/remote_account_provider/chain_pubsub_actor.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_pubsub_actor.rs
@@ -650,14 +650,12 @@ impl ChainPubsubActor {
                             "Failed to subscribe to account after retrying multiple times",
                         );
                     }
-                    Self::abort_and_signal_connection_issue(
-                        client_id,
-                        subs.clone(),
-                        program_subs.clone(),
-                        abort_sender,
-                        is_connected.clone(),
-                        &format!("Failed to subscribe to account {pubkey} after {initial_tries} retries")
-                    );
+                    // Fail only this subscription. Tearing the connection
+                    // down here would cancel every other (healthy)
+                    // subscription, which made mass resubscription after a
+                    // reconnect self-destruct on the first failed key.
+                    // Genuine connection loss is detected by the listener
+                    // tasks when their streams end.
                     subs.lock()
                         .expect("subscriptions lock poisoned")
                         .remove(&pubkey);
@@ -846,14 +844,8 @@ impl ChainPubsubActor {
                     100,
                     &SUBSCRIPTION_FAILURE_COUNT,
                 );
-                Self::abort_and_signal_connection_issue(
-                    client_id,
-                    subs.clone(),
-                    program_subs.clone(),
-                    abort_sender,
-                    is_connected.clone(),
-                    &format!("Failed to subscribe to program {program_pubkey}"),
-                );
+                // Fail only this subscription; see the account subscribe
+                // failure path for why we don't tear the connection down.
                 program_subs
                     .lock()
                     .expect("program_subs lock poisoned")

--- a/magicblock-chainlink/src/remote_account_provider/chain_pubsub_actor.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_pubsub_actor.rs
@@ -868,21 +868,20 @@ impl ChainPubsubActor {
                     100,
                     &SUBSCRIPTION_FAILURE_COUNT,
                 );
-                // Server-side rejections fail only this subscription;
-                // see the account subscribe failure path for details.
-                if is_connection_level_error(&err) {
-                    Self::abort_and_signal_connection_issue(
-                        client_id,
-                        subs.clone(),
-                        program_subs.clone(),
-                        abort_sender,
-                        is_connected.clone(),
-                        &format!(
-                            "Connection error subscribing to \
-                             program {program_pubkey}"
-                        ),
-                    );
-                }
+                // Unlike accounts, program subscriptions have no reconciler
+                // repair path, so any failure here would leave this client
+                // permanently missing the program stream. Signal the
+                // reconnector unconditionally: program subs are few and
+                // critical, and the reconnect path restores them with
+                // bounded backoff.
+                Self::abort_and_signal_connection_issue(
+                    client_id,
+                    subs.clone(),
+                    program_subs.clone(),
+                    abort_sender,
+                    is_connected.clone(),
+                    &format!("Failed to subscribe to program {program_pubkey}"),
+                );
                 program_subs
                     .lock()
                     .expect("program_subs lock poisoned")

--- a/magicblock-chainlink/src/remote_account_provider/chain_pubsub_actor.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_pubsub_actor.rs
@@ -48,9 +48,8 @@ use crate::remote_account_provider::{
 // Log every 10 secs (given chain slot time is 400ms)
 const CLOCK_LOG_SLOT_FREQ: u64 = 25;
 
-/// Errors that indicate the websocket connection itself is broken, as
-/// opposed to the server rejecting an individual request over a healthy
-/// connection.
+/// Errors indicating the websocket connection itself is broken, as opposed
+/// to the server rejecting an individual request.
 fn is_connection_level_error(err: &PubsubClientError) -> bool {
     matches!(
         err,
@@ -663,14 +662,11 @@ impl ChainPubsubActor {
                             "Failed to subscribe to account after retrying multiple times",
                         );
                     }
-                    // A server-side rejection fails only this subscription.
-                    // Tearing the connection down for it would cancel every
-                    // other (healthy) subscription, which made mass
-                    // resubscription after a reconnect self-destruct on the
-                    // first failed key. A broken connection however must be
-                    // signaled here: with no live listener yet (e.g. right
-                    // after a reconnect) nothing else would detect it and
-                    // the client would stay attached but dead forever.
+                    // Server-side rejections fail only this subscription:
+                    // tearing the connection down would cancel every other
+                    // healthy one. A broken connection must be signaled
+                    // though - without a live listener yet (e.g. right
+                    // after a reconnect) nothing else detects it.
                     if is_connection_level_error(&err) {
                         Self::abort_and_signal_connection_issue(
                             client_id,

--- a/magicblock-chainlink/src/remote_account_provider/chain_pubsub_client.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_pubsub_client.rs
@@ -261,52 +261,53 @@ impl ReconnectableClient for ChainPubsubClientImpl {
         pubkeys: HashSet<Pubkey>,
     ) -> RemoteAccountProviderResult<()> {
         const RESUB_MULTIPLE_RETRY_PER_PUBKEY: usize = 5;
-        let delay_ms = self.current_resub_delay_ms.load(Ordering::SeqCst);
-        let delay = Duration::from_millis(delay_ms);
+        // Failed keys are retried here over just the remainder. Returning an
+        // error instead would send the caller into a full reconnect, which
+        // drains every subscription and would destroy the restored progress,
+        // so we only do that when a whole pass makes zero progress (i.e. the
+        // connection is unusable and there is no progress to lose).
+        const MAX_PASSES: usize = 3;
         // Skip pubkeys that are already subscribed (survived the reconnect or
         // were restored by a previous partial pass) so retry passes only pay
         // for what is still missing.
         let subscribed = self.subscriptions_union();
-        let pubkeys_vec: Vec<Pubkey> = pubkeys
+        let mut remaining: Vec<Pubkey> = pubkeys
             .into_iter()
             .filter(|pk| !subscribed.contains(pk))
             .collect();
-        let total_subs = pubkeys_vec.len();
-        let mut failed = 0usize;
-        let mut last_err = None;
-        for (idx, pubkey) in pubkeys_vec.iter().enumerate() {
-            // Best effort: a failed key does not abort the pass. It stays
-            // unsubscribed and is retried on the next reconnect attempt or
-            // repaired by the subscription reconciler.
-            match self
-                .subscribe(*pubkey, Some(RESUB_MULTIPLE_RETRY_PER_PUBKEY))
-                .await
-            {
-                Ok(()) => {
-                    // Pace only successful subscribes; failed ones either
-                    // never reached the RPC or already backed off internally.
-                    if idx < total_subs - 1 {
+        let total_subs = remaining.len();
+
+        for _ in 0..MAX_PASSES {
+            if remaining.is_empty() {
+                break;
+            }
+            let delay_ms = self.current_resub_delay_ms.load(Ordering::SeqCst);
+            let delay = Duration::from_millis(delay_ms);
+            let mut failed = Vec::new();
+            let mut last_err = None;
+            for pubkey in &remaining {
+                match self
+                    .subscribe(*pubkey, Some(RESUB_MULTIPLE_RETRY_PER_PUBKEY))
+                    .await
+                {
+                    Ok(()) => {
+                        // Pace only successful subscribes; failed ones either
+                        // never reached the RPC or already backed off
+                        // internally.
                         tokio::time::sleep(delay).await;
                     }
-                }
-                Err(err) => {
-                    failed += 1;
-                    debug!(
-                        error = ?err,
-                        pubkey = %pubkey,
-                        "Re-subscription failed for pubkey",
-                    );
-                    last_err = Some(err);
+                    Err(err) => {
+                        debug!(
+                            error = ?err,
+                            pubkey = %pubkey,
+                            "Re-subscription failed for pubkey",
+                        );
+                        failed.push(*pubkey);
+                        last_err = Some(err);
+                    }
                 }
             }
-        }
-        // Report the number of subscriptions restored in this pass
-        metrics::set_pubsub_client_resubscribed_count(
-            &self.client_id,
-            total_subs - failed,
-        );
-        match last_err {
-            Some(err) => {
+            if !failed.is_empty() {
                 // Exponentially back off on resubscription attempts, so the next time we
                 // reconnect and try to resubscribe, we wait longer in between each subscription
                 // in order to avoid overwhelming the RPC with requests
@@ -314,20 +315,43 @@ impl ReconnectableClient for ChainPubsubClientImpl {
                     delay_ms.saturating_mul(2).min(MAX_RESUB_DELAY_MS);
                 self.current_resub_delay_ms
                     .store(new_delay, Ordering::SeqCst);
+            }
+            if failed.len() == remaining.len() {
+                metrics::set_pubsub_client_resubscribed_count(
+                    &self.client_id,
+                    total_subs - remaining.len(),
+                );
                 warn!(
                     total_subs,
-                    failed, "Re-subscription pass completed with failures",
+                    failed = failed.len(),
+                    "Re-subscription made no progress",
                 );
-                Err(err)
+                return Err(last_err.expect("failed is non-empty"));
             }
-            None => {
-                // Clean pass: restore the configured pacing so one bad
-                // stretch doesn't throttle all future reconnects.
-                self.current_resub_delay_ms
-                    .store(self.initial_resub_delay_ms, Ordering::SeqCst);
-                Ok(())
-            }
+            remaining = failed;
         }
+
+        // Report the number of subscriptions restored in this pass
+        metrics::set_pubsub_client_resubscribed_count(
+            &self.client_id,
+            total_subs - remaining.len(),
+        );
+        if remaining.is_empty() {
+            // Clean outcome: restore the configured pacing so one bad
+            // stretch doesn't throttle all future reconnects.
+            self.current_resub_delay_ms
+                .store(self.initial_resub_delay_ms, Ordering::SeqCst);
+        } else {
+            // Keep the client attached; the subscription reconciler repairs
+            // the leftover subscriptions in the background.
+            warn!(
+                total_subs,
+                failed = remaining.len(),
+                "Re-subscription completed with failures, \
+                 leaving repair to the reconciler",
+            );
+        }
+        Ok(())
     }
 
     fn current_resub_delay_ms(&self) -> Option<u64> {

--- a/magicblock-chainlink/src/remote_account_provider/chain_pubsub_client.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_pubsub_client.rs
@@ -113,6 +113,9 @@ pub struct ChainPubsubClientImpl {
     updates_rcvr: Arc<Mutex<Option<mpsc::Receiver<SubscriptionUpdate>>>>,
     client_id: String,
     current_resub_delay_ms: Arc<AtomicU64>,
+    /// The configured delay [Self::current_resub_delay_ms] is reset to
+    /// after a resubscription pass completes without failures.
+    initial_resub_delay_ms: u64,
 }
 
 impl ChainPubsubClientImpl {
@@ -130,13 +133,15 @@ impl ChainPubsubClientImpl {
             commitment,
         )
         .await?;
+        let initial_resub_delay_ms = resubscription_delay.as_millis() as u64;
         let current_resub_delay_ms =
-            Arc::new(AtomicU64::new(resubscription_delay.as_millis() as u64));
+            Arc::new(AtomicU64::new(initial_resub_delay_ms));
         Ok(Self {
             actor: Arc::new(actor),
             updates_rcvr: Arc::new(Mutex::new(Some(updates))),
             client_id,
             current_resub_delay_ms,
+            initial_resub_delay_ms,
         })
     }
 }
@@ -258,17 +263,50 @@ impl ReconnectableClient for ChainPubsubClientImpl {
         const RESUB_MULTIPLE_RETRY_PER_PUBKEY: usize = 5;
         let delay_ms = self.current_resub_delay_ms.load(Ordering::SeqCst);
         let delay = Duration::from_millis(delay_ms);
-        let pubkeys_vec: Vec<Pubkey> = pubkeys.into_iter().collect();
+        // Skip pubkeys that are already subscribed (survived the reconnect or
+        // were restored by a previous partial pass) so retry passes only pay
+        // for what is still missing.
+        let subscribed = self.subscriptions_union();
+        let pubkeys_vec: Vec<Pubkey> = pubkeys
+            .into_iter()
+            .filter(|pk| !subscribed.contains(pk))
+            .collect();
+        let total_subs = pubkeys_vec.len();
+        let mut failed = 0usize;
+        let mut last_err = None;
         for (idx, pubkey) in pubkeys_vec.iter().enumerate() {
-            if let Err(err) = self
+            // Best effort: a failed key does not abort the pass. It stays
+            // unsubscribed and is retried on the next reconnect attempt or
+            // repaired by the subscription reconciler.
+            match self
                 .subscribe(*pubkey, Some(RESUB_MULTIPLE_RETRY_PER_PUBKEY))
                 .await
             {
-                // Report the number of subscriptions we managed before failing
-                metrics::set_pubsub_client_resubscribed_count(
-                    &self.client_id,
-                    idx + 1,
-                );
+                Ok(()) => {
+                    // Pace only successful subscribes; failed ones either
+                    // never reached the RPC or already backed off internally.
+                    if idx < total_subs - 1 {
+                        tokio::time::sleep(delay).await;
+                    }
+                }
+                Err(err) => {
+                    failed += 1;
+                    debug!(
+                        error = ?err,
+                        pubkey = %pubkey,
+                        "Re-subscription failed for pubkey",
+                    );
+                    last_err = Some(err);
+                }
+            }
+        }
+        // Report the number of subscriptions restored in this pass
+        metrics::set_pubsub_client_resubscribed_count(
+            &self.client_id,
+            total_subs - failed,
+        );
+        match last_err {
+            Some(err) => {
                 // Exponentially back off on resubscription attempts, so the next time we
                 // reconnect and try to resubscribe, we wait longer in between each subscription
                 // in order to avoid overwhelming the RPC with requests
@@ -276,26 +314,20 @@ impl ReconnectableClient for ChainPubsubClientImpl {
                     delay_ms.saturating_mul(2).min(MAX_RESUB_DELAY_MS);
                 self.current_resub_delay_ms
                     .store(new_delay, Ordering::SeqCst);
-                debug!(
-                    error = ?err,
-                    total_subs = pubkeys_vec.len(),
-                    processed_subs = idx + 1,
-                    pubkey = %pubkey,
-                    "Re-subscription for multiple pubkeys failed to complete",
+                warn!(
+                    total_subs,
+                    failed, "Re-subscription pass completed with failures",
                 );
-                return Err(err);
+                Err(err)
             }
-            // Only sleep between subscriptions, not after the final one
-            if idx < pubkeys_vec.len() - 1 {
-                tokio::time::sleep(delay).await;
+            None => {
+                // Clean pass: restore the configured pacing so one bad
+                // stretch doesn't throttle all future reconnects.
+                self.current_resub_delay_ms
+                    .store(self.initial_resub_delay_ms, Ordering::SeqCst);
+                Ok(())
             }
         }
-        // Report successful resubscription of all pubkeys
-        metrics::set_pubsub_client_resubscribed_count(
-            &self.client_id,
-            pubkeys_vec.len(),
-        );
-        Ok(())
     }
 
     fn current_resub_delay_ms(&self) -> Option<u64> {

--- a/magicblock-chainlink/src/remote_account_provider/chain_pubsub_client.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_pubsub_client.rs
@@ -261,13 +261,10 @@ impl ReconnectableClient for ChainPubsubClientImpl {
         pubkeys: HashSet<Pubkey>,
     ) -> RemoteAccountProviderResult<()> {
         const RESUB_MULTIPLE_RETRY_PER_PUBKEY: usize = 5;
-        // Failed keys are retried here over just the remainder. Returning an
-        // error instead would send the caller into a full reconnect, which
-        // drains every subscription and would destroy restored progress.
+        // Failed keys are retried over just the remainder: erroring out
+        // instead triggers a full reconnect that drains every subscription.
         const MAX_PASSES: usize = 3;
-        // Skip pubkeys that are already subscribed (survived the reconnect or
-        // were restored by a previous partial pass) so retry passes only pay
-        // for what is still missing.
+        // Only resubscribe what is still missing
         let subscribed = self.subscriptions_union();
         let had_active_subs = !subscribed.is_empty();
         let mut remaining: Vec<Pubkey> = pubkeys
@@ -291,9 +288,8 @@ impl ReconnectableClient for ChainPubsubClientImpl {
                     .await
                 {
                     Ok(()) => {
-                        // Pace only successful subscribes (skipping the
-                        // trailing sleep); failed ones either never reached
-                        // the RPC or already backed off internally.
+                        // Pace successful subscribes only; failures
+                        // already backed off internally
                         if idx + 1 < remaining.len() {
                             tokio::time::sleep(delay).await;
                         }
@@ -322,11 +318,8 @@ impl ReconnectableClient for ChainPubsubClientImpl {
             remaining = failed;
             if no_progress {
                 // Further passes won't do better. Error out (triggering a
-                // full reconnect) only if the client has nothing to lose:
-                // no key restored in this call and no pre-existing
-                // subscription that the reconnect drain would destroy.
-                // Otherwise keep the partial progress and leave the
-                // remainder to the reconciler.
+                // full reconnect) only when there is nothing to lose:
+                // nothing restored here and no pre-existing subscriptions.
                 if remaining.len() == total_subs && !had_active_subs {
                     fatal_err = last_err;
                 }
@@ -334,7 +327,6 @@ impl ReconnectableClient for ChainPubsubClientImpl {
             }
         }
 
-        // Report the number of subscriptions restored in this call
         metrics::set_pubsub_client_resubscribed_count(
             &self.client_id,
             total_subs - remaining.len(),
@@ -344,13 +336,11 @@ impl ReconnectableClient for ChainPubsubClientImpl {
             return Err(err);
         }
         if remaining.is_empty() {
-            // Clean outcome: restore the configured pacing so one bad
-            // stretch doesn't throttle all future reconnects.
+            // Clean pass: restore the configured pacing
             self.current_resub_delay_ms
                 .store(self.initial_resub_delay_ms, Ordering::SeqCst);
         } else {
-            // Keep the client attached; the subscription reconciler repairs
-            // the leftover subscriptions in the background.
+            // Leftovers are repaired by the subscription reconciler
             warn!(
                 total_subs,
                 failed = remaining.len(),

--- a/magicblock-chainlink/src/remote_account_provider/chain_pubsub_client.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_pubsub_client.rs
@@ -263,19 +263,19 @@ impl ReconnectableClient for ChainPubsubClientImpl {
         const RESUB_MULTIPLE_RETRY_PER_PUBKEY: usize = 5;
         // Failed keys are retried here over just the remainder. Returning an
         // error instead would send the caller into a full reconnect, which
-        // drains every subscription and would destroy the restored progress,
-        // so we only do that when a whole pass makes zero progress (i.e. the
-        // connection is unusable and there is no progress to lose).
+        // drains every subscription and would destroy restored progress.
         const MAX_PASSES: usize = 3;
         // Skip pubkeys that are already subscribed (survived the reconnect or
         // were restored by a previous partial pass) so retry passes only pay
         // for what is still missing.
         let subscribed = self.subscriptions_union();
+        let had_active_subs = !subscribed.is_empty();
         let mut remaining: Vec<Pubkey> = pubkeys
             .into_iter()
             .filter(|pk| !subscribed.contains(pk))
             .collect();
         let total_subs = remaining.len();
+        let mut fatal_err = None;
 
         for _ in 0..MAX_PASSES {
             if remaining.is_empty() {
@@ -285,16 +285,18 @@ impl ReconnectableClient for ChainPubsubClientImpl {
             let delay = Duration::from_millis(delay_ms);
             let mut failed = Vec::new();
             let mut last_err = None;
-            for pubkey in &remaining {
+            for (idx, pubkey) in remaining.iter().enumerate() {
                 match self
                     .subscribe(*pubkey, Some(RESUB_MULTIPLE_RETRY_PER_PUBKEY))
                     .await
                 {
                     Ok(()) => {
-                        // Pace only successful subscribes; failed ones either
-                        // never reached the RPC or already backed off
-                        // internally.
-                        tokio::time::sleep(delay).await;
+                        // Pace only successful subscribes (skipping the
+                        // trailing sleep); failed ones either never reached
+                        // the RPC or already backed off internally.
+                        if idx + 1 < remaining.len() {
+                            tokio::time::sleep(delay).await;
+                        }
                     }
                     Err(err) => {
                         debug!(
@@ -316,26 +318,31 @@ impl ReconnectableClient for ChainPubsubClientImpl {
                 self.current_resub_delay_ms
                     .store(new_delay, Ordering::SeqCst);
             }
-            if failed.len() == remaining.len() {
-                metrics::set_pubsub_client_resubscribed_count(
-                    &self.client_id,
-                    total_subs - remaining.len(),
-                );
-                warn!(
-                    total_subs,
-                    failed = failed.len(),
-                    "Re-subscription made no progress",
-                );
-                return Err(last_err.expect("failed is non-empty"));
-            }
+            let no_progress = failed.len() == remaining.len();
             remaining = failed;
+            if no_progress {
+                // Further passes won't do better. Error out (triggering a
+                // full reconnect) only if the client has nothing to lose:
+                // no key restored in this call and no pre-existing
+                // subscription that the reconnect drain would destroy.
+                // Otherwise keep the partial progress and leave the
+                // remainder to the reconciler.
+                if remaining.len() == total_subs && !had_active_subs {
+                    fatal_err = last_err;
+                }
+                break;
+            }
         }
 
-        // Report the number of subscriptions restored in this pass
+        // Report the number of subscriptions restored in this call
         metrics::set_pubsub_client_resubscribed_count(
             &self.client_id,
             total_subs - remaining.len(),
         );
+        if let Some(err) = fatal_err {
+            warn!(total_subs, "Re-subscription made no progress");
+            return Err(err);
+        }
         if remaining.is_empty() {
             // Clean outcome: restore the configured pacing so one bad
             // stretch doesn't throttle all future reconnects.

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -209,13 +209,10 @@ fn spawn_deferred_pubsub_clients(
                 .await;
                 match result {
                     Ok((client, abort_rx)) => {
-                        // Attach without holding the subscription transition
-                        // lock: resubscribing a large set is paced and can
-                        // take minutes, which would starve foreground
-                        // subscription transitions. The reconnect path
-                        // already resubscribes lock-free; concurrent
-                        // transitions are reconciled via add_sub dedup and
-                        // the subscription reconciler.
+                        // Attach without the subscription transition lock:
+                        // a paced resub of a large set can take minutes and
+                        // would starve foreground transitions. The reconnect
+                        // path already resubscribes lock-free.
                         let add_result = submux
                             .add_client(
                                 client.clone(),
@@ -238,10 +235,9 @@ fn spawn_deferred_pubsub_clients(
                                     retry_in = ?retry_delay,
                                     "Deferred pubsub client failed to attach"
                                 );
-                                // Shut the client down so subscriptions that
-                                // were established before the failure don't
-                                // leak listener tasks; the retry starts over
-                                // with a fresh client.
+                                // Shut down so partially established
+                                // subscriptions don't leak listener tasks
+                                // before retrying with a fresh client
                                 if let Err(err) = client.shutdown().await {
                                     debug!(
                                         endpoint = %label,

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -16,10 +16,7 @@ use config::RemoteAccountProviderConfig;
 pub(crate) use errors::{
     RemoteAccountProviderError, RemoteAccountProviderResult,
 };
-use futures_util::{
-    future::{join_all, try_join_all},
-    stream::{FuturesUnordered, StreamExt},
-};
+use futures_util::future::{join_all, try_join_all};
 pub use lru_cache::{AccountsLruCache, AddAccountOutcome};
 use magicblock_config::config::GrpcConfig;
 pub(crate) use remote_account::RemoteAccount;
@@ -189,51 +186,70 @@ fn spawn_deferred_pubsub_clients(
     subscribed_accounts: Arc<AccountsLruCache>,
     subscription_transition_lock: Arc<AsyncMutex<()>>,
 ) {
-    tokio::spawn(async move {
-        let mut pubsub_futs = endpoints
-            .into_iter()
-            .map(|ep| {
-                connect_pubsub_client(
-                    ep,
+    // Deferred clients are the fallback update sources; retry connect/attach
+    // with capped backoff instead of dropping them permanently on failure.
+    const INITIAL_ATTACH_RETRY_DELAY: Duration = Duration::from_secs(1);
+    const MAX_ATTACH_RETRY_DELAY: Duration = Duration::from_secs(300);
+    for ep in endpoints {
+        let rpc_client = rpc_client.clone();
+        let chain_slot = chain_slot.clone();
+        let grpc_cfg = grpc_cfg.clone();
+        let submux = submux.clone();
+        let subscribed_accounts = subscribed_accounts.clone();
+        let subscription_transition_lock = subscription_transition_lock.clone();
+        tokio::spawn(async move {
+            let mut retry_delay = INITIAL_ATTACH_RETRY_DELAY;
+            loop {
+                let (label, result) = connect_pubsub_client(
+                    ep.clone(),
                     commitment,
                     rpc_client.clone(),
                     chain_slot.clone(),
                     resubscription_delay,
                     grpc_cfg.clone(),
                 )
-            })
-            .collect::<FuturesUnordered<_>>();
-        while let Some((label, result)) = pubsub_futs.next().await {
-            let (client, abort_rx) = match result {
-                Ok(client) => client,
-                Err(err) => {
-                    warn!(
+                .await;
+                match result {
+                    Ok((client, abort_rx)) => {
+                        let add_result = {
+                            let _transition_guard =
+                                subscription_transition_lock.lock().await;
+                            submux
+                                .add_client(
+                                    client,
+                                    abort_rx,
+                                    subscribed_accounts.clone(),
+                                )
+                                .await
+                        };
+                        match add_result {
+                            Ok(()) => {
+                                debug!(
+                                    endpoint = %label,
+                                    "Attached deferred pubsub client"
+                                );
+                                return;
+                            }
+                            Err(err) => warn!(
+                                endpoint = %label,
+                                error = %err,
+                                retry_in = ?retry_delay,
+                                "Deferred pubsub client failed to attach"
+                            ),
+                        }
+                    }
+                    Err(err) => warn!(
                         endpoint = %label,
                         error = %err,
-                        "Skipping deferred pubsub client that failed to connect"
-                    );
-                    continue;
+                        retry_in = ?retry_delay,
+                        "Deferred pubsub client failed to connect"
+                    ),
                 }
-            };
-
-            let add_result = {
-                let _transition_guard =
-                    subscription_transition_lock.lock().await;
-                submux
-                    .add_client(client, abort_rx, subscribed_accounts.clone())
-                    .await
-            };
-            if let Err(err) = add_result {
-                warn!(
-                    endpoint = %label,
-                    error = %err,
-                    "Skipping deferred pubsub client that failed to attach"
-                );
-                continue;
+                tokio::time::sleep(retry_delay).await;
+                retry_delay = (retry_delay * 2).min(MAX_ATTACH_RETRY_DELAY);
             }
-            debug!(endpoint = %label, "Attached deferred pubsub client");
-        }
-    });
+        });
+    }
 }
 
 // Maps pubkey -> (fetch_start_slot, requests_waiting)

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -195,18 +195,24 @@ fn spawn_deferred_pubsub_clients(
         let grpc_cfg = grpc_cfg.clone();
         let submux = submux.clone();
         let subscribed_accounts = subscribed_accounts.clone();
+        // Stop retrying when the owning mux shuts down so an unavailable
+        // endpoint doesn't leak this task past the provider's lifetime
+        let shutdown = submux.shutdown_token();
         tokio::spawn(async move {
             let mut retry_delay = INITIAL_ATTACH_RETRY_DELAY;
             loop {
-                let (label, result) = connect_pubsub_client(
+                let connect = connect_pubsub_client(
                     ep.clone(),
                     commitment,
                     rpc_client.clone(),
                     chain_slot.clone(),
                     resubscription_delay,
                     grpc_cfg.clone(),
-                )
-                .await;
+                );
+                let (label, result) = tokio::select! {
+                    _ = shutdown.cancelled() => return,
+                    connected = connect => connected,
+                };
                 match result {
                     Ok((client, abort_rx)) => {
                         // Attach without the subscription transition lock:
@@ -256,7 +262,10 @@ fn spawn_deferred_pubsub_clients(
                         "Deferred pubsub client failed to connect"
                     ),
                 }
-                tokio::time::sleep(retry_delay).await;
+                tokio::select! {
+                    _ = shutdown.cancelled() => return,
+                    _ = tokio::time::sleep(retry_delay) => {}
+                }
                 retry_delay = (retry_delay * 2).min(MAX_ATTACH_RETRY_DELAY);
             }
         });

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -219,13 +219,20 @@ fn spawn_deferred_pubsub_clients(
                         // a paced resub of a large set can take minutes and
                         // would starve foreground transitions. The reconnect
                         // path already resubscribes lock-free.
-                        let add_result = submux
-                            .add_client(
-                                client.clone(),
-                                abort_rx,
-                                subscribed_accounts.clone(),
-                            )
-                            .await;
+                        let attach = submux.add_client(
+                            client.clone(),
+                            abort_rx,
+                            subscribed_accounts.clone(),
+                        );
+                        let add_result = tokio::select! {
+                            _ = shutdown.cancelled() => {
+                                // Stop the partial client's subscription
+                                // work; the mux is gone anyway
+                                let _ = client.shutdown().await;
+                                return;
+                            }
+                            res = attach => res,
+                        };
                         match add_result {
                             Ok(()) => {
                                 debug!(

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -715,12 +715,15 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
         }
     }
 
-    /// Creates a background task that periodically updates the active subscriptions gauge
+    /// Creates a background task that periodically reconciles subscriptions
+    /// with the LRU (repairing missing ones, e.g. after a partial
+    /// resubscription) and optionally updates the active subscriptions gauge
     fn start_active_subscriptions_updater<PubsubClient: ChainPubsubClient>(
         subscribed_accounts: Arc<AccountsLruCache>,
         pubsub_client: Arc<PubsubClient>,
         removed_account_tx: mpsc::Sender<Pubkey>,
         subscription_key_locks: SubscriptionKeyLocks,
+        emit_metrics: bool,
     ) -> task::JoinHandle<()> {
         task::spawn(async move {
             let mut interval = time::interval(Duration::from_millis(
@@ -741,7 +744,9 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                     .await;
 
                 debug!(count = pubsub_total, "Updating active subscriptions");
-                set_monitored_accounts_count(pubsub_total);
+                if emit_metrics {
+                    set_monitored_accounts_count(pubsub_total);
+                }
             }
         })
     }
@@ -762,17 +767,16 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
         let subscription_key_locks: SubscriptionKeyLocks =
             Arc::new(AsyncMutex::new(HashMap::new()));
 
+        // The reconciler always runs: partial resubscriptions rely on it for
+        // repair. The config flag only gates the metrics emission.
         let active_subscriptions_updater =
-            if config.enable_subscription_metrics() {
-                Some(Self::start_active_subscriptions_updater(
-                    lrucache_subscribed_accounts.clone(),
-                    Arc::new(pubsub_client.clone()),
-                    removed_account_tx.clone(),
-                    subscription_key_locks.clone(),
-                ))
-            } else {
-                None
-            };
+            Some(Self::start_active_subscriptions_updater(
+                lrucache_subscribed_accounts.clone(),
+                Arc::new(pubsub_client.clone()),
+                removed_account_tx.clone(),
+                subscription_key_locks.clone(),
+                config.enable_subscription_metrics(),
+            ));
 
         let me = Self {
             fetching_accounts: Arc::<FetchingAccounts>::default(),

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -184,7 +184,6 @@ fn spawn_deferred_pubsub_clients(
     grpc_cfg: GrpcConfig,
     submux: SubMuxClient<ChainUpdatesClient>,
     subscribed_accounts: Arc<AccountsLruCache>,
-    subscription_transition_lock: Arc<AsyncMutex<()>>,
 ) {
     // Deferred clients are the fallback update sources; retry connect/attach
     // with capped backoff instead of dropping them permanently on failure.
@@ -196,7 +195,6 @@ fn spawn_deferred_pubsub_clients(
         let grpc_cfg = grpc_cfg.clone();
         let submux = submux.clone();
         let subscribed_accounts = subscribed_accounts.clone();
-        let subscription_transition_lock = subscription_transition_lock.clone();
         tokio::spawn(async move {
             let mut retry_delay = INITIAL_ATTACH_RETRY_DELAY;
             loop {
@@ -211,17 +209,20 @@ fn spawn_deferred_pubsub_clients(
                 .await;
                 match result {
                     Ok((client, abort_rx)) => {
-                        let add_result = {
-                            let _transition_guard =
-                                subscription_transition_lock.lock().await;
-                            submux
-                                .add_client(
-                                    client.clone(),
-                                    abort_rx,
-                                    subscribed_accounts.clone(),
-                                )
-                                .await
-                        };
+                        // Attach without holding the subscription transition
+                        // lock: resubscribing a large set is paced and can
+                        // take minutes, which would starve foreground
+                        // subscription transitions. The reconnect path
+                        // already resubscribes lock-free; concurrent
+                        // transitions are reconciled via add_sub dedup and
+                        // the subscription reconciler.
+                        let add_result = submux
+                            .add_client(
+                                client.clone(),
+                                abort_rx,
+                                subscribed_accounts.clone(),
+                            )
+                            .await;
                         match add_result {
                             Ok(()) => {
                                 debug!(
@@ -871,7 +872,6 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                         config.grpc().clone(),
                         provider.pubsub_client.clone(),
                         provider.lrucache_subscribed_accounts.clone(),
-                        provider.subscription_transition_lock.clone(),
                     );
                 }
                 Ok(provider)

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -590,8 +590,21 @@ pub struct RemoteAccountProvider<T: ChainRpcClient, U: ChainPubsubClient> {
 
     subscription_forwarder: Arc<mpsc::Sender<ForwardedSubscriptionUpdate>>,
 
-    /// Task that periodically updates the active subscriptions gauge
+    /// Task that periodically reconciles subscriptions and updates the
+    /// active subscriptions gauge
     _active_subscriptions_task_handle: Option<task::JoinHandle<()>>,
+}
+
+impl<T: ChainRpcClient, U: ChainPubsubClient> Drop
+    for RemoteAccountProvider<T, U>
+{
+    fn drop(&mut self) {
+        // The reconciler loops forever; abort it so a dropped provider
+        // doesn't leak the task and the state it holds
+        if let Some(handle) = &self._active_subscriptions_task_handle {
+            handle.abort();
+        }
+    }
 }
 
 // -----------------

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -216,7 +216,7 @@ fn spawn_deferred_pubsub_clients(
                                 subscription_transition_lock.lock().await;
                             submux
                                 .add_client(
-                                    client,
+                                    client.clone(),
                                     abort_rx,
                                     subscribed_accounts.clone(),
                                 )
@@ -230,12 +230,26 @@ fn spawn_deferred_pubsub_clients(
                                 );
                                 return;
                             }
-                            Err(err) => warn!(
-                                endpoint = %label,
-                                error = %err,
-                                retry_in = ?retry_delay,
-                                "Deferred pubsub client failed to attach"
-                            ),
+                            Err(err) => {
+                                warn!(
+                                    endpoint = %label,
+                                    error = %err,
+                                    retry_in = ?retry_delay,
+                                    "Deferred pubsub client failed to attach"
+                                );
+                                // Shut the client down so subscriptions that
+                                // were established before the failure don't
+                                // leak listener tasks; the retry starts over
+                                // with a fresh client.
+                                if let Err(err) = client.shutdown().await {
+                                    debug!(
+                                        endpoint = %label,
+                                        error = %err,
+                                        "Failed to shut down partially \
+                                         attached pubsub client"
+                                    );
+                                }
+                            }
                         }
                     }
                     Err(err) => warn!(

--- a/magicblock-chainlink/src/remote_account_provider/pubsub_common.rs
+++ b/magicblock-chainlink/src/remote_account_provider/pubsub_common.rs
@@ -31,7 +31,10 @@ impl PubsubClientConfig {
             if pubsub_url.to_lowercase().contains("helius") {
                 Some(HELIUS_PER_STREAM_SUBSCRIPTION_LIMIT)
             } else {
-                None
+                // Unlimited would funnel every subscription through a single
+                // websocket connection; cap it so large subscription sets fan
+                // out across the connection pool.
+                Some(DEFAULT_PER_STREAM_SUBSCRIPTION_LIMIT)
             };
         Self {
             pubsub_url,
@@ -184,6 +187,7 @@ pub enum ChainPubsubActorMessage {
 }
 
 pub const HELIUS_PER_STREAM_SUBSCRIPTION_LIMIT: usize = 80;
+pub const DEFAULT_PER_STREAM_SUBSCRIPTION_LIMIT: usize = 500;
 
 pub const SUBSCRIPTION_UPDATE_CHANNEL_SIZE: usize = 5_000;
 pub const MESSAGE_CHANNEL_SIZE: usize = 1_000;

--- a/magicblock-chainlink/src/remote_account_provider/pubsub_common.rs
+++ b/magicblock-chainlink/src/remote_account_provider/pubsub_common.rs
@@ -31,9 +31,8 @@ impl PubsubClientConfig {
             if pubsub_url.to_lowercase().contains("helius") {
                 Some(HELIUS_PER_STREAM_SUBSCRIPTION_LIMIT)
             } else {
-                // Unlimited would funnel every subscription through a single
-                // websocket connection; cap it so large subscription sets fan
-                // out across the connection pool.
+                // Cap so large subscription sets fan out across the
+                // connection pool instead of serializing on one socket
                 Some(DEFAULT_PER_STREAM_SUBSCRIPTION_LIMIT)
             };
         Self {

--- a/magicblock-chainlink/src/remote_account_provider/subscription_reconciler.rs
+++ b/magicblock-chainlink/src/remote_account_provider/subscription_reconciler.rs
@@ -117,6 +117,15 @@ pub(crate) async fn reconcile_subscriptions<PubsubClient: ChainPubsubClient>(
         return lru_count + never_evicted.len();
     };
 
+    // Never-evicted keys (e.g. the clock sysvar) are not tracked in the LRU,
+    // so the LRU diff below cannot repair them - collect the ones missing
+    // from any client to resubscribe them directly.
+    let missing_never_evicted: Vec<Pubkey> = never_evicted
+        .iter()
+        .filter(|pk| !pubsub_snapshot.intersection.contains(pk))
+        .copied()
+        .collect();
+
     let ensured_subs_without_never_evict: HashSet<_> = pubsub_snapshot
         .intersection
         .into_iter()
@@ -145,6 +154,27 @@ pub(crate) async fn reconcile_subscriptions<PubsubClient: ChainPubsubClient>(
         extra_in_pubsub_count = extra_in_pubsub.len(),
         "Reconciling subscriptions between LRU and pubsub client"
     );
+
+    // Resubscribe never-evicted keys missing from any client. Clients that
+    // already hold the subscription dedup the call.
+    if !missing_never_evicted.is_empty() {
+        warn!(
+            pubkeys = ?missing_never_evicted,
+            "Resubscribing missing never-evicted accounts"
+        );
+        for pubkey in missing_never_evicted {
+            let _subscription_guard =
+                acquire_subscription_key_guard(subscription_key_locks, pubkey)
+                    .await;
+            if let Err(e) = pubsub_client.subscribe(pubkey, None).await {
+                warn!(
+                    pubkey = %pubkey,
+                    error = ?e,
+                    "Failed to resubscribe never-evicted account"
+                );
+            }
+        }
+    }
 
     // For any sub that is in the LRU but not ensured by all clients we resubscribe.
     // This may call subscribe on some clients that already have the subscription and

--- a/magicblock-chainlink/src/submux/mod.rs
+++ b/magicblock-chainlink/src/submux/mod.rs
@@ -299,6 +299,12 @@ where
         me
     }
 
+    /// Token cancelled when the owning mux shuts down; ties background
+    /// tasks to this mux's lifetime.
+    pub(crate) fn shutdown_token(&self) -> CancellationToken {
+        self.shutdown_token.clone()
+    }
+
     // -----------------
     // Reconnection
     // -----------------

--- a/magicblock-chainlink/src/submux/mod.rs
+++ b/magicblock-chainlink/src/submux/mod.rs
@@ -455,8 +455,33 @@ where
             );
         }
 
+        let client_key = Self::client_key(&client);
         Self::connected_client_ids_lock(&self.connected_client_ids)
-            .insert(Self::client_key(&client));
+            .insert(client_key);
+
+        // Catch-up pass, mirroring reconnect_client: subscriptions added
+        // after the snapshots above but before this client became visible
+        // in connected_clients_snapshot() would otherwise be missed.
+        // Already-subscribed keys dedup, so this is cheap.
+        let programs =
+            self.program_subs_lock().iter().copied().collect::<Vec<_>>();
+        for program_id in programs {
+            if let Err(err) = client.subscribe_program(program_id).await {
+                Self::connected_client_ids_lock(&self.connected_client_ids)
+                    .remove(&client_key);
+                self.remove_client(&client);
+                return Err(err);
+            }
+        }
+        let mut account_subs =
+            subscribed_accounts_tracker.subscribed_accounts();
+        account_subs.extend(self.never_debounce.iter().copied());
+        if let Err(err) = client.resub_multiple(account_subs).await {
+            Self::connected_client_ids_lock(&self.connected_client_ids)
+                .remove(&client_key);
+            self.remove_client(&client);
+            return Err(err);
+        }
 
         let connected = self
             .connected_clients

--- a/magicblock-chainlink/src/submux/mod.rs
+++ b/magicblock-chainlink/src/submux/mod.rs
@@ -455,33 +455,8 @@ where
             );
         }
 
-        let client_key = Self::client_key(&client);
         Self::connected_client_ids_lock(&self.connected_client_ids)
-            .insert(client_key);
-
-        // Catch-up pass, mirroring reconnect_client: subscriptions added
-        // after the snapshots above but before this client became visible
-        // in connected_clients_snapshot() would otherwise be missed.
-        // Already-subscribed keys dedup, so this is cheap.
-        let programs =
-            self.program_subs_lock().iter().copied().collect::<Vec<_>>();
-        for program_id in programs {
-            if let Err(err) = client.subscribe_program(program_id).await {
-                Self::connected_client_ids_lock(&self.connected_client_ids)
-                    .remove(&client_key);
-                self.remove_client(&client);
-                return Err(err);
-            }
-        }
-        let mut account_subs =
-            subscribed_accounts_tracker.subscribed_accounts();
-        account_subs.extend(self.never_debounce.iter().copied());
-        if let Err(err) = client.resub_multiple(account_subs).await {
-            Self::connected_client_ids_lock(&self.connected_client_ids)
-                .remove(&client_key);
-            self.remove_client(&client);
-            return Err(err);
-        }
+            .insert(Self::client_key(&client));
 
         let connected = self
             .connected_clients
@@ -503,13 +478,46 @@ where
         }
 
         Self::spawn_reconnectors(
-            vec![(client, abort_rx)],
-            subscribed_accounts_tracker,
+            vec![(client.clone(), abort_rx)],
+            subscribed_accounts_tracker.clone(),
             self.program_subs.clone(),
             self.connected_client_ids.clone(),
             self.connected_clients.clone(),
             self.connected_clients_subscribing_immediately.clone(),
         );
+
+        // Catch-up pass, mirroring reconnect_client: subscriptions added
+        // after the snapshots above but before this client became visible
+        // in connected_clients_snapshot() would otherwise be missed.
+        // Already-subscribed keys dedup, so this is cheap. Failures don't
+        // roll the client back - foreground subscribes may already count
+        // it toward their confirmations - recovery is owned by the
+        // standard machinery: connection-level failures signal the
+        // reconnector spawned above, account stragglers are repaired by
+        // the reconciler.
+        let programs =
+            self.program_subs_lock().iter().copied().collect::<Vec<_>>();
+        for program_id in programs {
+            if let Err(err) = client.subscribe_program(program_id).await {
+                warn!(
+                    client_id = %client.id(),
+                    program_id = %program_id,
+                    error = %err,
+                    "Catch-up program subscription failed after attach"
+                );
+            }
+        }
+        let mut account_subs =
+            subscribed_accounts_tracker.subscribed_accounts();
+        account_subs.extend(self.never_debounce.iter().copied());
+        if let Err(err) = client.resub_multiple(account_subs).await {
+            warn!(
+                client_id = %client.id(),
+                error = %err,
+                "Catch-up account resubscription failed after attach"
+            );
+        }
+
         Ok(())
     }
 


### PR DESCRIPTION
## Problem

WS pubsub clients have been unable to recover from any disconnect (observed on mainnet for weeks, across providers): every reconnect attempt fails with `Client ws:X disconnected` / `Subscription for <pubkey> cancelled during setup`, fibonacci backoff caps at 3600s, and the validator ends up running on gRPC laserstreams alone. Endpoint probes from the affected node complete the WS handshake fine — the failure is self-inflicted:

- When a **single** account subscribe exhausts its retries during mass resubscription, `add_sub` tears the whole connection down: marks the client disconnected and **cancels every already-restored subscription** in the same pass.
- `resub_multiple` is atomic and non-resumable: first error aborts the pass, and the next attempt redoes all ~5000 subscriptions from scratch — with an inter-subscribe delay that doubles up to 800ms and never resets (a full pass approaches ~66 minutes, all through one socket since non-helius endpoints had no per-stream limit).
- One transient failure per hour-long pass is enough to fail forever.
- Deferred WS clients (used when gRPC is configured) are **dropped permanently** if their initial attach fails.

## Fix

- **Per-key failures stay per-key**: a subscribe that fails after retries no longer triggers `abort_and_signal_connection_issue`; it fails only that subscription. Connection teardown remains for genuine stream-end events detected by the listener tasks.
- **`resub_multiple` is best-effort and resumable**: skips already-subscribed keys, continues past failures (retried on the next pass or repaired by the reconciler), paces only successful subscribes, and resets the pacing delay to the configured value after a clean pass.
- **Per-stream subscription cap of 500 for non-helius endpoints** (was unlimited), so large subscription sets fan out across the pooled connections instead of serializing on a single socket.
- **Deferred client attach retries with capped backoff** (1s → 5min) instead of discarding the client on first failure.

Combined effect: reconnect passes preserve progress across attempts, so resubscription converges even on flaky providers instead of restarting from zero forever.

## Related

Complements #1397 (gRPC stream wedge): together they restore redundancy across all four account-update sources.

## Testing

- All `magicblock-chainlink` tests pass (300+), no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic, persistent retry and recovery for deferred pubsub clients to improve attachment reliability.
  * Introduced a default per-stream subscription limit for non-Helius endpoints to improve stability under load.
* **Bug Fixes**
  * Subscription-level failures (account/program) no longer trigger full pubsub connection aborts—only connection-level issues do.
  * Resubscriptions now use multi-pass reconciliation with better backoff, avoid redundant work, and restore retries more reliably.
* **Refactor**
  * Subscription updates now continuously rebalance while metrics emission is conditionally enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->