### PR TITLE
fix: try to reconstruct the in-flight blockhash when in replica mode

### DIFF
--- a/magicblock-ledger/src/store/api.rs
+++ b/magicblock-ledger/src/store/api.rs
@@ -360,6 +360,48 @@ impl Ledger {
         }
     }
 
+    /// Returns the position `(slot, index)` of the highest key persisted in
+    /// `slot_signatures_cf`, regardless of whether that slot has a finalized
+    /// block header.
+    ///
+    /// Unlike [`Self::get_latest_transaction_position`], which prefers the
+    /// latest *finalized* (blockhash) slot, this returns the true maximum key.
+    /// This is what a restarting replica needs to resume deduplication from the
+    /// last transaction of an in-progress (not-yet-finalized) slot.
+    ///
+    /// Returns `None` if no transactions exist in the ledger.
+    pub fn get_last_persisted_transaction_position(
+        &self,
+    ) -> LedgerResult<Option<(Slot, u32)>> {
+        let mut iter = self.slot_signatures_cf.iter(IteratorMode::End)?;
+        Ok(iter.next().map(|((slot, index), _)| (slot, index)))
+    }
+
+    /// Returns the signatures of all transactions persisted for `slot`, in
+    /// ascending transaction-index order (the same order in which the primary
+    /// scheduled and hashed them).
+    ///
+    /// Works for in-progress slots that have no finalized block header yet,
+    /// unlike [`Self::get_block`]. Used to rebuild the streaming-blockhash
+    /// accumulator after a mid-slot replica restart.
+    pub fn get_transaction_signatures_for_slot(
+        &self,
+        slot: Slot,
+    ) -> LedgerResult<Vec<Signature>> {
+        let iter = self
+            .slot_signatures_cf
+            .iter(IteratorMode::From((slot, 0), IteratorDirection::Forward))?;
+
+        let mut signatures = Vec::new();
+        for ((tx_slot, _tx_index), tx_signature) in iter {
+            if tx_slot != slot {
+                break;
+            }
+            signatures.push(Signature::try_from(&*tx_signature)?);
+        }
+        Ok(signatures)
+    }
+
     // -----------------
     // Block
     // -----------------
@@ -2783,5 +2825,105 @@ mod tests {
         // The original valid signature is not in the ledger
         let result = store.verify_transaction_signature(&real_sig).unwrap();
         assert_eq!(result, None);
+    }
+
+    /// Records a bare `(slot, index) -> signature` mapping in
+    /// `slot_signatures_cf`, the way replayed transactions do via
+    /// `record_transaction`. Keeps these focused tests independent of full
+    /// transaction encoding.
+    fn record_signature(
+        store: &Ledger,
+        slot: Slot,
+        index: u32,
+        sig: Signature,
+    ) {
+        let (meta, _writable, _readonly) = create_transaction_status_meta(5);
+        store
+            .write_transaction_status(slot, index, sig, vec![], vec![], meta)
+            .unwrap();
+    }
+
+    #[test]
+    fn test_get_transaction_signatures_for_slot_ascending() {
+        init_logger!();
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let store = Ledger::open(ledger_path.path()).unwrap();
+
+        let slot = 10;
+        let sig0 = Signature::from([0u8; 64]);
+        let sig1 = Signature::from([1u8; 64]);
+        let sig2 = Signature::from([2u8; 64]);
+        // Insert out of index order to prove sorting is by key, not insertion.
+        record_signature(&store, slot, 2, sig2);
+        record_signature(&store, slot, 0, sig0);
+        record_signature(&store, slot, 1, sig1);
+        // A signature in a neighbouring slot must not leak in.
+        record_signature(&store, slot + 1, 0, Signature::from([9u8; 64]));
+
+        let sigs = store.get_transaction_signatures_for_slot(slot).unwrap();
+        assert_eq!(sigs, vec![sig0, sig1, sig2]);
+
+        // A slot with no transactions yields an empty vector.
+        let empty = store.get_transaction_signatures_for_slot(999).unwrap();
+        assert!(empty.is_empty());
+    }
+
+    #[test]
+    fn test_get_last_persisted_transaction_position() {
+        init_logger!();
+        let ledger_path = get_tmp_ledger_path_auto_delete!();
+        let store = Ledger::open(ledger_path.path()).unwrap();
+
+        // Empty ledger has no position.
+        assert_eq!(
+            store.get_last_persisted_transaction_position().unwrap(),
+            None
+        );
+
+        // Finalized slot 10 (with a block header) and its transactions.
+        let finalized_slot = 10;
+        record_signature(&store, finalized_slot, 0, Signature::from([1u8; 64]));
+        record_signature(&store, finalized_slot, 1, Signature::from([2u8; 64]));
+        store
+            .write_block(LatestBlockInner::new(
+                finalized_slot,
+                Hash::new_unique(),
+                100,
+            ))
+            .unwrap();
+
+        // In-progress slot 11 has loose transactions but NO block header, so it
+        // is ahead of the latest finalized (blockhash) slot.
+        let inprogress_slot = 11;
+        record_signature(
+            &store,
+            inprogress_slot,
+            0,
+            Signature::from([3u8; 64]),
+        );
+        record_signature(
+            &store,
+            inprogress_slot,
+            1,
+            Signature::from([4u8; 64]),
+        );
+        record_signature(
+            &store,
+            inprogress_slot,
+            2,
+            Signature::from([5u8; 64]),
+        );
+
+        // The true maximum key is the in-progress slot's last transaction.
+        assert_eq!(
+            store.get_last_persisted_transaction_position().unwrap(),
+            Some((inprogress_slot, 2))
+        );
+        // Contrast: the block-header-anchored variant stops at the finalized
+        // slot and would resume dedup from the wrong position.
+        assert_eq!(
+            store.get_latest_transaction_position().unwrap(),
+            Some((finalized_slot, 1))
+        );
     }
 }

--- a/magicblock-processor/src/scheduler/mod.rs
+++ b/magicblock-processor/src/scheduler/mod.rs
@@ -291,6 +291,11 @@ impl TransactionScheduler {
                         }
                         SchedulerMode::Replica => {
                             self.coordinator.switch_to_replica_mode_globally();
+                            // A node that starts directly in replica mode may
+                            // have rebooted mid-slot: rebuild the in-memory
+                            // streaming-blockhash accumulator from the ledger so
+                            // the first reconstructed block verifies correctly.
+                            self.reconstruct_inprogress_hasher();
                         }
                     }
                 }
@@ -602,12 +607,52 @@ impl TransactionScheduler {
             // to recover from it, right now the log is used
             // for debugging purposes only
             // NOTE:
-            // This error will always be logged once
-            // when replica starts up with an empty ledger
+            // This may still be logged once when a replica starts up with an
+            // empty ledger (no previous blockhash to seed from). A mid-slot
+            // restart no longer triggers it: reconstruct_inprogress_hasher
+            // rebuilds the accumulator from the persisted in-progress slot.
             error!(
                 slot = block.slot,
                 "replication blockhash has diverged from local"
             )
+        }
+    }
+
+    /// Rebuilds the streaming-blockhash accumulator for the in-progress slot
+    /// after a mid-slot replica restart.
+    ///
+    /// At this point the hasher holds only the previous (finalized) blockhash
+    /// seed and `self.slot` is the not-yet-finalized slot. Its transactions may
+    /// already be persisted in the ledger (with `persist: true`) even though no
+    /// block header exists for it, so ledger replay never re-fed them. Hash
+    /// their signatures back in, in scheduled (ascending index) order, so the
+    /// first reconstructed block verifies against the authoritative hash.
+    ///
+    /// The replica's deduplication (initialized from the ledger's last persisted
+    /// position) skips redelivery of these same transactions, so they are hashed
+    /// exactly once.
+    fn reconstruct_inprogress_hasher(&mut self) {
+        let slot = self.slot;
+        match self.ledger.get_transaction_signatures_for_slot(slot) {
+            Ok(signatures) => {
+                for signature in &signatures {
+                    self.hasher.update(signature.as_ref());
+                }
+                if !signatures.is_empty() {
+                    info!(
+                        slot,
+                        count = signatures.len(),
+                        "reconstructed streaming blockhash for in-progress slot"
+                    );
+                }
+            }
+            Err(error) => {
+                warn!(
+                    %error,
+                    slot,
+                    "failed to reconstruct streaming blockhash from ledger"
+                );
+            }
         }
     }
 

--- a/magicblock-replicator/src/service/context.rs
+++ b/magicblock-replicator/src/service/context.rs
@@ -68,10 +68,16 @@ impl ReplicationContext {
         let producer_id = format!("{node_id}-producer");
         let consumer_id = format!("{node_id}-consumer");
 
-        let slot = accountsdb.slot();
-        let index = ledger
-            .get_highest_transaction_index_for_slot(slot)?
-            .unwrap_or_default();
+        // Resume deduplication from the ledger's last persisted transaction,
+        // which may live in an in-progress (not-yet-finalized) slot ahead of
+        // `accountsdb.slot()`. Using the true last position ensures redelivered
+        // already-applied transactions of that slot are skipped (not re-applied
+        // and not re-hashed) after a mid-slot restart.
+        let (slot, index) =
+            match ledger.get_last_persisted_transaction_position()? {
+                Some(position) => position,
+                None => (accountsdb.slot(), 0),
+            };
 
         info!(%node_id, %producer_id, %consumer_id, slot, "context initialized");
         Ok(Self {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved replay and replication recovery after mid-slot restarts.
  * Transaction processing now resumes from the last persisted transaction, reducing duplicate or missed work.
  * Block verification is now rebuilt correctly when switching into replica mode at runtime.
  * Signature lookups now return transactions in the correct order for a slot and stay scoped to that slot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->