### PR TITLE
fix: report clock instead of the slot-subscription placeholder in gRPC snapshots

### DIFF
--- a/magicblock-chainlink/src/remote_account_provider/chain_laser_client.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_laser_client.rs
@@ -241,7 +241,21 @@ impl ChainPubsubClient for ChainLaserClientImpl {
     }
 
     fn subscriptions_union(&self) -> HashSet<Pubkey> {
-        self.subscriptions.read().clone()
+        // Map the slot-subscription placeholder back to clock::ID (the
+        // inverse of the mapping in subscribe()) so snapshots are comparable
+        // across client types; otherwise the reconciler sees the clock as
+        // never ensured and resubscribes it on every tick.
+        self.subscriptions
+            .read()
+            .iter()
+            .map(|pk| {
+                if *pk == SLOT_SUBSCRIPTION_DUMMY {
+                    clock::ID
+                } else {
+                    *pk
+                }
+            })
+            .collect()
     }
 
     fn subs_immediately(&self) -> bool {


### PR DESCRIPTION
## Problem

`ChainLaserClientImpl::subscriptions_union` returns the raw internal set containing `SLOT_SUBSCRIPTION_DUMMY` (the placeholder gRPC clients track for their implicit slot subscription) instead of `clock::ID`. The cross-client subscription intersection therefore never contains the clock, so the never-evicted reconciliation added in #1398 considers it missing and resubscribes it on every tick — observable on devnet nodes as a `Resubscribing missing never-evicted accounts [SysvarC1ock...]` warning every 60s (harmless, since every client dedups the resubscribe, but noisy and defeats the check).

## Fix

Map the placeholder back to `clock::ID` when reporting the subscription set — the exact inverse of the mapping `subscribe()` applies on the way in. Snapshots become comparable across websocket and gRPC client types, and the placeholder no longer leaks out of the client.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subscription reconciliation so slot subscriptions are compared consistently across client types.
  * Ensured the returned set now translates the internal slot placeholder into the expected clock subscription identifier before merging results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->