### PR TITLE
refactor: move LatestBlockInner into core to be able to expose subscribe in LatestBlockProvider trait

### DIFF
--- a/magicblock-aperture/src/geyser.rs
+++ b/magicblock-aperture/src/geyser.rs
@@ -8,9 +8,9 @@ use agave_geyser_plugin_interface::geyser_plugin_interface::{
 use json::{JsonValueTrait, Value};
 use libloading::{Library, Symbol};
 use magicblock_core::link::{
-    accounts::AccountWithSlot, transactions::TransactionStatus,
+    accounts::AccountWithSlot, blocks::LatestBlockInner,
+    transactions::TransactionStatus,
 };
-use magicblock_ledger::LatestBlockInner;
 use solana_account::ReadableAccount;
 
 const ENTRYPOINT_SYMBOL: &[u8] = b"_create_plugin";

--- a/magicblock-aperture/src/processor.rs
+++ b/magicblock-aperture/src/processor.rs
@@ -2,10 +2,11 @@ use std::sync::Arc;
 
 use magicblock_config::config::ApertureConfig;
 use magicblock_core::link::{
-    accounts::AccountUpdateRx, blocks::BlockUpdateRx,
-    transactions::TransactionStatusRx, DispatchEndpoints,
+    accounts::AccountUpdateRx,
+    blocks::{BlockUpdateRx, LatestBlockInner},
+    transactions::TransactionStatusRx,
+    DispatchEndpoints,
 };
-use magicblock_ledger::LatestBlockInner;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, instrument, warn};
 

--- a/magicblock-aperture/src/state/blocks.rs
+++ b/magicblock-aperture/src/state/blocks.rs
@@ -1,8 +1,10 @@
 use std::{ops::Deref, sync::Arc, time::Duration};
 
 use arc_swap::ArcSwapAny;
-use magicblock_core::{link::blocks::BlockHash, Slot};
-use magicblock_ledger::LatestBlockInner;
+use magicblock_core::{
+    link::blocks::{BlockHash, LatestBlockInner},
+    Slot,
+};
 use solana_rpc_client_api::response::RpcBlockhash;
 
 use super::ExpiringCache;

--- a/magicblock-core/Cargo.toml
+++ b/magicblock-core/Cargo.toml
@@ -17,7 +17,7 @@ bytes = { workspace = true }
 
 serde = { workspace = true, features = ["derive"] }
 solana-account = { workspace = true }
-solana-account-decoder = { workspace = true }
+solana-account-decoder = { workspace = true, features = ["agave-unstable-api"] }
 solana-clock = { workspace = true }
 solana-hash = { workspace = true }
 solana-message = { workspace = true }
@@ -27,7 +27,7 @@ solana-signature = { workspace = true }
 solana-transaction = { workspace = true, features = ["blake3", "verify"] }
 solana-transaction-context = { workspace = true }
 solana-transaction-error = { workspace = true }
-solana-transaction-status-client-types = { workspace = true }
+solana-transaction-status-client-types = { workspace = true, features = ["agave-unstable-api"] }
 magicblock-magic-program-api = { workspace = true }
 spl-token = { workspace = true }
 spl-token-2022 = { workspace = true }

--- a/magicblock-core/src/link/blocks.rs
+++ b/magicblock-core/src/link/blocks.rs
@@ -1,3 +1,4 @@
+use solana_clock::Clock;
 use solana_hash::Hash;
 use tokio::sync::broadcast;
 
@@ -8,3 +9,26 @@ pub type BlockHash = Hash;
 /// Typically instantiated as `BlockUpdateRx<LatestBlockInner>` where the payload
 /// contains the latest block data (slot, blockhash, timestamp).
 pub type BlockUpdateRx<T> = broadcast::Receiver<T>;
+
+#[derive(Default, Clone)]
+pub struct LatestBlockInner {
+    pub slot: u64,
+    pub blockhash: BlockHash,
+    pub clock: Clock,
+}
+
+impl LatestBlockInner {
+    pub fn new(slot: u64, blockhash: BlockHash, timestamp: i64) -> Self {
+        let clock = Clock {
+            slot: slot + 1,
+            unix_timestamp: timestamp,
+            ..Default::default()
+        };
+
+        Self {
+            slot,
+            blockhash,
+            clock,
+        }
+    }
+}

--- a/magicblock-core/src/traits.rs
+++ b/magicblock-core/src/traits.rs
@@ -6,9 +6,11 @@ use solana_program::instruction::InstructionError;
 use solana_pubkey::Pubkey;
 use solana_signature::Signature;
 use solana_transaction_error::TransactionError;
+use tokio::sync::broadcast;
 
 use crate::{
     intent::{BaseActionCallback, CommittedAccount},
+    link::blocks::LatestBlockInner,
     Slot,
 };
 
@@ -28,6 +30,7 @@ pub trait LatestBlockProvider: Send + Sync + Clone + 'static {
     fn slot(&self) -> Slot;
     fn blockhash(&self) -> Hash;
     fn clock(&self) -> Clock;
+    fn subscribe(&self) -> broadcast::Receiver<LatestBlockInner>;
 }
 
 /// Interface for service handling callback execution/scheduling

--- a/magicblock-ledger/src/blockstore_processor/mod.rs
+++ b/magicblock-ledger/src/blockstore_processor/mod.rs
@@ -1,7 +1,10 @@
 use std::str::FromStr;
 
-use magicblock_core::link::transactions::{
-    ReplayPosition, SanitizeableTransaction, TransactionSchedulerHandle,
+use magicblock_core::link::{
+    blocks::LatestBlockInner,
+    transactions::{
+        ReplayPosition, SanitizeableTransaction, TransactionSchedulerHandle,
+    },
 };
 use num_format::{Locale, ToFormattedString};
 use solana_clock::{Slot, UnixTimestamp};
@@ -12,7 +15,7 @@ use tracing::{Level, *};
 
 use crate::{
     errors::{LedgerError, LedgerResult},
-    LatestBlockInner, Ledger,
+    Ledger,
 };
 
 #[derive(Debug)]

--- a/magicblock-ledger/src/lib.rs
+++ b/magicblock-ledger/src/lib.rs
@@ -5,18 +5,13 @@ pub use database::{
     meta::PerfSample,
     options::{LedgerOptions, BLOCKSTORE_DIRECTORY_ROCKS_LEVEL},
 };
-use magicblock_core::traits::LatestBlockProvider;
+use magicblock_core::{
+    link::blocks::LatestBlockInner, traits::LatestBlockProvider,
+};
 use solana_clock::Clock;
 use solana_hash::Hash;
 pub use store::api::{Ledger, SignatureInfosForAddress};
 use tokio::sync::broadcast;
-
-#[derive(Default, Clone)]
-pub struct LatestBlockInner {
-    pub slot: u64,
-    pub blockhash: Hash,
-    pub clock: Clock,
-}
 
 /// Atomically updated, shared, latest block information
 /// The instances of this type can be used by various components
@@ -33,21 +28,6 @@ pub struct LatestBlock {
     inner: Arc<ArcSwapAny<Arc<LatestBlockInner>>>,
     /// Notification mechanism to signal that the block has been modified,
     notifier: broadcast::Sender<LatestBlockInner>,
-}
-
-impl LatestBlockInner {
-    pub fn new(slot: u64, blockhash: Hash, timestamp: i64) -> Self {
-        let clock = Clock {
-            slot: slot + 1,
-            unix_timestamp: timestamp,
-            ..Default::default()
-        };
-        Self {
-            slot,
-            blockhash,
-            clock,
-        }
-    }
 }
 
 impl Default for LatestBlock {
@@ -92,6 +72,10 @@ impl LatestBlockProvider for LatestBlock {
 
     fn clock(&self) -> Clock {
         self.inner.load().clock.clone()
+    }
+
+    fn subscribe(&self) -> broadcast::Receiver<LatestBlockInner> {
+        self.subscribe()
     }
 }
 

--- a/magicblock-ledger/src/store/api.rs
+++ b/magicblock-ledger/src/store/api.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use bincode::{deserialize, serialize};
-use magicblock_core::link::blocks::BlockHash;
+use magicblock_core::link::blocks::{BlockHash, LatestBlockInner};
 use magicblock_metrics::metrics::{
     start_ledger_disable_compactions_timer, start_ledger_shutdown_timer,
     HistogramTimer,
@@ -42,7 +42,7 @@ use crate::{
     errors::{LedgerError, LedgerResult},
     metrics::LedgerRpcApiMetrics,
     store::utils::adjust_ulimit_nofile,
-    LatestBlock, LatestBlockInner,
+    LatestBlock,
 };
 
 #[derive(Default, Debug)]

--- a/magicblock-ledger/tests/get_block.rs
+++ b/magicblock-ledger/tests/get_block.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use magicblock_ledger::LatestBlockInner;
+use magicblock_core::link::blocks::LatestBlockInner;
 use solana_hash::Hash;
 use test_kit::init_logger;
 

--- a/magicblock-ledger/tests/test_ledger_truncator.rs
+++ b/magicblock-ledger/tests/test_ledger_truncator.rs
@@ -1,9 +1,8 @@
 mod common;
 use std::{sync::Arc, time::Duration};
 
-use magicblock_ledger::{
-    ledger_truncator::LedgerTruncator, LatestBlockInner, Ledger,
-};
+use magicblock_core::link::blocks::LatestBlockInner;
+use magicblock_ledger::{ledger_truncator::LedgerTruncator, Ledger};
 use solana_hash::Hash;
 use solana_signature::Signature;
 use test_kit::init_logger;

--- a/magicblock-processor/src/executor/mod.rs
+++ b/magicblock-processor/src/executor/mod.rs
@@ -9,6 +9,7 @@ use magicblock_accounts_db::AccountsDb;
 use magicblock_core::{
     link::{
         accounts::AccountUpdateTx,
+        blocks::LatestBlockInner,
         transactions::{
             ProcessableTransaction, ScheduledTasksTx,
             TransactionProcessingMode, TransactionStatusTx,
@@ -16,7 +17,7 @@ use magicblock_core::{
     },
     Slot,
 };
-use magicblock_ledger::{LatestBlock, LatestBlockInner, Ledger};
+use magicblock_ledger::{LatestBlock, Ledger};
 use solana_feature_set::FeatureSet;
 use solana_program::slot_hashes::SlotHashes;
 use solana_program_runtime::loaded_programs::{

--- a/magicblock-processor/src/scheduler/mod.rs
+++ b/magicblock-processor/src/scheduler/mod.rs
@@ -56,6 +56,7 @@ use locks::{ExecutorId, MAX_SVM_EXECUTORS};
 use magicblock_accounts_db::{traits::AccountsBank, AccountsDb};
 use magicblock_core::{
     link::{
+        blocks::LatestBlockInner,
         replication::{self, Message, SuperBlock},
         transactions::{
             ProcessableTransaction, SchedulerCommand, SchedulerCommandResult,
@@ -64,7 +65,7 @@ use magicblock_core::{
     },
     Slot,
 };
-use magicblock_ledger::{LatestBlock, LatestBlockInner, Ledger};
+use magicblock_ledger::{LatestBlock, Ledger};
 use magicblock_metrics::metrics;
 use solana_account::{from_account, to_account};
 use solana_program::{clock::Clock, hash::Hash, slot_hashes::SlotHashes};

--- a/test-kit/src/lib.rs
+++ b/test-kit/src/lib.rs
@@ -12,6 +12,7 @@ pub use guinea;
 use magicblock_accounts_db::{traits::AccountsBank, AccountsDb};
 use magicblock_core::{
     link::{
+        blocks::LatestBlockInner,
         link,
         transactions::{
             ReplayPosition, SanitizeableTransaction, SchedulerMode,
@@ -21,7 +22,7 @@ use magicblock_core::{
     },
     Slot,
 };
-use magicblock_ledger::{LatestBlockInner, Ledger};
+use magicblock_ledger::Ledger;
 use magicblock_processor::{
     build_svm_env,
     loader::load_upgradeable_programs,


### PR DESCRIPTION
…ibe method in LatestBlockProvider

<!--
PR title must match: type(scope): summary
Types: feat|fix|docs|chore|refactor|test|perf|ci|build
Examples:
  fix: avoid panic on empty slot
  feat(rpc): add getFoo endpoint
-->

## Summary
<!-- One sentence. Link to issue if applicable. -->
Committor service needs an ability to implement SlotTimer, the easiest way is to implement using `broadcast::Receiver<Slot>` return by `subscribe` in `LatestBlock`. 

To expose this method in LatestBlockProvider trait we have to move LatestBlockInner in `magicblock-core`

## Breaking Changes
- [x] None
- [ ] Yes — migration path described below


## Test Plan
<!-- How you verified this works. e.g., "unit tests", "ran locally against testnet", "existing tests pass" -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a shared block snapshot type and subscription support so components can receive the latest block updates consistently.

* **Refactor**
  * Consolidated block-related imports across the codebase to use a single source of truth.
  * Updated block handling to use the shared type throughout core, ledger, processor, and tests.

* **Bug Fixes**
  * Improved consistency around block metadata and update delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->