### PR TITLE
feat: add id for actions

### DIFF
--- a/magicblock-committor-service/src/tasks/mod.rs
+++ b/magicblock-committor-service/src/tasks/mod.rs
@@ -619,6 +619,7 @@ mod serialization_safety_test {
         // Test BaseAction V1 variant
         let base_action: BaseTaskImpl = BaseActionTask::V1(BaseActionTaskV1 {
             action: BaseAction {
+                id: 0,
                 destination_program: Pubkey::new_unique(),
                 source_program: None,
                 escrow_authority: Pubkey::new_unique(),
@@ -641,6 +642,7 @@ mod serialization_safety_test {
         let base_action_v2: BaseTaskImpl =
             BaseActionTask::V2(BaseActionTaskV2 {
                 action: BaseAction {
+                    id: 0,
                     destination_program: Pubkey::new_unique(),
                     source_program: Some(Pubkey::new_unique()),
                     escrow_authority: Pubkey::new_unique(),

--- a/magicblock-committor-service/src/tasks/task_strategist.rs
+++ b/magicblock-committor-service/src/tasks/task_strategist.rs
@@ -579,6 +579,7 @@ mod tests {
     fn create_test_base_action_task(len: usize) -> BaseActionTask {
         BaseActionTaskV1 {
             action: BaseAction {
+                id: 0,
                 destination_program: Pubkey::new_unique(),
                 source_program: None,
                 escrow_authority: Pubkey::new_unique(),

--- a/magicblock-core/Cargo.toml
+++ b/magicblock-core/Cargo.toml
@@ -17,7 +17,7 @@ bytes = { workspace = true }
 
 serde = { workspace = true, features = ["derive"] }
 solana-account = { workspace = true }
-solana-account-decoder = { workspace = true }
+solana-account-decoder = { workspace = true, features = ["agave-unstable-api"] }
 solana-clock = { workspace = true }
 solana-hash = { workspace = true }
 solana-message = { workspace = true }
@@ -27,7 +27,7 @@ solana-signature = { workspace = true }
 solana-transaction = { workspace = true, features = ["blake3", "verify"] }
 solana-transaction-context = { workspace = true }
 solana-transaction-error = { workspace = true }
-solana-transaction-status-client-types = { workspace = true }
+solana-transaction-status-client-types = { workspace = true, features = ["agave-unstable-api"] }
 magicblock-magic-program-api = { workspace = true }
 spl-token = { workspace = true }
 spl-token-2022 = { workspace = true }

--- a/programs/magicblock/src/magic_scheduled_base_intent.rs
+++ b/programs/magicblock/src/magic_scheduled_base_intent.rs
@@ -51,6 +51,10 @@ pub struct ConstructionContext<'a, 'ic, 'ix_data> {
     /// to the delegation program. Legacy `ScheduleBaseIntent` sets this to
     /// `false` for backward compatibility with old deployed contracts.
     pub secure: bool,
+    /// Next id to assign to a `BaseAction` being constructed. Incremented
+    /// as actions are built, so each action in a bundle gets a unique,
+    /// stable id in construction order.
+    next_action_id: u64,
 }
 
 impl<'a, 'ic, 'ix_data> ConstructionContext<'a, 'ic, 'ix_data> {
@@ -65,11 +69,18 @@ impl<'a, 'ic, 'ix_data> ConstructionContext<'a, 'ic, 'ix_data> {
             signers,
             invoke_context,
             secure,
+            next_action_id: 0,
         }
     }
 
     pub fn transaction_context(&self) -> &TransactionContext<'ix_data> {
         &*self.invoke_context.transaction_context
+    }
+
+    fn next_action_id(&mut self) -> u64 {
+        let id = self.next_action_id;
+        self.next_action_id += 1;
+        id
     }
 }
 
@@ -94,7 +105,7 @@ impl ScheduledIntentBundle {
         commit_id: u64,
         slot: Slot,
         payer_pubkey: &Pubkey,
-        context: &ConstructionContext<'_, '_, '_>,
+        context: &mut ConstructionContext<'_, '_, '_>,
     ) -> Result<ScheduledIntentBundle, InstructionError> {
         let intent_bundle = MagicIntentBundle::try_from_args(args, context)?;
         let blockhash = context.invoke_context.environment_config.blockhash;
@@ -246,10 +257,11 @@ impl From<MagicBaseIntent> for MagicIntentBundle {
 impl MagicIntentBundle {
     pub fn try_from_args(
         args: MagicIntentBundleArgs,
-        context: &ConstructionContext<'_, '_, '_>,
+        context: &mut ConstructionContext<'_, '_, '_>,
     ) -> Result<Self, InstructionError> {
         Self::validate(&args, context)?;
 
+        // NOTE: Order shall be identical to AddActionCallback's action ordering.
         let commit = args
             .commit
             .map(|value| CommitType::try_from_args(value, context))
@@ -260,6 +272,12 @@ impl MagicIntentBundle {
             .map(|value| CommitAndUndelegate::try_from_args(value, context))
             .transpose()?;
 
+        let actions = args
+            .standalone_actions
+            .into_iter()
+            .map(|args| BaseAction::try_from_args(args, context))
+            .collect::<Result<Vec<BaseAction>, InstructionError>>()?;
+
         let commit_finalize = args
             .commit_finalize
             .map(|value| CommitType::try_from_args(value, context))
@@ -269,12 +287,6 @@ impl MagicIntentBundle {
             .commit_finalize_and_undelegate
             .map(|value| CommitAndUndelegate::try_from_args(value, context))
             .transpose()?;
-
-        let actions = args
-            .standalone_actions
-            .into_iter()
-            .map(|args| BaseAction::try_from_args(args, context))
-            .collect::<Result<Vec<BaseAction>, InstructionError>>()?;
 
         let this = Self {
             commit,
@@ -569,33 +581,45 @@ impl MagicIntentBundle {
         x || y || z
     }
 
-    pub fn get_action_mut(&mut self, index: usize) -> Option<&mut BaseAction> {
-        let mut offset = 0usize;
-
+    pub fn get_action_mut(&mut self, id: u64) -> Option<&mut BaseAction> {
         if let Some(commit) = self.commit.as_mut() {
-            let count = commit.action_count();
-            if index < offset + count {
-                return commit.get_action_mut(index - offset);
+            if let Some(action) = commit.get_action_mut(id) {
+                return Some(action);
             }
-            offset += count;
         }
 
         if let Some(cau) = self.commit_and_undelegate.as_mut() {
-            let count = cau.action_count();
-            if index < offset + count {
-                return cau.get_action_mut(index - offset);
+            if let Some(action) = cau.get_action_mut(id) {
+                return Some(action);
             }
-            offset += count;
         }
 
-        self.standalone_actions.get_mut(index.checked_sub(offset)?)
+        if let Some(action) =
+            self.standalone_actions.iter_mut().find(|a| a.id == id)
+        {
+            return Some(action);
+        }
+
+        if let Some(commit_finalize) = self.commit_finalize.as_mut() {
+            if let Some(action) = commit_finalize.get_action_mut(id) {
+                return Some(action);
+            }
+        }
+
+        if let Some(cfau) = self.commit_finalize_and_undelegate.as_mut() {
+            if let Some(action) = cfau.get_action_mut(id) {
+                return Some(action);
+            }
+        }
+
+        None
     }
 }
 
 impl MagicBaseIntent {
     pub fn try_from_args(
         args: MagicBaseIntentArgs,
-        context: &ConstructionContext<'_, '_, '_>,
+        context: &mut ConstructionContext<'_, '_, '_>,
     ) -> Result<MagicBaseIntent, InstructionError> {
         match args {
             MagicBaseIntentArgs::BaseActions(base_actions) => {
@@ -708,7 +732,7 @@ pub struct CommitAndUndelegate {
 impl CommitAndUndelegate {
     pub fn try_from_args(
         args: CommitAndUndelegateArgs,
-        context: &ConstructionContext<'_, '_, '_>,
+        context: &mut ConstructionContext<'_, '_, '_>,
     ) -> Result<CommitAndUndelegate, InstructionError> {
         let account_indices = args.commit_type.committed_accounts_indices();
         Self::validate(account_indices.as_slice(), context)?;
@@ -791,17 +815,12 @@ impl CommitAndUndelegate {
         x || y
     }
 
-    pub fn action_count(&self) -> usize {
-        self.commit_action.action_count()
-            + self.undelegate_action.action_count()
-    }
-
-    pub fn get_action_mut(&mut self, index: usize) -> Option<&mut BaseAction> {
-        let commit_count = self.commit_action.action_count();
-        if index < commit_count {
-            return self.commit_action.get_action_mut(index);
+    pub fn get_action_mut(&mut self, id: u64) -> Option<&mut BaseAction> {
+        if let Some(action) = self.commit_action.get_action_mut(id) {
+            Some(action)
+        } else {
+            self.undelegate_action.get_action_mut(id)
         }
-        self.undelegate_action.get_action_mut(index - commit_count)
     }
 }
 
@@ -828,6 +847,9 @@ impl From<&ActionArgs> for ProgramArgs {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BaseAction {
+    /// Stable identity of this action within its intent bundle, used to
+    /// address it independently of its position (e.g. for patch removal).
+    pub id: u64,
     pub compute_units: u32,
     pub destination_program: Pubkey,
     pub source_program: Option<Pubkey>,
@@ -840,15 +862,15 @@ pub struct BaseAction {
 impl BaseAction {
     pub fn try_from_args(
         args: BaseActionArgs,
-        context: &ConstructionContext<'_, '_, '_>,
+        context: &mut ConstructionContext<'_, '_, '_>,
     ) -> Result<BaseAction, InstructionError> {
         // Since action on Base layer performed on behalf of some escrow
         // We need to ensure that action was authorized by legit owner
-        let authority_pubkey = get_instruction_pubkey_with_idx(
+        let authority_pubkey = *get_instruction_pubkey_with_idx(
             context.transaction_context(),
             args.escrow_authority as u16,
         )?;
-        if !context.signers.contains(authority_pubkey) {
+        if !context.signers.contains(&authority_pubkey) {
             ic_msg!(
                 context.invoke_context,
                 &format!(
@@ -881,10 +903,11 @@ impl BaseAction {
         };
 
         Ok(BaseAction {
+            id: context.next_action_id(),
             compute_units: args.compute_units,
             destination_program: args.destination_program,
             source_program,
-            escrow_authority: *authority_pubkey,
+            escrow_authority: authority_pubkey,
             data_per_program: args.args.into(),
             account_metas_per_program: args.accounts,
             callback: None,
@@ -980,7 +1003,7 @@ impl CommitType {
 
     pub fn try_from_args(
         args: CommitTypeArgs,
-        context: &ConstructionContext<'_, '_, '_>,
+        context: &mut ConstructionContext<'_, '_, '_>,
     ) -> Result<CommitType, InstructionError> {
         match args {
             CommitTypeArgs::Standalone(accounts) => {
@@ -1013,10 +1036,6 @@ impl CommitType {
                 )?;
                 Self::validate_accounts(&committed_accounts_ref, context)?;
 
-                let base_actions = base_actions
-                    .into_iter()
-                    .map(|args| BaseAction::try_from_args(args, context))
-                    .collect::<Result<Vec<BaseAction>, InstructionError>>()?;
                 let committed_accounts = committed_accounts_ref
                     .into_iter()
                     .map(|(pubkey, account)| {
@@ -1028,6 +1047,10 @@ impl CommitType {
                         ))
                     })
                     .collect::<Result<_, InstructionError>>()?;
+                let base_actions = base_actions
+                    .into_iter()
+                    .map(|args| BaseAction::try_from_args(args, context))
+                    .collect::<Result<Vec<BaseAction>, InstructionError>>()?;
 
                 Ok(CommitType::WithBaseActions {
                     committed_accounts,
@@ -1107,16 +1130,9 @@ impl CommitType {
         }
     }
 
-    pub fn action_count(&self) -> usize {
-        match self {
-            Self::Standalone(_) => 0,
-            Self::WithBaseActions { base_actions, .. } => base_actions.len(),
-        }
-    }
-
-    pub fn get_action_mut(&mut self, index: usize) -> Option<&mut BaseAction> {
+    pub fn get_action_mut(&mut self, id: u64) -> Option<&mut BaseAction> {
         if let Self::WithBaseActions { base_actions, .. } = self {
-            base_actions.get_mut(index)
+            base_actions.iter_mut().find(|a| a.id == id)
         } else {
             None
         }
@@ -1131,16 +1147,9 @@ pub enum UndelegateType {
 }
 
 impl UndelegateType {
-    pub fn action_count(&self) -> usize {
-        match self {
-            Self::Standalone => 0,
-            Self::WithBaseActions(actions) => actions.len(),
-        }
-    }
-
-    pub fn get_action_mut(&mut self, index: usize) -> Option<&mut BaseAction> {
+    pub fn get_action_mut(&mut self, id: u64) -> Option<&mut BaseAction> {
         if let Self::WithBaseActions(actions) = self {
-            actions.get_mut(index)
+            actions.iter_mut().find(|a| a.id == id)
         } else {
             None
         }
@@ -1148,7 +1157,7 @@ impl UndelegateType {
 
     pub fn try_from_args(
         args: UndelegateTypeArgs,
-        context: &ConstructionContext<'_, '_, '_>,
+        context: &mut ConstructionContext<'_, '_, '_>,
     ) -> Result<UndelegateType, InstructionError> {
         match args {
             UndelegateTypeArgs::Standalone => Ok(UndelegateType::Standalone),
@@ -1275,6 +1284,7 @@ mod tests {
 
     fn make_base_action(compute_units: u32) -> BaseAction {
         BaseAction {
+            id: 0,
             compute_units,
             destination_program: Pubkey::new_unique(),
             source_program: None,

--- a/programs/magicblock/src/schedule_transactions/process_add_action_callback.rs
+++ b/programs/magicblock/src/schedule_transactions/process_add_action_callback.rs
@@ -120,7 +120,7 @@ pub(crate) fn process_add_action_callback(
 
     let action = latest_intent
         .intent_bundle
-        .get_action_mut(args.action_index as usize)
+        .get_action_mut(args.action_index as u64)
         .ok_or_else(|| {
             ic_msg!(
                 invoke_context,

--- a/programs/magicblock/src/schedule_transactions/process_schedule_intent_bundle.rs
+++ b/programs/magicblock/src/schedule_transactions/process_schedule_intent_bundle.rs
@@ -83,41 +83,42 @@ pub(crate) fn process_schedule_intent_bundle(
 
     // Determine id and slot
     let (undelegated_pubkeys, scheduled_intent) = {
-        let construction_context = ConstructionContext::new(
+        let mut construction_context = ConstructionContext::new(
             parent_program_id,
             &signers,
             invoke_context,
             secure,
         );
 
-        // Collect all undelegated account refs.
-        let undelegated_accounts_ref = [
+        // Collect all undelegated account indices.
+        let undelegated_account_indices: Vec<u8> = [
             args.commit_and_undelegate.as_ref(),
             args.commit_finalize_and_undelegate.as_ref(),
         ]
         .into_iter()
         .flatten()
-        .map(|el| el.committed_accounts_indices())
-        .try_fold(vec![], |mut acc, indices| {
-            acc.extend(CommitType::extract_commit_accounts(
-                indices,
-                construction_context.transaction_context(),
-            )?);
-            Ok::<_, InstructionError>(acc)
-        })?;
+        .flat_map(|el| el.committed_accounts_indices())
+        .copied()
+        .collect();
 
+        // Recreate intent
         let scheduled_intent = ScheduledIntentBundle::try_new(
             args,
             intent_id,
             clock.slot,
             &payer_pubkey,
-            &construction_context,
+            &mut construction_context,
         )?;
 
-        let mut undelegated_pubkeys =
-            Vec::with_capacity(undelegated_accounts_ref.len());
         // Change owner to dlp and set undelegating flag.
         // Once account is undelegated we need to make it immutable in our validator.
+        let transaction_context = construction_context.transaction_context();
+        let undelegated_accounts_ref = CommitType::extract_commit_accounts(
+            &undelegated_account_indices,
+            transaction_context,
+        )?;
+        let mut undelegated_pubkeys =
+            Vec::with_capacity(undelegated_accounts_ref.len());
         for (pubkey, account_ref) in undelegated_accounts_ref.iter() {
             undelegated_pubkeys.push(pubkey.to_string());
             mark_account_as_undelegated(account_ref)?;

--- a/test-integration/test-committor-service/tests/test_intent_executor.rs
+++ b/test-integration/test-committor-service/tests/test_intent_executor.rs
@@ -1480,6 +1480,7 @@ fn succeeding_commit_action(
         },
     ];
     BaseAction {
+        id: 0,
         compute_units: 100_000,
         destination_program: program_flexi_counter::id(),
         source_program: Some(program_flexi_counter::id()),
@@ -1523,6 +1524,7 @@ fn succeeding_undelegate_action(
     ];
 
     UndelegateType::WithBaseActions(vec![BaseAction {
+        id: 0,
         compute_units: 100_000,
         destination_program: program_flexi_counter::id(),
         source_program: Some(program_flexi_counter::id()),
@@ -1566,6 +1568,7 @@ fn failing_undelegate_action(
     ];
 
     UndelegateType::WithBaseActions(vec![BaseAction {
+        id: 0,
         compute_units: 100_000,
         destination_program: program_flexi_counter::id(),
         source_program: Some(program_flexi_counter::id()),

--- a/test-integration/test-committor-service/tests/test_transaction_preparator.rs
+++ b/test-integration/test-committor-service/tests/test_transaction_preparator.rs
@@ -180,6 +180,7 @@ async fn test_prepare_commit_tx_with_base_actions() {
     // Create test data
     let committed_account = create_committed_account(&[1, 2, 3]);
     let base_action = BaseAction {
+        id: 0,
         compute_units: 30_000,
         destination_program: system_program::id(),
         source_program: None,


### PR DESCRIPTION
<!--
PR title must match: type(scope): summary
Types: feat|fix|docs|chore|refactor|test|perf|ci|build
Examples:
  fix: avoid panic on empty slot
  feat(rpc): add getFoo endpoint
-->

## Summary
<!-- One sentence. Link to issue if applicable. -->
Add a stable per-action id  so actions can be addressed independently of their position in the bundle — positional indexing.
This is needed for coming patching of intents as we have to refer to actions somehow

## Breaking Changes
- [ ] None
- [x] Yes — migration path described below

@lucacillario During deploy we need to make sure that MagicContext is empty

## Test Plan
<!-- How you verified this works. e.g., "unit tests", "ran locally against testnet", "existing tests pass" -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Scheduled actions now use stable identifiers, improving action retrieval and callback association.
  * Action construction and scheduling support consistent identifier assignment across bundles.

* **Bug Fixes**
  * Improved reliability when locating actions during scheduling and callback processing.

* **Tests**
  * Updated unit and integration test fixtures to include action identifiers.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->