### PR TITLE
Fix active delegation clone race

### DIFF
--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -610,6 +610,7 @@ where
     ) -> bool {
         let active_delegation_satisfies_request =
             request.delegation_actions.is_empty()
+                && request.delegated_to_other.is_none()
                 && !request.needs_undelegation;
         self.accounts_bank
             .get_account(&request.pubkey)
@@ -797,6 +798,7 @@ where
                     };
                     let active_delegation_satisfies_request =
                         owned_request.delegation_actions.is_empty()
+                            && owned_request.delegated_to_other.is_none()
                             && !owned_request.needs_undelegation;
                     let is_empty_placeholder =
                         Self::is_empty_placeholder_account(

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -600,19 +600,27 @@ where
             .fetch_add(1, Ordering::Relaxed)
     }
 
+    fn account_is_actively_delegated(account: &AccountSharedData) -> bool {
+        account.delegated() && !account.undelegating()
+    }
+
     fn local_account_satisfies_clone_request(
         &self,
-        pubkey: &Pubkey,
-        request_account: &AccountSharedData,
+        request: &AccountCloneRequest,
     ) -> bool {
+        let active_delegation_satisfies_request =
+            request.delegation_actions.is_empty()
+                && !request.needs_undelegation;
         self.accounts_bank
-            .get_account(pubkey)
+            .get_account(&request.pubkey)
             .is_some_and(|account| {
                 let local_slot = account.remote_slot();
-                let request_slot = request_account.remote_slot();
-                local_slot > request_slot
+                let request_slot = request.account.remote_slot();
+                (active_delegation_satisfies_request
+                    && Self::account_is_actively_delegated(&account))
+                    || local_slot > request_slot
                     || (local_slot == request_slot
-                        && account == *request_account)
+                        && account.eq(&request.account))
             })
     }
 
@@ -748,11 +756,9 @@ where
 
         loop {
             if self.local_account_satisfies_clone_request(
-                &pubkey,
-                &request
+                request
                     .as_ref()
-                    .expect("request must be present before ownership claim")
-                    .account,
+                    .expect("request must be present before ownership claim"),
             ) {
                 metrics::inc_chainlink_clone_accounts_total(
                     fetch_origin,
@@ -789,6 +795,9 @@ where
                             Box::new(err),
                         ));
                     };
+                    let active_delegation_satisfies_request =
+                        owned_request.delegation_actions.is_empty()
+                            && !owned_request.needs_undelegation;
                     let is_empty_placeholder =
                         Self::is_empty_placeholder_account(
                             &owned_request.account,
@@ -801,7 +810,26 @@ where
                         Outcome::Success,
                     );
                     let result = self.cloner.clone_account(owned_request).await;
-                    if result.is_ok() {
+                    let reconciled_active_delegation = result.is_err()
+                        && active_delegation_satisfies_request
+                        && self.accounts_bank.get_account(&pubkey).is_some_and(
+                            |account| {
+                                Self::account_is_actively_delegated(&account)
+                            },
+                        );
+                    if reconciled_active_delegation {
+                        debug!(
+                            pubkey = %pubkey,
+                            error = ?result,
+                            "Clone request satisfied by concurrently active local delegation"
+                        );
+                        metrics::inc_chainlink_clone_accounts_total(
+                            fetch_origin,
+                            remote_result,
+                            clone_intent,
+                            ChainlinkCloneOutcome::Skipped,
+                        );
+                    } else if result.is_ok() {
                         metrics::inc_chainlink_clone_accounts_total(
                             fetch_origin,
                             remote_result,
@@ -840,14 +868,19 @@ where
                             Outcome::Error,
                         );
                     }
-                    let completion = if result.is_ok() {
-                        CloneCompletion::Success
-                    } else {
-                        CloneCompletion::Failed
-                    };
+                    let completion =
+                        if result.is_ok() || reconciled_active_delegation {
+                            CloneCompletion::Success
+                        } else {
+                            CloneCompletion::Failed
+                        };
                     self.finish_pending_clone(pubkey, completion);
                     guard.dismiss();
-                    return result;
+                    return if reconciled_active_delegation {
+                        Ok(Signature::default())
+                    } else {
+                        result
+                    };
                 }
                 CloneClaim::Waiter(rx) => match rx.await {
                     Ok(CloneCompletion::Success) => continue,

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -6454,6 +6454,61 @@ async fn test_delegated_clone_does_not_override_active_local_target() {
 }
 
 #[tokio::test]
+async fn test_failed_plain_clone_accepts_concurrent_active_delegation() {
+    init_logger();
+    let validator_keypair = Keypair::new();
+    const CURRENT_SLOT: u64 = 100;
+
+    let account_pubkey = random_pubkey();
+    let FetcherTestCtx {
+        accounts_bank,
+        cloner,
+        fetch_cloner,
+        ..
+    } = setup(
+        std::iter::empty::<(Pubkey, Account)>(),
+        CURRENT_SLOT,
+        validator_keypair.insecure_clone(),
+    )
+    .await;
+    cloner.set_clone_delay(Duration::from_millis(200));
+    cloner.set_fail_next_clone(true);
+
+    let mut remote_account = non_empty_account();
+    remote_account.set_remote_slot(CURRENT_SLOT + 1);
+    let mut request = account_clone_request(remote_account);
+    request.pubkey = account_pubkey;
+
+    let clone_task = tokio::spawn(async move {
+        fetch_cloner
+            .clone_account_with_ownership(
+                request,
+                AccountFetchOrigin::GetAccount,
+            )
+            .await
+    });
+    cloner.wait_for_account_clone_count(1).await;
+
+    let mut local_account = non_empty_account();
+    local_account.set_remote_slot(CURRENT_SLOT);
+    local_account.set_delegated(true);
+    accounts_bank.insert(account_pubkey, local_account);
+
+    clone_task
+        .await
+        .expect("clone task should complete")
+        .expect("active local delegation should satisfy the failed clone");
+
+    assert_eq!(cloner.clone_request_count(), 1);
+    let account = accounts_bank
+        .get_account(&account_pubkey)
+        .expect("delegated account should remain in bank");
+    assert!(account.delegated());
+    assert_eq!(account.remote_slot(), CURRENT_SLOT);
+    assert_eq!(account.data(), &[1, 2, 3, 4]);
+}
+
+#[tokio::test]
 async fn test_projected_ata_clone_request_from_eata_update_keeps_actions() {
     init_logger();
     let validator_keypair = Keypair::new();

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -6509,6 +6509,54 @@ async fn test_failed_plain_clone_accepts_concurrent_active_delegation() {
 }
 
 #[tokio::test]
+async fn test_other_validator_delegation_does_not_accept_active_local_account()
+{
+    init_logger();
+    let validator_keypair = Keypair::new();
+    const CURRENT_SLOT: u64 = 100;
+
+    let account_pubkey = random_pubkey();
+    let FetcherTestCtx {
+        accounts_bank,
+        cloner,
+        fetch_cloner,
+        ..
+    } = setup(
+        std::iter::empty::<(Pubkey, Account)>(),
+        CURRENT_SLOT,
+        validator_keypair.insecure_clone(),
+    )
+    .await;
+
+    let mut local_account = non_empty_account();
+    local_account.set_remote_slot(CURRENT_SLOT);
+    local_account.set_delegated(true);
+    accounts_bank.insert(account_pubkey, local_account);
+
+    let mut remote_account = non_empty_account();
+    remote_account.set_remote_slot(CURRENT_SLOT + 1);
+    let mut request = account_clone_request(remote_account);
+    request.pubkey = account_pubkey;
+    request.delegated_to_other = Some(random_pubkey());
+    cloner.set_fail_next_clone(true);
+
+    fetch_cloner
+        .clone_account_with_ownership(request, AccountFetchOrigin::GetAccount)
+        .await
+        .expect_err(
+            "another validator's delegation must not accept local state",
+        );
+
+    assert_eq!(cloner.clone_request_count(), 1);
+    assert!(
+        accounts_bank
+            .get_account(&account_pubkey)
+            .is_some_and(|account| account.delegated()),
+        "failed clone must not be reconciled as success"
+    );
+}
+
+#[tokio::test]
 async fn test_projected_ata_clone_request_from_eata_update_keeps_actions() {
     init_logger();
     let validator_keypair = Keypair::new();


### PR DESCRIPTION
## Problem

An action dependency clone can race with local account delegation. If the clone executes after the account becomes actively delegated, it fails with `AccountIsDelegated`; Chainlink then treats the dependency failure as a post-action failure and enters undelegation rescue, dropping actions that still need to run.

## Solution

Treat active, non-undelegating local state as satisfying actionless clone requests. Re-check this postcondition after failed submissions and complete clone waiters successfully when concurrent delegation won. Action-bearing failures and undelegation rescue remain unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account cloning behavior when an actively delegated local account already satisfies a clone request.
  * Clone operations now reconcile concurrent delegation states without incorrectly reporting failures.
  * Preserved the existing delegated account and associated remote slot information during reconciliation.

* **Tests**
  * Added coverage for failed clone attempts that overlap with active delegation, confirming the operation completes successfully without duplicate requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->