### PR TITLE
fix: do not warn about the first false positive blockhash divergence

### DIFF
--- a/.agents/specs/validator-specification.md
+++ b/.agents/specs/validator-specification.md
@@ -119,6 +119,8 @@ Inside this repository, RPC/router-equivalent paths must preserve the same effec
 
 The transaction scheduler runs on a dedicated OS thread and uses a pool of executor workers. This is a critical performance path: preserve low-latency scheduling, bounded lock contention, and parallel execution for unrelated accounts. Do not add blocking I/O, unbounded work, excessive logging, or avoidable allocation/serialization to scheduler or executor hot paths unless there is no viable alternative, and explicitly document any unavoidable tradeoff.
 
+In replica mode, the scheduler compares each replicated blockhash with its local streaming hash. The first replicated block after scheduler startup is exempt from divergence logging because its predecessor may not be reconstructible after a restart. This exemption is consumed even when the hashes match and is not reset by later primary/replica mode transitions; every subsequent mismatch remains an error.
+
 This path is also security-critical. Atomic, all-or-nothing account lock acquisition (step 3 below) is what prevents concurrent transactions from racing on the same accounts; it must never be relaxed into partial or non-atomic locking. Because untrusted clients drive this loop, also guard against attacker-triggerable stalls and resource exhaustion: keep work bounded, never let one transaction block the scheduler indefinitely, and never let lock release/queueing leave the scheduler deadlocked.
 
 Required behavior:

--- a/magicblock-processor/src/scheduler/mod.rs
+++ b/magicblock-processor/src/scheduler/mod.rs
@@ -118,6 +118,8 @@ pub struct TransactionScheduler {
     pause_permit: Arc<Semaphore>,
     /// Streaming blockhash state
     hasher: Hasher,
+    /// Whether the next replicated block is the first one after startup.
+    is_initial_replica_block: bool,
     /// Time interval between consecutive slots
     slot_ticker: Interval,
     /// Number of slots to elapse, before we perform snapshot/checksum operations
@@ -181,6 +183,7 @@ impl TransactionScheduler {
             pause_permit: state.pause_permit,
             superblock_size: state.superblock_size,
             hasher,
+            is_initial_replica_block: true,
             slot_ticker,
             slot,
             index: 0,
@@ -600,17 +603,11 @@ impl TransactionScheduler {
     }
 
     /// Checks that the blockhash received from replication stream matches the local
-    fn verify_block_as_replica(&self, block: &LatestBlockInner) {
-        if block.blockhash.as_ref() != self.hasher.finalize().as_bytes() {
-            // TODO(bmuddha):
-            // this should never happen, and it's unclear how
-            // to recover from it, right now the log is used
-            // for debugging purposes only
-            // NOTE:
-            // This may still be logged once when a replica starts up with an
-            // empty ledger (no previous blockhash to seed from). A mid-slot
-            // restart no longer triggers it: reconstruct_inprogress_hasher
-            // rebuilds the accumulator from the persisted in-progress slot.
+    fn verify_block_as_replica(&mut self, block: &LatestBlockInner) {
+        let is_initial = std::mem::take(&mut self.is_initial_replica_block);
+        if !is_initial
+            && block.blockhash.as_ref() != self.hasher.finalize().as_bytes()
+        {
             error!(
                 slot = block.slot,
                 "replication blockhash has diverged from local"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved replica-mode block verification during scheduler startup.
  * The first replicated block is now exempt from divergence warnings while startup state is reconstructed.
  * Subsequent replicated blocks continue to be checked, with mismatches reported as errors.
  * The startup exemption is consumed once and is not restored by later mode changes.

* **Documentation**
  * Updated the scheduler security and performance specification to document the replica-mode verification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->