### PR TITLE
feat: send transactions directly to leader TPU

### DIFF
--- a/.agents/context/crates/magicblock-rpc-client.md
+++ b/.agents/context/crates/magicblock-rpc-client.md
@@ -7,7 +7,7 @@
 High-level responsibilities:
 
 - wrap an existing `Arc<solana_rpc_client::nonblocking::rpc_client::RpcClient>` in a cheap-to-clone `MagicblockRpcClient`;
-- send base-layer transactions with MagicBlock defaults (`skip_preflight: true`, base64 encoding) and optional processed/committed confirmation;
+- send base-layer transactions concurrently through JSON-RPC and, when a WebSocket URL is configured, directly to current/upcoming leader TPUs, with optional processed/committed confirmation;
 - coalesce concurrent signature-status polling and optionally use `signatureSubscribe` websocket notifications before falling back to batched polling;
 - cache recent blockhashes and slots briefly to reduce base-layer RPC load in high-volume settlement flows;
 - batch `getMultipleAccounts` requests so callers do not exceed RPC provider input limits;
@@ -81,6 +81,7 @@ The crate name is `magicblock-rpc-client`; the main type is spelled `MagicblockR
 - an internal blockhash/slot cache protected by Tokio mutexes;
 - optional `Arc<AtomicU64>` `chain_slot` for sharing the highest observed base-layer slot with other services;
 - an internal `SignatureConfirmer` for send confirmation.
+- a lazily initialized Solana TPU client when a WebSocket URL is available.
 
 Constructors:
 
@@ -141,7 +142,10 @@ Retry policy is intentionally conservative: IO errors, HTTP 5xx send errors, lat
 ```text
 caller builds/signs tx
   -> MagicblockRpcClient::send_transaction(tx, config)
-  -> RpcClient::send_transaction_with_config(tx, SEND_TRANSACTION_CONFIG)
+  -> concurrently:
+       RpcClient::send_transaction_with_config(tx, SEND_TRANSACTION_CONFIG)
+       TpuClient::send_wire_transaction(serialized tx)
+  -> accept either successful delivery (RPC is preferred when both succeed)
   -> if config == Send: return signature-only outcome
   -> wait_for_processed_status(signature, tx.recent_blockhash, ...)
   -> optionally wait_for_confirmed_status(signature, client.commitment(), ...)
@@ -151,10 +155,11 @@ caller builds/signs tx
 Important details:
 
 1. `send_transaction` always submits with `skip_preflight: true`; validation must come from callers, transaction construction, and post-send status checks.
-2. The processed wait uses `CommitmentConfig::processed()` regardless of the underlying client commitment.
-3. The committed wait uses `self.client.commitment()`, so construction sites must choose the desired commitment level on the underlying Solana `RpcClient`.
-4. Durable nonce transactions are explicitly unsupported by this helper because confirmation uses the transaction's recent blockhash.
-5. If processed status returns a transaction error, `send_transaction` returns `SentTransactionError` immediately and does not continue to the committed wait.
+2. A configured WebSocket URL enables lazy TPU leader discovery. TPU initialization or delivery failure is non-fatal while RPC delivery succeeds; if RPC delivery fails after TPU delivery succeeds, confirmation continues using the transaction's existing signature.
+3. The processed wait uses `CommitmentConfig::processed()` regardless of the underlying client commitment.
+4. The committed wait uses `self.client.commitment()`, so construction sites must choose the desired commitment level on the underlying Solana `RpcClient`.
+5. Durable nonce transactions are explicitly unsupported by this helper because confirmation uses the transaction's recent blockhash.
+6. If processed status returns a transaction error, `send_transaction` returns `SentTransactionError` immediately and does not continue to the committed wait.
 
 ### Signature confirmation with websocket fallback
 
@@ -212,6 +217,10 @@ Slot reads are cached for `400ms` in `get_cached_slot()`, and both fetched slots
 
 Avoid holding the `PollState` mutex across RPC calls. The current implementation snapshots signatures while locked, drops the lock for network I/O, then re-locks to apply statuses. Preserve that shape to avoid blocking new waiters and timeout cleanup behind remote RPC latency.
 
+### TPU future type erasure
+
+The TPU send future in `MagicblockRpcClient::send_transaction` is deliberately boxed behind `TpuSendFuture`. Do not inline the concrete Solana TPU leader-discovery/QUIC future into this generic async method: doing so makes every committor caller's state machine deeply nested and causes rustc query-depth overflow while compiling `magicblock-committor-service`.
+
 ### Commitment handling
 
 `status_result_for_commitment` only returns a result when the fetched `TransactionStatus` satisfies the requested commitment. This applies to errors as well as successes: a processed transaction error does not satisfy a confirmed waiter until Solana reports a status that satisfies confirmed commitment. Unit coverage exists for this behavior in `transaction_errors_wait_for_requested_commitment`.
@@ -238,9 +247,10 @@ This crate owns local confirmation and signature-status instrumentation call sit
 6. Do not hold async mutexes across Solana RPC/pubsub network calls.
 7. Blockhash and slot caches must be short-lived and monotonic where applicable; `chain_slot` updates must never move the observed slot backward.
 8. `get_multiple_accounts*` must preserve input order and output cardinality after chunking.
-9. `get_account` must continue to map Solana `AccountNotFound` user errors to `Ok(None)` rather than a hard error.
-10. ALT helpers must fail loudly on deserialization errors instead of treating malformed accounts as missing.
-11. Retry helpers must preserve caller-owned domain error mapping and must not hide unrecoverable transaction errors behind infinite retries.
+9. Direct TPU delivery must remain additive to RPC delivery: an unavailable TPU path must not prevent the existing RPC path, and either successful transport must be eligible for the existing confirmation flow.
+10. `get_account` must continue to map Solana `AccountNotFound` user errors to `Ok(None)` rather than a hard error.
+11. ALT helpers must fail loudly on deserialization errors instead of treating malformed accounts as missing.
+12. Retry helpers must preserve caller-owned domain error mapping and must not hide unrecoverable transaction errors behind infinite retries.
 12. Public error variants that carry signatures must continue to return them from `MagicBlockRpcClientError::signature()`.
 
 ## Common change areas and what to inspect

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -569,6 +569,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
 
 [[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "assert_matches"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -584,6 +623,17 @@ dependencies = [
  "compression-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -743,6 +793,12 @@ checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -817,6 +873,9 @@ name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "bitvec"
@@ -1044,6 +1103,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "caps"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd1ddba47aba30b6a889298ad0109c3b8dcb0e8fc993b459daa7067d46f865e0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "cassowary"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1069,6 +1137,12 @@ dependencies = [
  "libc",
  "shlex 2.0.1",
 ]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cexpr"
@@ -1203,6 +1277,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "compact_str"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1233,6 +1317,15 @@ name = "compression-core"
 version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "console"
@@ -1395,6 +1488,25 @@ name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1601,6 +1713,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
 
 [[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1615,6 +1740,20 @@ dependencies = [
  "const-oid",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint 0.4.6",
+ "num-traits",
+ "rusticata-macros",
 ]
 
 [[package]]
@@ -1703,6 +1842,29 @@ name = "displaydoc"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "dlopen2"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e2c5bd4158e66d1e215c49b837e11d62f3267b30c92f1d171c4d3105e3dc4d4"
+dependencies = [
+ "dlopen2_derive",
+ "libc",
+ "once_cell",
+ "winapi",
+]
+
+[[package]]
+name = "dlopen2_derive"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fbbb781877580993a8707ec48672673ec7b81eeba04cfd2310bd28c08e47c8f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1925,7 +2087,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1939,6 +2122,18 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fastbloom"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
+dependencies = [
+ "getrandom 0.3.4",
+ "libm",
+ "rand 0.9.4",
+ "siphasher 1.0.3",
+]
 
 [[package]]
 name = "fastrand"
@@ -2445,6 +2640,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -2530,6 +2731,12 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "histogram"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12cb882ccb290b8646e554b157ab0b71e64e8d5bef775cd66b6531e52d302669"
 
 [[package]]
 name = "hmac"
@@ -3025,6 +3232,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine 4.6.7",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3186,6 +3437,12 @@ dependencies = [
  "cfg-if",
  "windows-link",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "librocksdb-sys"
@@ -4017,12 +4274,14 @@ name = "magicblock-rpc-client"
 version = "0.13.5"
 dependencies = [
  "async-trait",
+ "bincode",
  "futures-util",
  "magicblock-metrics",
  "serde_json",
  "solana-account 3.4.0",
  "solana-account-decoder-client-types",
  "solana-address-lookup-table-interface 3.0.1",
+ "solana-client",
  "solana-clock 3.1.0",
  "solana-commitment-config",
  "solana-hash 4.2.0",
@@ -4336,6 +4595,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
 name = "nkeys"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4560,6 +4832,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4646,6 +4927,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4710,6 +4997,15 @@ dependencies = [
  "proc-macro2-diagnostics",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "pem"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
+dependencies = [
+ "base64 0.13.1",
 ]
 
 [[package]]
@@ -4970,7 +5266,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -4991,7 +5287,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -5192,6 +5488,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
+ "fastbloom",
  "getrandom 0.3.4",
  "lru-slab",
  "rand 0.9.4",
@@ -5199,6 +5496,7 @@ dependencies = [
  "rustc-hash 2.1.2",
  "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "slab",
  "thiserror 2.0.18",
  "tinyvec",
@@ -5384,6 +5682,26 @@ dependencies = [
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -5671,6 +5989,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5693,7 +6020,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5754,6 +6081,33 @@ dependencies = [
  "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs 0.8.4",
+ "rustls-platform-verifier-android",
+ "rustls-webpki 0.103.13",
+ "security-framework 3.7.0",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -6619,6 +6973,75 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-client"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f316a7ffb4eb715e1561237b87d51c1ec01275c331308ec9c7ab44f9ad23cc"
+dependencies = [
+ "async-trait",
+ "bincode",
+ "dashmap",
+ "futures",
+ "futures-util",
+ "indexmap 2.14.0",
+ "indicatif",
+ "log",
+ "quinn",
+ "rayon",
+ "solana-account 3.4.0",
+ "solana-client-traits",
+ "solana-commitment-config",
+ "solana-connection-cache",
+ "solana-epoch-info",
+ "solana-hash 4.2.0",
+ "solana-instruction 3.3.0",
+ "solana-keypair",
+ "solana-measure",
+ "solana-message 3.1.0",
+ "solana-net-utils",
+ "solana-pubkey 4.1.0",
+ "solana-pubsub-client",
+ "solana-quic-client",
+ "solana-rpc-client",
+ "solana-rpc-client-api",
+ "solana-rpc-client-nonce-utils",
+ "solana-signature 3.3.0",
+ "solana-signer",
+ "solana-streamer",
+ "solana-time-utils",
+ "solana-tls-utils",
+ "solana-tpu-client",
+ "solana-transaction",
+ "solana-transaction-error 3.1.0",
+ "solana-transaction-status-client-types",
+ "solana-udp-client",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "solana-client-traits"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08618ed587e128105510c54ae3e456b9a06d674d8640db75afe66dad65cb4e02"
+dependencies = [
+ "solana-account 3.4.0",
+ "solana-commitment-config",
+ "solana-epoch-info",
+ "solana-hash 3.1.0",
+ "solana-instruction 3.3.0",
+ "solana-keypair",
+ "solana-message 3.1.0",
+ "solana-pubkey 3.0.0",
+ "solana-signature 3.3.0",
+ "solana-signer",
+ "solana-system-interface 2.0.0",
+ "solana-transaction",
+ "solana-transaction-error 3.1.0",
+]
+
+[[package]]
 name = "solana-clock"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6729,6 +7152,29 @@ dependencies = [
  "solana-sdk-ids 3.1.0",
  "solana-short-vec 3.2.2",
  "solana-system-interface 2.0.0",
+]
+
+[[package]]
+name = "solana-connection-cache"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23dba82683e7a28bdf3ac5fca5be0b13b1b5231ea5e23c63b3a56d2ea273270d"
+dependencies = [
+ "async-trait",
+ "bincode",
+ "crossbeam-channel",
+ "futures-util",
+ "indexmap 2.14.0",
+ "log",
+ "rand 0.9.4",
+ "rayon",
+ "solana-keypair",
+ "solana-measure",
+ "solana-metrics",
+ "solana-time-utils",
+ "solana-transaction-error 3.1.0",
+ "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]
@@ -7409,6 +7855,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-measure"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebf38d1683798dc078c6d060cf283418c20aefc72055d4f1aa9a9dad40b3237f"
+
+[[package]]
 name = "solana-message"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7453,9 +7905,9 @@ dependencies = [
 
 [[package]]
 name = "solana-metrics"
-version = "4.0.3"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384f785e618935dbd92a8d2020c82f2d73746cd12822246604f3707e0f6fcc06"
+checksum = "7fc50a91b4ba7244fb3724c989e9fd4a348493dac8ee0779304515cf1eb7b312"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
@@ -7496,6 +7948,29 @@ name = "solana-native-token"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae8dd4c280dca9d046139eb5b7a5ac9ad10403fbd64964c7d7571214950d758f"
+
+[[package]]
+name = "solana-net-utils"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c00275a5d891fe8306e69d899ff5b96efbbe185cc96f8b8c32827c69f345a6b0"
+dependencies = [
+ "anyhow",
+ "bincode",
+ "bytes",
+ "cfg-if",
+ "dashmap",
+ "itertools 0.14.0",
+ "log",
+ "nix",
+ "rand 0.9.4",
+ "serde",
+ "socket2",
+ "solana-serde",
+ "solana-svm-type-overrides",
+ "tokio",
+ "url",
+]
 
 [[package]]
 name = "solana-nonce"
@@ -7577,8 +8052,46 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ad62e1045c2347a0c0e219a6ceb0abfe904be622920996bfcac8d116fabe3c7"
 dependencies = [
+ "bincode",
  "bitflags 2.13.0",
+ "cfg_eval",
+ "serde",
+ "serde_derive",
+ "serde_with",
  "solana-pubkey 4.1.0",
+]
+
+[[package]]
+name = "solana-perf"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2505e28e6b7674d6a69f746b7a926fa8b96ffde74ecccfc26aed244ff5bf6d87"
+dependencies = [
+ "ahash 0.8.12",
+ "bincode",
+ "bv",
+ "bytes",
+ "caps",
+ "curve25519-dalek 4.1.3",
+ "dlopen2",
+ "fnv",
+ "libc",
+ "log",
+ "nix",
+ "num_cpus",
+ "rand 0.9.4",
+ "rayon",
+ "serde",
+ "solana-hash 4.2.0",
+ "solana-message 3.1.0",
+ "solana-metrics",
+ "solana-packet 4.1.0",
+ "solana-pubkey 4.1.0",
+ "solana-sdk-ids 3.1.0",
+ "solana-short-vec 3.2.2",
+ "solana-signature 3.3.0",
+ "solana-time-utils",
+ "solana-transaction-context",
 ]
 
 [[package]]
@@ -7958,6 +8471,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-quic-client"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a43fb7fb4b31e56cf44d65d40bba4f4f66d92e248924cd9b9bddc57b0289376"
+dependencies = [
+ "async-lock",
+ "async-trait",
+ "futures",
+ "itertools 0.14.0",
+ "log",
+ "quinn",
+ "quinn-proto",
+ "rustls",
+ "solana-connection-cache",
+ "solana-keypair",
+ "solana-measure",
+ "solana-metrics",
+ "solana-net-utils",
+ "solana-pubkey 4.1.0",
+ "solana-rpc-client-api",
+ "solana-signer",
+ "solana-streamer",
+ "solana-tls-utils",
+ "solana-transaction-error 3.1.0",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
 name = "solana-rent"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8064,6 +8606,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-rpc-client-nonce-utils"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f9c7fdb241c37d6a71e7e3ef7fd5bb5734ef53b72d8208774dc52eca12d241"
+dependencies = [
+ "solana-account 3.4.0",
+ "solana-commitment-config",
+ "solana-hash 4.2.0",
+ "solana-message 3.1.0",
+ "solana-nonce 3.1.0",
+ "solana-pubkey 4.1.0",
+ "solana-rpc-client",
+ "solana-sdk-ids 3.1.0",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "solana-rpc-client-types"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8109,7 +8668,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "733b3657a0fab205102b799dbe17f85d3972cf984232c1b0b108fa6ba438e382"
 dependencies = [
  "byteorder",
- "combine",
+ "combine 3.8.1",
  "hash32",
  "libc",
  "log",
@@ -8540,6 +9099,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-streamer"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a07932bc815870b57aba2861cbffc976a7c9a89cb189b08930c05571daf409"
+dependencies = [
+ "arc-swap",
+ "bytes",
+ "crossbeam-channel",
+ "dashmap",
+ "futures",
+ "futures-util",
+ "histogram",
+ "indexmap 2.14.0",
+ "itertools 0.14.0",
+ "libc",
+ "log",
+ "nix",
+ "num_cpus",
+ "pem",
+ "percentage",
+ "quinn",
+ "quinn-proto",
+ "rand 0.9.4",
+ "rustls",
+ "smallvec",
+ "socket2",
+ "solana-keypair",
+ "solana-measure",
+ "solana-metrics",
+ "solana-net-utils",
+ "solana-packet 4.1.0",
+ "solana-perf",
+ "solana-pubkey 4.1.0",
+ "solana-signature 3.3.0",
+ "solana-signer",
+ "solana-time-utils",
+ "solana-tls-utils",
+ "solana-transaction-error 3.1.0",
+ "solana-transaction-metrics-tracker",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "x509-parser",
+]
+
+[[package]]
 name = "solana-svm"
 version = "4.0.0"
 source = "git+https://github.com/magicblock-labs/magicblock-svm.git?rev=190146af2ac0890848b50e8fc9d6c926c8205b5e#190146af2ac0890848b50e8fc9d6c926c8205b5e"
@@ -8834,6 +9439,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ced92c60aa76ec4780a9d93f3bd64dfa916e1b998eacc6f1c110f3f444f02c9"
 
 [[package]]
+name = "solana-tls-utils"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "066a26be63977ea6c32cb6815fa08e8543ccc83a1d58b469aee1b9c3973b9231"
+dependencies = [
+ "rustls",
+ "solana-keypair",
+ "solana-pubkey 4.1.0",
+ "solana-signer",
+ "x509-parser",
+]
+
+[[package]]
+name = "solana-tpu-client"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4564457a239ffa434fc92004b0de846779c00e05b106ab2e113f7384e4bf1115"
+dependencies = [
+ "async-trait",
+ "bincode",
+ "futures-util",
+ "indexmap 2.14.0",
+ "indicatif",
+ "log",
+ "rayon",
+ "solana-client-traits",
+ "solana-clock 3.1.0",
+ "solana-commitment-config",
+ "solana-connection-cache",
+ "solana-epoch-schedule 3.0.0",
+ "solana-measure",
+ "solana-message 3.1.0",
+ "solana-net-utils",
+ "solana-pubkey 4.1.0",
+ "solana-pubsub-client",
+ "solana-rpc-client",
+ "solana-rpc-client-api",
+ "solana-signature 3.3.0",
+ "solana-signer",
+ "solana-transaction",
+ "solana-transaction-error 3.1.0",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
 name = "solana-transaction"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8892,6 +9543,22 @@ dependencies = [
  "serde_derive",
  "solana-instruction-error",
  "solana-sanitize 3.0.1",
+]
+
+[[package]]
+name = "solana-transaction-metrics-tracker"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bece8b460e55e966a1898cba2fd718a65f7277a388035be0f830123e93057134"
+dependencies = [
+ "base64 0.22.1",
+ "bincode",
+ "log",
+ "rand 0.9.4",
+ "solana-packet 4.1.0",
+ "solana-perf",
+ "solana-short-vec 3.2.2",
+ "solana-signature 3.3.0",
 ]
 
 [[package]]
@@ -8959,6 +9626,22 @@ dependencies = [
  "solana-transaction-context",
  "solana-transaction-error 3.1.0",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "solana-udp-client"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fc3d4e54fae3c8378e7c556fff74b1866af5ab7fef46234521dc5040eab0ec"
+dependencies = [
+ "async-trait",
+ "solana-connection-cache",
+ "solana-keypair",
+ "solana-net-utils",
+ "solana-streamer",
+ "solana-transaction-error 3.1.0",
+ "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]
@@ -9594,7 +10277,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10504,6 +11187,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10543,7 +11235,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10691,6 +11383,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -10714,6 +11415,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -10760,6 +11476,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -10772,6 +11494,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -10781,6 +11509,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -10808,6 +11542,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -10817,6 +11557,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -10832,6 +11578,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -10841,6 +11593,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -10891,6 +11649,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -203,6 +203,7 @@ solana-bpf-loader-program = { version = "=4.0.0", features = [
     "agave-unstable-api",
 ] }
 solana-clock = { version = "3.0" }
+solana-client = { version = "=4.0.0", features = ["agave-unstable-api"] }
 solana-cluster-type = { version = "3.1" }
 solana-commitment-config = { version = "3.1" }
 solana-compute-budget = { version = "=4.0.0", features = [
@@ -246,7 +247,9 @@ solana-program = "3.0"
 solana-program-error = { version = "3.0" }
 solana-program-option = { version = "3.0" }
 solana-program-pack = { version = "3.0" }
-solana-program-runtime = { git = "https://github.com/magicblock-labs/magicblock-svm.git", rev = "190146af2ac0890848b50e8fc9d6c926c8205b5e" }
+solana-program-runtime = { git = "https://github.com/magicblock-labs/magicblock-svm.git", rev = "190146af2ac0890848b50e8fc9d6c926c8205b5e", features = [
+    "agave-unstable-api",
+] }
 solana-pubkey = { version = "4.1" }
 solana-pubsub-client = { version = "4.0" }
 solana-rent = { version = "3.0" }

--- a/magicblock-rpc-client/Cargo.toml
+++ b/magicblock-rpc-client/Cargo.toml
@@ -12,7 +12,9 @@ doctest = false
 
 [dependencies]
 tracing = { workspace = true }
+bincode = { workspace = true }
 magicblock-metrics = { workspace = true }
+solana-client = { workspace = true }
 solana-pubsub-client = { workspace = true }
 solana-rpc-client = { workspace = true }
 solana-rpc-client-api = { workspace = true }

--- a/magicblock-rpc-client/src/lib.rs
+++ b/magicblock-rpc-client/src/lib.rs
@@ -5,6 +5,8 @@ pub mod utils;
 
 use std::{
     collections::HashMap,
+    future::Future,
+    pin::Pin,
     sync::{
         atomic::{AtomicU64, Ordering},
         Arc,
@@ -19,6 +21,9 @@ use solana_account::Account;
 use solana_account_decoder_client_types::UiAccountEncoding;
 use solana_address_lookup_table_interface::state::{
     AddressLookupTable, LookupTableMeta,
+};
+use solana_client::{
+    nonblocking::tpu_client::TpuClient, tpu_client::TpuClientConfig,
 };
 use solana_clock::Slot;
 use solana_commitment_config::{CommitmentConfig, CommitmentLevel};
@@ -41,7 +46,7 @@ use solana_transaction_error::{TransactionError, TransactionResult};
 use solana_transaction_status_client_types::{
     EncodedConfirmedTransactionWithStatusMeta, UiTransactionEncoding,
 };
-use tokio::sync::Mutex as TMutex;
+use tokio::sync::{Mutex as TMutex, OnceCell};
 use tracing::*;
 
 /// The encoding to use when sending transactions
@@ -89,6 +94,9 @@ pub enum MagicBlockRpcClientError {
     #[error("Sent transaction {1} but got error: {0:?}")]
     SentTransactionError(TransactionError, Signature),
 }
+
+type TpuSendFuture<'a> = Pin<Box<dyn Future<Output = bool> + Send + 'a>>;
+type TpuSendFn = Arc<dyn Fn(Vec<u8>) -> TpuSendFuture<'static> + Send + Sync>;
 
 impl From<solana_rpc_client_api::client_error::Error>
     for MagicBlockRpcClientError
@@ -276,6 +284,8 @@ pub struct MagicblockRpcClient {
     cache: Arc<RpcClientCache>,
     chain_slot: Option<Arc<AtomicU64>>,
     confirmer: Arc<SignatureConfirmer>,
+    tpu_sender: Arc<OnceCell<Option<TpuSendFn>>>,
+    websocket_url: Option<String>,
 }
 
 impl From<RpcClient> for MagicblockRpcClient {
@@ -319,14 +329,47 @@ impl MagicblockRpcClient {
     ) -> Self {
         let confirmer = Arc::new(SignatureConfirmer::new(
             client.clone(),
-            SignatureConfirmerConfig::with_websocket_url(websocket_url),
+            SignatureConfirmerConfig::with_websocket_url(websocket_url.clone()),
         ));
         Self {
             client,
             cache: Arc::new(RpcClientCache::default()),
             chain_slot,
             confirmer,
+            tpu_sender: Arc::new(OnceCell::new()),
+            websocket_url,
         }
+    }
+
+    async fn tpu_sender(&self) -> Option<&TpuSendFn> {
+        self.tpu_sender
+            .get_or_init(|| async {
+                let websocket_url = self.websocket_url.as_deref()?;
+                match TpuClient::new(
+                    "magicblock-rpc-client",
+                    self.client.clone(),
+                    websocket_url,
+                    TpuClientConfig::default(),
+                )
+                .await
+                {
+                    Ok(client) => {
+                        let client = Arc::new(client);
+                        Some(Arc::new(move |wire_transaction| {
+                            let client = client.clone();
+                            Box::pin(async move {
+                                client.send_wire_transaction(wire_transaction).await
+                            }) as TpuSendFuture<'static>
+                        }) as TpuSendFn)
+                    }
+                    Err(err) => {
+                        warn!(?err, "Failed to initialize leader TPU client; continuing with RPC delivery");
+                        None
+                    }
+                }
+            })
+            .await
+            .as_ref()
     }
 
     pub async fn get_latest_blockhash(
@@ -650,13 +693,38 @@ impl MagicblockRpcClient {
         tx: &impl SerializableTransaction,
         config: &MagicBlockSendTransactionConfig,
     ) -> MagicBlockRpcClientResult<MagicBlockSendTransactionOutcome> {
-        let sig = self
+        let wire_transaction = bincode::serialize(tx).ok();
+        let rpc_send = self
             .client
-            .send_transaction_with_config(tx, SEND_TRANSACTION_CONFIG)
-            .await
-            .map_err(|e| {
-                MagicBlockRpcClientError::SendTransaction(Box::new(e))
-            })?;
+            .send_transaction_with_config(tx, SEND_TRANSACTION_CONFIG);
+        // Type-erase this future so every generic transaction caller does not
+        // inherit the deeply nested TPU client future in its async state machine.
+        let tpu_send: TpuSendFuture<'_> = Box::pin(async {
+            let Some(wire_transaction) = wire_transaction else {
+                warn!(
+                    "Failed to serialize transaction for leader TPU delivery"
+                );
+                return false;
+            };
+            let Some(tpu_sender) = self.tpu_sender().await else {
+                return false;
+            };
+            tpu_sender(wire_transaction).await
+        });
+
+        let (rpc_result, tpu_sent) = tokio::join!(rpc_send, tpu_send);
+        let sig = match rpc_result {
+            Ok(signature) => signature,
+            Err(err) if tpu_sent => {
+                warn!(?err, "RPC transaction delivery failed after leader TPU delivery succeeded");
+                *tx.get_signature()
+            }
+            Err(err) => {
+                return Err(MagicBlockRpcClientError::SendTransaction(
+                    Box::new(err),
+                ));
+            }
+        };
 
         let MagicBlockSendTransactionConfig::SendAndConfirm {
             wait_for_processed_level,


### PR DESCRIPTION
Implemented direct leader TPU transaction delivery while keeping the existing RPC load-balancer path as a fallback.

 ## Changes:

  - added the Solana TPU client dependency
  - initialized TPU leader discovery from the configured WebSocket endpoint
  - submitted transactions concurrently through RPC and current/upcoming leader TPUs
  - preserved confirmation when either delivery path succeeds
  - kept RPC delivery working when TPU initialization or submission fails
  - enabled the required Agave unstable API feature
  - type-erased the TPU future to prevent compiler query-depth errors
  - updated agent documentation

 ## Validation:

  - make fmt
  - cargo check -p magicblock-committor-service
  - cargo clippy -p magicblock-rpc-client --all-targets -- -D warnings
  - cargo test -p magicblock-rpc-client
  - git diff --check

 Part of  #749.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transactions can now be delivered concurrently through RPC and, when configured, directly to Solana leader TPUs.
  * RPC delivery remains preferred when both paths succeed.
  * Successful TPU delivery can allow confirmation to continue if RPC submission fails.

* **Documentation**
  * Updated transaction submission and confirmation guidance, including delivery behavior and reliability guarantees.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->