### PR TITLE
fix: increase RPC fetch retries to survive RPC lag behind pubsub tip

### DIFF
--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -515,7 +515,9 @@ unsafe impl Sync for ForwardedSubscriptionUpdate {}
 
 // Not sure why helius uses a different code for this error
 const HELIUS_CONTEXT_SLOT_NOT_REACHED: i64 = -32603;
-const RPC_FETCH_MAX_RETRIES: u64 = 3;
+// Retries must ride out the RPC lagging the pubsub tip by several seconds (15 = ~5.6s),
+// otherwise one-shot subscription updates (e.g. program upgrades) could be dropped
+const RPC_FETCH_MAX_RETRIES: u64 = 15;
 const RPC_FETCH_RETRY_DELAY: Duration = Duration::from_millis(400);
 const RPC_FETCH_TIMEOUT: Duration = Duration::from_secs(5);
 const MATCH_SLOTS_MAX_TOTAL_TIME: Duration = Duration::from_secs(10);


### PR DESCRIPTION
## Problem

When a subscription update arrives for an executable account (e.g. a program upgrade), the validator re-fetches the program + programdata with `min_context_slot` set to the update slot. The fetch retry budget (3 attempts, 400ms apart, ~0.85s total) may be shorter than the lag of the fetch RPC behind the pubsub/gRPC tip, so the fetch fails and the update is dropped permanently

## Fix

Increase `RPC_FETCH_MAX_RETRIES` from 3 to 15 (retry delay unchanged at 400ms), extending the min-context-slot chase window from ~0.85s to ~6s, which covers the observed RPC-behind-tip lag.