### PR TITLE
fix: evict accounts whose pubsub subscription cannot be re-established

### DIFF
--- a/magicblock-chainlink/src/remote_account_provider/chain_pubsub_actor.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_pubsub_actor.rs
@@ -324,7 +324,14 @@ impl ChainPubsubActor {
             .subscriptions
             .lock()
             .expect("subscriptions lock poisoned");
-        subs.keys().copied().collect()
+        // Dead or winding-down listeners are not live coverage.
+        subs.iter()
+            .filter(|(_, sub)| {
+                !sub.cancellation_token.is_cancelled()
+                    && !sub.completion_token.is_cancelled()
+            })
+            .map(|(pubkey, _)| *pubkey)
+            .collect()
     }
 
     pub async fn send_msg(
@@ -577,14 +584,36 @@ impl ChainPubsubActor {
         retries: Option<usize>,
         client_id: &str,
     ) {
-        if subs
-            .lock()
-            .expect("subscriptions lock poisoned")
-            .contains_key(&pubkey)
         {
-            trace!("Subscription already exists");
-            let _ = sub_response.send(Ok(()));
-            return;
+            let mut subs_lock =
+                subs.lock().expect("subscriptions lock poisoned");
+            match subs_lock.get(&pubkey) {
+                Some(sub)
+                    if !sub.cancellation_token.is_cancelled()
+                        && !sub.completion_token.is_cancelled() =>
+                {
+                    trace!("Subscription already exists");
+                    let _ = sub_response.send(Ok(()));
+                    return;
+                }
+                Some(sub) if sub.completion_token.is_cancelled() => {
+                    // Listener already finished: replace the orphaned entry
+                    // with a fresh subscription.
+                    subs_lock.remove(&pubkey);
+                }
+                Some(_) => {
+                    // Listener still winding down; fail so the caller retries.
+                    let _ = sub_response.send(Err(
+                        RemoteAccountProviderError::AccountSubscriptionsFailed(
+                            format!(
+                                "Subscription for {pubkey} is shutting down"
+                            ),
+                        ),
+                    ));
+                    return;
+                }
+                None => {}
+            }
         }
 
         trace!("Adding subscription");

--- a/magicblock-chainlink/src/remote_account_provider/chain_pubsub_actor.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_pubsub_actor.rs
@@ -588,28 +588,16 @@ impl ChainPubsubActor {
             let mut subs_lock =
                 subs.lock().expect("subscriptions lock poisoned");
             match subs_lock.get(&pubkey) {
-                Some(sub)
-                    if !sub.cancellation_token.is_cancelled()
-                        && !sub.completion_token.is_cancelled() =>
-                {
-                    trace!("Subscription already exists");
-                    let _ = sub_response.send(Ok(()));
-                    return;
-                }
                 Some(sub) if sub.completion_token.is_cancelled() => {
                     // Listener already finished: replace the orphaned entry
                     // with a fresh subscription.
                     subs_lock.remove(&pubkey);
                 }
                 Some(_) => {
-                    // Listener still winding down; fail so the caller retries.
-                    let _ = sub_response.send(Err(
-                        RemoteAccountProviderError::AccountSubscriptionsFailed(
-                            format!(
-                                "Subscription for {pubkey} is shutting down"
-                            ),
-                        ),
-                    ));
+                    // Active or winding down; a lost winding-down sub is
+                    // repaired by the reconciler.
+                    trace!("Subscription already exists");
+                    let _ = sub_response.send(Ok(()));
                     return;
                 }
                 None => {}

--- a/magicblock-chainlink/src/remote_account_provider/chain_pubsub_client.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_pubsub_client.rs
@@ -394,6 +394,7 @@ pub mod mock {
         pending_resubscribe_failures: Arc<Mutex<usize>>,
         pending_unsubscribe_failures: Arc<Mutex<usize>>,
         pending_program_subscribe_failures: Arc<Mutex<usize>>,
+        pending_silent_subscribe_noops: Arc<Mutex<usize>>,
         reconnectable: Arc<Mutex<bool>>,
         subscribe_blocked: Arc<Mutex<bool>>,
         subscribe_pause_after_insert: Arc<Mutex<bool>>,
@@ -423,6 +424,7 @@ pub mod mock {
                 pending_resubscribe_failures: Arc::new(Mutex::new(0)),
                 pending_unsubscribe_failures: Arc::new(Mutex::new(0)),
                 pending_program_subscribe_failures: Arc::new(Mutex::new(0)),
+                pending_silent_subscribe_noops: Arc::new(Mutex::new(0)),
                 reconnectable: Arc::new(Mutex::new(true)),
                 subscribe_blocked: Arc::new(Mutex::new(false)),
                 subscribe_pause_after_insert: Arc::new(Mutex::new(false)),
@@ -458,6 +460,12 @@ pub mod mock {
 
         pub fn fail_next_program_subscriptions(&self, n: usize) {
             *self.pending_program_subscribe_failures.lock() = n;
+        }
+
+        /// Next N subscribe() calls return Ok without registering the
+        /// subscription.
+        pub fn silently_noop_next_subscriptions(&self, n: usize) {
+            *self.pending_silent_subscribe_noops.lock() = n;
         }
 
         pub fn program_subscribe_attempts(&self) -> u64 {
@@ -634,6 +642,13 @@ pub mod mock {
                         "mock: subscribe while disconnected".to_string(),
                     ),
                 );
+            }
+            {
+                let mut to_noop = self.pending_silent_subscribe_noops.lock();
+                if *to_noop > 0 {
+                    *to_noop -= 1;
+                    return Ok(());
+                }
             }
             {
                 let mut subscribed_pubkeys = self.subscribed_pubkeys.lock();

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -441,8 +441,11 @@ impl From<SubscriptionReason> for SubscriptionReasonLabel {
     }
 }
 
+pub(crate) type SubscriptionOwnershipMap =
+    Arc<AsyncMutex<HashMap<Pubkey, SubscriptionOwnership>>>;
+
 #[derive(Debug, Default, Clone)]
-struct SubscriptionOwnership {
+pub(crate) struct SubscriptionOwnership {
     reasons: HashMap<SubscriptionReason, usize>,
 }
 
@@ -745,6 +748,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
         pubsub_client: Arc<PubsubClient>,
         removed_account_tx: mpsc::Sender<Pubkey>,
         subscription_key_locks: SubscriptionKeyLocks,
+        subscription_ownership: SubscriptionOwnershipMap,
         emit_metrics: bool,
     ) -> task::JoinHandle<()> {
         task::spawn(async move {
@@ -762,6 +766,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                         &never_evicted,
                         &removed_account_tx,
                         Some(&subscription_key_locks),
+                        Some(&subscription_ownership),
                     )
                     .await;
 
@@ -788,6 +793,8 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
             tokio::sync::mpsc::channel(100);
         let subscription_key_locks: SubscriptionKeyLocks =
             Arc::new(AsyncMutex::new(HashMap::new()));
+        let subscription_ownership: SubscriptionOwnershipMap =
+            Arc::new(AsyncMutex::new(HashMap::new()));
 
         // The reconciler always runs: partial resubscriptions rely on it for
         // repair. The config flag only gates the metrics emission.
@@ -797,13 +804,14 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                 Arc::new(pubsub_client.clone()),
                 removed_account_tx.clone(),
                 subscription_key_locks.clone(),
+                subscription_ownership.clone(),
                 config.enable_subscription_metrics(),
             ));
 
         let me = Self {
             fetching_accounts: Arc::<FetchingAccounts>::default(),
             next_fetching_account_generation: AtomicU64::default(),
-            subscription_ownership: Arc::new(AsyncMutex::new(HashMap::new())),
+            subscription_ownership,
             subscription_transition_lock: Arc::new(AsyncMutex::new(())),
             subscription_key_locks,
             rpc_client,

--- a/magicblock-chainlink/src/remote_account_provider/subscription_reconciler.rs
+++ b/magicblock-chainlink/src/remote_account_provider/subscription_reconciler.rs
@@ -11,7 +11,7 @@ use tracing::*;
 
 use super::{
     subscription_key_owned_guard_from_map, AccountsLruCache, ChainPubsubClient,
-    SubscriptionKeyLocks, SubscriptionOwnershipMap,
+    SubscriptionKeyLocks, SubscriptionOwnershipMap, SubscriptionReason,
 };
 use crate::remote_account_provider::RemoteAccountProviderError;
 
@@ -241,6 +241,16 @@ pub(crate) async fn reconcile_subscriptions<PubsubClient: ChainPubsubClient>(
                 .is_some_and(|s| s.union.contains(&pubkey));
             if delivered_somewhere {
                 continue;
+            }
+
+            // Undelegation tracking must stay watched until undelegation
+            // completes; keep the entry and retry next cycle.
+            if let Some(ownership) = subscription_ownership {
+                if ownership.lock().await.get(&pubkey).is_some_and(|own| {
+                    own.contains(SubscriptionReason::UndelegationTracking)
+                }) {
+                    continue;
+                }
             }
 
             // No client holds the subscription: evict so the account is
@@ -557,6 +567,44 @@ mod tests {
         assert!(!mock_client.subscriptions_union().contains(&pk));
         assert!(!lru.contains(&pk));
         assert_eq!(removed_rx.try_recv(), Ok(pk));
+    }
+
+    /// Accounts owned for undelegation tracking must never be evicted; they
+    /// are kept and retried on the next cycle.
+    #[tokio::test]
+    async fn test_undelegation_tracked_subscription_is_not_evicted() {
+        init_logger();
+
+        let (tx, rx) = mpsc::channel::<SubscriptionUpdate>(10);
+        let mock_client = ChainPubsubClientMock::new(tx, rx);
+
+        let lru = AccountsLruCache::new(NonZeroUsize::new(10).unwrap());
+        let pk = create_test_pubkey(1);
+        lru.add(pk);
+
+        let ownership: SubscriptionOwnershipMap = Default::default();
+        ownership
+            .lock()
+            .await
+            .entry(pk)
+            .or_default()
+            .acquire(SubscriptionReason::UndelegationTracking);
+
+        mock_client.silently_noop_next_subscriptions(1);
+
+        let (removed_tx, mut removed_rx) = mpsc::channel::<Pubkey>(10);
+        reconcile_subscriptions(
+            &lru,
+            &mock_client,
+            &[],
+            &removed_tx,
+            None,
+            Some(&ownership),
+        )
+        .await;
+
+        assert!(lru.contains(&pk));
+        assert!(removed_rx.try_recv().is_err());
     }
 
     /// Test case: Empty LRU should cause resubscribe of all LRU accounts if missing

--- a/magicblock-chainlink/src/remote_account_provider/subscription_reconciler.rs
+++ b/magicblock-chainlink/src/remote_account_provider/subscription_reconciler.rs
@@ -11,7 +11,7 @@ use tracing::*;
 
 use super::{
     subscription_key_owned_guard_from_map, AccountsLruCache, ChainPubsubClient,
-    SubscriptionKeyLocks,
+    SubscriptionKeyLocks, SubscriptionOwnershipMap,
 };
 use crate::remote_account_provider::RemoteAccountProviderError;
 
@@ -102,6 +102,7 @@ pub(crate) async fn reconcile_subscriptions<PubsubClient: ChainPubsubClient>(
     never_evicted: &[Pubkey],
     removed_account_tx: &mpsc::Sender<Pubkey>,
     subscription_key_locks: Option<&SubscriptionKeyLocks>,
+    subscription_ownership: Option<&SubscriptionOwnershipMap>,
 ) -> usize {
     let lru_pubkeys = subscribed_accounts.pubkeys();
     let lru_count = lru_pubkeys.len();
@@ -228,8 +229,42 @@ pub(crate) async fn reconcile_subscriptions<PubsubClient: ChainPubsubClient>(
                 continue;
             }
 
-            if let Err(e) = pubsub_client.subscribe(pubkey, None).await {
-                warn!(pubkey = %pubkey, error = ?e, "Failed to resubscribe account");
+            let resub_err = pubsub_client.subscribe(pubkey, None).await.err();
+            if let Some(err) = &resub_err {
+                warn!(pubkey = %pubkey, error = ?err, "Failed to resubscribe account");
+            }
+
+            // A subscription on any client keeps the account fresh; later
+            // cycles repair the remaining clients.
+            let delivered_somewhere = pubsub_client
+                .subscription_reconciliation_snapshot()
+                .is_some_and(|s| s.union.contains(&pubkey));
+            if delivered_somewhere {
+                continue;
+            }
+
+            // No client holds the subscription: evict so the account is
+            // re-cloned fresh on next use instead of going stale.
+            warn!(
+                pubkey = %pubkey,
+                error = ?resub_err,
+                "Resubscribe did not take effect on any client; evicting account to prevent stale state"
+            );
+            subscribed_accounts.remove(&pubkey);
+            if let Some(ownership) = subscription_ownership {
+                ownership.lock().await.remove(&pubkey);
+            }
+            if let Err(err) = removed_account_tx.send(pubkey).await {
+                warn!(pubkey = %pubkey, error = ?err, "Failed to send removal update for dead subscription");
+                inc_chainlink_subscription_cleanup_accounts(
+                    SubscriptionCleanupSource::Reconciler,
+                    SubscriptionCleanupOutcome::RemovalUpdateFailed,
+                );
+            } else {
+                inc_chainlink_subscription_cleanup_accounts(
+                    SubscriptionCleanupSource::Reconciler,
+                    SubscriptionCleanupOutcome::Unsubscribed,
+                );
             }
         }
     }
@@ -477,6 +512,51 @@ mod tests {
         assert!(subs.contains(&pk1));
         assert!(subs.contains(&pk2));
         assert!(subs.contains(&pk3));
+    }
+
+    /// A successfully re-established subscription must not trigger eviction.
+    #[tokio::test]
+    async fn test_repaired_subscription_is_not_evicted() {
+        init_logger();
+
+        let (tx, rx) = mpsc::channel::<SubscriptionUpdate>(10);
+        let mock_client = ChainPubsubClientMock::new(tx, rx);
+
+        let lru = AccountsLruCache::new(NonZeroUsize::new(10).unwrap());
+        let pk = create_test_pubkey(1);
+        lru.add(pk);
+
+        let (removed_tx, mut removed_rx) = mpsc::channel::<Pubkey>(10);
+        reconcile_subscriptions_local(&lru, &mock_client, &[], &removed_tx)
+            .await;
+
+        assert!(mock_client.subscriptions_union().contains(&pk));
+        assert!(lru.contains(&pk));
+        assert!(removed_rx.try_recv().is_err());
+    }
+
+    /// When no client holds the subscription after the resubscribe, the
+    /// account must be evicted instead of being left stale in the bank.
+    #[tokio::test]
+    async fn test_silently_dead_subscription_evicted_when_repair_fails() {
+        init_logger();
+
+        let (tx, rx) = mpsc::channel::<SubscriptionUpdate>(10);
+        let mock_client = ChainPubsubClientMock::new(tx, rx);
+
+        let lru = AccountsLruCache::new(NonZeroUsize::new(10).unwrap());
+        let pk = create_test_pubkey(1);
+        lru.add(pk);
+
+        mock_client.silently_noop_next_subscriptions(1);
+
+        let (removed_tx, mut removed_rx) = mpsc::channel::<Pubkey>(10);
+        reconcile_subscriptions_local(&lru, &mock_client, &[], &removed_tx)
+            .await;
+
+        assert!(!mock_client.subscriptions_union().contains(&pk));
+        assert!(!lru.contains(&pk));
+        assert_eq!(removed_rx.try_recv(), Ok(pk));
     }
 
     /// Test case: Empty LRU should cause resubscribe of all LRU accounts if missing
@@ -747,6 +827,7 @@ mod tests {
             pubsub_client,
             never_evicted,
             removed_account_tx,
+            None,
             None,
         )
         .await

--- a/magicblock-chainlink/src/remote_account_provider/tests.rs
+++ b/magicblock-chainlink/src/remote_account_provider/tests.rs
@@ -2524,6 +2524,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
             &never_evicted,
             &self.removed_account_tx,
             Some(&self.subscription_key_locks),
+            Some(&self.subscription_ownership),
         )
         .await
     }

--- a/magicblock-chainlink/src/submux/mod.rs
+++ b/magicblock-chainlink/src/submux/mod.rs
@@ -2271,7 +2271,8 @@ mod tests {
         let (removed_tx, mut removed_rx) = mpsc::channel::<Pubkey>(10);
 
         let count =
-            reconcile_subscriptions(&lru, &mux, &[], &removed_tx, None).await;
+            reconcile_subscriptions(&lru, &mux, &[], &removed_tx, None, None)
+                .await;
 
         assert_eq!(count, 1);
         assert_eq!(client1.subscribe_attempts(), before_client1_attempts);


### PR DESCRIPTION
## Problem

An account's pubsub subscription can die while client bookkeeping still claims it is live. Two compounding defects made this permanent:

1. **ws actor**: map entries whose listener was cancelled (e.g. orphaned by a timed-out reconnect drain) were still reported by `subscriptions()` as live coverage, and `add_sub` deduped any resubscribe against them with a fake `Ok` — no wire action.
2. **reconciler**: the repair for accounts flagged `in LRU but not in pubsub` was fire-and-forget; a silently no-oped subscribe left the account in the bank with no live subscription and no escalation.

## Fix

- **ws actor** (`chain_pubsub_actor.rs`): `subscriptions()` only reports entries with a live listener; `add_sub` replaces orphaned entries with a fresh subscription and fails honestly while a listener is winding down.
- **reconciler** (`subscription_reconciler.rs`): after resubscribing a flagged account, verify that at least one client actually holds the subscription (union check — a single delivering client keeps the account fresh). If none does, remove the account from the LRU and ownership map and send a removal notification: the existing guarded eviction path (delegated/undelegating/ephemeral protected, `is_watching` re-checked under the per-pubkey lock) submits `EvictAccount`, and the account is re-cloned fresh on next use.
