### PR TITLE
fix: disable replciation on standalone modes

### DIFF
--- a/.agents/context/crates/magicblock-core.md
+++ b/.agents/context/crates/magicblock-core.md
@@ -69,7 +69,9 @@ Main consumers include:
 
 ### Channel endpoints
 
-`link::link()` returns the two sides of the validator channel fabric:
+`link::link(replication_enabled)` returns the two sides of the validator channel fabric. The
+replication channel is built only when `replication_enabled` is set, so both halves exist or neither
+does; a standalone validator has no replication service to drain the stream:
 
 ```text
 DispatchEndpoints (RPC/API side)
@@ -84,7 +86,7 @@ ValidatorChannelEndpoints (processor/internal side)
   -> transaction_status: flume Sender<TransactionStatus>
   -> account_update: flume Sender<AccountWithSlot>
   -> tasks_service: UnboundedSender<TaskRequest>
-  -> replication_messages: mpsc Sender<Message>
+  -> replication_messages: Option<mpsc Sender<Message>>
   -> pause_permit: Arc<Semaphore>
 ```
 
@@ -154,8 +156,8 @@ Use `CoordinationMode::current()`, `needs_validator_signer()`, `should_schedule_
 
 ### Validator channel construction
 
-1. `magicblock-api` calls `magicblock_core::link::link()` during validator startup.
-2. `link()` creates bounded MPSC queues for transaction commands and replication messages, bounded `flume` queues for account/status events, an unbounded task queue, and a shared `Semaphore(1)` pause permit.
+1. `magicblock-api` calls `magicblock_core::link::link(!is_standalone)` during validator startup.
+2. `link()` creates a bounded MPSC queue for transaction commands, bounded `flume` queues for account/status events, an unbounded task queue, and a shared `Semaphore(1)` pause permit. The bounded MPSC replication queue is created only when replication is enabled; in standalone mode both endpoints get `None` and the scheduler emits nothing.
 3. The API/RPC side receives `DispatchEndpoints`; the processor side receives `ValidatorChannelEndpoints`.
 4. `TransactionSchedulerHandle` clones can be passed to RPC, cloner, accounts, ledger replay, task scheduler, and replication services.
 
@@ -252,7 +254,7 @@ Native-token projection is intentionally limited to local ATA/eATA projection se
 
 ## Important invariants
 
-1. `link::link()` must return paired endpoints connected to the same channels and pause semaphore; dispatch and validator sides must not be mismatched.
+1. `link::link()` must return paired endpoints connected to the same channels and pause semaphore; dispatch and validator sides must not be mismatched. The replication sender and receiver are created together or not at all: a standalone node holds neither, so no component can hold a sender whose receiver nobody drains.
 2. Scheduler command ordering must keep replay transactions and replicated block boundaries in the same FIFO stream.
 3. `TransactionSchedulerHandle::wait_for_idle()` must continue to pause scheduling while the returned permit is held; maintenance that relies on exclusive `AccountsDb` access depends on this.
 4. Bounded channels on hot paths must preserve intentional backpressure and avoid unbounded memory growth.

--- a/magicblock-account-cloner/src/lib.rs
+++ b/magicblock-account-cloner/src/lib.rs
@@ -747,7 +747,7 @@ mod tests {
 
     fn cloner() -> ChainlinkCloner {
         magicblock_program::validator::generate_validator_authority_if_needed();
-        let (dispatch, _) = link();
+        let (dispatch, _) = link(false);
         ChainlinkCloner::new(
             dispatch.transaction_scheduler,
             LatestBlock::default(),

--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -127,7 +127,8 @@ pub struct MagicValidator {
     replication_handle:
         Option<thread::JoinHandle<magicblock_replicator::Result<()>>>,
     mode_tx: Sender<SchedulerMode>,
-    replication_tx: Sender<Message>,
+    /// `None` when replication is disabled, i.e. the validator runs standalone.
+    replication_tx: Option<Sender<Message>>,
     unregister_handle: Option<thread::JoinHandle<()>>,
     is_standalone: bool,
 }
@@ -224,7 +225,7 @@ impl MagicValidator {
             None
         };
         let accountsdb = Arc::new(accountsdb);
-        let (mut dispatch, validator_channels) = link();
+        let (mut dispatch, validator_channels) = link(!is_standalone);
         let shared_chain_slot =
             (!Self::replication_mode_uses_disabled_chainlink(
                 &config.validator.replication_mode,
@@ -1022,7 +1023,14 @@ impl MagicValidator {
                 self.config.validator.replication_mode,
                 ReplicationMode::Primary(_)
             ) {
-                self.replication_tx
+                let replication_tx =
+                    self.replication_tx.as_ref().ok_or_else(|| {
+                        ApiError::FailedToSendModeSwitch(
+                            "replication sink missing in primary mode"
+                                .to_owned(),
+                        )
+                    })?;
+                replication_tx
                     .send(Message::Reset(self.accountsdb.slot()))
                     .await
                     .map_err(|e| {

--- a/magicblock-core/src/link.rs
+++ b/magicblock-core/src/link.rs
@@ -35,6 +35,7 @@ pub struct DispatchEndpoints {
     /// Receives scheduled (crank) tasks from transactions executor.
     pub tasks_service: Option<ScheduledTasksRx>,
     /// Receives replication events from the transaction scheduler.
+    /// `None` when replication is disabled, i.e. the validator runs standalone.
     pub replication_messages: Option<Receiver<Message>>,
 }
 
@@ -53,7 +54,8 @@ pub struct ValidatorChannelEndpoints {
     /// Sends scheduled (crank) tasks to tasks service from transactions executor.
     pub tasks_service: ScheduledTasksTx,
     /// Sends replication events to the replication service.
-    pub replication_messages: Sender<Message>,
+    /// `None` when replication is disabled, i.e. the validator runs standalone.
+    pub replication_messages: Option<Sender<Message>>,
     /// Semaphore used to pause scheduling for exclusive DB access (e.g., checksums).
     pub pause_permit: Arc<Semaphore>,
 }
@@ -61,18 +63,28 @@ pub struct ValidatorChannelEndpoints {
 /// Creates and connects the full set of communication channels between the dispatch
 /// layer and the validator core.
 ///
+/// The replication channel is only created when `replication_enabled` is set: both
+/// halves exist, or neither does. A standalone validator has no replication service
+/// to drain the stream, so handing out a sender would only produce failing sends.
+///
 /// # Returns
 ///
 /// A tuple containing:
 /// 1.  `DispatchEndpoints` for the "client" side (e.g., RPC servers).
 /// 2.  `ValidatorChannelEndpoints` for the "server" side (e.g., the transaction executor).
-pub fn link() -> (DispatchEndpoints, ValidatorChannelEndpoints) {
+pub fn link(
+    replication_enabled: bool,
+) -> (DispatchEndpoints, ValidatorChannelEndpoints) {
     let (tasks_tx, tasks_rx) = mpsc::unbounded_channel();
 
     // Bounded channels for command queues where applying backpressure is important.
     let (txn_to_process_tx, txn_to_process_rx) = mpsc::channel(LINK_CAPACITY);
     let (account_update_tx, account_update_rx) = flume::bounded(LINK_CAPACITY);
-    let (replication_tx, replication_rx) = mpsc::channel(LINK_CAPACITY);
+    let (replication_tx, replication_rx) =
+        match replication_enabled.then(|| mpsc::channel(LINK_CAPACITY)) {
+            Some((tx, rx)) => (Some(tx), Some(rx)),
+            None => (None, None),
+        };
     let (transaction_status_tx, transaction_status_rx) =
         flume::bounded(LINK_CAPACITY);
     // Semaphore(1) coordinates exclusive access: scheduler holds permit during
@@ -89,7 +101,7 @@ pub fn link() -> (DispatchEndpoints, ValidatorChannelEndpoints) {
         transaction_status: transaction_status_rx,
         account_update: account_update_rx,
         tasks_service: Some(tasks_rx),
-        replication_messages: Some(replication_rx),
+        replication_messages: replication_rx,
     };
 
     // Bundle the corresponding channel ends for the validator's internal core.
@@ -103,4 +115,20 @@ pub fn link() -> (DispatchEndpoints, ValidatorChannelEndpoints) {
     };
 
     (dispatch, validator)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn replication_endpoints_are_paired() {
+        let (dispatch, validator) = link(true);
+        assert!(dispatch.replication_messages.is_some());
+        assert!(validator.replication_messages.is_some());
+
+        let (dispatch, validator) = link(false);
+        assert!(dispatch.replication_messages.is_none());
+        assert!(validator.replication_messages.is_none());
+    }
 }

--- a/magicblock-processor/src/scheduler/mod.rs
+++ b/magicblock-processor/src/scheduler/mod.rs
@@ -25,7 +25,8 @@
 //! ## Primary Mode
 //!
 //! - Acts as the clock source, driving slot transitions via `slot_ticker`
-//! - Computes blockhash and broadcasts it via replication channel
+//! - Computes blockhash and broadcasts it via replication channel, unless the
+//!   validator runs standalone, in which case no replication sink is attached
 //! - Writes completed blocks to the ledger
 //!
 //! ## Replica Mode
@@ -38,7 +39,7 @@
 //! # Slot Transition Lifecycle
 //!
 //! 1. **Finalize current block** - compute blockhash, persist to ledger
-//! 2. **Broadcast block** - send to replication channel (primary only)
+//! 2. **Broadcast block** - send to replication channel (replicating primary only)
 //! 3. **Reset hasher** - seed with previous blockhash for next slot
 //! 4. **Advance slot** - increment slot number, reset transaction index
 //! 5. **Update program cache** - prune stale programs, re-root to new slot
@@ -113,8 +114,9 @@ pub struct TransactionScheduler {
     shutdown: CancellationToken,
     /// Receives mode transition commands (Primary or Replica) at runtime.
     mode_rx: Receiver<SchedulerMode>,
-    /// A sink for the events (transactions, blocks etc) that need to be replicated
-    replication_tx: Sender<Message>,
+    /// A sink for the events (transactions, blocks etc) that need to be replicated.
+    /// `None` when replication is disabled, i.e. the validator runs standalone.
+    replication_tx: Option<Sender<Message>>,
     /// Semaphore for coordinating exclusive DB access with external callers.
     /// Scheduler acquires permit when scheduling, releases when idle.
     pause_permit: Arc<Semaphore>,
@@ -320,10 +322,21 @@ impl TransactionScheduler {
         info!("Scheduler terminated");
     }
 
+    /// Whether this node is the source of a replication stream: primary mode with
+    /// a live sink. A standalone node runs as primary but has no sink attached.
+    fn is_replicating(&self) -> bool {
+        self.replication_tx.is_some() && self.coordinator.is_primary()
+    }
+
     /// Sends a replication message, logging any errors.
+    ///
+    /// A standalone validator has no sink, so the message is dropped.
     async fn send_replication(&self, msg: Message) {
+        let Some(tx) = &self.replication_tx else {
+            return;
+        };
         let kind = msg.kind();
-        if let Err(error) = self.replication_tx.send(msg).await {
+        if let Err(error) = tx.send(msg).await {
             error!(
                 %error,
                 kind,
@@ -349,7 +362,7 @@ impl TransactionScheduler {
             error!("failed to create accountsdb snapshot");
             return;
         };
-        if self.coordinator.is_primary() {
+        if self.is_replicating() {
             let msg = Message::SuperBlock(SuperBlock { slot, checksum });
             self.send_replication(msg).await;
         }
@@ -521,8 +534,8 @@ impl TransactionScheduler {
         let msg = txn
             .encoded
             .as_ref()
+            .filter(|_| is_execution && self.is_replicating())
             .cloned()
-            .filter(|_| is_execution && self.coordinator.is_primary())
             .map(|payload| {
                 Message::Transaction(replication::Transaction {
                     index,
@@ -569,12 +582,14 @@ impl TransactionScheduler {
             // of blocks might have identical timestamps
             .as_secs() as i64;
         let block = LatestBlockInner::new(self.slot, blockhash, timestamp);
-        let msg = Message::Block(replication::Block {
-            slot: block.slot,
-            hash: block.blockhash,
-            timestamp: block.clock.unix_timestamp,
-        });
-        self.send_replication(msg).await;
+        if self.is_replicating() {
+            let msg = Message::Block(replication::Block {
+                slot: block.slot,
+                hash: block.blockhash,
+                timestamp: block.clock.unix_timestamp,
+            });
+            self.send_replication(msg).await;
+        }
         block
     }
 

--- a/magicblock-processor/src/scheduler/state.rs
+++ b/magicblock-processor/src/scheduler/state.rs
@@ -55,7 +55,8 @@ pub struct TransactionSchedulerState {
     pub account_update_tx: AccountUpdateTx,
     pub transaction_status_tx: TransactionStatusTx,
     pub tasks_tx: ScheduledTasksTx,
-    pub replication_tx: Sender<Message>,
+    /// `None` when replication is disabled, i.e. the validator runs standalone.
+    pub replication_tx: Option<Sender<Message>>,
     /// Semaphore for pausing scheduling during exclusive DB access.
     pub pause_permit: Arc<Semaphore>,
 

--- a/test-kit/src/lib.rs
+++ b/test-kit/src/lib.rs
@@ -169,7 +169,7 @@ impl ExecutionTestEnv {
         let ledger =
             Arc::new(Ledger::open(dir.path()).expect("opening test ledger"));
 
-        let (dispatch, validator_channels) = link();
+        let (dispatch, validator_channels) = link(true);
         let blockhash = ledger.latest_block().load().blockhash;
         let svm_env = build_svm_env(&accountsdb, blockhash, fee);
         let payers = (0..executors).map(|_| Keypair::new()).collect();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for running validators without replication in standalone mode.
  * Replication channels are now created only when replication is enabled.
  * Standalone validators no longer send transactions, blocks, or headers to replication.
* **Bug Fixes**
  * Added validation and error handling when replication is required but unavailable.
  * Preserved existing replication behavior for enabled validator modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->