### PR TITLE
fix: retry transient commit intent failures

### DIFF
--- a/.agents/context/crates/magicblock-committor-service.md
+++ b/.agents/context/crates/magicblock-committor-service.md
@@ -47,7 +47,7 @@ For the general documentation-update rule, see .agents/memory/agent-memory-and-d
 | `src/config.rs` and `src/compute_budget.rs` | Chain/RPC configuration, default action timeout, and per-task compute-budget helpers. |
 | `src/committor_processor.rs` | Constructs `MagicblockRpcClient`, `TableMania`, `IntentPersisterImpl`, `IntentExecutionManager`, and `CacheTaskInfoFetcher`; exposes persistence queries and recovery helpers. |
 | `src/intent_execution_manager.rs` | Backpressure boundary between service and execution engine; enqueues bundles and falls back to an internal DB when the channel is full. |
-| `src/intent_execution_manager/intent_execution_engine.rs` | Main scheduler loop, executor semaphore (`MAX_EXECUTORS = 50`), result broadcasting, metrics, and successful-cleanup spawning. |
+| `src/intent_execution_manager/intent_execution_engine.rs` | Main scheduler loop, executor semaphore (`MAX_EXECUTORS = 50`), transient-failure intent retries (`MAX_INTENT_ATTEMPTS = 3` with jittered linear backoff, bounded by a `MAX_SLEEPING_RETRIES = 50` semaphore), result broadcasting, metrics, and per-attempt cleanup spawning. |
 | `src/intent_execution_manager/intent_scheduler.rs` | Pubkey conflict scheduler for committed accounts. Maintains FIFO blocking queues and prevents duplicate/concurrent conflicting intents. |
 | `src/intent_executor/` | Intent execution state machine, transaction client, factory, single-stage/two-stage executors, timeout helpers, and commit nonce fetcher/cache. |
 | `src/tasks/` | Atomic base-layer task types and task builders/strategist for commit, commit-finalize, undelegate, actions, buffers, ALTs, and compute budgets. |
@@ -180,9 +180,20 @@ Preserve the no-repersist path for recovered intents. Re-inserting rows can viol
 3. asks `IntentScheduler` whether it can run now;
 4. waits for one of `MAX_EXECUTORS = 50` semaphore permits;
 5. creates an executor and spawns intent execution;
-6. broadcasts the result, completes the scheduler entry, and cleans buffers/ALTs only after successful execution.
+6. broadcasts the result, completes the scheduler entry, and spawns per-attempt cleanup (full buffer/ALT cleanup only after success; failed attempts release only ALT reservations).
 
 The scheduler blocks on the union of `ScheduledIntentBundle::get_all_committed_pubkeys()`, including commit and commit-and-undelegate accounts in the same bundle. Standalone base actions with no committed pubkeys do not block on account keys.
+
+### Intent retry policy
+
+A failed execution is retried by the engine with a fresh executor, up to `MAX_INTENT_ATTEMPTS = 3` total attempts with jittered linear backoff, only when all of the following hold:
+
+- the error is classified transient by `IntentExecutorError::is_transient()` (transport/RPC-side, delegated down through `TransactionStrategyExecutionError`, `TaskBuilderError`, `TransactionPreparatorError`, and ultimately `MagicBlockRpcClientError::is_transient`); deterministic failures — signer errors, oversized strategies, on-chain instruction errors, finalize failures after a landed commit (`FailedToFinalizeError` with a commit signature, `FailedFinalizePreparationError`) — are terminal on the first attempt;
+- no action callbacks were scheduled during the failed attempt (a retry would double-report the intent outcome to user programs);
+- the intent contains at least one commit/finalize/undelegate task, whose on-chain commit nonce makes a duplicate landing fail the retried transaction atomically; action-only intents may only retry pre-send failures (the same guard restricts their in-loop send retries to blockhash-fetch errors);
+- a retry slot is free: retries release their executor permit while sleeping, and a `MAX_SLEEPING_RETRIES = 50` semaphore bounds the sleeping population — without a free slot the failure is terminal.
+
+Before each backoff, persisted commit rows are restored to `Pending` so a crash inside the retry window remains recoverable by `reschedule_pending_bundles` on restart. Each attempt surrenders its strategies to the execution report (including on preparation and patch failures), so per-attempt cleanup can release partially prepared ALT reservations and buffers.
 
 ### Intent execution and task strategy flow
 

--- a/.agents/context/crates/magicblock-rpc-client.md
+++ b/.agents/context/crates/magicblock-rpc-client.md
@@ -122,17 +122,17 @@ Common methods:
 
 ### Errors and retry utilities
 
-`MagicBlockRpcClientError` distinguishes native RPC failures, latest-blockhash/slot failures, ALT deserialize failures, send failures, status timeout/confirmation failures, and submitted transaction errors. `signature()` returns the associated transaction signature for errors that have one.
+`MagicBlockRpcClientError` distinguishes native RPC failures, latest-blockhash/slot failures, ALT deserialize failures, send failures, status timeout/confirmation failures, and submitted transaction errors. `signature()` returns the associated transaction signature for errors that have one. `is_transient()` classifies whether a retry may succeed: ALT deserialize failures and submitted transactions that failed with an on-chain instruction error are deterministic; everything else (transport, RPC availability, unconfirmed status) is transient.
 
 `utils.rs` exposes:
 
 - `send_transaction_with_retries(make_send_fut, mapper, stop_predicate)`, which repeatedly calls an async send operation until success, an unrecoverable mapped error, or a caller-supplied stop condition;
-- `SendErrorMapper`, which maps transport/send errors into a caller's execution error and decides retry delay versus break;
+- `SendErrorMapper`, which maps transport/send errors into a caller's execution error and decides retry delay versus break (`decide_flow` takes `&self`, so mappers can carry caller context such as the committor's action-only idempotency guard);
 - `TransactionErrorMapper`, which lets domain crates map Solana `TransactionError` values while falling back safely for unknown errors;
 - `map_magicblock_client_error` and `try_map_client_error`, used by committor code to preserve domain-specific transaction-error handling;
 - `decide_rpc_error_flow` and `decide_rpc_native_flow`, the shared retry policy for known retryable RPC conditions.
 
-Retry policy is intentionally conservative: IO errors, HTTP 5xx send errors, latest-blockhash fetch errors, and signature-status timeout/confirmation failures may retry; unknown transaction errors and most client errors break unless mapped by the caller.
+Retry policy: IO errors, status-less reqwest errors (connection reset/timeout — the transport-level failures), HTTP 5xx and 429 send errors, node-unhealthy RPC responses, latest-blockhash fetch errors, and signature-status timeout/confirmation failures may retry; unknown transaction errors and remaining client errors break unless mapped by the caller.
 
 ## Runtime flows
 

--- a/magicblock-committor-service/Cargo.toml
+++ b/magicblock-committor-service/Cargo.toml
@@ -60,6 +60,7 @@ solana-signature = { workspace = true, features = ["rand"] }
 rand = { workspace = true }
 tempfile = { workspace = true }
 test-kit = { workspace = true }
+tokio = { workspace = true, features = ["test-util"] }
 
 [features]
 default = []

--- a/magicblock-committor-service/src/intent_execution_manager/intent_execution_engine.rs
+++ b/magicblock-committor-service/src/intent_execution_manager/intent_execution_engine.rs
@@ -15,6 +15,7 @@ use tokio::{
         Semaphore,
     },
     task::JoinHandle,
+    time::sleep,
 };
 use tracing::{error, info, instrument, trace, warn};
 
@@ -38,6 +39,10 @@ use crate::{
 const SEMAPHORE_CLOSED_MSG: &str = "Executors semaphore closed!";
 /// Max number of executors that can send messages in parallel to Base layer
 const MAX_EXECUTORS: u8 = 50;
+/// Max executions of an intent whose failures were transient
+const MAX_INTENT_ATTEMPTS: u32 = 3;
+/// Backoff between intent attempts, scaled linearly by attempt number
+const INTENT_RETRY_BACKOFF: Duration = Duration::from_secs(1);
 
 pub type PatchedErrors = Vec<TransactionStrategyExecutionError>;
 
@@ -90,7 +95,7 @@ impl ResultSubscriber {
 
 pub(crate) struct IntentExecutionEngine<D, P, F> {
     db: Arc<D>,
-    executor_factory: F,
+    executor_factory: Arc<F>,
     intents_persister: Option<P>,
     receiver: mpsc::Receiver<ScheduledIntentBundle>,
 
@@ -115,7 +120,7 @@ where
         Self {
             db,
             intents_persister,
-            executor_factory,
+            executor_factory: Arc::new(executor_factory),
             receiver,
             running_executors: FuturesUnordered::new(),
             executors_semaphore: Arc::new(Semaphore::new(
@@ -171,12 +176,12 @@ where
                 .expect(SEMAPHORE_CLOSED_MSG);
 
             // Spawn executor
-            let executor = self.executor_factory.create_instance();
+            let executor_factory = self.executor_factory.clone();
             let persister = self.intents_persister.clone();
             let inner = self.inner.clone();
 
             let handle = tokio::spawn(Self::execute(
-                executor,
+                executor_factory,
                 persister,
                 intent,
                 inner,
@@ -269,10 +274,12 @@ where
         }
     }
 
-    /// Wrapper on [`IntentExecutor`] that handles its results and drops execution permit
-    #[instrument(skip(executor, persister, intent, inner_scheduler, execution_permit, result_sender), fields(intent_id = intent.id))]
+    /// Wrapper on [`IntentExecutor`] that handles its results and drops execution permit.
+    /// Transient failures are retried with a fresh executor while the scheduler
+    /// keeps conflicting intents blocked, preserving per-account commit order.
+    #[instrument(skip(executor_factory, persister, intent, inner_scheduler, execution_permit, result_sender), fields(intent_id = intent.id))]
     async fn execute(
-        mut executor: E,
+        executor_factory: Arc<F>,
         persister: Option<P>,
         intent: ScheduledIntentBundle,
         inner_scheduler: Arc<Mutex<IntentScheduler>>,
@@ -282,7 +289,33 @@ where
         let instant = Instant::now();
 
         // Execute an Intent
-        let result = executor.execute(intent.clone(), persister).await;
+        let mut attempt = 0;
+        let result = loop {
+            attempt += 1;
+            let mut executor = executor_factory.create_instance();
+            let result =
+                executor.execute(intent.clone(), persister.clone()).await;
+
+            tokio::spawn(async move {
+                if let Err(err) = executor.cleanup().await {
+                    error!(error = ?err, "Failed to cleanup after intent");
+                }
+            });
+
+            // Retry only plausibly transient failures, and never once action
+            // callbacks fired: a retry would double-report the intent outcome
+            let retriable = attempt < MAX_INTENT_ATTEMPTS
+                && result.callbacks_report.is_empty()
+                && matches!(&result.inner, Err(err) if err.is_transient());
+            if !retriable {
+                break result;
+            }
+
+            if let Err(err) = &result.inner {
+                warn!(intent_id = intent.id, attempt, error = ?err, "Transient intent failure, retrying");
+            }
+            sleep(INTENT_RETRY_BACKOFF * attempt).await;
+        };
         let _ = result.inner.as_ref().inspect_err(|err| {
             error!(intent_id = intent.id, error = ?err, "Failed to execute intent bundle");
         });
@@ -306,12 +339,6 @@ where
             .expect(POISONED_INNER_MSG)
             .complete(&intent)
             .expect("Valid completion of previously scheduled message");
-
-        tokio::spawn(async move {
-            if let Err(err) = executor.cleanup().await {
-                error!(error = ?err, "Failed to cleanup after intent");
-            }
-        });
 
         // Free worker
         drop(execution_permit);
@@ -367,6 +394,7 @@ mod tests {
 
     use async_trait::async_trait;
     use magicblock_program::magic_scheduled_base_intent::ScheduledIntentBundle;
+    use magicblock_rpc_client::MagicBlockRpcClientError;
     use solana_pubkey::{pubkey, Pubkey};
     use solana_signature::Signature;
     use solana_signer::SignerError;
@@ -399,16 +427,25 @@ mod tests {
         mpsc::Sender<ScheduledIntentBundle>,
         MockIntentExecutionEngine,
     ) {
-        test_utils::init_test_logger();
-
-        let (sender, receiver) = mpsc::channel(1000);
-
-        let db = Arc::new(DummyDB::new());
         let executor_factory = if !should_fail {
             MockIntentExecutorFactory::new()
         } else {
             MockIntentExecutorFactory::new_failing()
         };
+        setup_engine_with_factory(executor_factory)
+    }
+
+    fn setup_engine_with_factory(
+        executor_factory: MockIntentExecutorFactory,
+    ) -> (
+        mpsc::Sender<ScheduledIntentBundle>,
+        MockIntentExecutionEngine,
+    ) {
+        test_utils::init_test_logger();
+
+        let (sender, receiver) = mpsc::channel(1000);
+
+        let db = Arc::new(DummyDB::new());
         let worker = IntentExecutionEngine::new(
             db.clone(),
             executor_factory,
@@ -549,8 +586,8 @@ mod tests {
 
         let active_tasks = Arc::new(AtomicUsize::new(0));
         let max_concurrent = Arc::new(AtomicUsize::new(0));
-        worker
-            .executor_factory
+        Arc::get_mut(&mut worker.executor_factory)
+            .expect("factory not shared before spawn")
             .with_concurrency_tracking(&active_tasks, &max_concurrent);
 
         let result_subscriber = worker.spawn();
@@ -609,6 +646,94 @@ mod tests {
         }
     }
 
+    /// Transient failures are retried with a fresh executor until success
+    #[tokio::test]
+    async fn test_transient_failure_retried_until_success() {
+        let factory = MockIntentExecutorFactory::new_transient(2);
+        let created_instances = factory.created_instances.clone();
+        let (sender, worker) = setup_engine_with_factory(factory);
+        let result_subscriber = worker.spawn();
+        let mut result_receiver = result_subscriber.subscribe();
+
+        let msg = create_test_intent(
+            1,
+            &[pubkey!("1111111111111111111111111111111111111111111")],
+            false,
+        );
+        sender.send(msg).await.unwrap();
+
+        let result = result_receiver.recv().await.unwrap();
+        assert!(result.is_ok());
+        assert_eq!(created_instances.load(Ordering::SeqCst), 3);
+    }
+
+    /// Transient failures stop being retried once attempts are exhausted
+    #[tokio::test]
+    async fn test_transient_failure_exhausts_attempts() {
+        let factory = MockIntentExecutorFactory::new_transient(usize::MAX);
+        let created_instances = factory.created_instances.clone();
+        let (sender, worker) = setup_engine_with_factory(factory);
+        let result_subscriber = worker.spawn();
+        let mut result_receiver = result_subscriber.subscribe();
+
+        let msg = create_test_intent(
+            1,
+            &[pubkey!("1111111111111111111111111111111111111111111")],
+            false,
+        );
+        sender.send(msg).await.unwrap();
+
+        let result = result_receiver.recv().await.unwrap();
+        assert!(result.is_err());
+        assert_eq!(
+            created_instances.load(Ordering::SeqCst),
+            MAX_INTENT_ATTEMPTS as usize
+        );
+    }
+
+    /// Non-transient failures are terminal on the first attempt
+    #[tokio::test]
+    async fn test_non_transient_failure_not_retried() {
+        let factory = MockIntentExecutorFactory::new_failing();
+        let created_instances = factory.created_instances.clone();
+        let (sender, worker) = setup_engine_with_factory(factory);
+        let result_subscriber = worker.spawn();
+        let mut result_receiver = result_subscriber.subscribe();
+
+        let msg = create_test_intent(
+            1,
+            &[pubkey!("1111111111111111111111111111111111111111111")],
+            false,
+        );
+        sender.send(msg).await.unwrap();
+
+        let result = result_receiver.recv().await.unwrap();
+        assert!(result.is_err());
+        assert_eq!(created_instances.load(Ordering::SeqCst), 1);
+    }
+
+    /// Once action callbacks fired, even a transient failure must not retry
+    #[tokio::test]
+    async fn test_transient_failure_with_callbacks_not_retried() {
+        let mut factory = MockIntentExecutorFactory::new_transient(usize::MAX);
+        factory.report_callbacks_on_failure = true;
+        let created_instances = factory.created_instances.clone();
+        let (sender, worker) = setup_engine_with_factory(factory);
+        let result_subscriber = worker.spawn();
+        let mut result_receiver = result_subscriber.subscribe();
+
+        let msg = create_test_intent(
+            1,
+            &[pubkey!("1111111111111111111111111111111111111111111")],
+            false,
+        );
+        sender.send(msg).await.unwrap();
+
+        let result = result_receiver.recv().await.unwrap();
+        assert!(result.is_err());
+        assert_eq!(created_instances.load(Ordering::SeqCst), 1);
+    }
+
     #[tokio::test]
     async fn test_non_blocking_messages() {
         const NUM_MESSAGES: u64 = 200;
@@ -617,8 +742,8 @@ mod tests {
 
         let active_tasks = Arc::new(AtomicUsize::new(0));
         let max_concurrent = Arc::new(AtomicUsize::new(0));
-        worker
-            .executor_factory
+        Arc::get_mut(&mut worker.executor_factory)
+            .expect("factory not shared before spawn")
             .with_concurrency_tracking(&active_tasks, &max_concurrent);
 
         let result_subscriber = worker.spawn();
@@ -675,8 +800,8 @@ mod tests {
 
         let active_tasks = Arc::new(AtomicUsize::new(0));
         let max_concurrent = Arc::new(AtomicUsize::new(0));
-        worker
-            .executor_factory
+        Arc::get_mut(&mut worker.executor_factory)
+            .expect("factory not shared before spawn")
             .with_concurrency_tracking(&active_tasks, &max_concurrent);
 
         let result_subscriber = worker.spawn();
@@ -716,27 +841,46 @@ mod tests {
     }
 
     // Mock implementations for testing
+    #[derive(Clone)]
+    enum MockFailureMode {
+        None,
+        /// Deterministic (non-transient) failure on every attempt
+        Persistent,
+        /// Transient failure while the counter is above zero
+        Transient(Arc<AtomicUsize>),
+    }
+
     pub struct MockIntentExecutorFactory {
-        should_fail: bool,
+        failure_mode: MockFailureMode,
+        report_callbacks_on_failure: bool,
+        created_instances: Arc<AtomicUsize>,
         active_tasks: Option<Arc<AtomicUsize>>,
         max_concurrent: Option<Arc<AtomicUsize>>,
     }
 
     impl MockIntentExecutorFactory {
-        pub fn new() -> Self {
+        fn with_mode(failure_mode: MockFailureMode) -> Self {
             Self {
-                should_fail: false,
+                failure_mode,
+                report_callbacks_on_failure: false,
+                created_instances: Arc::new(AtomicUsize::new(0)),
                 active_tasks: None,
                 max_concurrent: None,
             }
         }
 
+        pub fn new() -> Self {
+            Self::with_mode(MockFailureMode::None)
+        }
+
         pub fn new_failing() -> Self {
-            Self {
-                should_fail: true,
-                active_tasks: None,
-                max_concurrent: None,
-            }
+            Self::with_mode(MockFailureMode::Persistent)
+        }
+
+        pub fn new_transient(failures: usize) -> Self {
+            Self::with_mode(MockFailureMode::Transient(Arc::new(
+                AtomicUsize::new(failures),
+            )))
         }
 
         pub fn with_concurrency_tracking(
@@ -753,8 +897,10 @@ mod tests {
         type Executor = MockIntentExecutor;
 
         fn create_instance(&self) -> Self::Executor {
+            self.created_instances.fetch_add(1, Ordering::SeqCst);
             MockIntentExecutor {
-                should_fail: self.should_fail,
+                failure_mode: self.failure_mode.clone(),
+                report_callbacks_on_failure: self.report_callbacks_on_failure,
                 active_tasks: self.active_tasks.clone(),
                 max_concurrent: self.max_concurrent.clone(),
             }
@@ -762,7 +908,8 @@ mod tests {
     }
 
     pub struct MockIntentExecutor {
-        should_fail: bool,
+        failure_mode: MockFailureMode,
+        report_callbacks_on_failure: bool,
         active_tasks: Option<Arc<AtomicUsize>>,
         max_concurrent: Option<Arc<AtomicUsize>>,
     }
@@ -810,8 +957,17 @@ mod tests {
             // Simulate some work
             sleep(Duration::from_millis(50)).await;
 
-            let result = if self.should_fail {
-                IntentExecutionResult {
+            let success = IntentExecutionResult {
+                inner: Ok(ExecutionOutput::TwoStage {
+                    commit_signature: Signature::default(),
+                    finalize_signature: Signature::default(),
+                }),
+                patched_errors: vec![],
+                callbacks_report: vec![],
+            };
+            let result = match &self.failure_mode {
+                MockFailureMode::None => success,
+                MockFailureMode::Persistent => IntentExecutionResult {
                     inner: Err(ExecutorError::FailedToCommitError {
                         err: TransactionStrategyExecutionError::InternalError(
                             InternalError::SignerError(SignerError::Custom(
@@ -827,15 +983,41 @@ mod tests {
                         ),
                     ],
                     callbacks_report: vec![],
-                }
-            } else {
-                IntentExecutionResult {
-                    inner: Ok(ExecutionOutput::TwoStage {
-                        commit_signature: Signature::default(),
-                        finalize_signature: Signature::default(),
-                    }),
-                    patched_errors: vec![],
-                    callbacks_report: vec![],
+                },
+                MockFailureMode::Transient(remaining) => {
+                    let should_fail = remaining
+                        .fetch_update(
+                            Ordering::SeqCst,
+                            Ordering::SeqCst,
+                            |value| value.checked_sub(1),
+                        )
+                        .is_ok();
+                    if should_fail {
+                        let callbacks_report = if self
+                            .report_callbacks_on_failure
+                        {
+                            vec![Ok(Signature::default())]
+                        } else {
+                            vec![]
+                        };
+                        IntentExecutionResult {
+                            inner: Err(ExecutorError::FailedToCommitError {
+                                err: TransactionStrategyExecutionError::InternalError(
+                                    InternalError::from(
+                                        MagicBlockRpcClientError::SentTransactionError(
+                                            TransactionError::BlockhashNotFound,
+                                            Signature::default(),
+                                        ),
+                                    ),
+                                ),
+                                signature: None,
+                            }),
+                            patched_errors: vec![],
+                            callbacks_report,
+                        }
+                    } else {
+                        success
+                    }
                 }
             };
 

--- a/magicblock-committor-service/src/intent_execution_manager/intent_execution_engine.rs
+++ b/magicblock-committor-service/src/intent_execution_manager/intent_execution_engine.rs
@@ -33,7 +33,8 @@ use crate::{
         intent_executor_factory::IntentExecutorFactory,
         ExecutionOutput, IntentExecutionResult, IntentExecutor,
     },
-    persist::IntentPersister,
+    persist::{CommitStatus, IntentPersister},
+    utils::persist_status_update_by_message_set,
 };
 
 const SEMAPHORE_CLOSED_MSG: &str = "Executors semaphore closed!";
@@ -310,6 +311,15 @@ where
             if !retriable {
                 break result;
             }
+
+            // The failed attempt persisted a failure status; restore Pending
+            // so a crash before the next attempt stays restart-recoverable
+            persist_status_update_by_message_set(
+                &persister,
+                intent.id,
+                &intent.get_all_committed_pubkeys(),
+                CommitStatus::Pending,
+            );
 
             if let Err(err) = &result.inner {
                 warn!(intent_id = intent.id, attempt, error = ?err, "Transient intent failure, retrying");
@@ -993,13 +1003,12 @@ mod tests {
                         )
                         .is_ok();
                     if should_fail {
-                        let callbacks_report = if self
-                            .report_callbacks_on_failure
-                        {
-                            vec![Ok(Signature::default())]
-                        } else {
-                            vec![]
-                        };
+                        let callbacks_report =
+                            if self.report_callbacks_on_failure {
+                                vec![Ok(Signature::default())]
+                            } else {
+                                vec![]
+                            };
                         IntentExecutionResult {
                             inner: Err(ExecutorError::FailedToCommitError {
                                 err: TransactionStrategyExecutionError::InternalError(

--- a/magicblock-committor-service/src/intent_execution_manager/intent_execution_engine.rs
+++ b/magicblock-committor-service/src/intent_execution_manager/intent_execution_engine.rs
@@ -341,9 +341,12 @@ where
             }
 
             // Release the executor slot during backoff so unrelated intents
-            // keep executing while this one waits out the outage
+            // keep executing while this one waits out the outage.
+            // Per-intent jitter decorrelates synchronized retry bursts when
+            // many intents fail together during an outage
+            let jitter = Duration::from_millis((intent.id % 8) * 125);
             drop(execution_permit.take());
-            sleep(INTENT_RETRY_BACKOFF * attempt).await;
+            sleep(INTENT_RETRY_BACKOFF * attempt + jitter).await;
             execution_permit =
                 match executors_semaphore.clone().acquire_owned().await {
                     Ok(permit) => Some(permit),

--- a/magicblock-committor-service/src/intent_execution_manager/intent_execution_engine.rs
+++ b/magicblock-committor-service/src/intent_execution_manager/intent_execution_engine.rs
@@ -44,6 +44,16 @@ const MAX_EXECUTORS: u8 = 50;
 const MAX_INTENT_ATTEMPTS: u32 = 3;
 /// Backoff between intent attempts, scaled linearly by attempt number
 const INTENT_RETRY_BACKOFF: Duration = Duration::from_secs(1);
+/// Max intents concurrently sleeping in retry backoff. Retries release their
+/// executor slot while sleeping; this cap keeps the total task population
+/// bounded when many intents fail together
+const MAX_SLEEPING_RETRIES: u8 = 50;
+
+/// Concurrency limits shared between the engine and its executor tasks
+struct ExecutionLimits {
+    executors: Arc<Semaphore>,
+    retries: Arc<Semaphore>,
+}
 
 pub type PatchedErrors = Vec<TransactionStrategyExecutionError>;
 
@@ -103,6 +113,7 @@ pub(crate) struct IntentExecutionEngine<D, P, F> {
     inner: Arc<Mutex<IntentScheduler>>,
     running_executors: FuturesUnordered<JoinHandle<()>>,
     executors_semaphore: Arc<Semaphore>,
+    retries_semaphore: Arc<Semaphore>,
 }
 
 impl<D, P, F, E> IntentExecutionEngine<D, P, F>
@@ -126,6 +137,9 @@ where
             running_executors: FuturesUnordered::new(),
             executors_semaphore: Arc::new(Semaphore::new(
                 MAX_EXECUTORS as usize,
+            )),
+            retries_semaphore: Arc::new(Semaphore::new(
+                MAX_SLEEPING_RETRIES as usize,
             )),
             inner: Arc::new(Mutex::new(IntentScheduler::new())),
         }
@@ -180,14 +194,17 @@ where
             let executor_factory = self.executor_factory.clone();
             let persister = self.intents_persister.clone();
             let inner = self.inner.clone();
-            let executors_semaphore = self.executors_semaphore.clone();
+            let limits = ExecutionLimits {
+                executors: self.executors_semaphore.clone(),
+                retries: self.retries_semaphore.clone(),
+            };
 
             let handle = tokio::spawn(Self::execute(
                 executor_factory,
                 persister,
                 intent,
                 inner,
-                executors_semaphore,
+                limits,
                 permit,
                 result_sender.clone(),
             ));
@@ -280,13 +297,13 @@ where
     /// Wrapper on [`IntentExecutor`] that handles its results and drops execution permit.
     /// Transient failures are retried with a fresh executor while the scheduler
     /// keeps conflicting intents blocked, preserving per-account commit order.
-    #[instrument(skip(executor_factory, persister, intent, inner_scheduler, executors_semaphore, execution_permit, result_sender), fields(intent_id = intent.id))]
+    #[instrument(skip(executor_factory, persister, intent, inner_scheduler, limits, execution_permit, result_sender), fields(intent_id = intent.id))]
     async fn execute(
         executor_factory: Arc<F>,
         persister: Option<P>,
         intent: ScheduledIntentBundle,
         inner_scheduler: Arc<Mutex<IntentScheduler>>,
-        executors_semaphore: Arc<Semaphore>,
+        limits: ExecutionLimits,
         execution_permit: OwnedSemaphorePermit,
         result_sender: broadcast::Sender<BroadcastedIntentExecutionResult>,
     ) {
@@ -327,6 +344,14 @@ where
                 break result;
             }
 
+            // Sleeping retries release their executor slot but must stay
+            // bounded; without a free retry slot the failure is terminal
+            let Ok(retry_permit) = limits.retries.clone().try_acquire_owned()
+            else {
+                warn!(intent_id = intent.id, "Retry capacity exhausted");
+                break result;
+            };
+
             // The failed attempt persisted a failure status; restore Pending
             // so a crash before the next attempt stays restart-recoverable
             persist_status_update_by_message_set(
@@ -348,13 +373,14 @@ where
             drop(execution_permit.take());
             sleep(INTENT_RETRY_BACKOFF * attempt + jitter).await;
             execution_permit =
-                match executors_semaphore.clone().acquire_owned().await {
+                match limits.executors.clone().acquire_owned().await {
                     Ok(permit) => Some(permit),
                     Err(_) => {
                         error!(SEMAPHORE_CLOSED_MSG);
                         break result;
                     }
                 };
+            drop(retry_permit);
         };
         let _ = result.inner.as_ref().inspect_err(|err| {
             error!(intent_id = intent.id, error = ?err, "Failed to execute intent bundle");

--- a/magicblock-committor-service/src/intent_execution_manager/intent_execution_engine.rs
+++ b/magicblock-committor-service/src/intent_execution_manager/intent_execution_engine.rs
@@ -180,12 +180,14 @@ where
             let executor_factory = self.executor_factory.clone();
             let persister = self.intents_persister.clone();
             let inner = self.inner.clone();
+            let executors_semaphore = self.executors_semaphore.clone();
 
             let handle = tokio::spawn(Self::execute(
                 executor_factory,
                 persister,
                 intent,
                 inner,
+                executors_semaphore,
                 permit,
                 result_sender.clone(),
             ));
@@ -278,16 +280,18 @@ where
     /// Wrapper on [`IntentExecutor`] that handles its results and drops execution permit.
     /// Transient failures are retried with a fresh executor while the scheduler
     /// keeps conflicting intents blocked, preserving per-account commit order.
-    #[instrument(skip(executor_factory, persister, intent, inner_scheduler, execution_permit, result_sender), fields(intent_id = intent.id))]
+    #[instrument(skip(executor_factory, persister, intent, inner_scheduler, executors_semaphore, execution_permit, result_sender), fields(intent_id = intent.id))]
     async fn execute(
         executor_factory: Arc<F>,
         persister: Option<P>,
         intent: ScheduledIntentBundle,
         inner_scheduler: Arc<Mutex<IntentScheduler>>,
+        executors_semaphore: Arc<Semaphore>,
         execution_permit: OwnedSemaphorePermit,
         result_sender: broadcast::Sender<BroadcastedIntentExecutionResult>,
     ) {
         let instant = Instant::now();
+        let mut execution_permit = Some(execution_permit);
 
         // Execute an Intent
         let mut attempt = 0;
@@ -324,7 +328,19 @@ where
             if let Err(err) = &result.inner {
                 warn!(intent_id = intent.id, attempt, error = ?err, "Transient intent failure, retrying");
             }
+
+            // Release the executor slot during backoff so unrelated intents
+            // keep executing while this one waits out the outage
+            drop(execution_permit.take());
             sleep(INTENT_RETRY_BACKOFF * attempt).await;
+            execution_permit =
+                match executors_semaphore.clone().acquire_owned().await {
+                    Ok(permit) => Some(permit),
+                    Err(_) => {
+                        error!(SEMAPHORE_CLOSED_MSG);
+                        break result;
+                    }
+                };
         };
         let _ = result.inner.as_ref().inspect_err(|err| {
             error!(intent_id = intent.id, error = ?err, "Failed to execute intent bundle");
@@ -657,7 +673,7 @@ mod tests {
     }
 
     /// Transient failures are retried with a fresh executor until success
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn test_transient_failure_retried_until_success() {
         let factory = MockIntentExecutorFactory::new_transient(2);
         let created_instances = factory.created_instances.clone();
@@ -678,7 +694,7 @@ mod tests {
     }
 
     /// Transient failures stop being retried once attempts are exhausted
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn test_transient_failure_exhausts_attempts() {
         let factory = MockIntentExecutorFactory::new_transient(usize::MAX);
         let created_instances = factory.created_instances.clone();

--- a/magicblock-committor-service/src/intent_execution_manager/intent_execution_engine.rs
+++ b/magicblock-committor-service/src/intent_execution_manager/intent_execution_engine.rs
@@ -40,14 +40,14 @@ use crate::{
 const SEMAPHORE_CLOSED_MSG: &str = "Executors semaphore closed!";
 /// Max number of executors that can send messages in parallel to Base layer
 const MAX_EXECUTORS: u8 = 50;
+/// Max intents concurrently sleeping in retry backoff. Retries release their
+/// executor slot while sleeping; this cap keeps the total task population
+/// bounded when many intents fail together
+const MAX_SLEEPING_RETRIERS: usize = 5_000;
 /// Max executions of an intent whose failures were transient
 const MAX_INTENT_ATTEMPTS: u32 = 3;
 /// Backoff between intent attempts, scaled linearly by attempt number
 const INTENT_RETRY_BACKOFF: Duration = Duration::from_secs(1);
-/// Max intents concurrently sleeping in retry backoff. Retries release their
-/// executor slot while sleeping; this cap keeps the total task population
-/// bounded when many intents fail together
-const MAX_SLEEPING_RETRIES: u8 = 50;
 
 /// Concurrency limits shared between the engine and its executor tasks
 struct ExecutionLimits {
@@ -138,9 +138,7 @@ where
             executors_semaphore: Arc::new(Semaphore::new(
                 MAX_EXECUTORS as usize,
             )),
-            retries_semaphore: Arc::new(Semaphore::new(
-                MAX_SLEEPING_RETRIES as usize,
-            )),
+            retries_semaphore: Arc::new(Semaphore::new(MAX_SLEEPING_RETRIERS)),
             inner: Arc::new(Mutex::new(IntentScheduler::new())),
         }
     }
@@ -308,15 +306,59 @@ where
         result_sender: broadcast::Sender<BroadcastedIntentExecutionResult>,
     ) {
         let instant = Instant::now();
-        let mut execution_permit = Some(execution_permit);
 
+        let (result, execution_permit) = Self::execute_with_retries(
+            executor_factory,
+            persister,
+            &intent,
+            limits,
+            execution_permit,
+        )
+        .await;
+
+        // Report
+        let _ = result.inner.as_ref().inspect_err(|err| {
+            error!(intent_id = intent.id, error = ?err, "Failed to execute intent bundle");
+        });
+        Self::execution_metrics(instant.elapsed(), &intent, &result.inner);
+        let broadcasted_result =
+            BroadcastedIntentExecutionResult::new(intent.id, result);
+        if let Err(err) = result_sender.send(broadcasted_result) {
+            warn!(error = ?err, "No result listeners");
+        }
+
+        // Unlock: remove executed task from Scheduler to unblock other intents
+        // SAFETY: Self::execute is called ONLY after IntentScheduler
+        // successfully is able to schedule execution of some Intent
+        // that means that the same Intent is SAFE to complete
+        inner_scheduler
+            .lock()
+            .expect(POISONED_INNER_MSG)
+            .complete(&intent)
+            .expect("Valid completion of previously scheduled message");
+
+        // Free worker
+        drop(execution_permit);
+    }
+
+    /// Executes an intent, retrying plausibly-transient failures with a
+    /// fresh executor. Returns the final result together with whichever
+    /// execution permit is still held (`None` only if the executors
+    /// semaphore closed mid-retry).
+    async fn execute_with_retries(
+        executor_factory: Arc<F>,
+        persister: Option<P>,
+        intent: &ScheduledIntentBundle,
+        limits: ExecutionLimits,
+        execution_permit: OwnedSemaphorePermit,
+    ) -> (IntentExecutionResult, Option<OwnedSemaphorePermit>) {
         // Commit tasks give on-chain dedup (commit nonce) to re-executed
         // sends; action-only intents can double-execute if their transaction
         // landed unobserved, so they only retry pre-send failures
         let has_dedup_guard = !intent.get_all_committed_pubkeys().is_empty();
 
-        // Execute an Intent
         let mut attempt = 0;
+        let mut execution_permit = Some(execution_permit);
         let result = loop {
             attempt += 1;
             let mut executor = executor_factory.create_instance();
@@ -329,18 +371,10 @@ where
                 }
             });
 
-            // Retry only plausibly transient failures, and never once action
-            // callbacks fired: a retry would double-report the intent outcome
-            let send_stage_failure = matches!(
-                &result.inner,
-                Err(IntentExecutorError::FailedToCommitError { .. })
-                    | Err(IntentExecutorError::FailedToFinalizeError { .. })
-            );
-            let retriable = attempt < MAX_INTENT_ATTEMPTS
-                && result.callbacks_report.is_empty()
-                && matches!(&result.inner, Err(err) if err.is_transient())
-                && (has_dedup_guard || !send_stage_failure);
-            if !retriable {
+            // break early if we can't retry anymore
+            if attempt >= MAX_INTENT_ATTEMPTS
+                || !result.is_retriable(has_dedup_guard)
+            {
                 break result;
             }
 
@@ -382,32 +416,8 @@ where
                 };
             drop(retry_permit);
         };
-        let _ = result.inner.as_ref().inspect_err(|err| {
-            error!(intent_id = intent.id, error = ?err, "Failed to execute intent bundle");
-        });
 
-        // Record metrics after execution
-        Self::execution_metrics(instant.elapsed(), &intent, &result.inner);
-
-        // Broadcast result to subscribers
-        let broadcasted_result =
-            BroadcastedIntentExecutionResult::new(intent.id, result);
-        if let Err(err) = result_sender.send(broadcasted_result) {
-            warn!(error = ?err, "No result listeners");
-        }
-
-        // Remove executed task from Scheduler to unblock other intents
-        // SAFETY: Self::execute is called ONLY after IntentScheduler
-        // successfully is able to schedule execution of some Intent
-        // that means that the same Intent is SAFE to complete
-        inner_scheduler
-            .lock()
-            .expect(POISONED_INNER_MSG)
-            .complete(&intent)
-            .expect("Valid completion of previously scheduled message");
-
-        // Free worker
-        drop(execution_permit);
+        (result, execution_permit)
     }
 
     /// Records metrics related to intent execution

--- a/magicblock-committor-service/src/intent_execution_manager/intent_execution_engine.rs
+++ b/magicblock-committor-service/src/intent_execution_manager/intent_execution_engine.rs
@@ -293,6 +293,11 @@ where
         let instant = Instant::now();
         let mut execution_permit = Some(execution_permit);
 
+        // Commit tasks give on-chain dedup (commit nonce) to re-executed
+        // sends; action-only intents can double-execute if their transaction
+        // landed unobserved, so they only retry pre-send failures
+        let has_dedup_guard = !intent.get_all_committed_pubkeys().is_empty();
+
         // Execute an Intent
         let mut attempt = 0;
         let result = loop {
@@ -309,9 +314,15 @@ where
 
             // Retry only plausibly transient failures, and never once action
             // callbacks fired: a retry would double-report the intent outcome
+            let send_stage_failure = matches!(
+                &result.inner,
+                Err(IntentExecutorError::FailedToCommitError { .. })
+                    | Err(IntentExecutorError::FailedToFinalizeError { .. })
+            );
             let retriable = attempt < MAX_INTENT_ATTEMPTS
                 && result.callbacks_report.is_empty()
-                && matches!(&result.inner, Err(err) if err.is_transient());
+                && matches!(&result.inner, Err(err) if err.is_transient())
+                && (has_dedup_guard || !send_stage_failure);
             if !retriable {
                 break result;
             }

--- a/magicblock-committor-service/src/intent_executor/error.rs
+++ b/magicblock-committor-service/src/intent_executor/error.rs
@@ -44,18 +44,11 @@ impl InternalError {
     }
 
     /// True when the failure is plausibly transient (transport, RPC
-    /// availability) and a re-send may succeed. Unmapped on-chain instruction
-    /// errors are deterministic and excluded.
+    /// availability) and a re-send may succeed.
     pub fn is_transient(&self) -> bool {
         match self {
             Self::SignerError(_) => false,
-            Self::MagicBlockRpcClientError(err) => match err.as_ref() {
-                MagicBlockRpcClientError::LookupTableDeserialize(_) => false,
-                MagicBlockRpcClientError::SentTransactionError(tx_err, _) => {
-                    !matches!(tx_err, TransactionError::InstructionError(..))
-                }
-                _ => true,
-            },
+            Self::MagicBlockRpcClientError(err) => err.is_transient(),
         }
     }
 
@@ -139,16 +132,23 @@ impl IntentExecutorError {
 
     /// True when re-executing the whole intent from scratch may succeed:
     /// the failure was transport/RPC-side rather than deterministic.
+    /// Once a commit landed (two-stage finalize failures) re-execution would
+    /// commit the same state again, so those are never transient.
     pub fn is_transient(&self) -> bool {
         match self {
             Self::EmptyIntentError
             | Self::FailedToFitError
             | Self::SignerError(_) => false,
             Self::TaskBuilderError(err) => err.is_transient(),
-            Self::FailedToCommitError { err, .. }
-            | Self::FailedToFinalizeError { err, .. } => err.is_transient(),
-            Self::FailedCommitPreparationError(err)
-            | Self::FailedFinalizePreparationError(err) => err.is_transient(),
+            Self::FailedToCommitError { err, .. } => err.is_transient(),
+            Self::FailedToFinalizeError {
+                err,
+                commit_signature: None,
+                ..
+            } => err.is_transient(),
+            Self::FailedToFinalizeError { .. }
+            | Self::FailedFinalizePreparationError(_) => false,
+            Self::FailedCommitPreparationError(err) => err.is_transient(),
         }
     }
 
@@ -550,14 +550,39 @@ mod tests {
         assert!(!err.is_transient());
 
         let err = TransactionStrategyExecutionError::InternalError(
-            InternalError::SignerError(
-                solana_signer::SignerError::Custom("oops".to_string()),
-            ),
+            InternalError::SignerError(solana_signer::SignerError::Custom(
+                "oops".to_string(),
+            )),
         );
         assert!(!err.is_transient());
 
         assert!(!super::IntentExecutorError::EmptyIntentError.is_transient());
         assert!(!super::IntentExecutorError::FailedToFitError.is_transient());
+    }
+
+    #[test]
+    fn finalize_failure_after_landed_commit_is_not_transient() {
+        let transient_err = || {
+            TransactionStrategyExecutionError::InternalError(
+                make_send_transaction_error("connection reset"),
+            )
+        };
+
+        // Single-stage: nothing landed, safe to re-execute
+        let err = super::IntentExecutorError::FailedToFinalizeError {
+            err: transient_err(),
+            commit_signature: None,
+            finalize_signature: None,
+        };
+        assert!(err.is_transient());
+
+        // Two-stage: commit landed, re-execution would commit again
+        let err = super::IntentExecutorError::FailedToFinalizeError {
+            err: transient_err(),
+            commit_signature: Some(solana_signature::Signature::default()),
+            finalize_signature: None,
+        };
+        assert!(!err.is_transient());
     }
 
     #[test]

--- a/magicblock-committor-service/src/intent_executor/error.rs
+++ b/magicblock-committor-service/src/intent_executor/error.rs
@@ -561,6 +561,77 @@ mod tests {
     }
 
     #[test]
+    fn builder_and_preparation_error_transience() {
+        use crate::{
+            intent_executor::task_info_fetcher::TaskInfoFetcherError,
+            tasks::task_builder::TaskBuilderError,
+            transaction_preparator::{
+                delivery_preparator::{
+                    DeliveryPreparatorError,
+                    InternalError as DeliveryInternalError,
+                },
+                error::TransactionPreparatorError,
+            },
+        };
+
+        fn transient_rpc_client_error() -> MagicBlockRpcClientError {
+            MagicBlockRpcClientError::SendTransaction(Box::new(
+                RpcClientError {
+                    request: Some(RpcRequest::SendTransaction),
+                    kind: Box::new(RpcClientErrorKind::Custom(
+                        "io".to_string(),
+                    )),
+                },
+            ))
+        }
+        fn transient_delivery_error() -> TransactionPreparatorError {
+            TransactionPreparatorError::from(
+                DeliveryPreparatorError::FailedToCreateALTError(
+                    DeliveryInternalError::MagicBlockRpcClientError(Box::new(
+                        transient_rpc_client_error(),
+                    )),
+                ),
+            )
+        }
+
+        // RPC-side commit-id fetch failures are transient
+        let err = super::IntentExecutorError::TaskBuilderError(
+            TaskBuilderError::CommitTasksBuildError(
+                TaskInfoFetcherError::MagicBlockRpcClientError(Box::new(
+                    transient_rpc_client_error(),
+                )),
+            ),
+        );
+        assert!(err.is_transient());
+
+        // Missing delegation metadata is deterministic
+        let err = super::IntentExecutorError::TaskBuilderError(
+            TaskBuilderError::MissingDelegationMetadata(
+                solana_pubkey::Pubkey::new_unique(),
+            ),
+        );
+        assert!(!err.is_transient());
+
+        // Commit-stage delivery preparation RPC failures are transient
+        let err = super::IntentExecutorError::FailedCommitPreparationError(
+            transient_delivery_error(),
+        );
+        assert!(err.is_transient());
+
+        // Oversized strategies are deterministic
+        let err = super::IntentExecutorError::FailedCommitPreparationError(
+            TransactionPreparatorError::FailedToFitError,
+        );
+        assert!(!err.is_transient());
+
+        // Finalize preparation runs after a landed commit - always terminal
+        let err = super::IntentExecutorError::FailedFinalizePreparationError(
+            transient_delivery_error(),
+        );
+        assert!(!err.is_transient());
+    }
+
+    #[test]
     fn finalize_failure_after_landed_commit_is_not_transient() {
         let transient_err = || {
             TransactionStrategyExecutionError::InternalError(

--- a/magicblock-committor-service/src/intent_executor/error.rs
+++ b/magicblock-committor-service/src/intent_executor/error.rs
@@ -43,6 +43,22 @@ impl InternalError {
         }
     }
 
+    /// True when the failure is plausibly transient (transport, RPC
+    /// availability) and a re-send may succeed. Unmapped on-chain instruction
+    /// errors are deterministic and excluded.
+    pub fn is_transient(&self) -> bool {
+        match self {
+            Self::SignerError(_) => false,
+            Self::MagicBlockRpcClientError(err) => match err.as_ref() {
+                MagicBlockRpcClientError::LookupTableDeserialize(_) => false,
+                MagicBlockRpcClientError::SentTransactionError(tx_err, _) => {
+                    !matches!(tx_err, TransactionError::InstructionError(..))
+                }
+                _ => true,
+            },
+        }
+    }
+
     pub fn is_transaction_too_large(&self) -> bool {
         fn is_send_transaction_too_large(err: &RpcClientError) -> bool {
             matches!(err.request, Some(RpcRequest::SendTransaction))
@@ -121,6 +137,21 @@ impl IntentExecutorError {
         }
     }
 
+    /// True when re-executing the whole intent from scratch may succeed:
+    /// the failure was transport/RPC-side rather than deterministic.
+    pub fn is_transient(&self) -> bool {
+        match self {
+            Self::EmptyIntentError
+            | Self::FailedToFitError
+            | Self::SignerError(_) => false,
+            Self::TaskBuilderError(err) => err.is_transient(),
+            Self::FailedToCommitError { err, .. }
+            | Self::FailedToFinalizeError { err, .. } => err.is_transient(),
+            Self::FailedCommitPreparationError(err)
+            | Self::FailedFinalizePreparationError(err) => err.is_transient(),
+        }
+    }
+
     pub fn signatures(&self) -> Option<(Signature, Option<Signature>)> {
         match self {
             IntentExecutorError::FailedToCommitError { signature, err: _ } => {
@@ -195,6 +226,15 @@ impl TransactionStrategyExecutionError {
     /// Number of compute budget instructions prepended to every transaction.
     /// Used to map instruction indices back to task indices.
     const TASK_OFFSET: u8 = 2;
+
+    /// On-chain domain errors are deterministic (and already have dedicated
+    /// recovery paths); only internal transport failures are transient.
+    pub fn is_transient(&self) -> bool {
+        match self {
+            Self::InternalError(err) => err.is_transient(),
+            _ => false,
+        }
+    }
 
     pub fn is_cpi_limit_error(&self) -> bool {
         matches!(
@@ -473,6 +513,51 @@ mod tests {
         let err =
             TransactionStrategyExecutionError::TransactionTooLargeError(inner);
         assert!(err.is_recoverable_by_two_stage());
+    }
+
+    #[test]
+    fn transport_errors_are_transient() {
+        let err = TransactionStrategyExecutionError::InternalError(
+            make_send_transaction_error("connection reset"),
+        );
+        assert!(err.is_transient());
+
+        let err = TransactionStrategyExecutionError::InternalError(
+            InternalError::MagicBlockRpcClientError(Box::new(
+                MagicBlockRpcClientError::SentTransactionError(
+                    solana_transaction_error::TransactionError::BlockhashNotFound,
+                    solana_signature::Signature::default(),
+                ),
+            )),
+        );
+        assert!(err.is_transient());
+    }
+
+    #[test]
+    fn deterministic_errors_are_not_transient() {
+        // Landed on-chain with an instruction error - deterministic
+        let err = TransactionStrategyExecutionError::InternalError(
+            InternalError::MagicBlockRpcClientError(Box::new(
+                MagicBlockRpcClientError::SentTransactionError(
+                    solana_transaction_error::TransactionError::InstructionError(
+                        2,
+                        solana_instruction::error::InstructionError::Custom(1),
+                    ),
+                    solana_signature::Signature::default(),
+                ),
+            )),
+        );
+        assert!(!err.is_transient());
+
+        let err = TransactionStrategyExecutionError::InternalError(
+            InternalError::SignerError(
+                solana_signer::SignerError::Custom("oops".to_string()),
+            ),
+        );
+        assert!(!err.is_transient());
+
+        assert!(!super::IntentExecutorError::EmptyIntentError.is_transient());
+        assert!(!super::IntentExecutorError::FailedToFitError.is_transient());
     }
 
     #[test]

--- a/magicblock-committor-service/src/intent_executor/intent_execution_client.rs
+++ b/magicblock-committor-service/src/intent_executor/intent_execution_client.rs
@@ -50,6 +50,9 @@ impl IntentExecutionClient {
     {
         struct IntentErrorMapper<TxMap> {
             transaction_error_mapper: TxMap,
+            /// Commit/finalize/undelegate tasks make a duplicate landing fail
+            /// the whole retried transaction, so re-sends cannot double-apply
+            has_dedup_guard: bool,
         }
         impl<TxMap> SendErrorMapper<InternalError> for IntentErrorMapper<TxMap>
         where
@@ -76,12 +79,25 @@ impl IntentExecutionClient {
             }
 
             fn decide_flow(
+                &self,
                 err: &Self::ExecutionError,
             ) -> ControlFlow<(), Duration> {
-                match err {
-                    TransactionStrategyExecutionError::InternalError(
-                        InternalError::MagicBlockRpcClientError(err),
-                    ) => decide_rpc_error_flow(err),
+                let TransactionStrategyExecutionError::InternalError(
+                    InternalError::MagicBlockRpcClientError(err),
+                ) = err
+                else {
+                    return ControlFlow::Break(());
+                };
+                if self.has_dedup_guard {
+                    return decide_rpc_error_flow(err);
+                }
+                // Action-only transactions have no on-chain dedup: a re-send
+                // with a fresh blockhash could execute the actions twice.
+                // Only failures from before signing & sending are retriable.
+                match err.as_ref() {
+                    MagicBlockRpcClientError::GetLatestBlockhash(_) => {
+                        decide_rpc_error_flow(err)
+                    }
                     _ => ControlFlow::Break(()),
                 }
             }
@@ -93,6 +109,9 @@ impl IntentExecutionClient {
         // Send with retries
         let send_error_mapper = IntentErrorMapper {
             transaction_error_mapper: IntentTransactionErrorMapper { tasks },
+            has_dedup_guard: tasks
+                .iter()
+                .any(|task| !matches!(task, BaseTaskImpl::BaseAction(_))),
         };
         let attempt = || async {
             self.send_prepared_message(authority, prepared_message.clone())

--- a/magicblock-committor-service/src/intent_executor/mod.rs
+++ b/magicblock-committor-service/src/intent_executor/mod.rs
@@ -571,6 +571,11 @@ where
         let result = self
             .execute_inner(base_intent, &mut execution_report, &persister)
             .await;
+        if result.is_err() {
+            // A stale cached blockhash may be the failure cause; drop it so
+            // an engine-level retry fetches a fresh one
+            self.intent_client.invalidate_cached_blockhash().await;
+        }
         if !pubkeys.is_empty() {
             // Reset TaskInfoFetcher, as cache could become invalid
             if result.is_err() {

--- a/magicblock-committor-service/src/intent_executor/mod.rs
+++ b/magicblock-committor-service/src/intent_executor/mod.rs
@@ -94,6 +94,27 @@ pub struct IntentExecutionResult {
     pub callbacks_report: Vec<Result<Signature, CallbackScheduleError>>,
 }
 
+impl IntentExecutionResult {
+    /// Whether a failed execution is safe to retry with a fresh executor.
+    ///
+    /// Never retries once action callbacks have reported (a retry would
+    /// double-report the outcome), and only retries plausibly transient
+    /// errors. Commit tasks give on-chain dedup (commit nonce) to re-executed
+    /// sends; action-only intents (`has_dedup_guard == false`) have no such
+    /// guard and can double-execute if their transaction landed unobserved,
+    /// so they only retry pre-send failures.
+    pub fn is_retriable(&self, has_dedup_guard: bool) -> bool {
+        let send_stage_failure = matches!(
+            &self.inner,
+            Err(IntentExecutorError::FailedToCommitError { .. })
+                | Err(IntentExecutorError::FailedToFinalizeError { .. })
+        );
+        self.callbacks_report.is_empty()
+            && matches!(&self.inner, Err(err) if err.is_transient())
+            && (has_dedup_guard || !send_stage_failure)
+    }
+}
+
 #[async_trait]
 pub trait IntentExecutor: Send + Sync + 'static {
     /// Executes Message on Base layer

--- a/magicblock-committor-service/src/intent_executor/single_stage_executor.rs
+++ b/magicblock-committor-service/src/intent_executor/single_stage_executor.rs
@@ -84,6 +84,8 @@ where
             self.current_attempt += 1;
 
             // Prepare & execute message
+            // Preparation failures here happen before anything landed, so
+            // they are commit-stage errors (safe to re-execute the intent)
             let execution_result = prepare_and_execute_strategy(
                 &self.intent_client,
                 &self.authority,
@@ -92,7 +94,7 @@ where
                 persister,
             )
             .await
-            .map_err(IntentExecutorError::FailedFinalizePreparationError)?;
+            .map_err(IntentExecutorError::FailedCommitPreparationError)?;
 
             // Process error: Ok - return, Err - handle further
             let execution_err = match execution_result {
@@ -293,7 +295,7 @@ where
             &None::<IntentPersisterImpl>,
         )
         .await
-        .map_err(IntentExecutorError::FailedFinalizePreparationError)?
+        .map_err(IntentExecutorError::FailedCommitPreparationError)?
         .map_err(|err| IntentExecutorError::FailedToFinalizeError {
             err,
             commit_signature: None,

--- a/magicblock-committor-service/src/intent_executor/single_stage_executor.rs
+++ b/magicblock-committor-service/src/intent_executor/single_stage_executor.rs
@@ -84,8 +84,6 @@ where
             self.current_attempt += 1;
 
             // Prepare & execute message
-            // Preparation failures here happen before anything landed, so
-            // they are commit-stage errors (safe to re-execute the intent)
             let execution_result = prepare_and_execute_strategy(
                 &self.intent_client,
                 &self.authority,
@@ -94,7 +92,7 @@ where
                 persister,
             )
             .await
-            .map_err(IntentExecutorError::FailedCommitPreparationError)?;
+            .map_err(IntentExecutorError::FailedFinalizePreparationError)?;
 
             // Process error: Ok - return, Err - handle further
             let execution_err = match execution_result {
@@ -295,7 +293,7 @@ where
             &None::<IntentPersisterImpl>,
         )
         .await
-        .map_err(IntentExecutorError::FailedCommitPreparationError)?
+        .map_err(IntentExecutorError::FailedFinalizePreparationError)?
         .map_err(|err| IntentExecutorError::FailedToFinalizeError {
             err,
             commit_signature: None,

--- a/magicblock-committor-service/src/intent_executor/task_info_fetcher.rs
+++ b/magicblock-committor-service/src/intent_executor/task_info_fetcher.rs
@@ -655,6 +655,16 @@ pub enum TaskInfoFetcherError {
 }
 
 impl TaskInfoFetcherError {
+    /// RPC-side fetch failures are transient; malformed or absent
+    /// delegation accounts are deterministic.
+    pub fn is_transient(&self) -> bool {
+        matches!(
+            self,
+            Self::MinContextSlotNotReachedError(_, _)
+                | Self::MagicBlockRpcClientError(_)
+        )
+    }
+
     pub fn map_client_error(
         min_context_slot: u64,
         e: MagicBlockRpcClientError,

--- a/magicblock-committor-service/src/intent_executor/task_info_fetcher.rs
+++ b/magicblock-committor-service/src/intent_executor/task_info_fetcher.rs
@@ -658,11 +658,11 @@ impl TaskInfoFetcherError {
     /// RPC-side fetch failures are transient; malformed or absent
     /// delegation accounts are deterministic.
     pub fn is_transient(&self) -> bool {
-        matches!(
-            self,
-            Self::MinContextSlotNotReachedError(_, _)
-                | Self::MagicBlockRpcClientError(_)
-        )
+        match self {
+            Self::MinContextSlotNotReachedError(_, _) => true,
+            Self::MagicBlockRpcClientError(err) => err.is_transient(),
+            _ => false,
+        }
     }
 
     pub fn map_client_error(

--- a/magicblock-committor-service/src/intent_executor/two_stage_executor.rs
+++ b/magicblock-committor-service/src/intent_executor/two_stage_executor.rs
@@ -116,7 +116,7 @@ where
             self.state.current_attempt += 1;
 
             // Prepare & execute message
-            let execution_result = match prepare_and_execute_strategy(
+            let execution_result = prepare_and_execute_strategy(
                 &self.intent_client,
                 &self.authority,
                 transaction_preparator,
@@ -124,23 +124,19 @@ where
                 persister,
             )
             .await
-            {
-                Ok(value) => value,
-                Err(err) => {
-                    // Preparation may have reserved ALTs or initialized
-                    // buffers already - surrender strategies for cleanup
-                    self.dispose_strategies();
-                    return Err(
-                        IntentExecutorError::FailedCommitPreparationError(err),
-                    );
-                }
-            };
+            .map_err(IntentExecutorError::FailedCommitPreparationError)
+            .inspect_err(|_| {
+                // Preparation may have reserved ALTs or initialized
+                // buffers already - surrender strategies for cleanup
+                self.dispose_strategies();
+            })?;
+
             let execution_err = match execution_result {
                 Ok(value) => break Ok(value),
                 Err(err) => err,
             };
 
-            let flow = match self
+            let flow = self
                 .patch_commit_strategy(
                     &execution_err,
                     task_info_fetcher,
@@ -148,13 +144,9 @@ where
                     committed_pubkeys,
                 )
                 .await
-            {
-                Ok(value) => value,
-                Err(err) => {
+                .inspect_err(|_| {
                     self.dispose_strategies();
-                    return Err(err);
-                }
-            };
+                })?;
             let cleanup = match flow {
                 ControlFlow::Continue(value) => value,
                 ControlFlow::Break(()) => {
@@ -426,7 +418,7 @@ where
             self.state.current_attempt += 1;
 
             // Prepare & execute message
-            let execution_result = match prepare_and_execute_strategy(
+            let execution_result = prepare_and_execute_strategy(
                 &self.intent_client,
                 &self.authority,
                 transaction_preparator,
@@ -434,33 +426,23 @@ where
                 persister,
             )
             .await
-            {
-                Ok(value) => value,
-                Err(err) => {
-                    // Preparation may have reserved ALTs or initialized
-                    // buffers already - surrender strategy for cleanup
-                    self.dispose_strategy();
-                    return Err(
-                        IntentExecutorError::FailedFinalizePreparationError(
-                            err,
-                        ),
-                    );
-                }
-            };
+            .map_err(IntentExecutorError::FailedFinalizePreparationError)
+            .inspect_err(|_| {
+                // Preparation may have reserved ALTs or initialized
+                // buffers already - surrender strategy for cleanup
+                self.dispose_strategy();
+            })?;
             let execution_err = match execution_result {
                 Ok(value) => break Ok(value),
                 Err(err) => err,
             };
 
-            let flow = match self.patch_finalize_strategy(&execution_err).await
-            {
-                Ok(value) => value,
-                Err(err) => {
+            let flow = self
+                .patch_finalize_strategy(&execution_err)
+                .await
+                .inspect_err(|_| {
                     self.dispose_strategy();
-                    return Err(err);
-                }
-            };
-
+                })?;
             let cleanup = match flow {
                 ControlFlow::Continue(cleanup) => cleanup,
                 ControlFlow::Break(()) => {

--- a/magicblock-committor-service/src/intent_executor/two_stage_executor.rs
+++ b/magicblock-committor-service/src/intent_executor/two_stage_executor.rs
@@ -116,7 +116,7 @@ where
             self.state.current_attempt += 1;
 
             // Prepare & execute message
-            let execution_result = prepare_and_execute_strategy(
+            let execution_result = match prepare_and_execute_strategy(
                 &self.intent_client,
                 &self.authority,
                 transaction_preparator,
@@ -124,20 +124,37 @@ where
                 persister,
             )
             .await
-            .map_err(IntentExecutorError::FailedCommitPreparationError)?;
+            {
+                Ok(value) => value,
+                Err(err) => {
+                    // Preparation may have reserved ALTs or initialized
+                    // buffers already - surrender strategies for cleanup
+                    self.dispose_strategies();
+                    return Err(
+                        IntentExecutorError::FailedCommitPreparationError(err),
+                    );
+                }
+            };
             let execution_err = match execution_result {
                 Ok(value) => break Ok(value),
                 Err(err) => err,
             };
 
-            let flow = self
+            let flow = match self
                 .patch_commit_strategy(
                     &execution_err,
                     task_info_fetcher,
                     transaction_preparator,
                     committed_pubkeys,
                 )
-                .await?;
+                .await
+            {
+                Ok(value) => value,
+                Err(err) => {
+                    self.dispose_strategies();
+                    return Err(err);
+                }
+            };
             let cleanup = match flow {
                 ControlFlow::Continue(value) => value,
                 ControlFlow::Break(()) => {
@@ -318,6 +335,16 @@ where
         }))
     }
 
+    /// Surrenders both strategies to the execution report so the engine
+    /// cleanup releases partially prepared resources (ALT reservations,
+    /// buffer accounts) of failed attempts
+    fn dispose_strategies(&mut self) {
+        let commit_strategy = mem::take(&mut self.state.commit_strategy);
+        self.execution_report.dispose(commit_strategy);
+        let finalize_strategy = mem::take(&mut self.state.finalize_strategy);
+        self.execution_report.dispose(finalize_strategy);
+    }
+
     pub fn has_callbacks(&self) -> bool {
         self.state.commit_strategy.has_actions_callbacks()
             || self.state.finalize_strategy.has_actions_callbacks()
@@ -399,7 +426,7 @@ where
             self.state.current_attempt += 1;
 
             // Prepare & execute message
-            let execution_result = prepare_and_execute_strategy(
+            let execution_result = match prepare_and_execute_strategy(
                 &self.intent_client,
                 &self.authority,
                 transaction_preparator,
@@ -407,13 +434,32 @@ where
                 persister,
             )
             .await
-            .map_err(IntentExecutorError::FailedFinalizePreparationError)?;
+            {
+                Ok(value) => value,
+                Err(err) => {
+                    // Preparation may have reserved ALTs or initialized
+                    // buffers already - surrender strategy for cleanup
+                    self.dispose_strategy();
+                    return Err(
+                        IntentExecutorError::FailedFinalizePreparationError(
+                            err,
+                        ),
+                    );
+                }
+            };
             let execution_err = match execution_result {
                 Ok(value) => break Ok(value),
                 Err(err) => err,
             };
 
-            let flow = self.patch_finalize_strategy(&execution_err).await?;
+            let flow = match self.patch_finalize_strategy(&execution_err).await
+            {
+                Ok(value) => value,
+                Err(err) => {
+                    self.dispose_strategy();
+                    return Err(err);
+                }
+            };
 
             let cleanup = match flow {
                 ControlFlow::Continue(cleanup) => cleanup,
@@ -445,6 +491,13 @@ where
                 Some(self.state.commit_signature),
             )
         })
+    }
+
+    /// Surrenders the finalize strategy to the execution report so the engine
+    /// cleanup releases partially prepared resources of failed attempts
+    fn dispose_strategy(&mut self) {
+        let finalize_strategy = mem::take(&mut self.state.finalize_strategy);
+        self.execution_report.dispose(finalize_strategy);
     }
 
     pub fn has_callbacks(&self) -> bool {

--- a/magicblock-committor-service/src/tasks/task_builder.rs
+++ b/magicblock-committor-service/src/tasks/task_builder.rs
@@ -471,6 +471,14 @@ impl TaskBuilderError {
             Self::MissingDelegationMetadata(_) => None,
         }
     }
+
+    pub fn is_transient(&self) -> bool {
+        match self {
+            Self::CommitTasksBuildError(err)
+            | Self::FinalizedTasksBuildError(err) => err.is_transient(),
+            Self::MissingDelegationMetadata(_) => false,
+        }
+    }
 }
 
 pub type TaskBuilderResult<T, E = TaskBuilderError> = Result<T, E>;

--- a/magicblock-committor-service/src/transaction_preparator/delivery_preparator.rs
+++ b/magicblock-committor-service/src/transaction_preparator/delivery_preparator.rs
@@ -400,6 +400,7 @@ impl DeliveryPreparator {
             }
 
             fn decide_flow(
+                &self,
                 err: &Self::ExecutionError,
             ) -> ControlFlow<(), Duration> {
                 match err {

--- a/magicblock-committor-service/src/transaction_preparator/delivery_preparator.rs
+++ b/magicblock-committor-service/src/transaction_preparator/delivery_preparator.rs
@@ -601,6 +601,13 @@ impl TransactionSendError {
             _ => None,
         }
     }
+
+    pub fn is_transient(&self) -> bool {
+        match self {
+            Self::CompileError(_) | Self::SignerError(_) => false,
+            Self::MagicBlockRpcClientError(err) => err.is_transient(),
+        }
+    }
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -619,6 +626,13 @@ impl BufferExecutionError {
         match self {
             Self::AccountAlreadyInitializedError(_, signature) => *signature,
             Self::TransactionSendError(err) => err.signature(),
+        }
+    }
+
+    pub fn is_transient(&self) -> bool {
+        match self {
+            Self::AccountAlreadyInitializedError(_, _) => false,
+            Self::TransactionSendError(err) => err.is_transient(),
         }
     }
 }
@@ -645,6 +659,20 @@ pub enum InternalError {
     MagicBlockRpcClientError(Box<MagicBlockRpcClientError>),
     #[error("BufferExecutionError: {0}")]
     BufferExecutionError(#[from] BufferExecutionError),
+}
+
+impl InternalError {
+    /// A from-scratch re-preparation recreates missing chunk PDAs, so those
+    /// count as transient alongside RPC and table-sync failures.
+    pub fn is_transient(&self) -> bool {
+        match self {
+            Self::ZeroRetriesRequestedError | Self::BorshError(_) => false,
+            Self::ChunksPDAMissingError(_) => true,
+            Self::TableManiaError(err) => err.is_transient(),
+            Self::MagicBlockRpcClientError(err) => err.is_transient(),
+            Self::BufferExecutionError(err) => err.is_transient(),
+        }
+    }
 }
 
 impl From<MagicBlockRpcClientError> for InternalError {

--- a/magicblock-committor-service/src/transaction_preparator/delivery_preparator.rs
+++ b/magicblock-committor-service/src/transaction_preparator/delivery_preparator.rs
@@ -632,7 +632,9 @@ impl BufferExecutionError {
 
     pub fn is_transient(&self) -> bool {
         match self {
-            Self::AccountAlreadyInitializedError(_, _) => false,
+            // Leftover buffer from a prior attempt: the cleanup-and-retry in
+            // `prepare_task_handling_errors` failed, a fresh attempt can heal
+            Self::AccountAlreadyInitializedError(_, _) => true,
             Self::TransactionSendError(err) => err.is_transient(),
         }
     }

--- a/magicblock-committor-service/src/transaction_preparator/delivery_preparator.rs
+++ b/magicblock-committor-service/src/transaction_preparator/delivery_preparator.rs
@@ -678,6 +678,13 @@ impl DeliveryPreparatorError {
             | Self::FailedToPrepareBufferAccounts(err) => err.signature(),
         }
     }
+
+    pub fn is_transient(&self) -> bool {
+        match self {
+            Self::FailedToCreateALTError(err)
+            | Self::FailedToPrepareBufferAccounts(err) => err.is_transient(),
+        }
+    }
 }
 
 pub type DeliveryPreparatorResult<T, E = DeliveryPreparatorError> =

--- a/magicblock-committor-service/src/transaction_preparator/error.rs
+++ b/magicblock-committor-service/src/transaction_preparator/error.rs
@@ -30,6 +30,13 @@ impl TransactionPreparatorError {
             _ => None,
         }
     }
+
+    pub fn is_transient(&self) -> bool {
+        match self {
+            Self::FailedToFitError | Self::SignerError(_) => false,
+            Self::DeliveryPreparationError(err) => err.is_transient(),
+        }
+    }
 }
 
 impl From<TaskStrategistError> for TransactionPreparatorError {

--- a/magicblock-rpc-client/src/lib.rs
+++ b/magicblock-rpc-client/src/lib.rs
@@ -110,6 +110,19 @@ impl MagicBlockRpcClientError {
             _ => None,
         }
     }
+
+    /// True when the failure is plausibly transient (transport, RPC
+    /// availability) and retrying may succeed. Unmapped on-chain instruction
+    /// errors are deterministic and excluded.
+    pub fn is_transient(&self) -> bool {
+        match self {
+            Self::LookupTableDeserialize(_) => false,
+            Self::SentTransactionError(tx_err, _) => {
+                !matches!(tx_err, TransactionError::InstructionError(..))
+            }
+            _ => true,
+        }
+    }
 }
 
 pub type MagicBlockRpcClientResult<T> =

--- a/magicblock-rpc-client/src/utils.rs
+++ b/magicblock-rpc-client/src/utils.rs
@@ -1,6 +1,9 @@
 use std::{future::Future, ops::ControlFlow, time::Duration};
 
-use solana_rpc_client_api::client_error::ErrorKind;
+use solana_rpc_client_api::{
+    client_error::ErrorKind,
+    custom_error::JSON_RPC_SERVER_ERROR_NODE_UNHEALTHY, request::RpcError,
+};
 use solana_signature::Signature;
 use solana_transaction_error::TransactionError;
 use tokio::time::{sleep, Instant};
@@ -211,17 +214,79 @@ pub fn decide_rpc_native_flow(
     match &*err.kind {
         // Retry IO errors
         ErrorKind::Io(_) => ControlFlow::Continue(Duration::from_millis(500)),
-        // Retry 5xx server errors
-        ErrorKind::Reqwest(err) => match err.status() {
-            Some(status) if status.is_server_error() => {
-                trace!(error = ?err, "Server error during sending transaction");
-                ControlFlow::Continue(Duration::from_millis(100))
-            }
-            _ => ControlFlow::Break(()),
-        },
+        ErrorKind::Reqwest(err) => {
+            trace!(error = ?err, "HTTP error during sending transaction");
+            decide_reqwest_flow(err.status().map(|status| status.as_u16()))
+        }
+        // Node behind on slots reports itself unhealthy - transient
+        ErrorKind::RpcError(RpcError::RpcResponseError {
+            code: JSON_RPC_SERVER_ERROR_NODE_UNHEALTHY,
+            ..
+        }) => ControlFlow::Continue(Duration::from_millis(500)),
         _ => {
             // Can't handle - propagate
             ControlFlow::Break(())
         }
+    }
+}
+
+/// A reqwest error with no status is a transport failure (connect, timeout,
+/// reset); 5xx and 429 are transient server conditions. All are retriable.
+fn decide_reqwest_flow(status: Option<u16>) -> ControlFlow<(), Duration> {
+    match status {
+        None => ControlFlow::Continue(Duration::from_millis(500)),
+        Some(status) if (500..600).contains(&status) => {
+            ControlFlow::Continue(Duration::from_millis(100))
+        }
+        Some(429) => ControlFlow::Continue(Duration::from_millis(500)),
+        Some(_) => ControlFlow::Break(()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_reqwest_transport_and_transient_statuses_retried() {
+        assert!(decide_reqwest_flow(None).is_continue());
+        assert!(decide_reqwest_flow(Some(500)).is_continue());
+        assert!(decide_reqwest_flow(Some(503)).is_continue());
+        assert!(decide_reqwest_flow(Some(429)).is_continue());
+    }
+
+    #[test]
+    fn test_reqwest_client_errors_not_retried() {
+        assert!(decide_reqwest_flow(Some(400)).is_break());
+        assert!(decide_reqwest_flow(Some(403)).is_break());
+        assert!(decide_reqwest_flow(Some(404)).is_break());
+    }
+
+    #[test]
+    fn test_node_unhealthy_rpc_error_retried() {
+        let err = solana_rpc_client_api::client_error::Error {
+            request: None,
+            kind: Box::new(ErrorKind::RpcError(RpcError::RpcResponseError {
+                code: JSON_RPC_SERVER_ERROR_NODE_UNHEALTHY,
+                message: "Node is behind".to_string(),
+                data:
+                    solana_rpc_client_api::request::RpcResponseErrorData::Empty,
+            })),
+        };
+        assert!(decide_rpc_native_flow(&err).is_continue());
+    }
+
+    #[test]
+    fn test_other_rpc_errors_not_retried() {
+        let err = solana_rpc_client_api::client_error::Error {
+            request: None,
+            kind: Box::new(ErrorKind::RpcError(RpcError::RpcResponseError {
+                code: -32602,
+                message: "invalid params".to_string(),
+                data:
+                    solana_rpc_client_api::request::RpcResponseErrorData::Empty,
+            })),
+        };
+        assert!(decide_rpc_native_flow(&err).is_break());
     }
 }

--- a/magicblock-rpc-client/src/utils.rs
+++ b/magicblock-rpc-client/src/utils.rs
@@ -15,6 +15,7 @@ pub trait SendErrorMapper<E> {
     type ExecutionError;
     fn map(&self, error: E) -> Self::ExecutionError;
     fn decide_flow(
+        &self,
         mapped_error: &Self::ExecutionError,
     ) -> ControlFlow<(), Duration>;
 }
@@ -60,7 +61,8 @@ where
             Err(err) => err,
         };
         let mapped_error = send_result_mapper.map(err);
-        let sleep_duration = match Map::decide_flow(&mapped_error) {
+        let sleep_duration = match send_result_mapper.decide_flow(&mapped_error)
+        {
             ControlFlow::Continue(value) => value,
             ControlFlow::Break(()) => return Err(mapped_error),
         };

--- a/magicblock-table-mania/src/error.rs
+++ b/magicblock-table-mania/src/error.rs
@@ -36,6 +36,19 @@ impl TableManiaError {
         }
     }
 
+    /// RPC-side failures and table-sync timeouts are transient;
+    /// misuse errors are deterministic.
+    pub fn is_transient(&self) -> bool {
+        match self {
+            Self::MagicBlockRpcClientError(err) => err.is_transient(),
+            Self::TimedOutWaitingForRemoteTablesToUpdate(_)
+            | Self::TimedOutWaitingForLocalTablesToUpdate(_) => true,
+            Self::CannotExtendDeactivatedTable(_)
+            | Self::InvalidAuthority(_, _)
+            | Self::MaxExtendPubkeysExceeded(_, _) => false,
+        }
+    }
+
     pub fn is_sent_transaction_invalid_instruction_data_at(
         &self,
         instruction_index: u8,


### PR DESCRIPTION
## Problem

A commit intent that hit a transient error was dropped permanently:

- The transaction send-retry loop treated status-less reqwest errors (connection reset/timeout), HTTP 429 and node-unhealthy RPC responses as fatal, so a single network blip failed the send on the first attempt.
- Once an intent failed, nothing retried it: the engine broadcast the failure, marked the intent complete and persisted `Failed` — a status restart recovery never picks up. Failed undelegating intents left accounts permanently stuck.

## Fix

- `magicblock-rpc-client`: retry status-less reqwest errors, 429 and node-unhealthy responses in `decide_rpc_native_flow`.
- `magicblock-committor-service`: classify executor errors as transient (transport/RPC-side) vs deterministic via `is_transient()` across the error taxonomy.
- Execution engine: re-execute a transiently failed intent up to 3 times with linear backoff, using a fresh executor per attempt. The scheduler keeps conflicting intents blocked for the duration, so per-account commit ordering is preserved. Intents whose action callbacks already fired are never retried (a retry would double-report the outcome to user programs).

Deterministic failures (ill-formed actions, signer errors, unmapped instruction errors, too-large transactions) still fail on the first attempt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic retries for eligible temporary intent execution failures, with bounded backoff and concurrency protection.
  * Improved retry decisions across transaction, task preparation, and execution stages.
  * Added recovery handling so failed attempts clean up resources safely and can resume after interruptions.
* **Bug Fixes**
  * Improved handling of temporary network, rate-limit, and unhealthy-node errors.
  * Prevented retries for deterministic failures and actions that may already have been reported.
* **Documentation**
  * Updated retry and recovery guidance to reflect the new behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->