### PR TITLE
fix: release replication sender that stalls the shutdown drain

### DIFF
--- a/.agents/context/crates/magicblock-api.md
+++ b/.agents/context/crates/magicblock-api.md
@@ -133,7 +133,7 @@ Caveats:
 2. Ledger replay uses `process_ledger` with a blockhash age derived from configured block time.
 3. After replay, Magic Program scheduled actions are cleared so replayed accept-commit transactions do not re-commit.
 4. Optional AccountsDb defragmentation runs before normal work starts; this is explicitly marked safe only before cleanup, scheduler mode changes, replication, slot ticks, or task recovery.
-5. Standalone/primary nodes reset the bank and, for primaries, send a replication `Message::Reset`.
+5. Standalone/primary nodes reset the bank and, for primaries, send a replication `Message::Reset`. The retained replication sender is dropped after this one-shot send: the shutdown drain treats channel closure as "producer finished", so only the scheduler may keep a sender clone.
 6. The intent execution service starts only after replay/reset and handles pending commit intent recovery before its normal accept loop.
 7. Standalone nodes switch the scheduler to `SchedulerMode::Primary`; primary/replica modes spawn the replication service instead.
 8. Non-replica validators start `UndelegationRequestService`; it consumes Chainlink observed requests and the configured polling backfill. Replicas keep Chainlink disabled and do not scan DLP requests.
@@ -167,7 +167,7 @@ This service is started only for non-replica validators.
 ### Shutdown flow: `MagicValidator::stop`
 
 1. Send unregister transaction in the background when standalone ephemeral on-chain coordination is enabled.
-2. Set the local `exit` flag and cancel the shared cancellation token.
+2. Set the local `exit` flag, drop any remaining replication sender, and cancel the shared cancellation token. The sender must be gone before the primary replication drain runs, otherwise the drain cannot observe channel closure and waits out its full timeout.
 3. Stop the undelegation request service, then the intent execution service.
 4. Stop claim-fees task.
 5. Join RPC thread, slot ticker, ledger truncator, replication thread, and transaction execution thread.

--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -1023,8 +1023,10 @@ impl MagicValidator {
                 self.config.validator.replication_mode,
                 ReplicationMode::Primary(_)
             ) {
+                // Take the sender: this is its only use, and the shutdown
+                // drain only completes once every sender clone is dropped.
                 let replication_tx =
-                    self.replication_tx.as_ref().ok_or_else(|| {
+                    self.replication_tx.take().ok_or_else(|| {
                         ApiError::FailedToSendModeSwitch(
                             "replication sink missing in primary mode"
                                 .to_owned(),
@@ -1157,6 +1159,11 @@ impl MagicValidator {
         let stop_start = Instant::now();
         self.start_unregister_validator_on_chain().await;
         self.exit.store(true, Ordering::Relaxed);
+
+        // Drop any remaining replication sender before cancelling: the
+        // replication drain treats a closed channel as "producer finished"
+        // and otherwise waits out its full timeout.
+        self.replication_tx = None;
 
         // Stop request ingress before stopping intent execution so shutdown
         // does not admit new local undelegation scheduling work.


### PR DESCRIPTION
## Problem

#1427 hardened the shutdown drain in the primary replication service: instead of treating an empty queue as done, `next_to_drain` now waits for the replication channel to close so the scheduler's final block is never dropped.

However, the channel can never close during shutdown. `MagicValidator` holds its own clone of the replication sender (`replication_tx`), which is used exactly once — to send the initial `Reset` message during `start()` — and is then kept alive for the entire process lifetime. Since `stop()` joins the replication service while `self` still owns that sender, `recv()` can never return `None`, and the drain always waits out the full `SHUTDOWN_DRAIN_TIMEOUT` (3s).

This is a regression on every graceful restart of a primary: the drain finishes its real work within milliseconds (the scheduler exits and drops its sender clone right after the cancel signal), then idles for the remaining ~3s. That stall sits in the window where the RPC servers and executors are already down, so it directly extends validator downtime during a restart.

## Fix

- `start()`: take the sender out of `self` for the one-shot `Reset` send, so it is dropped immediately after its only use.
- `stop()`: defensively clear `replication_tx` before cancelling the shutdown token, covering modes and failure paths where the `start()` branch never ran.

With both in place the scheduler owns the last sender clone: the drain still confirms every pending message, then observes channel closure (`ProducerFinished`) as #1427 intended, instead of hitting the timeout.

## Validation

- `cargo check -p magicblock-api` and nightly `fmt --check` pass.
- On a primary shutdown, `replication_service_join` should log ~tens of ms and the drain should log `replication shutdown drain complete` instead of `replication shutdown drain timed out`.