### PR TITLE
Revert "feat: tiered account subscriptions with gRPC-only coverage for missing accounts"

### DIFF
--- a/.agents/context/crates/magicblock-chainlink.md
+++ b/.agents/context/crates/magicblock-chainlink.md
@@ -162,21 +162,6 @@ Empty placeholders are created in `RemoteAccountProvider::try_get_multi` when RP
 4. Waits for either RPC results or a subscription update that is at least as new as the fetch start slot.
 5. Returns results in input order.
 
-Fetch-owned unknown accounts enter a bounded secondary subscription LRU rather
-than the primary working-set LRU. They retain full websocket and gRPC coverage
-while the fetch is pending. A winning not-found result switches to gRPC-only
-coverage when gRPC is available; a winning found result moves the account to
-the primary LRU. If protected primary entries leave no promotion capacity, the
-found fetch fails and its secondary subscription is rolled back. Refetching a
-confirmed miss restores full coverage for the duration of the new pending
-fetch. Results discarded by fetch/subscription generation arbitration
-must not change tiers. Per-account classification retains the winning slot and
-source while the subscription is owned: older updates are ignored for tier
-movement, and subscription data wins an equal-slot tie over RPC data.
-Classification-only ownership created before subscription acquisition is tagged
-with the fetch generation and removed on setup failure or cancellation, so stale
-cleanup cannot delete a newer generation's state.
-
 The lower pending-fetch dedup layer records `chainlink_pending_fetch_accounts_total`, `chainlink_pending_fetch_waiters_total`, `chainlink_pending_fetch_waiters_gauge`, and `chainlink_pending_fetch_owner_duration_seconds` with `layer="remote_account_provider"`. Claimed pubkeys record `owned`; calls that join existing `fetching_accounts` work record `joined_existing`, waiter total, and active waiter gauge. Subscription-update wins record `resolved_by_subscription_update`, while late RPC completions after such a win or replacement record `rpc_fetch_completed_after_update`. `FetchingAccountState` stores bounded metric metadata (`AccountFetchContext` and owner start time) so subscription-update completion preserves the original entrypoint/fetch reason without adding pubkey/signature labels.
 
 This pending-fetch instrumentation does not change fetch/clone behavior, dedup ownership, subscription ordering, or remote-fetch retry behavior; it only records counters, gauges, and histograms on existing control-flow edges.
@@ -294,7 +279,7 @@ Key behavior:
 
 - Clock sysvar updates update `chain_slot` and are not forwarded to the fetch cloner.
 - Non-clock updates become `ForwardedSubscriptionUpdate` with a `SubscriptionSource` (`Account` or program source).
-- If a subscription update arrives while an RPC fetch is pending, it resolves the pending fetch waiters only when its slot is at least the fetch start slot and does not regress the retained per-account classification.
+- If a subscription update arrives while an RPC fetch is pending and its slot is at least the fetch start slot, it resolves the pending fetch waiters instead of being forwarded as a separate update.
 - Account-subscription updates for pubkeys no longer watched are dropped and can enqueue a removal update if stale local state exists.
 - Program-subscription updates are allowed even if the pubkey is not in the direct-account LRU; delegated accounts may be tracked only by owner-program subscriptions.
 - Non-advancing updates are ignored unless they represent a same-slot delegated refresh needed for undelegate/redelegate recovery.
@@ -356,9 +341,6 @@ Ownership is reference-counted per reason. Releasing one reason does not unsubsc
 
 Registration outcome metrics (`chainlink_subscription_registration_accounts_total`, exported as `mbv_chainlink_subscription_registration_accounts_total`) are emitted once per claimed subscription attempt by entrypoint, fetch reason, subscription reason, and terminal registration outcome. Waiter-only fetch callers do not independently set up subscriptions and are not counted separately; direct `try_get_multi` owners preserve their `AccountFetchContext`, while callers without a fetch context use `entrypoint="internal", fetch_reason="requested_account"`.
 
-Capacity that is known to be exhausted before an upstream subscribe is reported
-as `rejected_no_capacity`; no compensating unsubscribe is issued in that case.
-
 Release and cleanup outcome metrics (`chainlink_subscription_release_accounts_total{reason,outcome}` and `chainlink_subscription_cleanup_accounts_total{cleanup_source,outcome}`, exported with the `mbv_` prefix) are emitted only on cold subscription release/cleanup transition paths, never on per-update hot loops. Release metrics classify each explicit `release_subscription_with_mode` / silent delegated-account release result (`unsubscribed`, `already_absent`, `unsubscribe_failed`, `retained_intentionally`, `retained_other_reasons`). Cleanup metrics classify the actual unsubscribe/removal action by `cleanup_source` (`normal_release`, `manual_unsubscribe`, `capacity_eviction`, `rejected_new_subscription`, `delegated_account_silent`, `reconciler`) and `outcome` (`unsubscribed`, `already_absent`, `unsubscribe_failed`, `removal_update_failed`, `retained_intentionally`). All labels are static/enum values only; no pubkey, signature, raw error, or endpoint labels are used.
 
 ### LRU and defensive eviction
@@ -370,22 +352,6 @@ Release and cleanup outcome metrics (`chainlink_subscription_release_accounts_to
 - accounts with `UndelegationTracking` ownership are protected,
 - if no candidate can be evicted, the new subscription is unsubscribed and `NoEvictableSubscriptionCapacity` is returned.
 
-A found RPC result or subscription update for an account in the secondary tier
-is rejected when it cannot be promoted into the primary tier; it must not be
-returned to fetch waiters or forwarded as a successful update.
-RPC-only slot-match retries apply the same tier classification before returning
-their results.
-
-Primary and secondary LRU membership is exclusive and both tiers use the same
-delegated, undelegating, in-flight-fetch, never-evict, and
-`UndelegationTracking` protections. Tier changes use the global subscription
-transition lock followed by the per-pubkey lock. Secondary capacity is bounded
-independently at the configured primary LRU capacity, so the total direct-watch
-bound is twice that setting. Pending fetches briefly retain websocket coverage;
-confirmed misses do not use websocket subscriptions while gRPC is healthy.
-The confirmed-missing set is a bounded subset of the secondary tier; pending or
-failed fetches remain secondary but retain full transport coverage.
-
 When an account is evicted from subscription capacity, the provider sends a removal update. `InnerChainlink::subscribe_account_removals` listens for these and may submit `Cloner::evict_account` to remove stale local state, but only if the bank account is neither delegated nor undelegating.
 
 Removal handling is serialized with same-pubkey subscription transitions via `evict_unwatched_with_subscription_lock`, preventing an evict transaction from being submitted after a fresh subscription re-watches the same pubkey.
@@ -395,23 +361,6 @@ Removal handling is serialized with same-pubkey subscription transitions via `ev
 If subscription metrics are enabled, a background task periodically runs `subscription_reconciler::reconcile_subscriptions` to compare the LRU with actual pubsub-client subscriptions, update metrics, and notify removal for subscriptions that vanished.
 
 When the pubsub client is `SubMuxClient`, reconciliation snapshots are intentionally based only on currently connected inner clients. Disconnected/reconnecting clients are ignored by `subscriptions_union()` and `subscriptions_intersection()` until the reconnect path has reconnected them, resubscribed programs/accounts from the authoritative trackers, performed its catch-up pass, and marked them connected again. Reconciler-triggered SubMux subscribe/unsubscribe repair operations also fan out only to connected clients; reconnecting clients catch up through the reconnect path instead. If no inner pubsub client is connected, reconciliation skips repair/noisy LRU-vs-pubsub mismatch reporting for that tick because there is no live client to inspect or repair.
-
-SubMux persists the desired gRPC-only policy for confirmed misses. Reconnects
-restore those keys on gRPC clients and exclude them from websocket
-clients; reconciliation compares transports separately so a lingering
-websocket leg cannot mask missing gRPC coverage. If every gRPC client is down,
-reconciliation restores full fallback coverage until gRPC returns.
-Repair is verified against a fresh subscription snapshot; a secondary entry
-without protected ownership, live delegated/undelegating state, or an in-flight
-fetch is evicted if neither preferred nor fallback subscription establishes
-coverage.
-
-Laserstream `Status` items are left to the pinned SDK's replaying reconnect
-path. The SDK retains write-updated account/program filters and its internal
-slot tracker across reconnects, and resets its retry budget only after stream
-progress. Exhausted retries, terminal stream errors, and fallen-behind errors
-still trigger a full actor rebuild. This avoids bulk resubscription churn on
-routine provider resets without silently losing dynamic subscriptions.
 
 ## SubMuxClient internals
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2527,7 +2527,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 [[package]]
 name = "helius-laserstream"
 version = "0.2.2"
-source = "git+https://github.com/magicblock-labs/laserstream-sdk.git?rev=295e8528662c1a9b486385643ba10434f3f210cf#295e8528662c1a9b486385643ba10434f3f210cf"
+source = "git+https://github.com/magicblock-labs/laserstream-sdk.git?branch=mbv-4.0%2Bconn-fix#97c2698dfa8b813de6ed53548e80ac0cc1d65e92"
 dependencies = [
  "async-stream",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ futures = "0.3"
 futures-util = "0.3.30"
 git-version = "0.3.9"
 guinea = { path = "./programs/guinea" }
-helius-laserstream = { git = "https://github.com/magicblock-labs/laserstream-sdk.git", rev = "295e8528662c1a9b486385643ba10434f3f210cf" }
+helius-laserstream = { git = "https://github.com/magicblock-labs/laserstream-sdk.git", branch = "mbv-4.0+conn-fix" }
 http-body-util = "0.1.3"
 humantime = { version = "1.1", package = "humantime-serde" }
 hyper = "1.6.0"

--- a/config.example.toml
+++ b/config.example.toml
@@ -250,11 +250,6 @@ reset = false
 # Env: MBV_CHAINLINK__MAX_MONITORED_ACCOUNTS
 max-monitored-accounts = 5000
 
-# Maximum number of accounts retained in the secondary subscription cache.
-# Default: 20000
-# Env: MBV_CHAINLINK__SECONDARY_MAX_MONITORED_ACCOUNTS
-secondary-max-monitored-accounts = 20000
-
 # When true, confined accounts are removed during accounts bank reset.
 # Default: false
 # Env: MBV_CHAINLINK__REMOVE_CONFINED_ACCOUNTS

--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -584,11 +584,6 @@ impl MagicValidator {
                     config.chainlink.max_monitored_accounts,
                 )
             })
-            .and_then(|conf| {
-                conf.with_secondary_subscriptions_lru_capacity(
-                    config.chainlink.secondary_max_monitored_accounts,
-                )
-            })
             .map(|conf| conf.with_grpc(config.grpc.clone()))
             .map_err(|err| {
                 ApiError::from(

--- a/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/actor.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/actor.rs
@@ -562,28 +562,13 @@ impl<H: StreamHandle, S: StreamFactory<H>> ChainLaserActor<H, S> {
     /// Common error handling for stream errors. Detects "fallen
     /// behind" errors and spawns diagnostics to compare our last
     /// known slot with the actual chain slot via RPC.
-    ///
-    /// Transient errors are only logged: the SDK reconnects the affected
-    /// stream itself with slot replay, while signaling a connection issue
-    /// here would tear down every healthy stream and resubscribe all
-    /// accounts on each routine provider reset.
     async fn handle_stream_error(
         &mut self,
         err: &LaserstreamError,
         source: &str,
     ) {
         if is_fallen_behind_error(err) {
-            // Replay from our tracked slot is no longer possible; a full
-            // resubscribe with a fresh slot is required.
             self.spawn_fallen_behind_diagnostics(source);
-        } else if is_sdk_reconnectable_status(err) {
-            debug!(
-                error = ?err,
-                slots = ?self.slots,
-                "SDK-reconnectable status in {} stream, awaiting reconnect",
-                source,
-            );
-            return;
         }
 
         warn!(
@@ -852,41 +837,5 @@ fn is_fallen_behind_error(err: &LaserstreamError) -> bool {
                     .contains("fallen behind")
         }
         _ => false,
-    }
-}
-
-/// Mid-stream status errors are informational: the SDK yields them and then
-/// reconnects the stream itself with slot replay. Fallen-behind errors and
-/// terminal errors (e.g. [LaserstreamError::MaxReconnectAttempts],
-/// [LaserstreamError::StreamEnded]) require a full resubscribe.
-fn is_sdk_reconnectable_status(err: &LaserstreamError) -> bool {
-    matches!(err, LaserstreamError::Status(_)) && !is_fallen_behind_error(err)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_stream_error_classification() {
-        let transient = LaserstreamError::Status(tonic::Status::unavailable(
-            "connection closed due to a deployment restart",
-        ));
-        assert!(is_sdk_reconnectable_status(&transient));
-        assert!(!is_fallen_behind_error(&transient));
-
-        let fallen_behind = LaserstreamError::Status(tonic::Status::new(
-            Code::DataLoss,
-            "client has fallen behind",
-        ));
-        assert!(is_fallen_behind_error(&fallen_behind));
-        assert!(!is_sdk_reconnectable_status(&fallen_behind));
-
-        let terminal = LaserstreamError::MaxReconnectAttempts(
-            tonic::Status::cancelled("Connection failed after 10 attempts"),
-        );
-        assert!(!is_sdk_reconnectable_status(&terminal));
-
-        assert!(!is_sdk_reconnectable_status(&LaserstreamError::StreamEnded));
     }
 }

--- a/magicblock-chainlink/src/remote_account_provider/chain_laser_client.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_laser_client.rs
@@ -16,8 +16,8 @@ use crate::remote_account_provider::{
     chain_laser_actor::{ChainLaserActor, SharedSubscriptions, Slots},
     chain_rpc_client::ChainRpcClientImpl,
     pubsub_common::{ChainPubsubActorMessage, SubscriptionUpdate},
-    ChainPubsubClient, PubsubTransport, ReconnectableClient,
-    RemoteAccountProviderError, RemoteAccountProviderResult,
+    ChainPubsubClient, ReconnectableClient, RemoteAccountProviderError,
+    RemoteAccountProviderResult,
 };
 
 /// Reserved pubkey used to track implicit slot subscriptions for GRPC clients.
@@ -266,10 +266,6 @@ impl ChainPubsubClient for ChainLaserClientImpl {
 
     fn id(&self) -> &str {
         &self.client_id
-    }
-
-    fn transport(&self) -> PubsubTransport {
-        PubsubTransport::Grpc
     }
 }
 

--- a/magicblock-chainlink/src/remote_account_provider/chain_pubsub_client.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_pubsub_client.rs
@@ -16,7 +16,7 @@ use tracing::*;
 
 use super::{
     chain_pubsub_actor::ChainPubsubActor,
-    errors::{RemoteAccountProviderError, RemoteAccountProviderResult},
+    errors::RemoteAccountProviderResult,
     pubsub_common::{ChainPubsubActorMessage, SubscriptionUpdate},
 };
 
@@ -26,15 +26,6 @@ const MAX_RESUB_DELAY_MS: u64 = 800;
 pub struct SubscriptionReconciliationSnapshot {
     pub union: HashSet<Pubkey>,
     pub intersection: HashSet<Pubkey>,
-}
-
-/// Transport kind of a pubsub client. Websocket subscriptions are
-/// per-account server-side resources, gRPC subscriptions are entries in a
-/// shared stream filter and scale much further.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PubsubTransport {
-    WebSocket,
-    Grpc,
 }
 
 // -----------------
@@ -91,47 +82,9 @@ pub trait ChainPubsubClient: Send + Sync + Clone + 'static {
         })
     }
 
-    /// Returns a reconciliation snapshot only when this client represents the
-    /// requested transport. Multiplexers override this to aggregate their
-    /// matching connected clients.
-    fn subscription_reconciliation_snapshot_for_transport(
-        &self,
-        transport: PubsubTransport,
-    ) -> Option<SubscriptionReconciliationSnapshot> {
-        (self.transport() == transport)
-            .then(|| self.subscription_reconciliation_snapshot())
-            .flatten()
-    }
-
     fn subs_immediately(&self) -> bool;
 
     fn id(&self) -> &str;
-
-    fn transport(&self) -> PubsubTransport {
-        PubsubTransport::WebSocket
-    }
-
-    /// Prefers gRPC-only coverage for `pubkey`.
-    /// Multiplexing implementors drop websocket legs only after gRPC
-    /// coverage is confirmed and err otherwise, leaving coverage untouched.
-    async fn prefer_grpc_subscription(
-        &self,
-        pubkey: Pubkey,
-    ) -> RemoteAccountProviderResult<()> {
-        match self.transport() {
-            PubsubTransport::Grpc => self.subscribe(pubkey, None).await,
-            // Dropping a ws subscription is only safe behind a multiplexer
-            // that confirmed gRPC coverage.
-            PubsubTransport::WebSocket => {
-                Err(RemoteAccountProviderError::AccountSubscriptionsTaskFailed(
-                    format!(
-                        "cannot prefer gRPC-only coverage for {pubkey} on a \
-                         websocket-only client"
-                    ),
-                ))
-            }
-        }
-    }
 }
 
 #[async_trait]
@@ -452,7 +405,6 @@ pub mod mock {
         program_subscribe_attempts: Arc<AtomicU64>,
         subscribe_notify: Arc<Notify>,
         client_id: String,
-        transport: Arc<Mutex<PubsubTransport>>,
     }
 
     impl ChainPubsubClientMock {
@@ -486,12 +438,7 @@ pub mod mock {
                     "mock:{}",
                     CLIENT_ID.fetch_add(1, AtomicOrdering::SeqCst)
                 ),
-                transport: Arc::new(Mutex::new(PubsubTransport::WebSocket)),
             }
-        }
-
-        pub fn set_transport(&self, transport: PubsubTransport) {
-            *self.transport.lock() = transport;
         }
 
         /// Simulate a disconnect: clear all subscriptions and mark client as disconnected.
@@ -800,10 +747,6 @@ pub mod mock {
 
         fn id(&self) -> &str {
             &self.client_id
-        }
-
-        fn transport(&self) -> PubsubTransport {
-            *self.transport.lock()
         }
     }
 

--- a/magicblock-chainlink/src/remote_account_provider/chain_updates_client.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_updates_client.rs
@@ -17,7 +17,7 @@ use crate::remote_account_provider::{
     chain_laser_actor::Slots, chain_laser_client::ChainLaserClientImpl,
     chain_rpc_client::ChainRpcClientImpl, chain_slot::ChainSlot,
     pubsub_common::SubscriptionUpdate, ChainPubsubClient,
-    ChainPubsubClientImpl, Endpoint, PubsubTransport, ReconnectableClient,
+    ChainPubsubClientImpl, Endpoint, ReconnectableClient,
     RemoteAccountProviderError, RemoteAccountProviderResult,
 };
 
@@ -167,14 +167,6 @@ impl ChainPubsubClient for ChainUpdatesClient {
         match self {
             WebSocket(client) => client.id(),
             Laser(client) => client.id(),
-        }
-    }
-
-    fn transport(&self) -> PubsubTransport {
-        use ChainUpdatesClient::*;
-        match self {
-            WebSocket(client) => client.transport(),
-            Laser(client) => client.transport(),
         }
     }
 }

--- a/magicblock-chainlink/src/remote_account_provider/config.rs
+++ b/magicblock-chainlink/src/remote_account_provider/config.rs
@@ -2,10 +2,7 @@ use std::{collections::HashSet, time::Duration};
 
 use magicblock_config::{
     config::{GrpcConfig, LifecycleMode},
-    consts::{
-        DEFAULT_MAX_MONITORED_ACCOUNTS, DEFAULT_RESUBSCRIPTION_DELAY_MS,
-        DEFAULT_SECONDARY_MAX_MONITORED_ACCOUNTS,
-    },
+    consts::{DEFAULT_MAX_MONITORED_ACCOUNTS, DEFAULT_RESUBSCRIPTION_DELAY_MS},
 };
 use solana_pubkey::Pubkey;
 
@@ -15,8 +12,6 @@ use super::{RemoteAccountProviderError, RemoteAccountProviderResult};
 pub struct RemoteAccountProviderConfig {
     /// How many accounts to monitor for changes
     subscribed_accounts_lru_capacity: usize,
-    /// How many accounts to retain in the secondary subscription cache
-    secondary_subscriptions_lru_capacity: usize,
     /// Lifecycle mode of the validator
     lifecycle_mode: LifecycleMode,
     /// Whether to enable metrics for account subscriptions
@@ -91,27 +86,12 @@ impl RemoteAccountProviderConfig {
         Ok(self)
     }
 
-    pub fn with_secondary_subscriptions_lru_capacity(
-        mut self,
-        capacity: usize,
-    ) -> RemoteAccountProviderResult<Self> {
-        if capacity == 0 {
-            return Err(RemoteAccountProviderError::InvalidLruCapacity);
-        }
-        self.secondary_subscriptions_lru_capacity = capacity;
-        Ok(self)
-    }
-
     pub fn lifecycle_mode(&self) -> &LifecycleMode {
         &self.lifecycle_mode
     }
 
     pub fn subscribed_accounts_lru_capacity(&self) -> usize {
         self.subscribed_accounts_lru_capacity
-    }
-
-    pub fn secondary_subscriptions_lru_capacity(&self) -> usize {
-        self.secondary_subscriptions_lru_capacity
     }
 
     pub fn enable_subscription_metrics(&self) -> bool {
@@ -140,8 +120,6 @@ impl Default for RemoteAccountProviderConfig {
     fn default() -> Self {
         Self {
             subscribed_accounts_lru_capacity: DEFAULT_MAX_MONITORED_ACCOUNTS,
-            secondary_subscriptions_lru_capacity:
-                DEFAULT_SECONDARY_MAX_MONITORED_ACCOUNTS,
             lifecycle_mode: LifecycleMode::default(),
             enable_subscription_metrics: true,
             program_subs: vec![dlp_api::id()].into_iter().collect(),

--- a/magicblock-chainlink/src/remote_account_provider/lru_cache.rs
+++ b/magicblock-chainlink/src/remote_account_provider/lru_cache.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, num::NonZeroUsize, sync::Arc};
+use std::{collections::HashSet, num::NonZeroUsize};
 
 use lru::LruCache;
 use magicblock_metrics::metrics::inc_evicted_accounts_count;
@@ -160,24 +160,6 @@ impl AccountsLruCache {
         }
     }
 
-    pub fn can_add_with_evict_filter<F>(
-        &self,
-        pubkey: &Pubkey,
-        is_evictable: F,
-    ) -> bool
-    where
-        F: Fn(&Pubkey) -> bool,
-    {
-        if self.accounts_to_never_evict.contains(pubkey) {
-            return true;
-        }
-
-        let subs = self.subscribed_accounts.lock();
-        subs.contains(pubkey)
-            || subs.len() < subs.cap().get()
-            || subs.iter().any(|(candidate, _)| is_evictable(candidate))
-    }
-
     pub fn contains(&self, pubkey: &Pubkey) -> bool {
         let subs = self.subscribed_accounts.lock();
         subs.contains(pubkey)
@@ -224,31 +206,6 @@ impl SubscribedAccountsTracker for AccountsLruCache {
     fn subscribed_accounts(&self) -> HashSet<Pubkey> {
         let subs = self.subscribed_accounts.lock();
         subs.iter().map(|(k, _)| *k).collect()
-    }
-}
-
-/// Authoritative account set used by SubMux reconnects. Transport policy is
-/// applied by SubMux; this tracker only exposes every account that must retain
-/// some subscription coverage.
-pub(crate) struct TieredSubscribedAccountsTracker {
-    primary: Arc<AccountsLruCache>,
-    secondary: Arc<AccountsLruCache>,
-}
-
-impl TieredSubscribedAccountsTracker {
-    pub(crate) fn new(
-        primary: Arc<AccountsLruCache>,
-        secondary: Arc<AccountsLruCache>,
-    ) -> Self {
-        Self { primary, secondary }
-    }
-}
-
-impl SubscribedAccountsTracker for TieredSubscribedAccountsTracker {
-    fn subscribed_accounts(&self) -> HashSet<Pubkey> {
-        let mut subscriptions = self.primary.pubkeys();
-        subscriptions.extend(self.secondary.pubkeys());
-        subscriptions
     }
 }
 

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{hash_map::Entry, HashMap, HashSet},
+    collections::{hash_map::Entry, HashMap},
     num::NonZeroUsize,
     sync::{
         atomic::{AtomicU64, Ordering},
@@ -9,8 +9,7 @@ use std::{
 };
 
 pub(crate) use chain_pubsub_client::{
-    ChainPubsubClient, ChainPubsubClientImpl, PubsubTransport,
-    ReconnectableClient,
+    ChainPubsubClient, ChainPubsubClientImpl, ReconnectableClient,
 };
 pub(crate) use chain_rpc_client::{ChainRpcClient, ChainRpcClientImpl};
 use config::RemoteAccountProviderConfig;
@@ -18,7 +17,6 @@ pub(crate) use errors::{
     RemoteAccountProviderError, RemoteAccountProviderResult,
 };
 use futures_util::future::{join_all, try_join_all};
-use lru_cache::TieredSubscribedAccountsTracker;
 pub use lru_cache::{AccountsLruCache, AddAccountOutcome};
 use magicblock_config::config::GrpcConfig;
 pub(crate) use remote_account::RemoteAccount;
@@ -190,7 +188,7 @@ fn spawn_deferred_pubsub_clients(
     resubscription_delay: Duration,
     grpc_cfg: GrpcConfig,
     submux: SubMuxClient<ChainUpdatesClient>,
-    subscribed_accounts: Arc<TieredSubscribedAccountsTracker>,
+    subscribed_accounts: Arc<AccountsLruCache>,
 ) {
     // Deferred clients are the fallback update sources; retry connect/attach
     // with capped backoff instead of dropping them permanently on failure.
@@ -290,7 +288,7 @@ fn spawn_deferred_pubsub_clients(
 type FetchResult = Result<RemoteAccount, RemoteAccountProviderError>;
 type FetchingAccountGeneration = u64;
 
-pub(crate) struct FetchingAccountState {
+struct FetchingAccountState {
     generation: FetchingAccountGeneration,
     fetch_start_slot: u64,
     fetch_context: AccountFetchContext,
@@ -298,7 +296,7 @@ pub(crate) struct FetchingAccountState {
     waiters: Vec<oneshot::Sender<FetchResult>>,
 }
 
-pub(crate) type FetchingAccounts = Mutex<HashMap<Pubkey, FetchingAccountState>>;
+type FetchingAccounts = Mutex<HashMap<Pubkey, FetchingAccountState>>;
 
 struct PendingFetchWaiterGaugeGuard {
     layer: ChainlinkPendingFetchLayer,
@@ -336,8 +334,6 @@ impl Drop for PendingFetchWaiterGaugeGuard {
 
 struct ClaimedSubscriptionSetupGuard {
     fetching_accounts: Arc<FetchingAccounts>,
-    subscription_ownership: SubscriptionOwnershipMap,
-    subscription_transition_lock: Arc<AsyncMutex<()>>,
     claimed_pubkeys: Vec<Pubkey>,
     claimed_generations: HashMap<Pubkey, FetchingAccountGeneration>,
     cancellation_error_text: Option<String>,
@@ -346,15 +342,11 @@ struct ClaimedSubscriptionSetupGuard {
 impl ClaimedSubscriptionSetupGuard {
     fn new(
         fetching_accounts: Arc<FetchingAccounts>,
-        subscription_ownership: SubscriptionOwnershipMap,
-        subscription_transition_lock: Arc<AsyncMutex<()>>,
         claimed_pubkeys: Vec<Pubkey>,
         claimed_generations: HashMap<Pubkey, FetchingAccountGeneration>,
     ) -> Self {
         Self {
             fetching_accounts,
-            subscription_ownership,
-            subscription_transition_lock,
             claimed_pubkeys,
             claimed_generations,
             cancellation_error_text: Some(
@@ -363,7 +355,7 @@ impl ClaimedSubscriptionSetupGuard {
         }
     }
 
-    fn cleanup_fetching_with_error(&self, waiter_error_text: &str) {
+    fn cleanup_with_error(&mut self, waiter_error_text: String) {
         {
             let mut fetching = self
                 .fetching_accounts
@@ -391,23 +383,13 @@ impl ClaimedSubscriptionSetupGuard {
                     for sender in state.waiters {
                         let _ = sender.send(Err(
                             RemoteAccountProviderError::AccountSubscriptionsTaskFailed(
-                                waiter_error_text.to_string(),
+                                waiter_error_text.clone(),
                             ),
                         ));
                     }
                 }
             }
         }
-    }
-
-    async fn cleanup_with_error(&mut self, waiter_error_text: String) {
-        self.cleanup_fetching_with_error(&waiter_error_text);
-        cleanup_classification_placeholders(
-            &self.subscription_ownership,
-            &self.subscription_transition_lock,
-            &self.claimed_generations,
-        )
-        .await;
         self.disarm();
     }
 
@@ -424,38 +406,7 @@ impl Drop for ClaimedSubscriptionSetupGuard {
         else {
             return;
         };
-        self.cleanup_fetching_with_error(&waiter_error_text);
-
-        let subscription_ownership = self.subscription_ownership.clone();
-        let subscription_transition_lock =
-            self.subscription_transition_lock.clone();
-        let claimed_generations = std::mem::take(&mut self.claimed_generations);
-        task::spawn(async move {
-            cleanup_classification_placeholders(
-                &subscription_ownership,
-                &subscription_transition_lock,
-                &claimed_generations,
-            )
-            .await;
-        });
-    }
-}
-
-async fn cleanup_classification_placeholders(
-    subscription_ownership: &SubscriptionOwnershipMap,
-    subscription_transition_lock: &Arc<AsyncMutex<()>>,
-    claimed_generations: &HashMap<Pubkey, FetchingAccountGeneration>,
-) {
-    let _transition_guard = subscription_transition_lock.lock().await;
-    let mut ownership = subscription_ownership.lock().await;
-    for (pubkey, generation) in claimed_generations {
-        if ownership.get(pubkey).is_some_and(|entry| {
-            entry.is_empty()
-                && entry.classification_placeholder_generation
-                    == Some(*generation)
-        }) {
-            ownership.remove(pubkey);
-        }
+        self.cleanup_with_error(waiter_error_text);
     }
 }
 
@@ -498,28 +449,13 @@ impl From<SubscriptionReason> for SubscriptionReasonLabel {
 pub(crate) type SubscriptionOwnershipMap =
     Arc<AsyncMutex<HashMap<Pubkey, SubscriptionOwnership>>>;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum SubscriptionClassificationSource {
-    Fetch,
-    Subscription,
-}
-
-#[derive(Debug, Clone, Copy)]
-struct SubscriptionClassification {
-    slot: u64,
-    source: SubscriptionClassificationSource,
-}
-
 #[derive(Debug, Default, Clone)]
 pub(crate) struct SubscriptionOwnership {
     reasons: HashMap<SubscriptionReason, usize>,
-    last_classification: Option<SubscriptionClassification>,
-    classification_placeholder_generation: Option<FetchingAccountGeneration>,
 }
 
 impl SubscriptionOwnership {
     fn acquire(&mut self, reason: SubscriptionReason) {
-        self.classification_placeholder_generation = None;
         *self.reasons.entry(reason).or_default() += 1;
     }
 
@@ -550,479 +486,6 @@ impl SubscriptionOwnership {
     }
 }
 
-/// Shared state for serialized movement between the primary and secondary
-/// subscription tiers.
-struct SubscriptionTierCtx<U: ChainPubsubClient> {
-    primary: Arc<AccountsLruCache>,
-    secondary: Arc<AccountsLruCache>,
-    pubsub_client: U,
-    subscription_ownership:
-        Arc<AsyncMutex<HashMap<Pubkey, SubscriptionOwnership>>>,
-    subscription_transition_lock: Arc<AsyncMutex<()>>,
-    subscription_key_locks: SubscriptionKeyLocks,
-    fetching_accounts: Arc<FetchingAccounts>,
-    capacity_eviction_protection: SharedCapacityEvictionProtectionPredicate,
-    confirmed_missing_subscriptions: Arc<Mutex<HashSet<Pubkey>>>,
-    removed_account_tx: mpsc::Sender<Pubkey>,
-}
-
-impl<U: ChainPubsubClient> SubscriptionTierCtx<U> {
-    fn capacity_eviction_protection_for(
-        &self,
-        pubkey: &Pubkey,
-    ) -> CapacityEvictionProtection {
-        let guard = self
-            .capacity_eviction_protection
-            .read()
-            .unwrap_or_else(|poison| poison.into_inner());
-        guard.as_ref().map(|predicate| predicate(pubkey)).unwrap_or(
-            CapacityEvictionProtection {
-                delegated: false,
-                undelegating: false,
-            },
-        )
-    }
-
-    fn is_confirmed_missing(&self, pubkey: &Pubkey) -> bool {
-        self.confirmed_missing_subscriptions
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner())
-            .contains(pubkey)
-    }
-
-    fn set_confirmed_missing(&self, pubkey: Pubkey, confirmed: bool) {
-        let mut subscriptions = self
-            .confirmed_missing_subscriptions
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
-        if confirmed {
-            subscriptions.insert(pubkey);
-        } else {
-            subscriptions.remove(&pubkey);
-        }
-    }
-
-    async fn record_classification(
-        &self,
-        pubkey: Pubkey,
-        slot: u64,
-        source: SubscriptionClassificationSource,
-    ) -> bool {
-        let mut ownership = self.subscription_ownership.lock().await;
-        let Some(ownership) = ownership.get_mut(&pubkey) else {
-            return false;
-        };
-
-        Self::record_classification_entry(ownership, slot, source)
-    }
-
-    /// Like [Self::record_classification] but creates the ownership entry,
-    /// which the pending fetch's in-flight acquisition adopts right after.
-    async fn record_classification_for_pending_fetch(
-        &self,
-        pubkey: Pubkey,
-        slot: u64,
-        source: SubscriptionClassificationSource,
-        generation: FetchingAccountGeneration,
-    ) -> bool {
-        let mut ownership = self.subscription_ownership.lock().await;
-        let ownership = ownership.entry(pubkey).or_default();
-        let apply_classification =
-            Self::record_classification_entry(ownership, slot, source);
-        if ownership.is_empty() {
-            ownership.classification_placeholder_generation = Some(generation);
-        }
-        apply_classification
-    }
-
-    fn record_classification_entry(
-        ownership: &mut SubscriptionOwnership,
-        slot: u64,
-        source: SubscriptionClassificationSource,
-    ) -> bool {
-        if ownership.last_classification.is_some_and(|last| {
-            Self::classification_is_stale(last, slot, source)
-        }) {
-            return false;
-        }
-
-        ownership.last_classification =
-            Some(SubscriptionClassification { slot, source });
-        true
-    }
-
-    /// Records the RPC result's classification and applies the resulting tier
-    /// movement when it is still current.
-    async fn apply_fetch_classification(
-        &self,
-        pubkey: &Pubkey,
-        response_slot: u64,
-        not_found: bool,
-    ) -> RemoteAccountProviderResult<()> {
-        let apply_classification = self
-            .record_classification(
-                *pubkey,
-                response_slot,
-                SubscriptionClassificationSource::Fetch,
-            )
-            .await;
-        if !apply_classification {
-            return Ok(());
-        }
-
-        if not_found {
-            self.move_not_found_to_secondary_locked(*pubkey).await;
-            Ok(())
-        } else {
-            // A confirmed miss that exists after all is gRPC-only; restore
-            // full coverage on promotion.
-            let restore_full_coverage = self.is_confirmed_missing(pubkey);
-            let was_secondary = self.secondary.contains(pubkey);
-            self.set_confirmed_missing(*pubkey, false);
-            let promotion_result = self
-                .try_promote_found_to_primary_locked(
-                    *pubkey,
-                    restore_full_coverage,
-                )
-                .await;
-            if was_secondary && matches!(promotion_result, Ok(false)) {
-                self.cleanup_rejected_subscription(*pubkey).await?;
-                self.secondary.remove(pubkey);
-                self.subscription_ownership.lock().await.remove(pubkey);
-                return Err(
-                    RemoteAccountProviderError::NoEvictableSubscriptionCapacity {
-                        pubkey: *pubkey,
-                    },
-                );
-            }
-            promotion_result.map(|_| ())
-        }
-    }
-
-    async fn classification_is_current(
-        &self,
-        pubkey: Pubkey,
-        slot: u64,
-        source: SubscriptionClassificationSource,
-    ) -> bool {
-        self.subscription_ownership
-            .lock()
-            .await
-            .get(&pubkey)
-            .and_then(|ownership| ownership.last_classification)
-            .is_none_or(|last| {
-                !Self::classification_is_stale(last, slot, source)
-            })
-    }
-
-    fn classification_is_stale(
-        last: SubscriptionClassification,
-        slot: u64,
-        source: SubscriptionClassificationSource,
-    ) -> bool {
-        slot < last.slot
-            || (slot == last.slot
-                && source == SubscriptionClassificationSource::Fetch
-                && last.source
-                    == SubscriptionClassificationSource::Subscription)
-    }
-
-    async fn add_with_protection(
-        &self,
-        cache: &AccountsLruCache,
-        pubkey: Pubkey,
-    ) -> AddAccountOutcome {
-        let ownership = self.subscription_ownership.lock().await;
-        let fetching = self
-            .fetching_accounts
-            .lock()
-            .expect("fetching_accounts lock poisoned");
-        cache.add_with_evict_filter(pubkey, |candidate| {
-            cache.can_evict(candidate)
-                && !fetching.contains_key(candidate)
-                && !self
-                    .capacity_eviction_protection_for(candidate)
-                    .is_protected()
-                && !ownership.get(candidate).is_some_and(|ownership| {
-                    ownership.contains(SubscriptionReason::UndelegationTracking)
-                })
-        })
-    }
-
-    async fn has_capacity_with_protection(
-        &self,
-        cache: &AccountsLruCache,
-        pubkey: &Pubkey,
-    ) -> bool {
-        let ownership = self.subscription_ownership.lock().await;
-        let fetching = self
-            .fetching_accounts
-            .lock()
-            .expect("fetching_accounts lock poisoned");
-        cache.can_add_with_evict_filter(pubkey, |candidate| {
-            cache.can_evict(candidate)
-                && !fetching.contains_key(candidate)
-                && !self
-                    .capacity_eviction_protection_for(candidate)
-                    .is_protected()
-                && !ownership.get(candidate).is_some_and(|ownership| {
-                    ownership.contains(SubscriptionReason::UndelegationTracking)
-                })
-        })
-    }
-
-    fn rollback_admission(
-        cache: &AccountsLruCache,
-        admitted: &Pubkey,
-        evicted: Pubkey,
-    ) {
-        cache.remove(admitted);
-        let restored = cache.add_with_evict_filter(evicted, |_| false);
-        debug_assert!(matches!(
-            restored,
-            AddAccountOutcome::Added | AddAccountOutcome::AlreadyPresent
-        ));
-    }
-
-    async fn cleanup_evicted(
-        &self,
-        cache: &AccountsLruCache,
-        admitted: &Pubkey,
-        evicted: Pubkey,
-    ) -> RemoteAccountProviderResult<()> {
-        let _evicted_guard = subscription_key_owned_guard_from_map(
-            &self.subscription_key_locks,
-            evicted,
-        )
-        .await;
-        let cleanup_outcome =
-            match self.pubsub_client.unsubscribe(evicted).await {
-                Ok(()) => SubscriptionCleanupOutcome::Unsubscribed,
-                Err(
-                    RemoteAccountProviderError::AccountSubscriptionDoesNotExist(
-                        _,
-                    ),
-                ) => SubscriptionCleanupOutcome::AlreadyAbsent,
-                Err(err) => {
-                    inc_chainlink_subscription_cleanup_accounts(
-                        SubscriptionCleanupSource::CapacityEviction,
-                        SubscriptionCleanupOutcome::UnsubscribeFailed,
-                    );
-                    Self::rollback_admission(cache, admitted, evicted);
-                    return Err(err);
-                }
-            };
-
-        inc_chainlink_subscription_cleanup_accounts(
-            SubscriptionCleanupSource::CapacityEviction,
-            cleanup_outcome,
-        );
-        self.subscription_ownership.lock().await.remove(&evicted);
-        self.set_confirmed_missing(evicted, false);
-        if let Err(err) = self.removed_account_tx.send(evicted).await {
-            warn!(evicted = %evicted, error = ?err, "Failed to send removal update for evicted account");
-            inc_chainlink_subscription_cleanup_accounts(
-                SubscriptionCleanupSource::CapacityEviction,
-                SubscriptionCleanupOutcome::RemovalUpdateFailed,
-            );
-        }
-        Ok(())
-    }
-
-    async fn cleanup_rejected_subscription(
-        &self,
-        pubkey: Pubkey,
-    ) -> RemoteAccountProviderResult<()> {
-        match self.pubsub_client.unsubscribe(pubkey).await {
-            Ok(()) => {
-                inc_chainlink_subscription_cleanup_accounts(
-                    SubscriptionCleanupSource::RejectedNewSubscription,
-                    SubscriptionCleanupOutcome::Unsubscribed,
-                );
-                Ok(())
-            }
-            Err(
-                RemoteAccountProviderError::AccountSubscriptionDoesNotExist(_),
-            ) => {
-                inc_chainlink_subscription_cleanup_accounts(
-                    SubscriptionCleanupSource::RejectedNewSubscription,
-                    SubscriptionCleanupOutcome::AlreadyAbsent,
-                );
-                Ok(())
-            }
-            Err(err) => {
-                inc_chainlink_subscription_cleanup_accounts(
-                    SubscriptionCleanupSource::RejectedNewSubscription,
-                    SubscriptionCleanupOutcome::UnsubscribeFailed,
-                );
-                Err(err)
-            }
-        }
-    }
-
-    async fn register_secondary_locked(
-        &self,
-        pubkey: &Pubkey,
-        reason: SubscriptionReason,
-        origin: SubscriptionRegistrationOrigin,
-    ) -> RemoteAccountProviderResult<()> {
-        if !self
-            .has_capacity_with_protection(&self.secondary, pubkey)
-            .await
-        {
-            inc_chainlink_subscription_registration_accounts(
-                origin,
-                reason.into(),
-                SubscriptionRegistrationOutcome::RejectedNoCapacity,
-            );
-            return Err(
-                RemoteAccountProviderError::NoEvictableSubscriptionCapacity {
-                    pubkey: *pubkey,
-                },
-            );
-        }
-
-        // Keep full redundancy until the RPC result confirms the account is
-        // missing. The reconciler switches confirmed misses to gRPC-only.
-        self.pubsub_client.subscribe(*pubkey, None).await?;
-
-        match self.add_with_protection(&self.secondary, *pubkey).await {
-            AddAccountOutcome::AlreadyPresent => {
-                inc_chainlink_subscription_registration_accounts(
-                    origin,
-                    reason.into(),
-                    SubscriptionRegistrationOutcome::AlreadyPresent,
-                );
-            }
-            AddAccountOutcome::Added => {
-                inc_chainlink_subscription_registration_accounts(
-                    origin,
-                    reason.into(),
-                    SubscriptionRegistrationOutcome::AddedBelowCapacity,
-                );
-            }
-            AddAccountOutcome::Evicted(evicted) => {
-                if let Err(err) =
-                    self.cleanup_evicted(&self.secondary, pubkey, evicted).await
-                {
-                    if let Err(cleanup_err) =
-                        self.cleanup_rejected_subscription(*pubkey).await
-                    {
-                        warn!(pubkey = %pubkey, error = ?cleanup_err, "Failed to clean up rejected secondary subscription");
-                        return Err(cleanup_err);
-                    }
-                    inc_chainlink_subscription_registration_accounts(
-                        origin,
-                        reason.into(),
-                        SubscriptionRegistrationOutcome::UnsubscribeEvictedError,
-                    );
-                    return Err(err);
-                }
-                inc_chainlink_subscription_registration_accounts(
-                    origin,
-                    reason.into(),
-                    SubscriptionRegistrationOutcome::EvictedCandidate,
-                );
-            }
-            AddAccountOutcome::NoEvictableCandidate => {
-                self.cleanup_rejected_subscription(*pubkey).await?;
-                inc_chainlink_subscription_registration_accounts(
-                    origin,
-                    reason.into(),
-                    SubscriptionRegistrationOutcome::RejectedAndUnsubscribed,
-                );
-                return Err(
-                    RemoteAccountProviderError::NoEvictableSubscriptionCapacity {
-                        pubkey: *pubkey,
-                    },
-                );
-            }
-        }
-
-        self.set_confirmed_missing(*pubkey, false);
-        Ok(())
-    }
-
-    async fn move_not_found_to_secondary_locked(&self, pubkey: Pubkey) {
-        if self
-            .capacity_eviction_protection_for(&pubkey)
-            .is_protected()
-        {
-            return;
-        }
-
-        let direct_only = self
-            .subscription_ownership
-            .lock()
-            .await
-            .get(&pubkey)
-            .is_some_and(|ownership| {
-                ownership.reasons.len() == 1
-                    && ownership.contains(SubscriptionReason::DirectAccount)
-            });
-        if !direct_only {
-            return;
-        }
-
-        if self.secondary.contains(&pubkey) {
-            self.set_confirmed_missing(pubkey, true);
-            return;
-        }
-        if !self.primary.contains(&pubkey) {
-            return;
-        }
-
-        match self.add_with_protection(&self.secondary, pubkey).await {
-            AddAccountOutcome::Added | AddAccountOutcome::AlreadyPresent => {}
-            AddAccountOutcome::Evicted(evicted) => {
-                if let Err(err) = self
-                    .cleanup_evicted(&self.secondary, &pubkey, evicted)
-                    .await
-                {
-                    debug!(pubkey = %pubkey, error = ?err, "Could not move not-found account to secondary tier");
-                    return;
-                }
-            }
-            AddAccountOutcome::NoEvictableCandidate => return,
-        }
-
-        self.primary.remove(&pubkey);
-        // The reconciler applies the gRPC-only transport policy off the
-        // locked path.
-        self.set_confirmed_missing(pubkey, true);
-    }
-
-    async fn try_promote_found_to_primary_locked(
-        &self,
-        pubkey: Pubkey,
-        restore_full_coverage: bool,
-    ) -> RemoteAccountProviderResult<bool> {
-        if !self.secondary.contains(&pubkey) {
-            return Ok(false);
-        }
-
-        if restore_full_coverage {
-            self.pubsub_client.subscribe(pubkey, None).await?;
-            self.set_confirmed_missing(pubkey, false);
-        }
-        match self.add_with_protection(&self.primary, pubkey).await {
-            AddAccountOutcome::Added | AddAccountOutcome::AlreadyPresent => {
-                self.secondary.remove(&pubkey);
-                self.set_confirmed_missing(pubkey, false);
-                Ok(true)
-            }
-            AddAccountOutcome::Evicted(evicted) => {
-                self.cleanup_evicted(&self.primary, &pubkey, evicted)
-                    .await?;
-                self.secondary.remove(&pubkey);
-                self.set_confirmed_missing(pubkey, false);
-                Ok(true)
-            }
-            AddAccountOutcome::NoEvictableCandidate => Ok(false),
-        }
-    }
-}
-
 pub(crate) enum SubscriptionReleaseMode {
     Single,
     All,
@@ -1040,9 +503,9 @@ impl CapacityEvictionProtection {
     }
 }
 
-pub(crate) type CapacityEvictionProtectionPredicate =
+type CapacityEvictionProtectionPredicate =
     dyn Fn(&Pubkey) -> CapacityEvictionProtection + Send + Sync;
-pub(crate) type SharedCapacityEvictionProtectionPredicate =
+type SharedCapacityEvictionProtectionPredicate =
     Arc<RwLock<Option<Arc<CapacityEvictionProtectionPredicate>>>>;
 
 pub struct ForwardedSubscriptionUpdate {
@@ -1132,15 +595,6 @@ pub struct RemoteAccountProvider<T: ChainRpcClient, U: ChainPubsubClient> {
 
     /// Tracks which accounts are currently subscribed to
     lrucache_subscribed_accounts: Arc<AccountsLruCache>,
-
-    /// Tracks fetch-owned accounts outside the primary working-set LRU.
-    /// Pending fetches retain full coverage; confirmed misses prefer gRPC-only
-    /// coverage until an account update promotes them to the primary tier.
-    secondary_subscriptions: Arc<AccountsLruCache>,
-    /// Bounded subset of the secondary tier proven missing by a winning RPC
-    /// result. Reconciliation uses this to distinguish them from pending or
-    /// failed fetches that must retain full transport coverage.
-    confirmed_missing_subscriptions: Arc<Mutex<HashSet<Pubkey>>>,
 
     capacity_eviction_protection: SharedCapacityEvictionProtectionPredicate,
 
@@ -1348,17 +802,12 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
     /// Creates a background task that periodically reconciles subscriptions
     /// with the LRU (repairing missing ones, e.g. after a partial
     /// resubscription) and optionally updates the active subscriptions gauge
-    #[allow(clippy::too_many_arguments)]
     fn start_active_subscriptions_updater<PubsubClient: ChainPubsubClient>(
         subscribed_accounts: Arc<AccountsLruCache>,
-        secondary_subscriptions: Arc<AccountsLruCache>,
-        confirmed_missing_subscriptions: Arc<Mutex<HashSet<Pubkey>>>,
         pubsub_client: Arc<PubsubClient>,
         removed_account_tx: mpsc::Sender<Pubkey>,
         subscription_key_locks: SubscriptionKeyLocks,
         subscription_ownership: SubscriptionOwnershipMap,
-        fetching_accounts: Arc<FetchingAccounts>,
-        capacity_eviction_protection: SharedCapacityEvictionProtectionPredicate,
         emit_metrics: bool,
     ) -> task::JoinHandle<()> {
         task::spawn(async move {
@@ -1372,15 +821,11 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                 let pubsub_total =
                     subscription_reconciler::reconcile_subscriptions(
                         &subscribed_accounts,
-                        &secondary_subscriptions,
-                        &confirmed_missing_subscriptions,
                         pubsub_client.as_ref(),
                         &never_evicted,
                         &removed_account_tx,
                         Some(&subscription_key_locks),
                         Some(&subscription_ownership),
-                        Some(fetching_accounts.as_ref()),
-                        Some(&capacity_eviction_protection),
                     )
                     .await;
 
@@ -1403,63 +848,27 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
         lrucache_subscribed_accounts: Arc<AccountsLruCache>,
         chain_slot: ChainSlot,
     ) -> RemoteAccountProviderResult<Self> {
-        let secondary_subscriptions = Arc::new(AccountsLruCache::new(
-            // SAFETY: config guarantees a non-zero capacity
-            NonZeroUsize::new(config.secondary_subscriptions_lru_capacity())
-                .expect("lru capacity must be non-zero"),
-        ));
-        Self::new_with_secondary_subscriptions(
-            rpc_client,
-            pubsub_client,
-            subscription_forwarder,
-            config,
-            lrucache_subscribed_accounts,
-            secondary_subscriptions,
-            chain_slot,
-        )
-        .await
-    }
-
-    async fn new_with_secondary_subscriptions(
-        rpc_client: T,
-        pubsub_client: U,
-        subscription_forwarder: mpsc::Sender<ForwardedSubscriptionUpdate>,
-        config: &RemoteAccountProviderConfig,
-        lrucache_subscribed_accounts: Arc<AccountsLruCache>,
-        secondary_subscriptions: Arc<AccountsLruCache>,
-        chain_slot: ChainSlot,
-    ) -> RemoteAccountProviderResult<Self> {
         let (removed_account_tx, removed_account_rx) =
             tokio::sync::mpsc::channel(100);
         let subscription_key_locks: SubscriptionKeyLocks =
             Arc::new(AsyncMutex::new(HashMap::new()));
-        let confirmed_missing_subscriptions =
-            Arc::new(Mutex::new(HashSet::new()));
         let subscription_ownership: SubscriptionOwnershipMap =
             Arc::new(AsyncMutex::new(HashMap::new()));
-        let fetching_accounts = Arc::<FetchingAccounts>::default();
-        let capacity_eviction_protection:
-            SharedCapacityEvictionProtectionPredicate =
-            Arc::new(RwLock::new(None));
 
         // The reconciler always runs: partial resubscriptions rely on it for
         // repair. The config flag only gates the metrics emission.
         let active_subscriptions_updater =
             Some(Self::start_active_subscriptions_updater(
                 lrucache_subscribed_accounts.clone(),
-                secondary_subscriptions.clone(),
-                confirmed_missing_subscriptions.clone(),
                 Arc::new(pubsub_client.clone()),
                 removed_account_tx.clone(),
                 subscription_key_locks.clone(),
                 subscription_ownership.clone(),
-                fetching_accounts.clone(),
-                capacity_eviction_protection.clone(),
                 config.enable_subscription_metrics(),
             ));
 
         let me = Self {
-            fetching_accounts,
+            fetching_accounts: Arc::<FetchingAccounts>::default(),
             next_fetching_account_generation: AtomicU64::default(),
             subscription_ownership,
             subscription_transition_lock: Arc::new(AsyncMutex::new(())),
@@ -1470,9 +879,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
             last_update_slot: Arc::<AtomicU64>::default(),
             received_updates_count: Arc::<AtomicU64>::default(),
             lrucache_subscribed_accounts,
-            secondary_subscriptions,
-            confirmed_missing_subscriptions,
-            capacity_eviction_protection,
+            capacity_eviction_protection: Arc::new(RwLock::new(None)),
             subscription_forwarder: Arc::new(subscription_forwarder),
             removed_account_tx,
             removed_account_rx: Mutex::new(Some(removed_account_rx)),
@@ -1565,10 +972,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                         config.resubscription_delay(),
                         config.grpc().clone(),
                         provider.pubsub_client.clone(),
-                        Arc::new(TieredSubscribedAccountsTracker::new(
-                            provider.lrucache_subscribed_accounts.clone(),
-                            provider.secondary_subscriptions.clone(),
-                        )),
+                        provider.lrucache_subscribed_accounts.clone(),
                     );
                 }
                 Ok(provider)
@@ -1655,18 +1059,9 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
             let cap = config.subscribed_accounts_lru_capacity();
             NonZeroUsize::new(cap).expect("non-zero capacity")
         }));
-        let secondary_subscriptions = Arc::new(AccountsLruCache::new({
-            let cap = config.secondary_subscriptions_lru_capacity();
-            NonZeroUsize::new(cap).expect("non-zero capacity")
-        }));
-        let subscribed_accounts_tracker =
-            Arc::new(TieredSubscribedAccountsTracker::new(
-                subscribed_accounts.clone(),
-                secondary_subscriptions.clone(),
-            ));
 
         let submux =
-            SubMuxClient::new(pubsubs, subscribed_accounts_tracker, None);
+            SubMuxClient::new(pubsubs, subscribed_accounts.clone(), None);
 
         if !config.program_subs().is_empty() {
             let count = config.program_subs().len();
@@ -1681,13 +1076,12 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
         let provider = RemoteAccountProvider::<
             ChainRpcClientImpl,
             SubMuxClient<ChainUpdatesClient>,
-        >::new_with_secondary_subscriptions(
+        >::new(
             rpc_client,
             submux,
             subscription_forwarder,
             config,
             subscribed_accounts,
-            secondary_subscriptions,
             ChainSlot::new(chain_slot),
         )
         .await?;
@@ -1696,7 +1090,6 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
 
     pub(crate) fn promote_accounts(&self, pubkeys: &[&Pubkey]) {
         self.lrucache_subscribed_accounts.promote_multi(pubkeys);
-        self.secondary_subscriptions.promote_multi(pubkeys);
     }
 
     pub(crate) async fn get_slot(&self) -> RemoteAccountProviderResult<u64> {
@@ -1752,6 +1145,22 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
         *guard = Some(Arc::new(predicate));
     }
 
+    fn capacity_eviction_protection_for(
+        &self,
+        pubkey: &Pubkey,
+    ) -> CapacityEvictionProtection {
+        let guard = self
+            .capacity_eviction_protection
+            .read()
+            .unwrap_or_else(|poison| poison.into_inner());
+        guard.as_ref().map(|predicate| predicate(pubkey)).unwrap_or(
+            CapacityEvictionProtection {
+                delegated: false,
+                undelegating: false,
+            },
+        )
+    }
+
     pub fn try_get_removed_account_rx(
         &self,
     ) -> RemoteAccountProviderResult<mpsc::Receiver<Pubkey>> {
@@ -1785,7 +1194,6 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
         let received_updates_count = self.received_updates_count.clone();
         let last_update_slot = self.last_update_slot.clone();
         let subscription_forwarder = self.subscription_forwarder.clone();
-        let subscription_tiers = Arc::new(self.subscription_tier_ctx());
         task::spawn(async move {
             while let Some(update) = updates.recv().await {
                 let slot = update.slot;
@@ -1821,210 +1229,64 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                         }
                     };
 
-                    let account_is_found = remote_account.is_found();
-
-                    // Fast path: fetch arbitration and tier movement only
-                    // apply while a fetch is pending or the account sits in
-                    // the secondary tier. All other updates forward without
-                    // the transition lock, which acquire/promotion hold
-                    // across network calls.
-                    let needs_tier_handling =
-                        subscription_tiers.secondary.contains(&update.pubkey)
-                            || fetching_accounts
-                                .lock()
-                                .expect("fetching_accounts lock poisoned")
-                                .contains_key(&update.pubkey);
-
-                    // Serialize fetch arbitration and tier movement so a late
-                    // RPC result cannot overwrite this subscription update.
-                    let mut classification_error = None;
-                    let (forward_update, _accepted_update, resolved_fetch) =
-                        if !needs_tier_handling {
-                            // Record so a lagging RPC result cannot later win
-                            // classification against this newer update.
-                            if account_is_found {
-                                subscription_tiers
-                                    .record_classification(
-                                        update.pubkey,
-                                        slot,
-                                        SubscriptionClassificationSource::Subscription,
-                                    )
-                                    .await;
-                            }
-                            (
-                                Some(ForwardedSubscriptionUpdate {
-                                    pubkey: update.pubkey,
-                                    account: remote_account.clone(),
-                                    source: update.source,
-                                }),
-                                true,
-                                None,
-                            )
-                        } else {
-                            let _transition_guard = subscription_tiers
-                                .subscription_transition_lock
-                                .lock()
-                                .await;
-                            let _subscription_guard =
-                                subscription_key_owned_guard_from_map(
-                                    &subscription_tiers.subscription_key_locks,
-                                    update.pubkey,
+                    // Check if we're currently fetching this account
+                    let forward_update = {
+                        let mut fetching = fetching_accounts
+                            .lock()
+                            .expect("fetching_accounts lock poisoned");
+                        if let Some(generation) = fetching
+                            .get(&update.pubkey)
+                            .map(|state| state.generation)
+                        {
+                            if let Some(state) =
+                                remove_fetching_account_if_generation_matches(
+                                    &mut fetching,
+                                    &update.pubkey,
+                                    generation,
                                 )
-                                .await;
-                            let classification_is_current = subscription_tiers
-                                .classification_is_current(
-                                    update.pubkey,
-                                    slot,
-                                    SubscriptionClassificationSource::Subscription,
-                                )
-                                .await;
-                            let result = if classification_is_current {
-                                let mut fetching = fetching_accounts
-                                    .lock()
-                                    .expect("fetching_accounts lock poisoned");
-                                if let Some(generation) = fetching
-                                    .get(&update.pubkey)
-                                    .map(|state| state.generation)
-                                {
-                                    if let Some(state) =
-                                    remove_fetching_account_if_generation_matches(
-                                        &mut fetching,
-                                        &update.pubkey,
-                                        generation,
-                                    )
-                                {
-                                    // If subscription update is newer than when we started fetching,
-                                    // resolve with the subscription data instead
-                                    if slot >= state.fetch_start_slot {
-                                        trace!(pubkey = %update.pubkey, slot = slot, fetch_start_slot = state.fetch_start_slot, generation, "Using subscription update instead of fetch");
-                                        metrics::observe_chainlink_pending_fetch_owner_duration_seconds_with_context(
-                                            state.fetch_context,
-                                            ChainlinkPendingFetchLayer::RemoteAccountProvider,
-                                            ChainlinkPendingFetchOutcome::ResolvedBySubscriptionUpdate,
-                                            state.owner_started_at.elapsed().as_secs_f64(),
-                                        );
-                                        metrics::inc_chainlink_pending_fetch_accounts_with_context(
-                                            state.fetch_context,
-                                            ChainlinkPendingFetchLayer::RemoteAccountProvider,
-                                            ChainlinkPendingFetchOutcome::ResolvedBySubscriptionUpdate,
-                                            1,
-                                        );
+                            {
+                                // If subscription update is newer than when we started fetching,
+                                // resolve with the subscription data instead
+                                if slot >= state.fetch_start_slot {
+                                    trace!(pubkey = %update.pubkey, slot = slot, fetch_start_slot = state.fetch_start_slot, generation, "Using subscription update instead of fetch");
+                                    metrics::observe_chainlink_pending_fetch_owner_duration_seconds_with_context(
+                                        state.fetch_context,
+                                        ChainlinkPendingFetchLayer::RemoteAccountProvider,
+                                        ChainlinkPendingFetchOutcome::ResolvedBySubscriptionUpdate,
+                                        state.owner_started_at.elapsed().as_secs_f64(),
+                                    );
+                                    metrics::inc_chainlink_pending_fetch_accounts_with_context(
+                                        state.fetch_context,
+                                        ChainlinkPendingFetchLayer::RemoteAccountProvider,
+                                        ChainlinkPendingFetchOutcome::ResolvedBySubscriptionUpdate,
+                                        1,
+                                    );
 
-                                        (None, true, Some((generation, state.waiters)))
-                                    } else {
-                                        // Subscription is stale, put the fetch tracking back
-                                        debug!(pubkey = %update.pubkey, slot = slot, fetch_start_slot = state.fetch_start_slot, generation, "Received stale subscription update");
-                                        fetching.insert(update.pubkey, state);
-                                        (None, false, None)
+                                    // Resolve all pending requests with subscription data
+                                    for sender in state.waiters {
+                                        let _ = sender
+                                            .send(Ok(remote_account.clone()));
                                     }
+                                    None
                                 } else {
-                                    (None, false, None)
-                                }
-                                } else {
-                                    (
-                                        Some(ForwardedSubscriptionUpdate {
-                                            pubkey: update.pubkey,
-                                            account: remote_account.clone(),
-                                            source: update.source,
-                                        }),
-                                        true,
-                                        None,
-                                    )
+                                    // Subscription is stale, put the fetch tracking back
+                                    debug!(pubkey = %update.pubkey, slot = slot, fetch_start_slot = state.fetch_start_slot, generation, "Received stale subscription update");
+                                    fetching.insert(update.pubkey, state);
+                                    None
                                 }
                             } else {
-                                debug!(pubkey = %update.pubkey, slot, "Ignoring stale subscription classification");
-                                (None, false, None)
-                            };
-
-                            // The in-flight acquisition may not have created
-                            // the ownership entry yet; record so the later
-                            // RPC result loses arbitration.
-                            let apply_classification = result.1
-                                && account_is_found
-                                && match result.2.as_ref() {
-                                    Some((generation, _)) => {
-                                        subscription_tiers
-                                            .record_classification_for_pending_fetch(
-                                                update.pubkey,
-                                                slot,
-                                                SubscriptionClassificationSource::Subscription,
-                                                *generation,
-                                            )
-                                            .await
-                                    }
-                                    None => {
-                                        subscription_tiers
-                                            .record_classification(
-                                                update.pubkey,
-                                                slot,
-                                                SubscriptionClassificationSource::Subscription,
-                                            )
-                                            .await
-                                    }
-                                };
-                            if apply_classification
-                                && subscription_tiers
-                                    .secondary
-                                    .contains(&update.pubkey)
-                            {
-                                match subscription_tiers
-                                    .try_promote_found_to_primary_locked(
-                                        update.pubkey,
-                                        true,
-                                    )
-                                    .await
-                                {
-                                    Ok(true) => {}
-                                    Ok(false) => {
-                                        let err = RemoteAccountProviderError::NoEvictableSubscriptionCapacity {
-                                            pubkey: update.pubkey,
-                                        };
-                                        match subscription_tiers
-                                            .cleanup_rejected_subscription(
-                                                update.pubkey,
-                                            )
-                                            .await
-                                        {
-                                            Ok(()) => {
-                                                subscription_tiers
-                                                    .secondary
-                                                    .remove(&update.pubkey);
-                                                subscription_tiers
-                                                    .subscription_ownership
-                                                    .lock()
-                                                    .await
-                                                    .remove(&update.pubkey);
-                                            }
-                                            Err(cleanup_err) => {
-                                                warn!(pubkey = %update.pubkey, error = ?cleanup_err, "Failed to clean up rejected found subscription");
-                                            }
-                                        }
-                                        classification_error =
-                                            Some(err.to_string());
-                                    }
-                                    Err(err) => {
-                                        warn!(pubkey = %update.pubkey, error = ?err, "Failed to promote found account to primary subscription tier");
-                                        classification_error =
-                                            Some(err.to_string());
-                                    }
-                                }
+                                None
                             }
-                            result
-                        };
-
-                    if let Some((_, waiters)) = resolved_fetch {
-                        for sender in waiters {
-                            let response = match classification_error.as_ref() {
-                                Some(err) => Err(RemoteAccountProviderError::AccountResolutionsFailed(err.clone())),
-                                None => Ok(remote_account.clone()),
-                            };
-                            let _ = sender.send(response);
+                        } else {
+                            Some(ForwardedSubscriptionUpdate {
+                                pubkey: update.pubkey,
+                                account: remote_account,
+                                source: update.source,
+                            })
                         }
-                    }
+                    };
 
-                    if let Some(forward_update) = forward_update
-                        .filter(|_| classification_error.is_none())
-                    {
+                    if let Some(forward_update) = forward_update {
                         if let Err(err) =
                             subscription_forwarder.send(forward_update).await
                         {
@@ -2170,25 +1432,6 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                     }
                 }
             };
-            let _transition_guard =
-                self.subscription_transition_lock.lock().await;
-            for (pubkey, remote_account) in pubkeys.iter().zip(&remote_accounts)
-            {
-                let _subscription_guard =
-                    subscription_key_owned_guard_from_map(
-                        &self.subscription_key_locks,
-                        *pubkey,
-                    )
-                    .await;
-                self.subscription_tier_ctx()
-                    .apply_fetch_classification(
-                        pubkey,
-                        remote_account.slot(),
-                        !remote_account.is_found(),
-                    )
-                    .await?;
-            }
-            drop(_transition_guard);
             let slots_match_result = slots_match_and_meet_min_context(
                 &remote_accounts,
                 config.min_context_slot,
@@ -2372,8 +1615,6 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
             let mut subscription_setup_guard =
                 ClaimedSubscriptionSetupGuard::new(
                     self.fetching_accounts.clone(),
-                    self.subscription_ownership.clone(),
-                    self.subscription_transition_lock.clone(),
                     claimed_pubkeys.clone(),
                     claimed_generations.clone(),
                 );
@@ -2381,9 +1622,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                 .setup_subscriptions(&claimed_pubkeys, fetch_context)
                 .await
             {
-                subscription_setup_guard
-                    .cleanup_with_error(err.to_string())
-                    .await;
+                subscription_setup_guard.cleanup_with_error(err.to_string());
                 return Err(err);
             }
             subscription_setup_guard.disarm();
@@ -2583,8 +1822,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
 
         let mut errors = Vec::new();
         let mut acquired = Vec::new();
-        for (result, pubkey) in
-            subscription_results.into_iter().zip(pubkeys.iter())
+        for (result, pubkey) in subscription_results.iter().zip(pubkeys.iter())
         {
             match result {
                 Err(err) => {
@@ -2592,7 +1830,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                         pubkey = %pubkey, err = ?err,
                         "Failed to subscribe to account"
                     );
-                    errors.push((*pubkey, err));
+                    errors.push(format!("{}: {}", pubkey, err));
                 }
                 Ok(()) => acquired.push(*pubkey),
             }
@@ -2625,22 +1863,12 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                     }
                 }
             }
-            // A single failure keeps its type so callers can react to
-            // specific variants (e.g. capacity exhaustion).
-            if errors.len() == 1 {
-                // SAFETY: len checked above
-                return Err(errors.pop().unwrap().1);
-            }
             return Err(
                 RemoteAccountProviderError::AccountSubscriptionsTaskFailed(
                     format!(
                         "{} subscription(s) failed: [{}]",
                         errors.len(),
-                        errors
-                            .iter()
-                            .map(|(pubkey, err)| format!("{pubkey}: {err}"))
-                            .collect::<Vec<_>>()
-                            .join(", ")
+                        errors.join(", ")
                     ),
                 ),
             );
@@ -2656,36 +1884,6 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
         reason: SubscriptionReason,
         origin: SubscriptionRegistrationOrigin,
     ) -> RemoteAccountProviderResult<()> {
-        if matches!(origin, SubscriptionRegistrationOrigin::Fetch(_))
-            && reason == SubscriptionReason::DirectAccount
-            && self.lrucache_subscribed_accounts.can_evict(pubkey)
-        {
-            return self
-                .subscription_tier_ctx()
-                .register_secondary_locked(pubkey, reason, origin)
-                .await;
-        }
-
-        let tier_ctx = self.subscription_tier_ctx();
-        if !tier_ctx
-            .has_capacity_with_protection(
-                &self.lrucache_subscribed_accounts,
-                pubkey,
-            )
-            .await
-        {
-            inc_chainlink_subscription_registration_accounts(
-                origin,
-                reason.into(),
-                SubscriptionRegistrationOutcome::RejectedNoCapacity,
-            );
-            return Err(
-                RemoteAccountProviderError::NoEvictableSubscriptionCapacity {
-                    pubkey: *pubkey,
-                },
-            );
-        }
-
         // 1. First realize subscription
         if let Err(err) = self.pubsub_client.subscribe(*pubkey, None).await {
             inc_chainlink_subscription_registration_accounts(
@@ -2699,9 +1897,48 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
         // 2. Add to LRU cache
         // If an account is evicted then we need to unsubscribe from it
         // and then inform upstream that we are no longer tracking it
-        let add_outcome = tier_ctx
-            .add_with_protection(&self.lrucache_subscribed_accounts, *pubkey)
-            .await;
+        let add_outcome = {
+            let ownership = self.subscription_ownership.lock().await;
+            self.lrucache_subscribed_accounts.add_with_evict_filter(
+                *pubkey,
+                |candidate| {
+                    if !self.lrucache_subscribed_accounts.can_evict(candidate) {
+                        trace!(
+                            candidate = %candidate,
+                            "Skipping capacity eviction candidate from never-evict set"
+                        );
+                        return false;
+                    }
+
+                    let protection =
+                        self.capacity_eviction_protection_for(candidate);
+                    if protection.is_protected() {
+                        trace!(
+                            candidate = %candidate,
+                            delegated = protection.delegated,
+                            undelegating = protection.undelegating,
+                            "Skipping capacity eviction candidate protected by bank state"
+                        );
+                        return false;
+                    }
+
+                    let protected_by_ownership =
+                        ownership.get(candidate).is_some_and(|ownership| {
+                            ownership.contains(
+                                SubscriptionReason::UndelegationTracking,
+                            )
+                        });
+                    if protected_by_ownership {
+                        trace!(
+                            candidate = %candidate,
+                            reason = ?SubscriptionReason::UndelegationTracking,
+                            "Skipping capacity eviction candidate protected by subscription ownership"
+                        );
+                    }
+                    !protected_by_ownership
+                },
+            )
+        };
 
         match add_outcome {
             AddAccountOutcome::AlreadyPresent => {
@@ -2720,35 +1957,105 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
             }
             AddAccountOutcome::Evicted(evicted) => {
                 trace!(evicted = %evicted, "Evicting account");
-                if let Err(err) = tier_ctx
-                    .cleanup_evicted(
-                        &self.lrucache_subscribed_accounts,
-                        pubkey,
-                        evicted,
-                    )
-                    .await
-                {
-                    if let Err(cleanup_err) =
-                        tier_ctx.cleanup_rejected_subscription(*pubkey).await
-                    {
-                        warn!(pubkey = %pubkey, error = ?cleanup_err, "Failed to clean up rejected primary subscription");
-                        return Err(cleanup_err);
-                    }
-                    inc_chainlink_subscription_registration_accounts(
-                        origin,
-                        reason.into(),
-                        SubscriptionRegistrationOutcome::UnsubscribeEvictedError,
-                    );
-                    return Err(err);
-                }
+
+                // LRU eviction is a forced full removal, but keep local
+                // ownership intact until pubsub confirms the subscription is
+                // gone so a failed unsubscribe cannot leave ownership state
+                // inconsistent with the active subscription.
+                let cleanup_outcome =
+                    match self.pubsub_client.unsubscribe(evicted).await {
+                        Ok(()) => SubscriptionCleanupOutcome::Unsubscribed,
+                        Err(err)
+                            if matches!(
+                                err,
+                                RemoteAccountProviderError::AccountSubscriptionDoesNotExist(
+                                    _
+                                )
+                            ) =>
+                        {
+                            debug!(evicted = %evicted, error = ?err, "Evicted pubsub subscription was already absent");
+                            SubscriptionCleanupOutcome::AlreadyAbsent
+                        }
+                        Err(err) => {
+                            // Should we retry here?
+                            warn!(evicted = %evicted, error = ?err, "Failed to unsubscribe from pubsub for evicted account");
+                            inc_chainlink_subscription_cleanup_accounts(
+                                SubscriptionCleanupSource::CapacityEviction,
+                                SubscriptionCleanupOutcome::UnsubscribeFailed,
+                            );
+                            self.subscription_ownership
+                                .lock()
+                                .await
+                                .entry(*pubkey)
+                                .or_default()
+                                .acquire(reason);
+                            inc_chainlink_subscription_registration_accounts(
+                                origin,
+                                reason.into(),
+                                SubscriptionRegistrationOutcome::UnsubscribeEvictedError,
+                            );
+                            return Err(err);
+                        }
+                    };
+
+                inc_chainlink_subscription_cleanup_accounts(
+                    SubscriptionCleanupSource::CapacityEviction,
+                    cleanup_outcome,
+                );
                 inc_chainlink_subscription_registration_accounts(
                     origin,
                     reason.into(),
                     SubscriptionRegistrationOutcome::EvictedCandidate,
                 );
+                self.subscription_ownership.lock().await.remove(&evicted);
+
+                // Inform upstream so it can remove it from the store. Failure
+                // to notify is non-fatal here because the LRU, pubsub, and
+                // ownership state have already been updated consistently.
+                if let Err(err) = self.send_removal_update(evicted).await {
+                    warn!(evicted = %evicted, error = ?err, "Failed to send removal update for evicted account");
+                }
             }
             AddAccountOutcome::NoEvictableCandidate => {
-                tier_ctx.cleanup_rejected_subscription(*pubkey).await?;
+                if let Err(err) = self.pubsub_client.unsubscribe(*pubkey).await
+                {
+                    if matches!(
+                        err,
+                        RemoteAccountProviderError::AccountSubscriptionDoesNotExist(
+                            _
+                        )
+                    ) {
+                        // Nothing to roll back on pubsub; continue with the
+                        // local cleanup/removal for the rejected pubkey.
+                        inc_chainlink_subscription_cleanup_accounts(
+                            SubscriptionCleanupSource::RejectedNewSubscription,
+                            SubscriptionCleanupOutcome::AlreadyAbsent,
+                        );
+                    } else {
+                        debug!(
+                            pubkey = %pubkey,
+                            error = ?err,
+                            "Failed to unsubscribe new subscription after all LRU candidates were protected"
+                        );
+                        inc_chainlink_subscription_cleanup_accounts(
+                            SubscriptionCleanupSource::RejectedNewSubscription,
+                            SubscriptionCleanupOutcome::UnsubscribeFailed,
+                        );
+                        inc_chainlink_subscription_registration_accounts(
+                            origin,
+                            reason.into(),
+                            SubscriptionRegistrationOutcome::UnsubscribeRejectedError,
+                        );
+                        return Err(err);
+                    }
+                } else {
+                    inc_chainlink_subscription_cleanup_accounts(
+                        SubscriptionCleanupSource::RejectedNewSubscription,
+                        SubscriptionCleanupOutcome::Unsubscribed,
+                    );
+                }
+                self.subscription_ownership.lock().await.remove(pubkey);
+                self.lrucache_subscribed_accounts.remove(pubkey);
                 debug!(
                     pubkey = %pubkey,
                     "No evictable subscription capacity available; all LRU candidates are protected"
@@ -2766,7 +2073,6 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
             }
         }
 
-        self.remove_from_secondary(pubkey);
         Ok(())
     }
 
@@ -2785,39 +2091,6 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
     /// part of the provider's internal logic.
     pub fn is_watching(&self, pubkey: &Pubkey) -> bool {
         self.lrucache_subscribed_accounts.contains(pubkey)
-            || self.secondary_subscriptions.contains(pubkey)
-    }
-
-    /// Removes a pubkey from the secondary LRU; safe for never-evict keys.
-    fn remove_from_secondary(&self, pubkey: &Pubkey) {
-        if self.secondary_subscriptions.contains(pubkey) {
-            self.secondary_subscriptions.remove(pubkey);
-        }
-        self.confirmed_missing_subscriptions
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner())
-            .remove(pubkey);
-    }
-
-    fn subscription_tier_ctx(&self) -> SubscriptionTierCtx<U> {
-        SubscriptionTierCtx {
-            primary: self.lrucache_subscribed_accounts.clone(),
-            secondary: self.secondary_subscriptions.clone(),
-            pubsub_client: self.pubsub_client.clone(),
-            subscription_ownership: self.subscription_ownership.clone(),
-            subscription_transition_lock: self
-                .subscription_transition_lock
-                .clone(),
-            subscription_key_locks: self.subscription_key_locks.clone(),
-            fetching_accounts: self.fetching_accounts.clone(),
-            capacity_eviction_protection: self
-                .capacity_eviction_protection
-                .clone(),
-            confirmed_missing_subscriptions: self
-                .confirmed_missing_subscriptions
-                .clone(),
-            removed_account_tx: self.removed_account_tx.clone(),
-        }
     }
 
     pub(crate) async fn evict_unwatched_with_subscription_lock<F, Fut>(
@@ -2899,78 +2172,10 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
 
         let mut ownership = self.subscription_ownership.lock().await;
         if let Some(existing) = ownership.get_mut(pubkey) {
-            let classification_placeholder_generation =
-                existing.classification_placeholder_generation;
-            let acquired_reason =
-                !skip_existing_reason || !existing.contains(reason);
-            if acquired_reason {
+            if !skip_existing_reason || !existing.contains(reason) {
                 existing.acquire(reason);
             }
-            drop(ownership);
-
-            let repair_result = if self
-                .lrucache_subscribed_accounts
-                .contains(pubkey)
-            {
-                self.lrucache_subscribed_accounts.promote_multi(&[pubkey]);
-                Ok(())
-            } else if self.secondary_subscriptions.contains(pubkey) {
-                self.secondary_subscriptions.promote_multi(&[pubkey]);
-                let keep_secondary =
-                    matches!(origin, SubscriptionRegistrationOrigin::Fetch(_))
-                        && reason == SubscriptionReason::DirectAccount;
-                if !keep_secondary {
-                    match self
-                        .subscription_tier_ctx()
-                        .try_promote_found_to_primary_locked(*pubkey, true)
-                        .await
-                    {
-                        Ok(true) => Ok(()),
-                        Ok(false)
-                            if reason
-                                == SubscriptionReason::UndelegationTracking =>
-                        {
-                            Ok(())
-                        }
-                        Ok(false) => Err(
-                            RemoteAccountProviderError::NoEvictableSubscriptionCapacity {
-                                pubkey: *pubkey,
-                            },
-                        ),
-                        Err(err) => Err(err),
-                    }
-                } else {
-                    let confirmed_missing = self
-                        .confirmed_missing_subscriptions
-                        .lock()
-                        .unwrap_or_else(|poison| poison.into_inner())
-                        .contains(pubkey);
-                    if confirmed_missing {
-                        self.pubsub_client.subscribe(*pubkey, None).await?;
-                        self.confirmed_missing_subscriptions
-                            .lock()
-                            .unwrap_or_else(|poison| poison.into_inner())
-                            .remove(pubkey);
-                    }
-                    Ok(())
-                }
-            } else {
-                self.register_subscription(pubkey, reason, origin).await
-            };
-
-            if let Err(err) = repair_result {
-                if acquired_reason {
-                    if let Some(existing) =
-                        self.subscription_ownership.lock().await.get_mut(pubkey)
-                    {
-                        if existing.release(reason) {
-                            existing.classification_placeholder_generation =
-                                classification_placeholder_generation;
-                        }
-                    }
-                }
-                return Err(err);
-            }
+            self.lrucache_subscribed_accounts.add(*pubkey);
             inc_chainlink_subscription_registration_accounts(
                 origin,
                 reason.into(),
@@ -3048,6 +2253,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                 );
                 return Ok(false);
             }
+            ownership.remove(pubkey);
             released_count
         };
 
@@ -3064,9 +2270,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                 reason.into(),
                 SubscriptionReleaseOutcome::Unsubscribed,
             );
-            self.subscription_ownership.lock().await.remove(pubkey);
             self.lrucache_subscribed_accounts.remove(pubkey);
-            self.remove_from_secondary(pubkey);
         } else {
             inc_chainlink_subscription_release_accounts(
                 reason.into(),
@@ -3156,6 +2360,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                 return Ok(false);
             }
 
+            ownership.remove(pubkey);
             released_count
         };
 
@@ -3169,9 +2374,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                     SubscriptionCleanupSource::DelegatedAccountSilent,
                     SubscriptionCleanupOutcome::Unsubscribed,
                 );
-                self.subscription_ownership.lock().await.remove(pubkey);
                 self.lrucache_subscribed_accounts.remove(pubkey);
-                self.remove_from_secondary(pubkey);
                 trace!(
                     pubkey = %pubkey,
                     ?reason,
@@ -3195,9 +2398,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                         SubscriptionCleanupSource::DelegatedAccountSilent,
                         SubscriptionCleanupOutcome::AlreadyAbsent,
                     );
-                    self.subscription_ownership.lock().await.remove(pubkey);
                     self.lrucache_subscribed_accounts.remove(pubkey);
-                    self.remove_from_secondary(pubkey);
                     trace!(
                         pubkey = %pubkey,
                         ?reason,
@@ -3259,9 +2460,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
             return Ok(());
         }
 
-        if !self.lrucache_subscribed_accounts.contains(pubkey)
-            && !self.secondary_subscriptions.contains(pubkey)
-        {
+        if !self.lrucache_subscribed_accounts.contains(pubkey) {
             trace!(pubkey = %pubkey, "Already unsubscribed from LRU");
             inc_chainlink_subscription_cleanup_accounts(
                 SubscriptionCleanupSource::ManualUnsubscribe,
@@ -3280,7 +2479,6 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
 
         if success {
             self.lrucache_subscribed_accounts.remove(pubkey);
-            self.remove_from_secondary(pubkey);
             self.subscription_ownership.lock().await.remove(pubkey);
         }
 
@@ -3307,7 +2505,6 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
         let commitment = self.rpc_client.commitment();
         let mark_empty_if_not_found =
             mark_empty_if_not_found.unwrap_or(&[]).to_vec();
-        let subscription_tiers = self.subscription_tier_ctx();
         tokio::spawn(async move {
             use RemoteAccount::*;
 
@@ -3524,7 +2721,6 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
 
             let mut found_count = 0u64;
             let mut not_found_count = 0u64;
-            let mut not_found_pubkeys = HashSet::new();
 
             let remote_accounts: Vec<RemoteAccount> = pubkeys
                 .iter()
@@ -3540,7 +2736,6 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                     }
                     None if mark_empty_if_not_found.contains(pubkey) => {
                         not_found_count += 1;
-                        not_found_pubkeys.insert(*pubkey);
                         inc_chainlink_empty_placeholder_accounts_total_with_context(
                             fetch_context,
                             ChainlinkEmptyPlaceholderStage::ConvertedToEmpty,
@@ -3560,7 +2755,6 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                     }
                     None => {
                         not_found_count += 1;
-                        not_found_pubkeys.insert(*pubkey);
                         NotFound(response_slot)
                     }
                 })
@@ -3589,17 +2783,8 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
             for (pubkey, remote_account) in
                 pubkeys.iter().zip(remote_accounts.iter())
             {
-                let (waiters, classification_result) = {
-                    let _transition_guard = subscription_tiers
-                        .subscription_transition_lock
-                        .lock()
-                        .await;
-                    let _subscription_guard =
-                        subscription_key_owned_guard_from_map(
-                            &subscription_tiers.subscription_key_locks,
-                            *pubkey,
-                        )
-                        .await;
+                let waiters = {
+                    let mut fetching = fetching_accounts.lock().unwrap();
                     // Remove from fetching and get pending requests
                     // Note: the account might have been resolved by a
                     // subscription update already or replaced by a newer owner.
@@ -3607,35 +2792,20 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                     else {
                         continue;
                     };
-                    let state = {
-                        let mut fetching = fetching_accounts.lock().unwrap();
+                    if let Some(state) =
                         remove_fetching_account_if_generation_matches(
                             &mut fetching,
                             pubkey,
                             generation,
                         )
-                    };
-                    if let Some(state) = state {
-                        let waiters = state.waiters;
-
-                        let classification_result = subscription_tiers
-                            .apply_fetch_classification(
-                                pubkey,
-                                response_slot,
-                                not_found_pubkeys.contains(pubkey),
-                            )
-                            .await;
+                    {
                         observe_chainlink_pending_fetch_owner_duration_seconds_with_context(
                             state.fetch_context,
                             ChainlinkPendingFetchLayer::RemoteAccountProvider,
-                            if classification_result.is_ok() {
-                                ChainlinkPendingFetchOutcome::OwnerSucceeded
-                            } else {
-                                ChainlinkPendingFetchOutcome::OwnerFailed
-                            },
+                            ChainlinkPendingFetchOutcome::OwnerSucceeded,
                             state.owner_started_at.elapsed().as_secs_f64(),
                         );
-                        (waiters, classification_result)
+                        state.waiters
                     } else {
                         inc_chainlink_pending_fetch_accounts_with_context(
                             fetch_context,
@@ -3643,6 +2813,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                             ChainlinkPendingFetchOutcome::RpcFetchCompletedAfterUpdate,
                             1,
                         );
+                        // Account was already resolved or replaced, skip.
                         if tracing::enabled!(tracing::Level::TRACE) {
                             trace!(
                                 "Account {pubkey} generation {generation} was already resolved or replaced"
@@ -3654,20 +2825,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
 
                 // Send the fetch result to all waiting requests
                 for request in waiters {
-                    let result = match &classification_result {
-                        Ok(()) => Ok(remote_account.clone()),
-                        Err(RemoteAccountProviderError::NoEvictableSubscriptionCapacity { pubkey }) => {
-                            Err(RemoteAccountProviderError::NoEvictableSubscriptionCapacity {
-                                pubkey: *pubkey,
-                            })
-                        }
-                        Err(err) => Err(
-                            RemoteAccountProviderError::AccountResolutionsFailed(
-                                err.to_string(),
-                            ),
-                        ),
-                    };
-                    let _ = request.send(result);
+                    let _ = request.send(Ok(remote_account.clone()));
                 }
             }
         });

--- a/magicblock-chainlink/src/remote_account_provider/subscription_reconciler.rs
+++ b/magicblock-chainlink/src/remote_account_provider/subscription_reconciler.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::HashSet,
-    sync::{atomic::AtomicU16, Mutex},
-};
+use std::{collections::HashSet, sync::atomic::AtomicU16};
 
 use magicblock_core::logger::log_trace_warn;
 use magicblock_metrics::metrics::{
@@ -14,9 +11,7 @@ use tracing::*;
 
 use super::{
     subscription_key_owned_guard_from_map, AccountsLruCache, ChainPubsubClient,
-    FetchingAccounts, PubsubTransport,
-    SharedCapacityEvictionProtectionPredicate, SubscriptionKeyLocks,
-    SubscriptionOwnershipMap, SubscriptionReason,
+    SubscriptionKeyLocks, SubscriptionOwnershipMap, SubscriptionReason,
 };
 use crate::remote_account_provider::RemoteAccountProviderError;
 
@@ -101,26 +96,16 @@ pub(crate) async fn unsubscribe_and_notify_removal<T: ChainPubsubClient>(
 ///
 /// Returns the expected total number of monitored accounts: LRU-tracked accounts
 /// plus never-evicted accounts.
-#[allow(clippy::too_many_arguments)]
 pub(crate) async fn reconcile_subscriptions<PubsubClient: ChainPubsubClient>(
     subscribed_accounts: &AccountsLruCache,
-    secondary_subscriptions: &AccountsLruCache,
-    confirmed_missing_subscriptions: &Mutex<HashSet<Pubkey>>,
     pubsub_client: &PubsubClient,
     never_evicted: &[Pubkey],
     removed_account_tx: &mpsc::Sender<Pubkey>,
     subscription_key_locks: Option<&SubscriptionKeyLocks>,
     subscription_ownership: Option<&SubscriptionOwnershipMap>,
-    fetching_accounts: Option<&FetchingAccounts>,
-    capacity_eviction_protection: Option<
-        &SharedCapacityEvictionProtectionPredicate,
-    >,
 ) -> usize {
     let lru_pubkeys = subscribed_accounts.pubkeys();
     let lru_count = lru_pubkeys.len();
-    let secondary_pubkeys = secondary_subscriptions.pubkeys();
-    let expected_total =
-        lru_count + never_evicted.len() + secondary_pubkeys.len();
 
     let Some(pubsub_snapshot) =
         pubsub_client.subscription_reconciliation_snapshot()
@@ -130,7 +115,7 @@ pub(crate) async fn reconcile_subscriptions<PubsubClient: ChainPubsubClient>(
             never_evicted_count = never_evicted.len(),
             "Skipping subscription reconciliation because no connected pubsub client is available"
         );
-        return expected_total;
+        return lru_count + never_evicted.len();
     };
 
     // Never-evicted keys (e.g. the clock sysvar) are not tracked in the LRU,
@@ -144,14 +129,12 @@ pub(crate) async fn reconcile_subscriptions<PubsubClient: ChainPubsubClient>(
 
     let ensured_subs_without_never_evict: HashSet<_> = pubsub_snapshot
         .intersection
-        .iter()
-        .copied()
+        .into_iter()
         .filter(|pk| !never_evicted.contains(pk))
         .collect();
     let partial_subs_without_never_evict: HashSet<_> = pubsub_snapshot
         .union
-        .iter()
-        .copied()
+        .into_iter()
         .filter(|pk| !never_evicted.contains(pk))
         .collect();
 
@@ -159,46 +142,10 @@ pub(crate) async fn reconcile_subscriptions<PubsubClient: ChainPubsubClient>(
     let extra_in_lru: HashSet<_> = lru_pubkeys
         .difference(&ensured_subs_without_never_evict)
         .collect();
-    // B) Subs not in either tier that some clients hold
+    // B) Subs not in LRU that some clients are subscribed to
     let extra_in_pubsub: HashSet<_> = partial_subs_without_never_evict
         .difference(&lru_pubkeys)
-        .filter(|pk| !secondary_pubkeys.contains(pk))
         .collect();
-    // C) Confirmed misses prefer gRPC-only coverage. Pending/unclassified
-    // secondary accounts, and every secondary account while gRPC is
-    // unavailable, retain full coverage.
-    let grpc_snapshot = pubsub_client
-        .subscription_reconciliation_snapshot_for_transport(
-            PubsubTransport::Grpc,
-        );
-    let websocket_snapshot = pubsub_client
-        .subscription_reconciliation_snapshot_for_transport(
-            PubsubTransport::WebSocket,
-        );
-    let secondary_to_repair: Vec<Pubkey> = {
-        let confirmed_missing = confirmed_missing_subscriptions
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
-        secondary_pubkeys
-            .iter()
-            .filter(|pubkey| {
-                if confirmed_missing.contains(pubkey) {
-                    match &grpc_snapshot {
-                        Some(grpc) => {
-                            !grpc.intersection.contains(pubkey)
-                                || websocket_snapshot
-                                    .as_ref()
-                                    .is_some_and(|ws| ws.union.contains(pubkey))
-                        }
-                        None => !pubsub_snapshot.intersection.contains(pubkey),
-                    }
-                } else {
-                    !pubsub_snapshot.intersection.contains(pubkey)
-                }
-            })
-            .copied()
-            .collect()
-    };
 
     trace!(
         lru_count = lru_count,
@@ -348,9 +295,7 @@ pub(crate) async fn reconcile_subscriptions<PubsubClient: ChainPubsubClient>(
                 acquire_subscription_key_guard(subscription_key_locks, pubkey)
                     .await;
 
-            if subscribed_accounts.contains(&pubkey)
-                || secondary_subscriptions.contains(&pubkey)
-            {
+            if subscribed_accounts.contains(&pubkey) {
                 trace!(
                     pubkey = %pubkey,
                     "Skipping stale unsubscribe because pubkey entered LRU after reconciliation snapshot"
@@ -385,99 +330,10 @@ pub(crate) async fn reconcile_subscriptions<PubsubClient: ChainPubsubClient>(
             .await;
         }
     }
-    // Restore the desired transport coverage for secondary accounts.
-    for pubkey in secondary_to_repair {
-        let _subscription_guard =
-            acquire_subscription_key_guard(subscription_key_locks, pubkey)
-                .await;
-
-        if !secondary_subscriptions.contains(&pubkey) {
-            continue;
-        }
-
-        let grpc_preferred = confirmed_missing_subscriptions
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner())
-            .contains(&pubkey);
-        let has_grpc = grpc_snapshot.is_some();
-        let preferred_result = if grpc_preferred && has_grpc {
-            pubsub_client.prefer_grpc_subscription(pubkey).await
-        } else {
-            pubsub_client.subscribe(pubkey, None).await
-        };
-        if let Err(err) = &preferred_result {
-            debug!(pubkey = %pubkey, error = ?err, "Secondary repair failed; restoring full coverage");
-        }
-        let preferred_covered = pubsub_client
-            .subscription_reconciliation_snapshot()
-            .is_some_and(|snapshot| snapshot.union.contains(&pubkey));
-        if preferred_result.is_err() || !preferred_covered {
-            if let Err(err) = pubsub_client.subscribe(pubkey, None).await {
-                warn!(pubkey = %pubkey, error = ?err, "Failed to repair secondary account subscription");
-            }
-        }
-
-        let covered = pubsub_client
-            .subscription_reconciliation_snapshot()
-            .is_some_and(|snapshot| snapshot.union.contains(&pubkey));
-        if covered {
-            continue;
-        }
-
-        if fetching_accounts.is_some_and(|fetching_accounts| {
-            fetching_accounts
-                .lock()
-                .unwrap_or_else(|poison| poison.into_inner())
-                .contains_key(&pubkey)
-        }) {
-            continue;
-        }
-
-        if capacity_eviction_protection.is_some_and(|protection| {
-            protection
-                .read()
-                .unwrap_or_else(|poison| poison.into_inner())
-                .as_ref()
-                .is_some_and(|predicate| predicate(&pubkey).is_protected())
-        }) {
-            continue;
-        }
-
-        if let Some(ownership) = subscription_ownership {
-            if ownership.lock().await.get(&pubkey).is_some_and(|own| {
-                own.contains(SubscriptionReason::UndelegationTracking)
-            }) {
-                continue;
-            }
-        }
-
-        warn!(pubkey = %pubkey, "Secondary repair did not take effect on any client; evicting account to prevent stale state");
-        secondary_subscriptions.remove(&pubkey);
-        confirmed_missing_subscriptions
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner())
-            .remove(&pubkey);
-        if let Some(ownership) = subscription_ownership {
-            ownership.lock().await.remove(&pubkey);
-        }
-        if let Err(err) = removed_account_tx.send(pubkey).await {
-            warn!(pubkey = %pubkey, error = ?err, "Failed to send removal update for dead secondary subscription");
-            inc_chainlink_subscription_cleanup_accounts(
-                SubscriptionCleanupSource::Reconciler,
-                SubscriptionCleanupOutcome::RemovalUpdateFailed,
-            );
-        } else {
-            inc_chainlink_subscription_cleanup_accounts(
-                SubscriptionCleanupSource::Reconciler,
-                SubscriptionCleanupOutcome::Unsubscribed,
-            );
-        }
-    }
-
     // We assume that reconciling worked and now our subscribed accounts are up to date
     // Pubsubs should be subscribed to all accounts in LRU accounts and accounts that
     // are never evicted (not tracked in LRU)
-    expected_total
+    lru_count + never_evicted.len()
 }
 
 async fn acquire_subscription_key_guard(
@@ -506,196 +362,16 @@ mod tests {
     use super::*;
     use crate::{
         remote_account_provider::{
-            chain_pubsub_client::{
-                mock::ChainPubsubClientMock, PubsubTransport,
-            },
-            lru_cache::AccountsLruCache,
-            pubsub_common::SubscriptionUpdate,
-            CapacityEvictionProtection, FetchingAccountState,
+            chain_pubsub_client::mock::ChainPubsubClientMock,
+            lru_cache::AccountsLruCache, pubsub_common::SubscriptionUpdate,
         },
         testing::init_logger,
-        AccountFetchContext,
     };
 
     fn create_test_pubkey(seed: u8) -> Pubkey {
         let mut bytes = [0u8; 32];
         bytes[0] = seed;
         Pubkey::from(bytes)
-    }
-
-    /// Secondary-tier accounts in pubsub but not in the main LRU must not be
-    /// unsubscribed as stale.
-    #[tokio::test]
-    async fn test_secondary_account_is_not_unsubscribed() {
-        init_logger();
-
-        let (tx, rx) = mpsc::channel::<SubscriptionUpdate>(10);
-        let mock_client = ChainPubsubClientMock::new(tx, rx);
-        mock_client.set_transport(PubsubTransport::Grpc);
-
-        let pk = create_test_pubkey(1);
-        mock_client.insert_subscription(pk);
-
-        let lru = AccountsLruCache::new(NonZeroUsize::new(10).unwrap());
-        let secondary = AccountsLruCache::new(NonZeroUsize::new(10).unwrap());
-        secondary.add(pk);
-
-        let (removed_tx, mut removed_rx) = mpsc::channel::<Pubkey>(10);
-        reconcile_subscriptions(
-            &lru,
-            &secondary,
-            &Mutex::new(HashSet::new()),
-            &mock_client,
-            &[],
-            &removed_tx,
-            None,
-            None,
-            None,
-            None,
-        )
-        .await;
-
-        assert!(mock_client.subscriptions_union().contains(&pk));
-        assert!(removed_rx.try_recv().is_err());
-    }
-
-    /// Secondary-tier accounts no client holds get their gRPC coverage restored.
-    #[tokio::test]
-    async fn test_secondary_account_grpc_coverage_is_restored() {
-        init_logger();
-
-        let (tx, rx) = mpsc::channel::<SubscriptionUpdate>(10);
-        let mock_client = ChainPubsubClientMock::new(tx, rx);
-        mock_client.set_transport(PubsubTransport::Grpc);
-
-        let pk = create_test_pubkey(1);
-        let lru = AccountsLruCache::new(NonZeroUsize::new(10).unwrap());
-        let secondary = AccountsLruCache::new(NonZeroUsize::new(10).unwrap());
-        secondary.add(pk);
-
-        let (removed_tx, mut removed_rx) = mpsc::channel::<Pubkey>(10);
-        reconcile_subscriptions(
-            &lru,
-            &secondary,
-            &Mutex::new(HashSet::new()),
-            &mock_client,
-            &[],
-            &removed_tx,
-            None,
-            None,
-            None,
-            None,
-        )
-        .await;
-
-        assert!(mock_client.subscriptions_union().contains(&pk));
-        assert!(removed_rx.try_recv().is_err());
-    }
-
-    #[tokio::test]
-    async fn test_secondary_noop_repair_respects_protections_then_evicts() {
-        init_logger();
-
-        let (tx, rx) = mpsc::channel::<SubscriptionUpdate>(10);
-        let mock_client = ChainPubsubClientMock::new(tx, rx);
-        mock_client.set_transport(PubsubTransport::Grpc);
-
-        let pk = create_test_pubkey(1);
-        let lru = AccountsLruCache::new(NonZeroUsize::new(10).unwrap());
-        let secondary = AccountsLruCache::new(NonZeroUsize::new(10).unwrap());
-        secondary.add(pk);
-        let confirmed_missing = Mutex::new(HashSet::from([pk]));
-        let ownership: SubscriptionOwnershipMap = Default::default();
-        ownership
-            .lock()
-            .await
-            .entry(pk)
-            .or_default()
-            .acquire(SubscriptionReason::DirectAccount);
-        let fetching_accounts = FetchingAccounts::default();
-        let capacity_eviction_protection:
-            SharedCapacityEvictionProtectionPredicate = Default::default();
-        fetching_accounts.lock().unwrap().insert(
-            pk,
-            FetchingAccountState {
-                generation: 1,
-                fetch_start_slot: 0,
-                fetch_context: AccountFetchContext::rpc_get_account(),
-                owner_started_at: std::time::Instant::now(),
-                waiters: Vec::new(),
-            },
-        );
-        mock_client.silently_noop_next_subscriptions(2);
-
-        let (removed_tx, mut removed_rx) = mpsc::channel::<Pubkey>(10);
-        reconcile_subscriptions(
-            &lru,
-            &secondary,
-            &confirmed_missing,
-            &mock_client,
-            &[],
-            &removed_tx,
-            None,
-            Some(&ownership),
-            Some(&fetching_accounts),
-            Some(&capacity_eviction_protection),
-        )
-        .await;
-
-        assert!(secondary.contains(&pk));
-        assert!(confirmed_missing.lock().unwrap().contains(&pk));
-        assert!(ownership.lock().await.contains_key(&pk));
-        assert!(removed_rx.try_recv().is_err());
-        assert_eq!(mock_client.subscribe_attempts(), 2);
-
-        fetching_accounts.lock().unwrap().remove(&pk);
-        *capacity_eviction_protection.write().unwrap() =
-            Some(Arc::new(|_| CapacityEvictionProtection {
-                delegated: true,
-                undelegating: false,
-            }));
-        mock_client.silently_noop_next_subscriptions(2);
-        reconcile_subscriptions(
-            &lru,
-            &secondary,
-            &confirmed_missing,
-            &mock_client,
-            &[],
-            &removed_tx,
-            None,
-            Some(&ownership),
-            Some(&fetching_accounts),
-            Some(&capacity_eviction_protection),
-        )
-        .await;
-
-        assert!(secondary.contains(&pk));
-        assert!(confirmed_missing.lock().unwrap().contains(&pk));
-        assert!(ownership.lock().await.contains_key(&pk));
-        assert!(removed_rx.try_recv().is_err());
-        assert_eq!(mock_client.subscribe_attempts(), 4);
-
-        *capacity_eviction_protection.write().unwrap() = None;
-        mock_client.silently_noop_next_subscriptions(2);
-        reconcile_subscriptions(
-            &lru,
-            &secondary,
-            &confirmed_missing,
-            &mock_client,
-            &[],
-            &removed_tx,
-            None,
-            Some(&ownership),
-            Some(&fetching_accounts),
-            Some(&capacity_eviction_protection),
-        )
-        .await;
-
-        assert!(!secondary.contains(&pk));
-        assert!(!confirmed_missing.lock().unwrap().contains(&pk));
-        assert!(!ownership.lock().await.contains_key(&pk));
-        assert_eq!(removed_rx.try_recv(), Ok(pk));
-        assert_eq!(mock_client.subscribe_attempts(), 6);
     }
 
     #[tokio::test]
@@ -919,15 +595,11 @@ mod tests {
         let (removed_tx, mut removed_rx) = mpsc::channel::<Pubkey>(10);
         reconcile_subscriptions(
             &lru,
-            &AccountsLruCache::new(NonZeroUsize::new(10).unwrap()),
-            &Mutex::new(HashSet::new()),
             &mock_client,
             &[],
             &removed_tx,
             None,
             Some(&ownership),
-            None,
-            None,
         )
         .await;
 
@@ -1198,16 +870,11 @@ mod tests {
         never_evicted: &[Pubkey],
         removed_account_tx: &mpsc::Sender<Pubkey>,
     ) -> usize {
-        let secondary = AccountsLruCache::new(NonZeroUsize::new(10).unwrap());
         reconcile_subscriptions(
             subscribed_accounts,
-            &secondary,
-            &Mutex::new(HashSet::new()),
             pubsub_client,
             never_evicted,
             removed_account_tx,
-            None,
-            None,
             None,
             None,
         )

--- a/magicblock-chainlink/src/remote_account_provider/tests.rs
+++ b/magicblock-chainlink/src/remote_account_provider/tests.rs
@@ -68,9 +68,6 @@ async fn setup_provider_with_lru_capacity(
 
     let (forward_tx, forward_rx) = mpsc::channel(1_000);
     let (subscribed_accounts, config) = create_test_lru_cache(lru_capacity);
-    let config = config
-        .with_secondary_subscriptions_lru_capacity(lru_capacity)
-        .unwrap();
     let chain_slot = Arc::<AtomicU64>::default();
 
     let provider = Arc::new(
@@ -181,555 +178,6 @@ async fn wait_for_pending_account_delta_at_least(
         );
         tokio::time::sleep(Duration::from_millis(10)).await;
     }
-}
-
-async fn wait_until(what: &str, condition: impl Fn() -> bool) {
-    let start = tokio::time::Instant::now();
-    let timeout = Duration::from_secs(2);
-    loop {
-        if condition() {
-            break;
-        }
-        assert!(start.elapsed() < timeout, "timed out waiting for {what}");
-        tokio::time::sleep(Duration::from_millis(10)).await;
-    }
-}
-
-/// Accounts that do not exist on chain stay in the secondary LRU and move to
-/// the primary LRU once they are created.
-#[tokio::test]
-async fn test_not_found_account_stays_secondary_and_promotes_on_creation() {
-    init_logger();
-
-    let existing = random_pubkey();
-    let missing = random_pubkey();
-    let ctx = setup_provider(
-        existing,
-        Account {
-            lamports: 500,
-            ..Default::default()
-        },
-    )
-    .await;
-    ctx.pubsub_client.set_transport(PubsubTransport::Grpc);
-
-    let res = ctx
-        .provider
-        .try_get(missing, AccountFetchContext::rpc_get_account())
-        .await
-        .unwrap();
-    assert!(!res.is_found());
-    let fetch_slot = res.slot();
-
-    // The account remains in the secondary tier after the fetch resolves.
-    let provider = ctx.provider.clone();
-    wait_until("account to enter secondary tier", || {
-        provider.secondary_subscriptions.contains(&missing)
-    })
-    .await;
-    assert!(!ctx.provider.lrucache_subscribed_accounts.contains(&missing));
-    assert!(ctx.provider.is_watching(&missing));
-    assert!(ctx.pubsub_client.subscriptions_union().contains(&missing));
-    assert!(ctx
-        .provider
-        .confirmed_missing_subscriptions
-        .lock()
-        .unwrap()
-        .contains(&missing));
-
-    // An older update must not undo the newer not-found classification.
-    let transition_guard =
-        ctx.provider.subscription_transition_lock.lock().await;
-    let updates_before = ctx.provider.received_updates_count();
-    ctx.pubsub_client
-        .send_account_update(
-            missing,
-            fetch_slot.saturating_sub(1),
-            &Account {
-                lamports: 900,
-                ..Default::default()
-            },
-        )
-        .await;
-    let provider = ctx.provider.clone();
-    wait_until("older subscription update to be processed", || {
-        provider.received_updates_count() > updates_before
-    })
-    .await;
-    drop(transition_guard);
-    let transition_guard =
-        ctx.provider.subscription_transition_lock.lock().await;
-    drop(transition_guard);
-    assert!(ctx.provider.secondary_subscriptions.contains(&missing));
-    assert!(!ctx.provider.lrucache_subscribed_accounts.contains(&missing));
-
-    // A newer creation update promotes the account to the primary LRU.
-    ctx.pubsub_client
-        .send_account_update(
-            missing,
-            fetch_slot + 1,
-            &Account {
-                lamports: 1_000,
-                ..Default::default()
-            },
-        )
-        .await;
-    let provider = ctx.provider.clone();
-    wait_until("account to be promoted", || {
-        provider.lrucache_subscribed_accounts.contains(&missing)
-            && !provider.secondary_subscriptions.contains(&missing)
-    })
-    .await;
-    assert!(!ctx
-        .provider
-        .confirmed_missing_subscriptions
-        .lock()
-        .unwrap()
-        .contains(&missing));
-}
-
-#[tokio::test]
-async fn test_subscription_creation_fails_when_primary_capacity_is_protected() {
-    init_logger();
-
-    let protected = random_pubkey();
-    let missing = random_pubkey();
-    let mut ctx = setup_provider_with_lru_capacity(
-        protected,
-        Account {
-            lamports: 1,
-            ..Default::default()
-        },
-        1,
-    )
-    .await;
-    ctx.pubsub_client.set_transport(PubsubTransport::Grpc);
-
-    ctx.provider
-        .try_get(protected, AccountFetchContext::rpc_get_account())
-        .await
-        .unwrap();
-    ctx.provider
-        .acquire_subscription(
-            &protected,
-            SubscriptionReason::UndelegationTracking,
-        )
-        .await
-        .unwrap();
-    let fetch_slot = ctx
-        .provider
-        .try_get(missing, AccountFetchContext::rpc_get_account())
-        .await
-        .unwrap()
-        .slot();
-
-    let updates_before = ctx.provider.received_updates_count();
-    ctx.pubsub_client
-        .send_account_update(
-            missing,
-            fetch_slot + 1,
-            &Account {
-                lamports: 1,
-                ..Default::default()
-            },
-        )
-        .await;
-    let provider = ctx.provider.clone();
-    wait_until("subscription update to be rejected", || {
-        provider.received_updates_count() > updates_before
-    })
-    .await;
-    let transition_guard =
-        ctx.provider.subscription_transition_lock.lock().await;
-    drop(transition_guard);
-
-    assert!(ctx
-        .provider
-        .lrucache_subscribed_accounts
-        .contains(&protected));
-    assert!(!ctx.provider.secondary_subscriptions.contains(&missing));
-    assert!(!ctx.provider.is_watching(&missing));
-    assert!(!ctx.pubsub_client.subscriptions_union().contains(&missing));
-    assert!(ctx._forward_rx.try_recv().is_err());
-}
-
-#[tokio::test]
-async fn test_repeated_not_found_fetch_preserves_primary_working_set() {
-    init_logger();
-
-    let existing = random_pubkey();
-    let missing = random_pubkey();
-    let ctx = setup_provider_with_lru_capacity(
-        existing,
-        Account {
-            lamports: 500,
-            ..Default::default()
-        },
-        1,
-    )
-    .await;
-    ctx.pubsub_client.set_transport(PubsubTransport::Grpc);
-
-    assert!(ctx
-        .provider
-        .try_get(existing, AccountFetchContext::rpc_get_account())
-        .await
-        .unwrap()
-        .is_found());
-    assert!(ctx
-        .provider
-        .lrucache_subscribed_accounts
-        .contains(&existing));
-
-    for _ in 0..2 {
-        assert!(!ctx
-            .provider
-            .try_get(missing, AccountFetchContext::rpc_get_account())
-            .await
-            .unwrap()
-            .is_found());
-    }
-
-    assert!(ctx
-        .provider
-        .lrucache_subscribed_accounts
-        .contains(&existing));
-    assert!(!ctx.provider.lrucache_subscribed_accounts.contains(&missing));
-    assert!(ctx.provider.secondary_subscriptions.contains(&missing));
-    assert!(!ctx.provider.secondary_subscriptions.contains(&existing));
-}
-
-#[tokio::test]
-async fn test_refetching_confirmed_miss_restores_full_coverage_while_pending() {
-    init_logger();
-
-    let existing = random_pubkey();
-    let missing = random_pubkey();
-    let ctx = setup_provider(existing, Account::default()).await;
-    ctx.pubsub_client.set_transport(PubsubTransport::Grpc);
-
-    assert!(!ctx
-        .provider
-        .try_get(missing, AccountFetchContext::rpc_get_account())
-        .await
-        .unwrap()
-        .is_found());
-    assert!(ctx
-        .provider
-        .confirmed_missing_subscriptions
-        .lock()
-        .unwrap()
-        .contains(&missing));
-    let subscribe_attempts = ctx.pubsub_client.subscribe_attempts();
-
-    ctx.rpc_client.block_fetches();
-    let task_handle = tokio::spawn({
-        let provider = ctx.provider.clone();
-        async move {
-            provider
-                .try_get(missing, AccountFetchContext::rpc_get_account())
-                .await
-        }
-    });
-    let provider = ctx.provider.clone();
-    wait_until("confirmed miss refetch to restore full coverage", || {
-        provider.is_pending(&missing)
-            && !provider
-                .confirmed_missing_subscriptions
-                .lock()
-                .unwrap()
-                .contains(&missing)
-    })
-    .await;
-    assert!(ctx.pubsub_client.subscribe_attempts() > subscribe_attempts);
-
-    ctx.rpc_client.allow_fetches();
-    let remote_account =
-        tokio::time::timeout(Duration::from_secs(2), task_handle)
-            .await
-            .expect("refetch should complete")
-            .expect("refetch should not panic")
-            .expect("refetch should succeed");
-    assert!(!remote_account.is_found());
-    assert!(ctx
-        .provider
-        .confirmed_missing_subscriptions
-        .lock()
-        .unwrap()
-        .contains(&missing));
-}
-
-#[tokio::test]
-async fn test_manual_unsubscribe_removes_secondary_account() {
-    init_logger();
-
-    let existing = random_pubkey();
-    let missing = random_pubkey();
-    let ctx = setup_provider(existing, Account::default()).await;
-    ctx.pubsub_client.set_transport(PubsubTransport::Grpc);
-    let mut removed_rx = ctx.provider.try_get_removed_account_rx().unwrap();
-
-    assert!(!ctx
-        .provider
-        .try_get(missing, AccountFetchContext::rpc_get_account())
-        .await
-        .unwrap()
-        .is_found());
-    assert!(ctx.provider.secondary_subscriptions.contains(&missing));
-
-    ctx.provider.unsubscribe(&missing).await.unwrap();
-
-    assert!(!ctx.provider.is_watching(&missing));
-    assert!(!ctx.pubsub_client.subscriptions_union().contains(&missing));
-    assert!(
-        !ctx.provider
-            .has_subscription_reason(
-                &missing,
-                SubscriptionReason::DirectAccount
-            )
-            .await
-    );
-    assert_eq!(removed_rx.recv().await, Some(missing));
-}
-
-#[tokio::test]
-async fn test_failed_membership_repair_rolls_back_new_reason() {
-    init_logger();
-
-    let pubkey = random_pubkey();
-    let ctx = setup_provider(pubkey, Account::default()).await;
-    ctx.provider
-        .acquire_subscription(&pubkey, SubscriptionReason::DirectAccount)
-        .await
-        .unwrap();
-
-    ctx.provider.lrucache_subscribed_accounts.remove(&pubkey);
-    ctx.pubsub_client.simulate_disconnect();
-    assert!(ctx
-        .provider
-        .acquire_subscription(&pubkey, SubscriptionReason::DelegationRecord)
-        .await
-        .is_err());
-
-    assert!(
-        ctx.provider
-            .has_subscription_reason(&pubkey, SubscriptionReason::DirectAccount)
-            .await
-    );
-    assert!(
-        !ctx.provider
-            .has_subscription_reason(
-                &pubkey,
-                SubscriptionReason::DelegationRecord,
-            )
-            .await
-    );
-}
-
-#[tokio::test]
-async fn test_secondary_critical_acquire_fails_without_primary_capacity() {
-    init_logger();
-
-    let protected = random_pubkey();
-    let missing = random_pubkey();
-    let ctx =
-        setup_provider_with_lru_capacity(protected, Account::default(), 1)
-            .await;
-    ctx.pubsub_client.set_transport(PubsubTransport::Grpc);
-
-    ctx.provider
-        .acquire_subscription(
-            &protected,
-            SubscriptionReason::UndelegationTracking,
-        )
-        .await
-        .unwrap();
-    assert!(!ctx
-        .provider
-        .try_get(missing, AccountFetchContext::rpc_get_account())
-        .await
-        .unwrap()
-        .is_found());
-
-    let err = ctx
-        .provider
-        .acquire_subscription(&missing, SubscriptionReason::DelegationRecord)
-        .await
-        .unwrap_err();
-    assert!(matches!(
-        err,
-        RemoteAccountProviderError::NoEvictableSubscriptionCapacity { pubkey }
-            if pubkey == missing
-    ));
-    assert!(ctx
-        .provider
-        .lrucache_subscribed_accounts
-        .contains(&protected));
-    assert!(ctx.provider.secondary_subscriptions.contains(&missing));
-    assert!(
-        !ctx.provider
-            .has_subscription_reason(
-                &missing,
-                SubscriptionReason::DelegationRecord,
-            )
-            .await
-    );
-}
-
-#[tokio::test]
-async fn test_secondary_capacity_preserves_protected_account() {
-    init_logger();
-
-    let primary = random_pubkey();
-    let protected_missing = random_pubkey();
-    let rejected_missing = random_pubkey();
-    let ctx = setup_provider_with_lru_capacity(
-        primary,
-        Account {
-            lamports: 1,
-            ..Default::default()
-        },
-        1,
-    )
-    .await;
-    ctx.pubsub_client.set_transport(PubsubTransport::Grpc);
-
-    ctx.provider
-        .acquire_subscription(
-            &primary,
-            SubscriptionReason::UndelegationTracking,
-        )
-        .await
-        .unwrap();
-    assert!(!ctx
-        .provider
-        .try_get(protected_missing, AccountFetchContext::rpc_get_account(),)
-        .await
-        .unwrap()
-        .is_found());
-    ctx.provider
-        .acquire_subscription(
-            &protected_missing,
-            SubscriptionReason::UndelegationTracking,
-        )
-        .await
-        .unwrap();
-
-    let subscribe_attempts = ctx.pubsub_client.subscribe_attempts();
-    ctx.pubsub_client.fail_next_unsubscriptions(1);
-    let err = ctx
-        .provider
-        .try_get(rejected_missing, AccountFetchContext::rpc_get_account())
-        .await
-        .unwrap_err();
-    assert!(matches!(
-        err,
-        RemoteAccountProviderError::NoEvictableSubscriptionCapacity { .. }
-    ));
-    assert!(ctx
-        .provider
-        .secondary_subscriptions
-        .contains(&protected_missing));
-    assert!(ctx.provider.is_watching(&protected_missing));
-    assert!(!ctx.provider.is_watching(&rejected_missing));
-    assert!(!ctx
-        .pubsub_client
-        .subscriptions_union()
-        .contains(&rejected_missing));
-    assert_eq!(ctx.pubsub_client.subscribe_attempts(), subscribe_attempts);
-}
-
-#[tokio::test]
-async fn test_secondary_eviction_failure_restores_previous_account() {
-    init_logger();
-
-    let existing = random_pubkey();
-    let first_missing = random_pubkey();
-    let second_missing = random_pubkey();
-    let ctx = setup_provider_with_lru_capacity(
-        existing,
-        Account {
-            lamports: 1,
-            ..Default::default()
-        },
-        1,
-    )
-    .await;
-    ctx.pubsub_client.set_transport(PubsubTransport::Grpc);
-
-    assert!(!ctx
-        .provider
-        .try_get(first_missing, AccountFetchContext::rpc_get_account())
-        .await
-        .unwrap()
-        .is_found());
-    ctx.pubsub_client.fail_next_unsubscriptions(1);
-
-    assert!(ctx
-        .provider
-        .try_get(second_missing, AccountFetchContext::rpc_get_account())
-        .await
-        .is_err());
-    assert!(ctx
-        .provider
-        .secondary_subscriptions
-        .contains(&first_missing));
-    assert!(ctx.provider.is_watching(&first_missing));
-    assert!(ctx
-        .pubsub_client
-        .subscriptions_union()
-        .contains(&first_missing));
-    assert!(!ctx.provider.is_watching(&second_missing));
-}
-
-#[tokio::test]
-async fn test_found_fetch_fails_when_primary_capacity_is_protected() {
-    init_logger();
-
-    let protected = random_pubkey();
-    let found = random_pubkey();
-    let ctx = setup_provider_with_lru_capacity(
-        protected,
-        Account {
-            lamports: 1,
-            ..Default::default()
-        },
-        1,
-    )
-    .await;
-    ctx.rpc_client.add_account(
-        found,
-        Account {
-            lamports: 1,
-            ..Default::default()
-        },
-    );
-    ctx.provider
-        .acquire_subscription(
-            &protected,
-            SubscriptionReason::UndelegationTracking,
-        )
-        .await
-        .unwrap();
-
-    let err = ctx
-        .provider
-        .try_get(found, AccountFetchContext::rpc_get_account())
-        .await
-        .unwrap_err();
-    assert!(matches!(
-        err,
-        RemoteAccountProviderError::AccountResolutionsFailed(message)
-            if message.contains("NoEvictableSubscriptionCapacity")
-                && message.contains(&found.to_string())
-    ));
-    assert!(ctx
-        .provider
-        .lrucache_subscribed_accounts
-        .contains(&protected));
-    assert!(!ctx.provider.secondary_subscriptions.contains(&found));
-    assert!(!ctx.provider.is_watching(&found));
-    assert!(!ctx.pubsub_client.subscriptions_union().contains(&found));
 }
 
 struct TestSlotConfig {
@@ -858,150 +306,6 @@ async fn setup_matching_slots(
         .unwrap(),
         forward_rx,
     )
-}
-
-#[tokio::test]
-async fn test_classification_placeholder_cleanup_is_generation_scoped() {
-    let pubkey = solana_pubkey::Pubkey::new_unique();
-    let subscription_ownership: SubscriptionOwnershipMap = Default::default();
-    let subscription_transition_lock = Arc::new(AsyncMutex::new(()));
-    let placeholder = SubscriptionOwnership {
-        classification_placeholder_generation: Some(2),
-        ..Default::default()
-    };
-    subscription_ownership
-        .lock()
-        .await
-        .insert(pubkey, placeholder);
-
-    cleanup_classification_placeholders(
-        &subscription_ownership,
-        &subscription_transition_lock,
-        &HashMap::from([(pubkey, 1)]),
-    )
-    .await;
-    assert!(subscription_ownership.lock().await.contains_key(&pubkey));
-
-    cleanup_classification_placeholders(
-        &subscription_ownership,
-        &subscription_transition_lock,
-        &HashMap::from([(pubkey, 2)]),
-    )
-    .await;
-    assert!(!subscription_ownership.lock().await.contains_key(&pubkey));
-}
-
-#[tokio::test]
-async fn test_cancelled_subscription_setup_cleans_classification_placeholder() {
-    let pubkey = solana_pubkey::Pubkey::new_unique();
-    let generation = 1;
-    let (sender, receiver) = oneshot::channel();
-    let fetching_accounts = Arc::new(Mutex::new(HashMap::from([(
-        pubkey,
-        FetchingAccountState {
-            generation,
-            fetch_start_slot: 0,
-            fetch_context: AccountFetchContext::rpc_get_account(),
-            owner_started_at: std::time::Instant::now(),
-            waiters: vec![sender],
-        },
-    )])));
-    let subscription_ownership: SubscriptionOwnershipMap = Default::default();
-    let subscription_transition_lock = Arc::new(AsyncMutex::new(()));
-    let placeholder = SubscriptionOwnership {
-        classification_placeholder_generation: Some(generation),
-        ..Default::default()
-    };
-    subscription_ownership
-        .lock()
-        .await
-        .insert(pubkey, placeholder);
-
-    let transition_guard = subscription_transition_lock.lock().await;
-    let guard = ClaimedSubscriptionSetupGuard::new(
-        fetching_accounts.clone(),
-        subscription_ownership.clone(),
-        subscription_transition_lock.clone(),
-        vec![pubkey],
-        HashMap::from([(pubkey, generation)]),
-    );
-    drop(guard);
-
-    assert!(!fetching_accounts.lock().unwrap().contains_key(&pubkey));
-    assert!(receiver.await.unwrap().is_err());
-    assert!(subscription_ownership.lock().await.contains_key(&pubkey));
-    drop(transition_guard);
-
-    tokio::time::timeout(Duration::from_secs(1), async {
-        while subscription_ownership.lock().await.contains_key(&pubkey) {
-            tokio::task::yield_now().await;
-        }
-    })
-    .await
-    .expect("classification placeholder cleanup should complete");
-}
-
-#[tokio::test]
-async fn test_failed_placeholder_adoption_preserves_generation_for_cleanup() {
-    let pubkey = solana_pubkey::Pubkey::new_unique();
-    let account = Account {
-        lamports: 1_000_000,
-        data: vec![],
-        owner: system_program::id(),
-        executable: false,
-        rent_epoch: 0,
-    };
-    let ProviderTestCtx {
-        provider,
-        pubsub_client,
-        _forward_rx,
-        ..
-    } = setup_provider(pubkey, account).await;
-    let generation = 1;
-    let placeholder = SubscriptionOwnership {
-        classification_placeholder_generation: Some(generation),
-        ..Default::default()
-    };
-    provider
-        .subscription_ownership
-        .lock()
-        .await
-        .insert(pubkey, placeholder);
-
-    pubsub_client.simulate_disconnect();
-    assert!(provider
-        .acquire_subscription_with_origin(
-            &pubkey,
-            SubscriptionReason::DirectAccount,
-            SubscriptionRegistrationOrigin::Fetch(
-                AccountFetchContext::rpc_get_account(),
-            ),
-        )
-        .await
-        .is_err());
-
-    let ownership = provider.subscription_ownership.lock().await;
-    let placeholder = ownership
-        .get(&pubkey)
-        .expect("failed adoption should retain the placeholder for cleanup");
-    assert!(placeholder.is_empty());
-    assert_eq!(
-        placeholder.classification_placeholder_generation,
-        Some(generation)
-    );
-    drop(ownership);
-
-    cleanup_classification_placeholders(
-        &provider.subscription_ownership,
-        &provider.subscription_transition_lock,
-        &HashMap::from([(pubkey, generation)]),
-    )
-    .await;
-    assert!(!provider
-        .subscription_ownership
-        .lock()
-        .await
-        .contains_key(&pubkey));
 }
 
 #[tokio::test]
@@ -1248,10 +552,7 @@ async fn test_try_get_multi_setup_subscriptions_failure_cleans_up_pending_entry(
         .expect("owner task should complete")
         .expect("owner task should not panic");
     let err = result.expect_err("setup_subscriptions should fail");
-    assert!(matches!(
-        err,
-        RemoteAccountProviderError::AccountSubscriptionsTaskFailed(_)
-    ));
+    assert!(err.to_string().contains("subscription(s) failed"));
     assert!(!provider.is_pending(&pubkey));
 
     pubsub_client.try_reconnect().await.unwrap();
@@ -1355,14 +656,8 @@ async fn test_try_get_multi_waiter_receives_setup_subscriptions_failure() {
 
     let first_err = first_result.expect_err("owner should fail");
     let second_err = second_result.expect_err("waiter should fail");
-    assert!(matches!(
-        first_err,
-        RemoteAccountProviderError::AccountSubscriptionsTaskFailed(_)
-    ));
-    assert!(matches!(
-        second_err,
-        RemoteAccountProviderError::AccountResolutionsFailed(_)
-    ));
+    assert!(first_err.to_string().contains("subscription(s) failed"));
+    assert!(second_err.to_string().contains("subscription(s) failed"));
     assert!(!provider.is_pending(&pubkey));
 }
 
@@ -2158,6 +1453,7 @@ async fn test_pending_fetch_metrics_count_subscription_update_resolution_and_lat
     let rpc_client = ChainRpcClientMockBuilder::new()
         .slot(CURRENT_SLOT)
         .clock_sysvar_for_slot(CURRENT_SLOT)
+        .account(pubkey, account)
         .build();
     let (updates_sender, updates_receiver) = mpsc::channel(1_000);
     let pubsub_client =
@@ -2232,9 +1528,6 @@ async fn test_pending_fetch_metrics_count_subscription_update_resolution_and_lat
         "remote provider subscription-resolution metric should increase by at least 1; got {resolved_delta}"
     );
 
-    // A discarded result must not reclassify the account even when its
-    // response slot is newer than the subscription update that won.
-    rpc_client.set_current_slot(fetch_start_slot + 1);
     rpc_client.allow_fetches();
     wait_for_pending_account_delta_at_least(
         fetch_context,
@@ -2243,10 +1536,6 @@ async fn test_pending_fetch_metrics_count_subscription_update_resolution_and_lat
         1,
     )
     .await;
-    let transition_guard = provider.subscription_transition_lock.lock().await;
-    drop(transition_guard);
-    assert!(provider.lrucache_subscribed_accounts.contains(&pubkey));
-    assert!(!provider.secondary_subscriptions.contains(&pubkey));
 }
 
 #[tokio::test]
@@ -2584,70 +1873,6 @@ async fn test_get_accounts_until_slots_match_waits_when_chain_slot_smaller_than_
 }
 
 #[tokio::test]
-async fn test_slot_match_retry_reclassifies_found_account_to_primary() {
-    const CURRENT_SLOT: u64 = 42;
-    let missing = random_pubkey();
-    let existing = random_pubkey();
-    let account = Account {
-        lamports: 1,
-        ..Default::default()
-    };
-    let rpc_client = ChainRpcClientMockBuilder::new()
-        .slot(CURRENT_SLOT)
-        .clock_sysvar_for_slot(CURRENT_SLOT)
-        .account(existing, account.clone())
-        .build();
-    let (updates_tx, updates_rx) = mpsc::channel(100);
-    let pubsub_client = ChainPubsubClientMock::new(updates_tx, updates_rx);
-    let (forward_tx, _forward_rx) = mpsc::channel(100);
-    let (subscribed_accounts, config) = create_test_lru_cache(1000);
-    let provider = Arc::new(
-        RemoteAccountProvider::new(
-            rpc_client.clone(),
-            pubsub_client,
-            forward_tx,
-            &config,
-            subscribed_accounts,
-            ChainSlot::new(Arc::<AtomicU64>::default()),
-        )
-        .await
-        .unwrap(),
-    );
-
-    let rpc_to_advance = rpc_client.clone();
-    let account_to_add = account.clone();
-    let advance_handle = tokio::spawn(async move {
-        tokio::time::sleep(Duration::from_millis(100)).await;
-        rpc_to_advance.add_account(missing, account_to_add);
-        rpc_to_advance.set_slot(CURRENT_SLOT + 1);
-    });
-
-    let remote_accounts = provider
-        .try_get_multi_until_slots_match(
-            &[missing, existing],
-            Some(MatchSlotsConfig {
-                max_retries: 10,
-                retry_interval_ms: 10,
-                min_context_slot: Some(CURRENT_SLOT + 1),
-                companion_fetch_kind: ChainlinkCompanionFetchKind::ProgramData,
-            }),
-            AccountFetchContext::rpc_get_account(),
-        )
-        .await
-        .unwrap();
-    advance_handle.await.unwrap();
-
-    assert!(remote_accounts.iter().all(RemoteAccount::is_found));
-    assert!(provider.lrucache_subscribed_accounts.contains(&missing));
-    assert!(!provider.secondary_subscriptions.contains(&missing));
-    assert!(!provider
-        .confirmed_missing_subscriptions
-        .lock()
-        .unwrap()
-        .contains(&missing));
-}
-
-#[tokio::test]
 async fn test_get_accounts_until_slots_match_finding_matching_slot_but_one_account_slot_smaller_than_min_context_slot(
 ) {
     const CURRENT_SLOT: u64 = 42;
@@ -2964,7 +2189,7 @@ async fn test_capacity_eviction_skips_undelegation_tracking_reason() {
 }
 
 #[tokio::test]
-async fn test_capacity_eviction_unsubscribe_failure_restores_previous_owner() {
+async fn test_capacity_eviction_unsubscribe_failure_records_new_owner() {
     init_logger();
     let _metric_guard = SUBSCRIPTION_LIFECYCLE_METRIC_TEST_GUARD.lock().await;
 
@@ -3011,9 +2236,16 @@ async fn test_capacity_eviction_unsubscribe_failure_restores_previous_owner() {
         err,
         RemoteAccountProviderError::AccountSubscriptionsTaskFailed(_)
     ));
-    assert!(provider.is_watching(&pubkey1));
-    assert!(!provider.is_watching(&pubkey2));
-    assert!(!provider
+    assert!(provider.is_watching(&pubkey2));
+    assert!(
+        provider
+            .has_subscription_reason(
+                &pubkey2,
+                SubscriptionReason::DirectAccount
+            )
+            .await
+    );
+    assert!(provider
         .pubsub_client()
         .subscriptions_union()
         .contains(&pubkey2));
@@ -3129,7 +2361,11 @@ async fn test_capacity_eviction_all_protected_returns_error_without_unsubscribin
     let registration_before = registration_metric_value(
         SubscriptionRegistrationOrigin::Internal,
         SubscriptionReasonLabel::DirectAccount,
-        SubscriptionRegistrationOutcome::RejectedNoCapacity,
+        SubscriptionRegistrationOutcome::RejectedAndUnsubscribed,
+    );
+    let cleanup_before = cleanup_metric_value(
+        SubscriptionCleanupSource::RejectedNewSubscription,
+        SubscriptionCleanupOutcome::Unsubscribed,
     );
 
     let err = provider
@@ -3140,9 +2376,14 @@ async fn test_capacity_eviction_all_protected_returns_error_without_unsubscribin
     let registration_after = registration_metric_value(
         SubscriptionRegistrationOrigin::Internal,
         SubscriptionReasonLabel::DirectAccount,
-        SubscriptionRegistrationOutcome::RejectedNoCapacity,
+        SubscriptionRegistrationOutcome::RejectedAndUnsubscribed,
+    );
+    let cleanup_after = cleanup_metric_value(
+        SubscriptionCleanupSource::RejectedNewSubscription,
+        SubscriptionCleanupOutcome::Unsubscribed,
     );
     assert_eq!(registration_after - registration_before, 1);
+    assert_eq!(cleanup_after - cleanup_before, 1);
 
     assert!(matches!(
         err,
@@ -3494,15 +2735,11 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
             self.lrucache_subscribed_accounts.never_evicted_accounts();
         subscription_reconciler::reconcile_subscriptions(
             &self.lrucache_subscribed_accounts,
-            &self.secondary_subscriptions,
-            &self.confirmed_missing_subscriptions,
             &self.pubsub_client,
             &never_evicted,
             &self.removed_account_tx,
             Some(&self.subscription_key_locks),
             Some(&self.subscription_ownership),
-            Some(self.fetching_accounts.as_ref()),
-            Some(&self.capacity_eviction_protection),
         )
         .await
     }

--- a/magicblock-chainlink/src/submux/mod.rs
+++ b/magicblock-chainlink/src/submux/mod.rs
@@ -19,10 +19,10 @@ use tracing::*;
 
 use crate::remote_account_provider::{
     chain_pubsub_client::{
-        ChainPubsubClient, PubsubTransport, ReconnectableClient,
+        ChainPubsubClient, ReconnectableClient,
         SubscriptionReconciliationSnapshot,
     },
-    errors::{RemoteAccountProviderError, RemoteAccountProviderResult},
+    errors::RemoteAccountProviderResult,
     pubsub_common::SubscriptionUpdate,
 };
 
@@ -35,7 +35,6 @@ pub use self::debounce_state::DebounceState;
 
 mod subscription_task;
 pub use self::subscription_task::AccountSubscriptionTask;
-use self::subscription_task::{SUBSCRIBE_TIMEOUT, UNSUBSCRIBE_TIMEOUT};
 
 mod subscribed_accounts_tracker;
 pub use self::subscribed_accounts_tracker::SubscribedAccountsTracker;
@@ -147,9 +146,6 @@ where
     never_debounce: HashSet<Pubkey>,
     /// Map of program account subscriptions we are holding inside the pubsub clients
     program_subs: Arc<Mutex<HashSet<Pubkey>>>,
-    /// Accounts whose desired coverage excludes websocket clients while at
-    /// least one gRPC client is available.
-    grpc_only_subscriptions: Arc<Mutex<HashSet<Pubkey>>>,
     /// Client handles currently considered connected by the mux.
     connected_client_ids: Arc<Mutex<HashSet<usize>>>,
     /// Number of currently connected pubsub clients.
@@ -229,8 +225,6 @@ where
             vec![clock::ID].into_iter().collect();
 
         let program_subs: Arc<Mutex<HashSet<Pubkey>>> = Default::default();
-        let grpc_only_subscriptions: Arc<Mutex<HashSet<Pubkey>>> =
-            Default::default();
         let connected_client_ids: Arc<Mutex<HashSet<usize>>> =
             Arc::new(Mutex::new(
                 clients
@@ -265,19 +259,15 @@ where
             }
         }
 
-        let clients_only = Arc::new(Mutex::new(
-            clients
-                .iter()
-                .map(|(client, _)| client.clone())
-                .collect::<Vec<_>>(),
-        ));
+        let clients_only = clients
+            .iter()
+            .map(|(client, _)| client.clone())
+            .collect::<Vec<_>>();
 
         Self::spawn_reconnectors(
             clients,
-            clients_only.clone(),
             subscribed_accounts_tracker,
             program_subs.clone(),
-            grpc_only_subscriptions.clone(),
             connected_client_ids.clone(),
             connected_clients.clone(),
             connected_clients_subscribing_immediately.clone(),
@@ -285,7 +275,7 @@ where
 
         let shutdown_token = CancellationToken::new();
         let me = Self {
-            clients: clients_only,
+            clients: Arc::new(Mutex::new(clients_only)),
             out_tx,
             out_rx: Arc::new(Mutex::new(Some(out_rx))),
             dedup_cache: dedup_cache.clone(),
@@ -295,7 +285,6 @@ where
             debounce_states: debounce_states.clone(),
             never_debounce,
             program_subs,
-            grpc_only_subscriptions,
             connected_client_ids,
             connected_clients,
             connected_clients_subscribing_immediately,
@@ -319,23 +308,18 @@ where
     // -----------------
     // Reconnection
     // -----------------
-    #[allow(clippy::too_many_arguments)]
     fn spawn_reconnectors<U: SubscribedAccountsTracker>(
         clients: Vec<(Arc<T>, mpsc::Receiver<()>)>,
-        all_clients: Arc<Mutex<Vec<Arc<T>>>>,
         subscribed_accounts_tracker: Arc<U>,
         program_subs: Arc<Mutex<HashSet<Pubkey>>>,
-        grpc_only_subscriptions: Arc<Mutex<HashSet<Pubkey>>>,
         connected_client_ids: Arc<Mutex<HashSet<usize>>>,
         connected_clients: Arc<AtomicU16>,
         connected_clients_subscribing_immediately: Arc<AtomicU16>,
     ) {
         for (client, mut abort_rx) in clients.into_iter() {
-            let all_clients = all_clients.clone();
             let subscribed_accounts_tracker =
                 subscribed_accounts_tracker.clone();
             let program_subs = program_subs.clone();
-            let grpc_only_subscriptions = grpc_only_subscriptions.clone();
             let connected_client_ids = connected_client_ids.clone();
             let connected_clients = connected_clients.clone();
             let connected_clients_subscribing_immediately =
@@ -379,10 +363,8 @@ where
 
                     Self::reconnect_client_with_backoff(
                         client.clone(),
-                        all_clients.clone(),
                         subscribed_accounts_tracker.clone(),
                         program_subs.clone(),
-                        grpc_only_subscriptions.clone(),
                         connected_client_ids.clone(),
                         connected_clients.clone(),
                         connected_clients_subscribing_immediately.clone(),
@@ -422,81 +404,6 @@ where
             .collect()
     }
 
-    fn reconciliation_snapshot_from_clients(
-        clients: Vec<Arc<T>>,
-    ) -> Option<SubscriptionReconciliationSnapshot> {
-        if clients.is_empty() {
-            return None;
-        }
-
-        let mut union = HashSet::new();
-        let mut intersection_sets = Vec::with_capacity(clients.len());
-        for client in clients {
-            let Some(snapshot) = client.subscription_reconciliation_snapshot()
-            else {
-                continue;
-            };
-            union.extend(snapshot.union);
-            intersection_sets.push(snapshot.intersection);
-        }
-
-        let smallest = intersection_sets.iter().min_by_key(|set| set.len())?;
-        let intersection = smallest
-            .iter()
-            .filter(|pubkey| {
-                intersection_sets
-                    .iter()
-                    .filter(|set| !std::ptr::eq(*set, smallest))
-                    .all(|set| set.contains(pubkey))
-            })
-            .copied()
-            .collect();
-
-        Some(SubscriptionReconciliationSnapshot {
-            union,
-            intersection,
-        })
-    }
-
-    fn account_subscriptions_for_client<U: SubscribedAccountsTracker>(
-        tracker: &U,
-        grpc_only_subscriptions: &Arc<Mutex<HashSet<Pubkey>>>,
-        clients: &Mutex<Vec<Arc<T>>>,
-        connected_client_ids: &Arc<Mutex<HashSet<usize>>>,
-        client: &T,
-    ) -> HashSet<Pubkey> {
-        // The tracker is authoritative. The policy set only removes
-        // confirmed misses from websocket reconnects while a connected
-        // gRPC client can cover them; otherwise websocket clients restore
-        // full coverage.
-        let mut subscriptions = tracker.subscribed_accounts();
-        if client.transport() == PubsubTransport::WebSocket
-            && Self::has_connected_grpc_client(clients, connected_client_ids)
-        {
-            let grpc_only = grpc_only_subscriptions
-                .lock()
-                .unwrap_or_else(|poison| poison.into_inner());
-            subscriptions.retain(|pubkey| !grpc_only.contains(pubkey));
-        }
-        subscriptions
-    }
-
-    fn has_connected_grpc_client(
-        clients: &Mutex<Vec<Arc<T>>>,
-        connected_client_ids: &Arc<Mutex<HashSet<usize>>>,
-    ) -> bool {
-        let clients = clients
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner())
-            .clone();
-        let connected_ids =
-            Self::connected_client_ids_lock(connected_client_ids);
-        clients.iter().any(|client| {
-            client.transport() == PubsubTransport::Grpc
-                && connected_ids.contains(&Self::client_key(client))
-        })
-    }
-
     fn remove_client(&self, target: &Arc<T>) {
         {
             let mut clients = self.clients_lock();
@@ -530,13 +437,8 @@ where
             }
         }
 
-        let mut account_subs = Self::account_subscriptions_for_client(
-            subscribed_accounts_tracker.as_ref(),
-            &self.grpc_only_subscriptions,
-            &self.clients,
-            &self.connected_client_ids,
-            client.as_ref(),
-        );
+        let mut account_subs =
+            subscribed_accounts_tracker.subscribed_accounts();
         account_subs.extend(self.never_debounce.iter().copied());
         if let Err(err) = client.resub_multiple(account_subs).await {
             self.remove_client(&client);
@@ -577,10 +479,8 @@ where
 
         Self::spawn_reconnectors(
             vec![(client.clone(), abort_rx)],
-            self.clients.clone(),
             subscribed_accounts_tracker.clone(),
             self.program_subs.clone(),
-            self.grpc_only_subscriptions.clone(),
             self.connected_client_ids.clone(),
             self.connected_clients.clone(),
             self.connected_clients_subscribing_immediately.clone(),
@@ -607,13 +507,8 @@ where
                 );
             }
         }
-        let mut account_subs = Self::account_subscriptions_for_client(
-            subscribed_accounts_tracker.as_ref(),
-            &self.grpc_only_subscriptions,
-            &self.clients,
-            &self.connected_client_ids,
-            client.as_ref(),
-        );
+        let mut account_subs =
+            subscribed_accounts_tracker.subscribed_accounts();
         account_subs.extend(self.never_debounce.iter().copied());
         if let Err(err) = client.resub_multiple(account_subs).await {
             warn!(
@@ -643,23 +538,18 @@ where
     #[instrument(
         skip(
             client,
-            all_clients,
             accounts_tracker,
             program_subs,
-            grpc_only_subscriptions,
             connected_client_ids,
             connected_clients,
             connected_clients_subscribing_immediately
         ),
         fields(client_id = %client.id())
     )]
-    #[allow(clippy::too_many_arguments)]
     async fn reconnect_client_with_backoff<U: SubscribedAccountsTracker>(
         client: Arc<T>,
-        all_clients: Arc<Mutex<Vec<Arc<T>>>>,
         accounts_tracker: Arc<U>,
         program_subs: Arc<Mutex<HashSet<Pubkey>>>,
-        grpc_only_subscriptions: Arc<Mutex<HashSet<Pubkey>>>,
         connected_client_ids: Arc<Mutex<HashSet<usize>>>,
         connected_clients: Arc<AtomicU16>,
         connected_clients_subscribing_immediately: Arc<AtomicU16>,
@@ -686,10 +576,8 @@ where
             }
             match Self::reconnect_client(
                 client.clone(),
-                &all_clients,
                 &accounts_tracker,
                 &program_subs,
-                &grpc_only_subscriptions,
                 connected_client_ids.clone(),
                 connected_clients.clone(),
                 connected_clients_subscribing_immediately.clone(),
@@ -752,16 +640,13 @@ where
     }
 
     #[instrument(
-        skip(client, all_clients, accounts_tracker, program_subs, grpc_only_subscriptions, connected_client_ids, connected_clients, connected_clients_subscribing_immediately),
+        skip(client, accounts_tracker, program_subs, connected_client_ids, connected_clients, connected_clients_subscribing_immediately),
         fields(client_id = %client.id())
     )]
-    #[allow(clippy::too_many_arguments)]
     async fn reconnect_client<U: SubscribedAccountsTracker>(
         client: Arc<T>,
-        all_clients: &Arc<Mutex<Vec<Arc<T>>>>,
         accounts_tracker: &Arc<U>,
         program_subs: &Arc<Mutex<HashSet<Pubkey>>>,
-        grpc_only_subscriptions: &Arc<Mutex<HashSet<Pubkey>>>,
         connected_client_ids: Arc<Mutex<HashSet<usize>>>,
         connected_clients: Arc<AtomicU16>,
         connected_clients_subscribing_immediately: Arc<AtomicU16>,
@@ -793,13 +678,7 @@ where
         // Resubscribe all accounts from the authoritative tracker.
         // This ensures subscriptions are restored even if all clients lost their state
         // during disconnect/abort.
-        let account_subs = Self::account_subscriptions_for_client(
-            accounts_tracker.as_ref(),
-            grpc_only_subscriptions,
-            all_clients,
-            &connected_client_ids,
-            client.as_ref(),
-        );
+        let account_subs = accounts_tracker.subscribed_accounts();
 
         if let Err(err) = client.resub_multiple(account_subs).await {
             debug!(
@@ -830,14 +709,10 @@ where
                 }
             }
 
-            let account_subs = Self::account_subscriptions_for_client(
-                accounts_tracker.as_ref(),
-                grpc_only_subscriptions,
-                all_clients,
-                &connected_client_ids,
-                client.as_ref(),
-            );
-            if let Err(err) = client.resub_multiple(account_subs).await {
+            if let Err(err) = client
+                .resub_multiple(accounts_tracker.subscribed_accounts())
+                .await
+            {
                 Self::connected_client_ids_lock(&connected_client_ids)
                     .remove(&client_key);
                 return Err(err);
@@ -1176,7 +1051,6 @@ where
             debounce_states: self.debounce_states.clone(),
             never_debounce: self.never_debounce.clone(),
             program_subs: self.program_subs.clone(),
-            grpc_only_subscriptions: self.grpc_only_subscriptions.clone(),
             connected_client_ids: self.connected_client_ids.clone(),
             connected_clients: self.connected_clients.clone(),
             connected_clients_subscribing_immediately: self
@@ -1210,25 +1084,13 @@ where
         pubkey: Pubkey,
         retries: Option<usize>,
     ) -> RemoteAccountProviderResult<()> {
-        let was_grpc_only = self
-            .grpc_only_subscriptions
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner())
-            .remove(&pubkey);
-        let result = AccountSubscriptionTask::Subscribe(
+        AccountSubscriptionTask::Subscribe(
             pubkey,
             retries,
             self.required_account_subscription_confirmations(),
         )
         .process(self.connected_clients_snapshot())
-        .await;
-        if result.is_err() && was_grpc_only {
-            self.grpc_only_subscriptions
-                .lock()
-                .unwrap_or_else(|poison| poison.into_inner())
-                .insert(pubkey);
-        }
-        result
+        .await
     }
 
     async fn subscribe_program(
@@ -1281,126 +1143,9 @@ where
         &self,
         pubkey: Pubkey,
     ) -> RemoteAccountProviderResult<()> {
-        let was_grpc_only = self
-            .grpc_only_subscriptions
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner())
-            .remove(&pubkey);
-        let result = AccountSubscriptionTask::Unsubscribe(pubkey)
+        AccountSubscriptionTask::Unsubscribe(pubkey)
             .process(self.connected_clients_snapshot())
-            .await;
-        if result.is_err() && was_grpc_only {
-            self.grpc_only_subscriptions
-                .lock()
-                .unwrap_or_else(|poison| poison.into_inner())
-                .insert(pubkey);
-        }
-        result
-    }
-
-    async fn prefer_grpc_subscription(
-        &self,
-        pubkey: Pubkey,
-    ) -> RemoteAccountProviderResult<()> {
-        let clients = self.connected_clients_snapshot();
-
-        // Only drop websocket legs once at least one gRPC client holds the
-        // subscription; otherwise leave existing coverage untouched. Calls
-        // run concurrently and bounded so a stalled client cannot wedge
-        // subscription transitions.
-        let grpc_results = futures_util::future::join_all(
-            clients
-                .iter()
-                .filter(|c| c.transport() == PubsubTransport::Grpc)
-                .map(|client| async move {
-                    match tokio::time::timeout(
-                        SUBSCRIBE_TIMEOUT,
-                        client.subscribe(pubkey, None),
-                    )
-                    .await
-                    {
-                        Ok(result) => result,
-                        Err(_) => Err(
-                            RemoteAccountProviderError::AccountSubscriptionsTaskFailed(
-                                format!(
-                                    "Subscribe timed out after {SUBSCRIBE_TIMEOUT:?} for client {}",
-                                    client.id()
-                                ),
-                            ),
-                        ),
-                    }
-                }),
-        )
-        .await;
-        let mut grpc_covered = false;
-        let mut last_err = None;
-        for result in grpc_results {
-            match result {
-                Ok(()) => grpc_covered = true,
-                Err(err) => last_err = Some(err),
-            }
-        }
-        // A no-op subscribe can mask lost coverage; trust only the snapshot.
-        if grpc_covered {
-            grpc_covered = self
-                .subscription_reconciliation_snapshot_for_transport(
-                    PubsubTransport::Grpc,
-                )
-                .is_some_and(|snapshot| snapshot.union.contains(&pubkey));
-        }
-        if !grpc_covered {
-            return Err(last_err.unwrap_or_else(|| {
-                RemoteAccountProviderError::AccountSubscriptionsTaskFailed(
-                    format!(
-                        "No connected gRPC client to hold subscription for {pubkey}"
-                    ),
-                )
-            }));
-        }
-
-        self.grpc_only_subscriptions
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner())
-            .insert(pubkey);
-
-        futures_util::future::join_all(
-            clients
-                .iter()
-                .filter(|c| c.transport() == PubsubTransport::WebSocket)
-                .map(|client| async move {
-                    match tokio::time::timeout(
-                        UNSUBSCRIBE_TIMEOUT,
-                        client.unsubscribe(pubkey),
-                    )
-                    .await
-                    {
-                        Ok(Ok(()))
-                        | Ok(Err(
-                            RemoteAccountProviderError::AccountSubscriptionDoesNotExist(
-                                _,
-                            ),
-                        )) => {}
-                        Ok(Err(err)) => {
-                            warn!(
-                                pubkey = %pubkey,
-                                client_id = %client.id(),
-                                error = ?err,
-                                "Failed to drop websocket leg for gRPC-only coverage"
-                            );
-                        }
-                        Err(_) => {
-                            warn!(
-                                pubkey = %pubkey,
-                                client_id = %client.id(),
-                                timeout_ms = UNSUBSCRIBE_TIMEOUT.as_millis() as u64,
-                                "Timed out dropping websocket leg for gRPC-only coverage"
-                            );
-                        }
-                    }
-                }),
-        )
-        .await;
-        Ok(())
+            .await
     }
 
     async fn shutdown(&self) -> RemoteAccountProviderResult<()> {
@@ -1459,21 +1204,46 @@ where
     fn subscription_reconciliation_snapshot(
         &self,
     ) -> Option<SubscriptionReconciliationSnapshot> {
-        Self::reconciliation_snapshot_from_clients(
-            self.connected_clients_snapshot(),
-        )
-    }
+        let connected_clients = self.connected_clients_snapshot();
+        if connected_clients.is_empty() {
+            return None;
+        }
 
-    fn subscription_reconciliation_snapshot_for_transport(
-        &self,
-        transport: PubsubTransport,
-    ) -> Option<SubscriptionReconciliationSnapshot> {
-        let clients = self
-            .connected_clients_snapshot()
-            .into_iter()
-            .filter(|client| client.transport() == transport)
+        let mut union = HashSet::new();
+        let mut intersection_sets = Vec::with_capacity(connected_clients.len());
+        for client in connected_clients {
+            let snapshot = match client.subscription_reconciliation_snapshot() {
+                Some(snapshot) => snapshot,
+                None => continue,
+            };
+            union.extend(snapshot.union);
+            intersection_sets.push(snapshot.intersection);
+        }
+
+        if intersection_sets.is_empty() {
+            return None;
+        }
+
+        // Find the smallest set to iterate over, then check membership
+        // in all others — no intermediate cloning/collecting.
+        // SAFETY: we return above if the set is empty, so unwrap is safe here.
+        let smallest =
+            intersection_sets.iter().min_by_key(|s| s.len()).unwrap();
+        let intersection = smallest
+            .iter()
+            .filter(|pk| {
+                intersection_sets
+                    .iter()
+                    .filter(|s| !std::ptr::eq(*s, smallest))
+                    .all(|s| s.contains(pk))
+            })
+            .copied()
             .collect();
-        Self::reconciliation_snapshot_from_clients(clients)
+
+        Some(SubscriptionReconciliationSnapshot {
+            union,
+            intersection,
+        })
     }
 
     /// Returns true if any inner client subscribes immediately
@@ -2465,173 +2235,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_prefer_grpc_subscription_drops_ws_legs() {
-        init_logger();
-
-        let (tx1, rx1) = mpsc::channel(10_000);
-        let (tx2, rx2) = mpsc::channel(10_000);
-        let ws_client = Arc::new(ChainPubsubClientMock::new(tx1, rx1));
-        let grpc_client = Arc::new(ChainPubsubClientMock::new(tx2, rx2));
-        grpc_client.set_transport(PubsubTransport::Grpc);
-
-        let pk = Pubkey::new_unique();
-        let (mux, _aborts) = new_submux_with_abort(
-            vec![ws_client.clone(), grpc_client.clone()],
-            vec![pk],
-            Some(100),
-        );
-
-        mux.subscribe(pk, None).await.unwrap();
-        assert!(ws_client.subscriptions_union().contains(&pk));
-        assert!(grpc_client.subscriptions_union().contains(&pk));
-
-        mux.prefer_grpc_subscription(pk).await.unwrap();
-        assert!(!ws_client.subscriptions_union().contains(&pk));
-        assert!(grpc_client.subscriptions_union().contains(&pk));
-
-        mux.shutdown().await.unwrap();
-    }
-
-    #[tokio::test]
-    async fn test_grpc_only_subscription_is_restored_on_grpc_reconnect() {
-        init_logger();
-
-        let (tx1, rx1) = mpsc::channel(10_000);
-        let (tx2, rx2) = mpsc::channel(10_000);
-        let ws_client = Arc::new(ChainPubsubClientMock::new(tx1, rx1));
-        let grpc_client = Arc::new(ChainPubsubClientMock::new(tx2, rx2));
-        grpc_client.set_transport(PubsubTransport::Grpc);
-
-        let pubkey = Pubkey::new_unique();
-        let (mux, aborts) = new_submux_with_abort(
-            vec![ws_client.clone(), grpc_client.clone()],
-            vec![pubkey],
-            Some(100),
-        );
-
-        mux.subscribe(pubkey, None).await.unwrap();
-        mux.prefer_grpc_subscription(pubkey).await.unwrap();
-        grpc_client.simulate_disconnect();
-        aborts[1].send(()).await.unwrap();
-
-        let deadline = Instant::now() + Duration::from_secs(1);
-        while !grpc_client.subscriptions_union().contains(&pubkey) {
-            assert!(
-                Instant::now() < deadline,
-                "gRPC subscription did not recover"
-            );
-            sleep_ms(10).await;
-        }
-
-        assert!(!ws_client.subscriptions_union().contains(&pubkey));
-        mux.shutdown().await.unwrap();
-    }
-
-    #[tokio::test]
-    async fn test_reconcile_replaces_lingering_ws_with_grpc_coverage() {
-        init_logger();
-
-        let (tx1, rx1) = mpsc::channel(10_000);
-        let (tx2, rx2) = mpsc::channel(10_000);
-        let ws_client = Arc::new(ChainPubsubClientMock::new(tx1, rx1));
-        let grpc_client = Arc::new(ChainPubsubClientMock::new(tx2, rx2));
-        grpc_client.set_transport(PubsubTransport::Grpc);
-
-        let pubkey = Pubkey::new_unique();
-        let (mux, _aborts) = new_submux_with_abort(
-            vec![ws_client.clone(), grpc_client.clone()],
-            vec![pubkey],
-            Some(100),
-        );
-        ws_client.insert_subscription(pubkey);
-
-        let primary = AccountsLruCache::new(NonZeroUsize::new(10).unwrap());
-        let secondary = AccountsLruCache::new(NonZeroUsize::new(10).unwrap());
-        secondary.add(pubkey);
-        let (removed_tx, mut removed_rx) = mpsc::channel(10);
-
-        reconcile_subscriptions(
-            &primary,
-            &secondary,
-            &Mutex::new(HashSet::from([pubkey])),
-            &mux,
-            &[],
-            &removed_tx,
-            None,
-            None,
-            None,
-            None,
-        )
-        .await;
-
-        assert!(!ws_client.subscriptions_union().contains(&pubkey));
-        assert!(grpc_client.subscriptions_union().contains(&pubkey));
-        assert!(removed_rx.try_recv().is_err());
-        mux.shutdown().await.unwrap();
-    }
-
-    #[tokio::test]
-    async fn test_reconcile_keeps_pending_secondary_fully_covered() {
-        init_logger();
-
-        let (tx1, rx1) = mpsc::channel(10_000);
-        let (tx2, rx2) = mpsc::channel(10_000);
-        let ws_client = Arc::new(ChainPubsubClientMock::new(tx1, rx1));
-        let grpc_client = Arc::new(ChainPubsubClientMock::new(tx2, rx2));
-        grpc_client.set_transport(PubsubTransport::Grpc);
-
-        let pubkey = Pubkey::new_unique();
-        let (mux, _aborts) = new_submux_with_abort(
-            vec![ws_client.clone(), grpc_client.clone()],
-            vec![pubkey],
-            Some(100),
-        );
-        ws_client.insert_subscription(pubkey);
-
-        let primary = AccountsLruCache::new(NonZeroUsize::new(10).unwrap());
-        let secondary = AccountsLruCache::new(NonZeroUsize::new(10).unwrap());
-        secondary.add(pubkey);
-        let (removed_tx, mut removed_rx) = mpsc::channel(10);
-
-        reconcile_subscriptions(
-            &primary,
-            &secondary,
-            &Mutex::new(HashSet::new()),
-            &mux,
-            &[],
-            &removed_tx,
-            None,
-            None,
-            None,
-            None,
-        )
-        .await;
-
-        assert!(ws_client.subscriptions_union().contains(&pubkey));
-        assert!(grpc_client.subscriptions_union().contains(&pubkey));
-        assert!(removed_rx.try_recv().is_err());
-        mux.shutdown().await.unwrap();
-    }
-
-    #[tokio::test]
-    async fn test_prefer_grpc_subscription_without_grpc_keeps_ws_legs() {
-        init_logger();
-
-        let (tx1, rx1) = mpsc::channel(10_000);
-        let ws_client = Arc::new(ChainPubsubClientMock::new(tx1, rx1));
-
-        let pk = Pubkey::new_unique();
-        let (mux, _aborts) =
-            new_submux_with_abort(vec![ws_client.clone()], vec![pk], Some(100));
-
-        mux.subscribe(pk, None).await.unwrap();
-        assert!(mux.prefer_grpc_subscription(pk).await.is_err());
-        assert!(ws_client.subscriptions_union().contains(&pk));
-
-        mux.shutdown().await.unwrap();
-    }
-
-    #[tokio::test]
     async fn test_reconcile_skips_repair_when_no_submux_clients_connected() {
         init_logger();
 
@@ -2665,22 +2268,11 @@ mod tests {
 
         let lru = AccountsLruCache::new(NonZeroUsize::new(10).unwrap());
         lru.add(pk);
-        let secondary = AccountsLruCache::new(NonZeroUsize::new(10).unwrap());
         let (removed_tx, mut removed_rx) = mpsc::channel::<Pubkey>(10);
 
-        let count = reconcile_subscriptions(
-            &lru,
-            &secondary,
-            &Mutex::new(HashSet::new()),
-            &mux,
-            &[],
-            &removed_tx,
-            None,
-            None,
-            None,
-            None,
-        )
-        .await;
+        let count =
+            reconcile_subscriptions(&lru, &mux, &[], &removed_tx, None, None)
+                .await;
 
         assert_eq!(count, 1);
         assert_eq!(client1.subscribe_attempts(), before_client1_attempts);

--- a/magicblock-chainlink/src/submux/subscription_task.rs
+++ b/magicblock-chainlink/src/submux/subscription_task.rs
@@ -11,9 +11,9 @@ use tracing::*;
 
 /// Timeout for each subscription attempt
 /// NOTE: if retries are defined the timeout is applied per retry
-pub(crate) const SUBSCRIBE_TIMEOUT: Duration = Duration::from_millis(2_000);
+const SUBSCRIBE_TIMEOUT: Duration = Duration::from_millis(2_000);
 /// Timeout for each unsubscription attempt
-pub(crate) const UNSUBSCRIBE_TIMEOUT: Duration = Duration::from_millis(1_000);
+const UNSUBSCRIBE_TIMEOUT: Duration = Duration::from_millis(1_000);
 /// Minimum interval between alerts for total subscription failures
 const ALERT_ON_TOTAL_SUB_FAILURE_INTERVAL: Duration = Duration::from_mins(5);
 

--- a/magicblock-config/src/config/chain.rs
+++ b/magicblock-config/src/config/chain.rs
@@ -53,10 +53,6 @@ pub struct ChainLinkConfig {
     /// updates.
     pub max_monitored_accounts: usize,
 
-    /// The maximum number of accounts to retain in the secondary subscription
-    /// cache.
-    pub secondary_max_monitored_accounts: usize,
-
     /// When true, confined accounts are removed during accounts bank reset.
     pub remove_confined_accounts: bool,
 
@@ -83,8 +79,6 @@ impl Default for ChainLinkConfig {
     fn default() -> Self {
         Self {
             max_monitored_accounts: consts::DEFAULT_MAX_MONITORED_ACCOUNTS,
-            secondary_max_monitored_accounts:
-                consts::DEFAULT_SECONDARY_MAX_MONITORED_ACCOUNTS,
             remove_confined_accounts: false,
             allowed_programs: None,
             resubscription_delay: Duration::from_millis(

--- a/magicblock-config/src/consts.rs
+++ b/magicblock-config/src/consts.rs
@@ -85,9 +85,6 @@ pub const DEFAULT_UNDELEGATION_REQUEST_POLL_INTERVAL_SECS: u64 = 5 * 60;
 /// Default capacity for the LRU cache of subscribed accounts
 pub const DEFAULT_MAX_MONITORED_ACCOUNTS: usize = 5_000;
 
-/// Default capacity for the secondary LRU cache of subscribed accounts
-pub const DEFAULT_SECONDARY_MAX_MONITORED_ACCOUNTS: usize = 20_000;
-
 /// Default base URL for Range risk service
 pub const DEFAULT_RISK_BASE_URL: &str = "https://api.range.org/v1";
 

--- a/magicblock-config/src/tests.rs
+++ b/magicblock-config/src/tests.rs
@@ -299,7 +299,6 @@ fn test_chainlink_config() {
         r#"
         [chainlink]
         max-monitored-accounts = 5000
-        secondary-max-monitored-accounts = 20000
         resubscription-delay = "50ms"
         undelegation-request-poll-interval = "5m"
 
@@ -315,7 +314,6 @@ fn test_chainlink_config() {
     let config = run_cli(vec![config_path.to_str().unwrap()]);
 
     assert_eq!(config.chainlink.max_monitored_accounts, 5000);
-    assert_eq!(config.chainlink.secondary_max_monitored_accounts, 20000);
     assert_eq!(
         config.chainlink.resubscription_delay,
         std::time::Duration::from_millis(50)
@@ -505,7 +503,6 @@ fn test_example_config_full_coverage() {
     // 9. Chainlink (Cloning)
     // ========================================================================
     assert_eq!(config.chainlink.max_monitored_accounts, 5000);
-    assert_eq!(config.chainlink.secondary_max_monitored_accounts, 20_000);
     assert!(!config.chainlink.risk.enabled);
 
     // ========================================================================
@@ -605,10 +602,6 @@ fn test_env_vars_full_coverage() {
         EnvVarGuard::new("MBV_LEDGER__RESET", "true"),
         // --- Chainlink ---
         EnvVarGuard::new("MBV_CHAINLINK__MAX_MONITORED_ACCOUNTS", "123"),
-        EnvVarGuard::new(
-            "MBV_CHAINLINK__SECONDARY_MAX_MONITORED_ACCOUNTS",
-            "456",
-        ),
         EnvVarGuard::new("MBV_CHAINLINK__RESUBSCRIPTION_DELAY", "150ms"),
         EnvVarGuard::new(
             "MBV_CHAINLINK__UNDELEGATION_REQUEST_POLL_INTERVAL",
@@ -684,7 +677,6 @@ fn test_env_vars_full_coverage() {
 
     // Chainlink
     assert_eq!(config.chainlink.max_monitored_accounts, 123);
-    assert_eq!(config.chainlink.secondary_max_monitored_accounts, 456);
     assert_eq!(
         config.chainlink.resubscription_delay,
         Duration::from_millis(150)

--- a/magicblock-metrics/src/metrics/types.rs
+++ b/magicblock-metrics/src/metrics/types.rs
@@ -663,7 +663,6 @@ pub enum SubscriptionRegistrationOutcome {
     EvictedCandidate,
     SubscribeError,
     UnsubscribeEvictedError,
-    RejectedNoCapacity,
     RejectedAndUnsubscribed,
     UnsubscribeRejectedError,
 }
@@ -676,7 +675,6 @@ impl SubscriptionRegistrationOutcome {
             Self::EvictedCandidate => "evicted_candidate",
             Self::SubscribeError => "subscribe_error",
             Self::UnsubscribeEvictedError => "unsubscribe_evicted_error",
-            Self::RejectedNoCapacity => "rejected_no_capacity",
             Self::RejectedAndUnsubscribed => "rejected_and_unsubscribed",
             Self::UnsubscribeRejectedError => "unsubscribe_rejected_error",
         }

--- a/test-integration/Cargo.lock
+++ b/test-integration/Cargo.lock
@@ -2586,7 +2586,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 [[package]]
 name = "helius-laserstream"
 version = "0.2.2"
-source = "git+https://github.com/magicblock-labs/laserstream-sdk.git?rev=295e8528662c1a9b486385643ba10434f3f210cf#295e8528662c1a9b486385643ba10434f3f210cf"
+source = "git+https://github.com/magicblock-labs/laserstream-sdk.git?branch=mbv-4.0%2Bconn-fix#97c2698dfa8b813de6ed53548e80ac0cc1d65e92"
 dependencies = [
  "async-stream",
  "futures",


### PR DESCRIPTION
Reverts magicblock-labs/magicblock-validator#1428

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Simplified account subscription management for more predictable monitoring behavior.
  * Improved handling of subscription updates received during account data requests.
  * Strengthened connection-error handling and recovery for streaming account updates.
  * Streamlined subscription reconciliation after reconnects.

* **Configuration**
  * Removed the secondary monitored-accounts limit from Chainlink configuration and example settings.

* **Metrics**
  * Removed the obsolete “rejected due to capacity” registration outcome.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->