### PR TITLE
Drop strictly stale subscription updates before remote fetch

### DIFF
--- a/.agents/context/crates/magicblock-chainlink.md
+++ b/.agents/context/crates/magicblock-chainlink.md
@@ -297,7 +297,8 @@ Key behavior:
 - If a subscription update arrives while an RPC fetch is pending, it resolves the pending fetch waiters only when its slot is at least the fetch start slot and does not regress the retained per-account classification.
 - Account-subscription updates for pubkeys no longer watched are dropped and can enqueue a removal update if stale local state exists.
 - Program-subscription updates are allowed even if the pubkey is not in the direct-account LRU; delegated accounts may be tracked only by owner-program subscriptions.
-- Non-advancing updates are ignored unless they represent a same-slot delegated refresh needed for undelegate/redelegate recovery.
+- Updates whose slot is strictly below the bank's remote slot are dropped in `process_subscription_update` before the resolve path issues any remote account/delegation-record fetch; their companion-fetch side effects (opportunistic refresh from a stale update's fetch) no longer run. Newer state still arrives via its own subscription update or on-demand fetch.
+- Same-slot non-advancing updates still flow through the resolve path and are ignored afterwards unless they represent a same-slot delegated refresh needed for undelegate/redelegate recovery.
 - Delegated updates cause direct subscription cleanup; undelegation-completion updates retain/directly ensure subscriptions as appropriate and release `UndelegationTracking` ownership.
 
 ### DLP undelegation request scanning

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -1558,6 +1558,22 @@ where
             return;
         }
 
+        // A strictly older update can never advance the bank; drop it before
+        // the resolve path issues remote fetches. Same-slot updates fall
+        // through to the full non-advancing check, which needs resolved state.
+        if self
+            .accounts_bank
+            .get_account(&pubkey)
+            .is_some_and(|in_bank| in_bank.remote_slot() > update_slot)
+        {
+            trace!(
+                pubkey = %pubkey,
+                update_slot,
+                "Ignoring out-of-order subscription update"
+            );
+            return;
+        }
+
         let companion_fetch_log_context = CompanionFetchLogContext {
             origin: AccountFetchContext::subscription_update(
                 AccountFetchReason::SubscriptionUpdateClone,


### PR DESCRIPTION
## Problem

In `process_subscription_update`, the out-of-order guard (`non_advancing_slot`) runs only **after** `resolve_account_to_clone_from_forwarded_sub_with_unsubscribe`. For DLP-owned accounts that resolve path issues a remote `getMultipleAccounts` of the account + its delegation record — so a late or duplicate update pays a billed upstream RPC round-trip just to be ignored.

Late updates are routine: multi-client redundancy races past the submux (pubkey, slot) dedup window, debounce flushes, and reconnect replays all deliver updates the bank has already superseded.

## Change

Before resolving, drop any update whose slot is **strictly below** the bank's remote slot for that account — it can never advance the bank.

Deliberately conservative:
- **Same-slot updates fall through unchanged** to the existing non-advancing check, which needs resolved state for the same-slot delegated-refresh exception and the projected-ATA clone path.
- Accounts not in the bank are unaffected.

One incidental behavior note: previously a stale DLP-owned update's fetch could return *newer* chain state (fetch slot ≥ update slot) and apply it opportunistically. That refresh was a side effect of wasted work, not a guarantee — newer state still arrives through its own subscription update or on-demand fetch.

Companion to #1450; expected ~5–10% reduction in upstream RPC volume on top of it.

16 lines, all existing tests pass (333).