### PR TITLE
perf: prefilter DLP program updates

### DIFF
--- a/.agents/context/crates/magicblock-chainlink.md
+++ b/.agents/context/crates/magicblock-chainlink.md
@@ -284,7 +284,7 @@ Key behavior:
 - If a subscription update arrives while an RPC fetch is pending and its slot is at least the fetch start slot, it resolves the pending fetch waiters instead of being forwarded as a separate update.
 - Account-subscription updates for pubkeys no longer watched are dropped and can enqueue a removal update if stale local state exists.
 - Program-subscription updates are allowed even if the pubkey is not in the direct-account LRU, but DLP-owned program updates are first classified for local interest before any delegation-record companion fetch.
-- Absent and unwatched DLP-owned program updates are dropped without fetching a delegation record; explicit RPC/transaction ensure paths still resolve delegation records and clone delegated accounts normally.
+- Absent and unwatched DLP-owned program updates are not dropped solely for lacking local interest. Ordinary non-internal DLP-owned user-account updates still reach greedy discovery so Chainlink can resolve a valid delegation record and execute post-delegation actions. Only updates that are provably irrelevant without delegation-record resolution, such as true internal DLP payloads or raw eATA projection updates without local ATA/eATA projection interest, are dropped before discovery.
 - Existing local delegated non-undelegating accounts are authoritative. DLP program updates for them clean up direct subscriptions and must not fetch a delegation record, clone, or overwrite local state.
 - Existing local undelegating accounts bypass the internal-DLP early drop and continue undelegation completion/redelegation processing so completion remains observable.
 - Non-advancing updates are ignored unless they represent a same-slot delegated refresh needed for undelegate/redelegate recovery.
@@ -301,9 +301,9 @@ The scan uses Base64Zstd account encoding and gets a nearby base-chain slot for 
 
 ### Greedy discovery
 
-Greedy discovery is restricted to locally interesting subscription updates. For DLP-owned program-subscription firehose updates, Chainlink first classifies the pubkey using local bank state, direct-watch state, and ATA/eATA projection interest.
+For DLP-owned program-subscription firehose updates, Chainlink first classifies the pubkey using local bank state, direct-watch state, and ATA/eATA projection interest.
 
-Absent and unwatched DLP-owned program updates are dropped before delegation-record resolution, including updates that would later prove delegated to another validator. This avoids unnecessary companion fetches for irrelevant DLP firehose traffic.
+Greedy discovery remains enabled for ordinary non-internal DLP-owned user-account updates, even when the account is absent locally and not directly watched. This preserves clone-time post-delegation action execution for new delegations discovered from the DLP program subscription. The prefilter may only skip delegation-record resolution for updates that are provably irrelevant from local state and payload shape, including internal DLP records/metadata/commit state and raw eATA updates with no local projection interest.
 
 Updates for directly watched accounts or locally relevant ATA/eATA projection state may still greedily fetch and clone if the delegation record says the account belongs to this validator (or is confined). Explicit RPC/transaction ensure paths are not narrowed by this prefilter: they still fetch delegation records and clone delegated accounts normally.
 
@@ -311,9 +311,11 @@ Updates delegated to other validators are ignored after discovery so this valida
 
 ### Internal DLP update filtering and collision sighting
 
-DLP-owned program-subscription updates are classified for local interest before internal-DLP payload filtering or collision handling. Irrelevant absent/unwatched updates are dropped immediately with zero delegation-record fetches. Updates for existing local delegated non-undelegating accounts clean up direct subscriptions and return without overwriting locally authoritative state. Updates for existing local undelegating accounts and locally relevant ATA/eATA projections continue past the internal-DLP early drop so undelegation completion and projection processing can run.
+DLP-owned program-subscription updates are classified before internal-DLP payload filtering or collision handling. Updates for existing local delegated non-undelegating accounts clean up direct subscriptions and return without overwriting locally authoritative state. Updates for existing local undelegating accounts and locally relevant ATA/eATA projections continue past the internal-DLP early drop so undelegation completion and projection processing can run.
 
 Program-subscription updates whose payload parses as an internal DLP account (delegation record, delegation metadata, commit record, program config) are then dropped in `FetchCloner::process_subscription_update` **before** greedy discovery, with zero remote fetches — their derived "record of a record" PDA never exists, and these updates dominate the DLP program-subscription firehose.
+
+The internal-DLP fast path must not classify ordinary non-internal user-account updates as irrelevant merely because they are absent locally; those updates must fall through to greedy discovery so valid same-slot delegation records can trigger clone and post-delegation action handling.
 
 The exception is a delegated account whose app data byte-collides with an internal DLP discriminator (LE u64 100–103). Such accounts must still reach greedy discovery so their post-delegation actions execute. `DlpCollisionTracker` (single lock, so check-then-park is atomic against sight-then-release) resolves this without a fetch:
 

--- a/.agents/context/crates/magicblock-chainlink.md
+++ b/.agents/context/crates/magicblock-chainlink.md
@@ -300,6 +300,17 @@ If a subscription update discovers a DLP-owned account absent from the bank, Cha
 
 Updates delegated to other validators are ignored after discovery so this validator does not clone state it cannot execute against.
 
+### Internal DLP update filtering and collision sighting
+
+Program-subscription updates whose payload parses as an internal DLP account (delegation record, delegation metadata, commit record, program config) are dropped in `FetchCloner::process_subscription_update` **before** greedy discovery, with zero remote fetches — their derived "record of a record" PDA never exists, and these updates dominate the DLP program-subscription firehose.
+
+The exception is a delegated account whose app data byte-collides with an internal DLP discriminator (LE u64 100–103). Such accounts must still reach greedy discovery so their post-delegation actions execute. `DlpCollisionTracker` (single lock, so check-then-park is atomic against sight-then-release) resolves this without a fetch:
+
+- Every delegation-record-shaped program update records a sighting (`record pubkey -> slot`) before being dropped.
+- An internal-looking account update whose derived delegation-record PDA was sighted at or after its own slot proceeds to greedy discovery (a fresh delegation writes both accounts in one slot).
+- Otherwise the update is parked keyed by its derived record PDA; a later record sighting (e.g. delayed by SubMux debounce) pops and releases it directly into `maybe_greedily_clone_discovered_delegated_account`. Discovery declining means drop, as for any internal update.
+- Genuine internal PDAs always miss the sighting cache and are dropped. A missed sighting (LRU eviction, lost delivery) degrades to lazy on-demand cloning via the normal getAccount/send-transaction paths — never to incorrect state.
+
 ## RemoteAccountProvider internals
 
 `RemoteAccountProvider` owns direct remote access and subscription state.

--- a/.agents/context/crates/magicblock-chainlink.md
+++ b/.agents/context/crates/magicblock-chainlink.md
@@ -249,9 +249,11 @@ Chainlink has special handling for associated token accounts and ephemeral ATAs:
 - For each ATA, Chainlink derives the companion eATA PDA with `try_derive_eata_address_and_bump`.
 - It subscribes to both ATA and eATA using `SubscriptionReason::AtaProjection`.
 - If the eATA exists, has a delegation record for this validator, and can be projected, Chainlink clones a projected delegated ATA into the local bank.
+- Raw eATA program-subscription updates are projection candidates only when there is local projection interest: a watched ATA/eATA projection subscription, a watched raw eATA, or a supported base ATA already present locally. Without that interest, Chainlink drops the update without fetching the eATA's delegation record or companion base ATA state.
 - Projection preserves the base ATA's owner and data length, which is important for Token-2022 extensions.
 - Missing eATAs can be remembered in `known_empty_eatas`, but only after confirmed `NotFound` while an eATA subscription is live.
 - Raw eATA PDAs are not marked delegated directly; their state is projected into the corresponding base ATA.
+- Explicit RPC/transaction ensure paths still resolve eATA delegation records and project delegated ATAs normally when the requested account requires it; the local-interest narrowing applies to program-subscription firehose updates.
 
 Pitfalls:
 
@@ -281,7 +283,10 @@ Key behavior:
 - Non-clock updates become `ForwardedSubscriptionUpdate` with a `SubscriptionSource` (`Account` or program source).
 - If a subscription update arrives while an RPC fetch is pending and its slot is at least the fetch start slot, it resolves the pending fetch waiters instead of being forwarded as a separate update.
 - Account-subscription updates for pubkeys no longer watched are dropped and can enqueue a removal update if stale local state exists.
-- Program-subscription updates are allowed even if the pubkey is not in the direct-account LRU; delegated accounts may be tracked only by owner-program subscriptions.
+- Program-subscription updates are allowed even if the pubkey is not in the direct-account LRU, but DLP-owned program updates are first classified for local interest before any delegation-record companion fetch.
+- Absent and unwatched DLP-owned program updates are dropped without fetching a delegation record; explicit RPC/transaction ensure paths still resolve delegation records and clone delegated accounts normally.
+- Existing local delegated non-undelegating accounts are authoritative. DLP program updates for them clean up direct subscriptions and must not fetch a delegation record, clone, or overwrite local state.
+- Existing local undelegating accounts bypass the internal-DLP early drop and continue undelegation completion/redelegation processing so completion remains observable.
 - Non-advancing updates are ignored unless they represent a same-slot delegated refresh needed for undelegate/redelegate recovery.
 - Delegated updates cause direct subscription cleanup; undelegation-completion updates retain/directly ensure subscriptions as appropriate and release `UndelegationTracking` ownership.
 
@@ -296,13 +301,19 @@ The scan uses Base64Zstd account encoding and gets a nearby base-chain slot for 
 
 ### Greedy discovery
 
-If a subscription update discovers a DLP-owned account absent from the bank, Chainlink may greedily fetch and clone it if the delegation record says it belongs to this validator (or is confined). This is especially important for delegated eATA discovery and owner-program subscriptions.
+Greedy discovery is restricted to locally interesting subscription updates. For DLP-owned program-subscription firehose updates, Chainlink first classifies the pubkey using local bank state, direct-watch state, and ATA/eATA projection interest.
+
+Absent and unwatched DLP-owned program updates are dropped before delegation-record resolution, including updates that would later prove delegated to another validator. This avoids unnecessary companion fetches for irrelevant DLP firehose traffic.
+
+Updates for directly watched accounts or locally relevant ATA/eATA projection state may still greedily fetch and clone if the delegation record says the account belongs to this validator (or is confined). Explicit RPC/transaction ensure paths are not narrowed by this prefilter: they still fetch delegation records and clone delegated accounts normally.
 
 Updates delegated to other validators are ignored after discovery so this validator does not clone state it cannot execute against.
 
 ### Internal DLP update filtering and collision sighting
 
-Program-subscription updates whose payload parses as an internal DLP account (delegation record, delegation metadata, commit record, program config) are dropped in `FetchCloner::process_subscription_update` **before** greedy discovery, with zero remote fetches — their derived "record of a record" PDA never exists, and these updates dominate the DLP program-subscription firehose.
+DLP-owned program-subscription updates are classified for local interest before internal-DLP payload filtering or collision handling. Irrelevant absent/unwatched updates are dropped immediately with zero delegation-record fetches. Updates for existing local delegated non-undelegating accounts clean up direct subscriptions and return without overwriting locally authoritative state. Updates for existing local undelegating accounts and locally relevant ATA/eATA projections continue past the internal-DLP early drop so undelegation completion and projection processing can run.
+
+Program-subscription updates whose payload parses as an internal DLP account (delegation record, delegation metadata, commit record, program config) are then dropped in `FetchCloner::process_subscription_update` **before** greedy discovery, with zero remote fetches — their derived "record of a record" PDA never exists, and these updates dominate the DLP program-subscription firehose.
 
 The exception is a delegated account whose app data byte-collides with an internal DLP discriminator (LE u64 100–103). Such accounts must still reach greedy discovery so their post-delegation actions execute. `DlpCollisionTracker` (single lock, so check-then-park is atomic against sight-then-release) resolves this without a fetch:
 

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/ata_projection.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/ata_projection.rs
@@ -156,34 +156,10 @@ where
         return None;
     }
 
-    let has_local_base_ata = ata_pubkeys
-        .iter()
-        .any(|ata_pubkey| this.accounts_bank.get_account(ata_pubkey).is_some());
-    let mut has_base_ata_projection_interest = false;
-    for ata_pubkey in ata_pubkeys.iter() {
-        if this
-            .remote_account_provider
-            .has_subscription_reason(
-                ata_pubkey,
-                SubscriptionReason::AtaProjection,
-            )
-            .await
-        {
-            has_base_ata_projection_interest = true;
-            break;
-        }
-    }
-    let has_raw_eata_projection_interest = this
-        .remote_account_provider
-        .has_subscription_reason(
-            &eata_pubkey,
-            SubscriptionReason::AtaProjection,
-        )
-        .await;
     if matches!(update_source, SubscriptionSource::Program)
-        && !has_local_base_ata
-        && !has_base_ata_projection_interest
-        && !has_raw_eata_projection_interest
+        && !this
+            .raw_eata_has_local_projection_interest(eata_pubkey, eata_account)
+            .await?
     {
         return None;
     }

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/ata_projection.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/ata_projection.rs
@@ -159,6 +159,20 @@ where
     let has_local_base_ata = ata_pubkeys
         .iter()
         .any(|ata_pubkey| this.accounts_bank.get_account(ata_pubkey).is_some());
+    let mut has_base_ata_projection_interest = false;
+    for ata_pubkey in ata_pubkeys.iter() {
+        if this
+            .remote_account_provider
+            .has_subscription_reason(
+                ata_pubkey,
+                SubscriptionReason::AtaProjection,
+            )
+            .await
+        {
+            has_base_ata_projection_interest = true;
+            break;
+        }
+    }
     let has_raw_eata_projection_interest = this
         .remote_account_provider
         .has_subscription_reason(
@@ -168,6 +182,7 @@ where
         .await;
     if matches!(update_source, SubscriptionSource::Program)
         && !has_local_base_ata
+        && !has_base_ata_projection_interest
         && !has_raw_eata_projection_interest
     {
         return None;

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/ata_projection.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/ata_projection.rs
@@ -42,6 +42,17 @@ pub(crate) fn derive_eata_pubkey_from_ata_layout(
     derive_eata_pubkey(ata_info_from_layout(ata_pubkey, ata_account)?)
 }
 
+pub(crate) fn derive_supported_ata_pubkeys(
+    owner: &Pubkey,
+    mint: &Pubkey,
+) -> Vec<Pubkey> {
+    try_derive_supported_ata_pubkeys(owner, mint)
+        .token_2022_first()
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>()
+}
+
 pub(crate) fn derive_supported_ata_pubkeys_from_raw_eata(
     eata_pubkey: &Pubkey,
     eata_account: &AccountSharedData,
@@ -51,13 +62,7 @@ pub(crate) fn derive_supported_ata_pubkeys_from_raw_eata(
         eata_account.data(),
         EATA_PROGRAM_ID,
     )?;
-    Some(
-        try_derive_supported_ata_pubkeys(&wallet_owner, &mint)
-            .token_2022_first()
-            .into_iter()
-            .flatten()
-            .collect::<Vec<_>>(),
-    )
+    Some(derive_supported_ata_pubkeys(&wallet_owner, &mint))
 }
 
 fn derive_eata_pubkey(ata_info: AtaInfo) -> Option<Pubkey> {
@@ -212,12 +217,7 @@ where
         eata_account.data(),
         deleg_record.owner,
     )?;
-    let ata_pubkeys = try_derive_supported_ata_pubkeys(&wallet_owner, &mint);
-    let ata_pubkeys = ata_pubkeys
-        .token_2022_first()
-        .into_iter()
-        .flatten()
-        .collect::<Vec<_>>();
+    let ata_pubkeys = derive_supported_ata_pubkeys(&wallet_owner, &mint);
 
     // eATA updates only carry the projected balance fields. The base ATA is
     // required so the clone preserves the actual token program owner and any

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/ata_projection.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/ata_projection.rs
@@ -41,6 +41,24 @@ pub(crate) fn derive_eata_pubkey_from_ata_layout(
     derive_eata_pubkey(ata_info_from_layout(ata_pubkey, ata_account)?)
 }
 
+pub(crate) fn derive_supported_ata_pubkeys_from_raw_eata(
+    eata_pubkey: &Pubkey,
+    eata_account: &AccountSharedData,
+) -> Option<Vec<Pubkey>> {
+    let (wallet_owner, mint) = delegation::parse_raw_eata_pda(
+        eata_pubkey,
+        eata_account.data(),
+        EATA_PROGRAM_ID,
+    )?;
+    Some(
+        try_derive_supported_ata_pubkeys(&wallet_owner, &mint)
+            .token_2022_first()
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>(),
+    )
+}
+
 fn derive_eata_pubkey(ata_info: AtaInfo) -> Option<Pubkey> {
     let (eata_pubkey, _) =
         try_derive_eata_address_and_bump(&ata_info.owner, &ata_info.mint)?;

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/ata_projection.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/ata_projection.rs
@@ -22,8 +22,9 @@ use super::{
 use crate::{
     cloner::{AccountCloneRequest, Cloner, DelegationActions},
     remote_account_provider::{
-        ChainPubsubClient, ChainRpcClient, MatchSlotsConfig, RemoteAccount,
-        ResolvedAccountSharedData, SubscriptionReason,
+        pubsub_common::SubscriptionSource, ChainPubsubClient, ChainRpcClient,
+        MatchSlotsConfig, RemoteAccount, ResolvedAccountSharedData,
+        SubscriptionReason,
     },
 };
 
@@ -121,6 +122,7 @@ pub(crate) async fn maybe_build_projected_ata_clone_request_from_subscription_up
     this: &FetchCloner<T, U, V, C>,
     eata_pubkey: Pubkey,
     eata_account: &AccountSharedData,
+    update_source: SubscriptionSource,
     deleg_record: Option<&DelegationRecord>,
     delegation_actions: &DelegationActions,
     companion_fetch_log_context: &CompanionFetchLogContext,
@@ -143,11 +145,28 @@ where
         .await;
     }
 
-    delegation::parse_raw_eata_pda(
-        &eata_pubkey,
-        eata_account.data(),
-        EATA_PROGRAM_ID,
-    )?;
+    let ata_pubkeys =
+        derive_supported_ata_pubkeys_from_raw_eata(&eata_pubkey, eata_account)?;
+    if ata_pubkeys.is_empty() {
+        return None;
+    }
+
+    let has_local_base_ata = ata_pubkeys
+        .iter()
+        .any(|ata_pubkey| this.accounts_bank.get_account(ata_pubkey).is_some());
+    let has_raw_eata_projection_interest = this
+        .remote_account_provider
+        .has_subscription_reason(
+            &eata_pubkey,
+            SubscriptionReason::AtaProjection,
+        )
+        .await;
+    if matches!(update_source, SubscriptionSource::Program)
+        && !has_local_base_ata
+        && !has_raw_eata_projection_interest
+    {
+        return None;
+    }
 
     let (deleg_record, delegation_actions) =
         delegation::fetch_and_parse_delegation_record(

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -430,8 +430,6 @@ where
                     })
             },
         );
-        me.keep_dlp_program_update_interest_primitives_reachable();
-
         me.clone()
             .start_subscription_listener(subscription_updates_rx);
 
@@ -441,14 +439,6 @@ where
     /// Get the current fetch count
     pub fn fetch_count(&self) -> u64 {
         self.fetch_count.load(Ordering::Relaxed)
-    }
-
-    fn keep_dlp_program_update_interest_primitives_reachable(&self) {
-        let _ = DlpProgramUpdateInterest::DropIrrelevant;
-        let _ = Self::classify_dlp_program_update_interest;
-        let _ = Self::has_local_ata_projection_interest;
-        let _ = ata_projection::derive_supported_ata_pubkeys_from_raw_eata;
-        let _ = RemoteAccountProvider::<T, U>::has_subscription_reason;
     }
 
     async fn classify_dlp_program_update_interest(
@@ -1666,6 +1656,50 @@ where
         pubkey: Pubkey,
         update: ForwardedSubscriptionUpdate,
     ) {
+        let dlp_program_interest =
+            if matches!(update.source, SubscriptionSource::Program)
+                && update.account.is_owned_by_delegation_program()
+            {
+                match update.account.fresh_account() {
+                    Some(account) => Some(
+                        self.classify_dlp_program_update_interest(
+                            pubkey, &account,
+                        )
+                        .await,
+                    ),
+                    None => None,
+                }
+            } else {
+                None
+            };
+
+        match dlp_program_interest {
+            Some(DlpProgramUpdateInterest::DropIrrelevant) => {
+                if !update.account.fresh_account().is_some_and(|account| {
+                    is_internal_dlp_account_data(account.data())
+                }) {
+                    trace!(
+                        pubkey = %pubkey,
+                        "Dropping irrelevant DLP program subscription update"
+                    );
+                    return;
+                }
+            }
+            Some(DlpProgramUpdateInterest::DropLocalDelegatedAuthoritative) => {
+                self.cleanup_direct_subscription_for_delegated_account(pubkey)
+                    .await;
+                trace!(
+                    pubkey = %pubkey,
+                    "Dropping DLP program update for locally authoritative delegated account"
+                );
+                return;
+            }
+            Some(DlpProgramUpdateInterest::ProcessUndelegating)
+            | Some(DlpProgramUpdateInterest::ProcessAtaProjection)
+            | Some(DlpProgramUpdateInterest::ProcessDirectlyWatched)
+            | None => {}
+        }
+
         // Internal DLP payloads (records/metadata/commit state) can never be
         // greedily cloned, so drop them before discovery issues remote
         // fetches. The exception is an account whose app data collides with
@@ -1673,7 +1707,11 @@ where
         // delegation record, whose sighting routes the account update to
         // discovery — immediately when the record arrived first, or by
         // releasing the parked update once the record arrives later.
-        if matches!(update.source, SubscriptionSource::Program)
+        if !matches!(
+            dlp_program_interest,
+            Some(DlpProgramUpdateInterest::ProcessUndelegating)
+                | Some(DlpProgramUpdateInterest::ProcessAtaProjection)
+        ) && matches!(update.source, SubscriptionSource::Program)
             && update.account.is_owned_by_delegation_program()
             && update.account.fresh_account().is_some_and(|account| {
                 is_internal_dlp_account_data(account.data())

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -20,8 +20,7 @@ use magicblock_accounts_db::traits::AccountsBank;
 use magicblock_aml::RiskService;
 use magicblock_config::config::AllowedProgram;
 use magicblock_core::token_programs::{
-    is_ata, normalize_native_token_account_for_local_clone,
-    try_derive_supported_ata_pubkeys, EATA_PROGRAM_ID,
+    is_ata, normalize_native_token_account_for_local_clone, EATA_PROGRAM_ID,
 };
 use magicblock_metrics::metrics::{
     self, AccountFetchContext, AccountFetchReason, BankPrecheckOutcome,
@@ -2445,11 +2444,7 @@ where
             deleg_record.owner,
         )
         .map(|(wallet_owner, mint)| {
-            try_derive_supported_ata_pubkeys(&wallet_owner, &mint)
-                .token_2022_first()
-                .into_iter()
-                .flatten()
-                .collect::<Vec<_>>()
+            ata_projection::derive_supported_ata_pubkeys(&wallet_owner, &mint)
         })
         .unwrap_or_default();
         let mut pubkeys_to_clone =

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -1707,14 +1707,23 @@ where
         pubkey: Pubkey,
         update: ForwardedSubscriptionUpdate,
     ) {
+        let fresh_update_account = update.account.fresh_account();
+        let is_dlp_owned_update = fresh_update_account
+            .as_ref()
+            .is_some_and(|account| account.owner() == &dlp_api::id());
+        let is_internal_dlp_update =
+            fresh_update_account.as_ref().is_some_and(|account| {
+                is_internal_dlp_account_data(account.data())
+            });
+
         let dlp_program_interest =
             if matches!(update.source, SubscriptionSource::Program)
-                && update.account.is_owned_by_delegation_program()
+                && is_dlp_owned_update
             {
-                match update.account.fresh_account() {
+                match fresh_update_account.as_ref() {
                     Some(account) => Some(
                         self.classify_dlp_program_update_interest(
-                            pubkey, &account,
+                            pubkey, account,
                         )
                         .await,
                     ),
@@ -1726,9 +1735,7 @@ where
 
         match dlp_program_interest {
             Some(DlpProgramUpdateInterest::DropIrrelevant) => {
-                if !update.account.fresh_account().is_some_and(|account| {
-                    is_internal_dlp_account_data(account.data())
-                }) {
+                if !is_internal_dlp_update {
                     trace!(
                         pubkey = %pubkey,
                         "Dropping irrelevant DLP program subscription update"
@@ -1762,10 +1769,10 @@ where
             dlp_program_interest,
             Some(DlpProgramUpdateInterest::ProcessUndelegating)
                 | Some(DlpProgramUpdateInterest::ProcessAtaProjection)
-        ) && update.account.is_owned_by_delegation_program()
+        ) && is_dlp_owned_update
         {
-            if let Some(account) = update.account.fresh_account() {
-                if is_internal_dlp_account_data(account.data()) {
+            if let Some(account) = fresh_update_account.as_ref() {
+                if is_internal_dlp_update {
                     // Sight records from either source: SubMux dedup can
                     // deliver a directly watched record account-sourced.
                     let released = is_delegation_record_data(account.data())

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -207,6 +207,15 @@ const PARKED_COLLISION_UPDATES_CAPACITY: NonZeroUsize =
         }
     };
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DlpProgramUpdateInterest {
+    DropIrrelevant,
+    DropLocalDelegatedAuthoritative,
+    ProcessUndelegating,
+    ProcessAtaProjection,
+    ProcessDirectlyWatched,
+}
+
 /// Tracks delegation-record sightings from the DLP program subscription and
 /// internal-looking account updates parked until their record is sighted.
 /// A single lock keeps check-then-park atomic against sight-then-release, so
@@ -421,6 +430,7 @@ where
                     })
             },
         );
+        me.keep_dlp_program_update_interest_primitives_reachable();
 
         me.clone()
             .start_subscription_listener(subscription_updates_rx);
@@ -431,6 +441,88 @@ where
     /// Get the current fetch count
     pub fn fetch_count(&self) -> u64 {
         self.fetch_count.load(Ordering::Relaxed)
+    }
+
+    fn keep_dlp_program_update_interest_primitives_reachable(&self) {
+        let _ = DlpProgramUpdateInterest::DropIrrelevant;
+        let _ = Self::classify_dlp_program_update_interest;
+        let _ = Self::has_local_ata_projection_interest;
+        let _ = ata_projection::derive_supported_ata_pubkeys_from_raw_eata;
+        let _ = RemoteAccountProvider::<T, U>::has_subscription_reason;
+    }
+
+    async fn classify_dlp_program_update_interest(
+        &self,
+        pubkey: Pubkey,
+        account: &AccountSharedData,
+    ) -> DlpProgramUpdateInterest {
+        if let Some(local_account) = self.accounts_bank.get_account(&pubkey) {
+            if local_account.undelegating() {
+                return DlpProgramUpdateInterest::ProcessUndelegating;
+            }
+            if local_account.delegated() {
+                return DlpProgramUpdateInterest::DropLocalDelegatedAuthoritative;
+            }
+        }
+
+        if self.remote_account_provider.is_watching(&pubkey) {
+            return DlpProgramUpdateInterest::ProcessDirectlyWatched;
+        }
+
+        if self
+            .has_local_ata_projection_interest(pubkey, account)
+            .await
+        {
+            return DlpProgramUpdateInterest::ProcessAtaProjection;
+        }
+
+        DlpProgramUpdateInterest::DropIrrelevant
+    }
+
+    async fn has_local_ata_projection_interest(
+        &self,
+        pubkey: Pubkey,
+        account: &AccountSharedData,
+    ) -> bool {
+        if let Some(eata_pubkey) =
+            ata_projection::derive_eata_pubkey_from_ata_account(
+                &pubkey, account,
+            )
+        {
+            if self
+                .remote_account_provider
+                .has_subscription_reason(
+                    &pubkey,
+                    SubscriptionReason::AtaProjection,
+                )
+                .await
+                || self
+                    .remote_account_provider
+                    .has_subscription_reason(
+                        &eata_pubkey,
+                        SubscriptionReason::AtaProjection,
+                    )
+                    .await
+            {
+                return true;
+            }
+        }
+
+        if let Some(ata_pubkeys) =
+            ata_projection::derive_supported_ata_pubkeys_from_raw_eata(
+                &pubkey, account,
+            )
+        {
+            if ata_pubkeys.iter().any(|ata_pubkey| {
+                self.accounts_bank.get_account(ata_pubkey).is_some()
+            }) {
+                return true;
+            }
+        }
+
+        self.remote_account_provider
+            .has_subscription_reason(&pubkey, SubscriptionReason::AtaProjection)
+            .await
     }
 
     #[instrument(skip(self, pubkeys))]

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -1497,13 +1497,8 @@ where
         pubkey: Pubkey,
         update: ForwardedSubscriptionUpdate,
     ) {
-        if self
-            .maybe_greedily_clone_discovered_delegated_account(pubkey, &update)
-            .await
-        {
-            return;
-        }
-
+        // Internal DLP payloads (records/metadata/commit state) can never be
+        // greedily cloned, so drop them before discovery issues remote fetches.
         if matches!(update.source, SubscriptionSource::Program)
             && update.account.is_owned_by_delegation_program()
             && update.account.fresh_account().is_some_and(|account| {
@@ -1512,8 +1507,15 @@ where
         {
             trace!(
                 pubkey = %pubkey,
-                "Dropping internal DLP program subscription update after discovery miss"
+                "Dropping internal DLP program subscription update"
             );
+            return;
+        }
+
+        if self
+            .maybe_greedily_clone_discovered_delegated_account(pubkey, &update)
+            .await
+        {
             return;
         }
 

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -554,10 +554,18 @@ where
                 &pubkey, account,
             )
         {
-            if ata_pubkeys.iter().any(|ata_pubkey| {
-                self.accounts_bank.get_account(ata_pubkey).is_some()
-            }) {
-                return true;
+            for ata_pubkey in ata_pubkeys.iter() {
+                if self.accounts_bank.get_account(ata_pubkey).is_some()
+                    || self
+                        .remote_account_provider
+                        .has_subscription_reason(
+                            ata_pubkey,
+                            SubscriptionReason::AtaProjection,
+                        )
+                        .await
+                {
+                    return true;
+                }
             }
         }
 

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -1803,6 +1803,7 @@ where
             context_slot: update_slot,
         };
 
+        let update_source = update.source;
         let (resolved_account, deleg_record, delegation_actions) = self
             .resolve_account_to_clone_from_forwarded_sub_with_unsubscribe(
                 update,
@@ -1817,9 +1818,10 @@ where
                 AccountFetchReason::SubscriptionUpdateClone,
             );
         let projected_ata_clone_request = self
-            .maybe_build_projected_ata_clone_request_from_subscription_update(
+            .maybe_build_projected_ata_clone_request_from_subscription_update_with_source(
                 pubkey,
                 &account,
+                update_source,
                 deleg_record.as_ref(),
                 &delegation_actions,
                 &companion_fetch_log_context,
@@ -2751,10 +2753,31 @@ where
         delegation_actions: &DelegationActions,
         companion_fetch_log_context: &CompanionFetchLogContext,
     ) -> Option<AccountCloneRequest> {
+        self.maybe_build_projected_ata_clone_request_from_subscription_update_with_source(
+            eata_pubkey,
+            eata_account,
+            SubscriptionSource::Account,
+            deleg_record,
+            delegation_actions,
+            companion_fetch_log_context,
+        )
+        .await
+    }
+
+    async fn maybe_build_projected_ata_clone_request_from_subscription_update_with_source(
+        &self,
+        eata_pubkey: Pubkey,
+        eata_account: &AccountSharedData,
+        update_source: SubscriptionSource,
+        deleg_record: Option<&DelegationRecord>,
+        delegation_actions: &DelegationActions,
+        companion_fetch_log_context: &CompanionFetchLogContext,
+    ) -> Option<AccountCloneRequest> {
         ata_projection::maybe_build_projected_ata_clone_request_from_subscription_update(
             self,
             eata_pubkey,
             eata_account,
+            update_source,
             deleg_record,
             delegation_actions,
             companion_fetch_log_context,

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -144,10 +144,9 @@ where
     /// Negative cache for derived eATAs confirmed missing on chain.
     known_empty_eatas: Arc<PlMutex<LruCache<Pubkey, ()>>>,
 
-    /// Slots at which delegation-record-shaped program updates were last
-    /// seen, used to recognize freshly delegated accounts whose app data
-    /// collides with an internal DLP discriminator.
-    seen_delegation_record_slots: Arc<PlMutex<LruCache<Pubkey, u64>>>,
+    /// Recognizes freshly delegated accounts whose app data collides with an
+    /// internal DLP discriminator via delegation-record sightings.
+    dlp_collision_tracker: Arc<PlMutex<DlpCollisionTracker>>,
 
     /// Tracks in-flight clone operations.
     /// The first caller to claim a key becomes the owner and performs
@@ -198,9 +197,62 @@ const SEEN_DELEGATION_RECORD_SLOTS_CAPACITY: NonZeroUsize =
         }
     };
 
-/// Grace period for an account update to be matched with its same-slot
-/// delegation-record update when the record is delivered slightly later.
-const DELEGATION_RECORD_SIGHTING_GRACE: Duration = Duration::from_millis(250);
+/// Capacity for internal-looking account updates parked until their
+/// delegation record is sighted.
+const PARKED_COLLISION_UPDATES_CAPACITY: NonZeroUsize =
+    match NonZeroUsize::new(1_024) {
+        Some(n) => n,
+        None => {
+            panic!("PARKED_COLLISION_UPDATES_CAPACITY must be non-zero")
+        }
+    };
+
+/// Tracks delegation-record sightings from the DLP program subscription and
+/// internal-looking account updates parked until their record is sighted.
+/// A single lock keeps check-then-park atomic against sight-then-release, so
+/// an update can never be parked after its record sighting already passed.
+struct DlpCollisionTracker {
+    record_slots: LruCache<Pubkey, u64>,
+    parked: LruCache<Pubkey, ForwardedSubscriptionUpdate>,
+}
+
+impl DlpCollisionTracker {
+    fn new() -> Self {
+        Self {
+            record_slots: LruCache::new(SEEN_DELEGATION_RECORD_SLOTS_CAPACITY),
+            parked: LruCache::new(PARKED_COLLISION_UPDATES_CAPACITY),
+        }
+    }
+
+    /// Records a delegation-record-shaped update sighting and releases any
+    /// account update parked while waiting for this record.
+    fn sight_record(
+        &mut self,
+        record_pubkey: Pubkey,
+        slot: u64,
+    ) -> Option<ForwardedSubscriptionUpdate> {
+        self.record_slots.put(record_pubkey, slot);
+        self.parked.pop(&record_pubkey)
+    }
+
+    /// True when the pubkey's delegation record was sighted at or after the
+    /// update slot: a fresh delegation writes both accounts in one slot, so
+    /// the sighting marks a delegated account whose app data collides with an
+    /// internal DLP discriminator. Otherwise the update is parked so a late
+    /// (e.g. debounced) record sighting can release it.
+    fn check_or_park(&mut self, update: &ForwardedSubscriptionUpdate) -> bool {
+        let record_pubkey =
+            delegation_record_pda_from_delegated_account(&update.pubkey);
+        let sighted = self
+            .record_slots
+            .get(&record_pubkey)
+            .is_some_and(|&record_slot| record_slot >= update.account.slot());
+        if !sighted {
+            self.parked.put(record_pubkey, update.clone());
+        }
+        sighted
+    }
+}
 
 /// A pending fetch+clone operation claimed by one dedup call, resolved by
 /// the batch worker spawned for that call.
@@ -237,9 +289,7 @@ where
             allowed_programs: self.allowed_programs.clone(),
             programs_not_to_subscribe: self.programs_not_to_subscribe.clone(),
             known_empty_eatas: self.known_empty_eatas.clone(),
-            seen_delegation_record_slots: self
-                .seen_delegation_record_slots
-                .clone(),
+            dlp_collision_tracker: self.dlp_collision_tracker.clone(),
             pending_clones: self.pending_clones.clone(),
             pending_undelegations: self.pending_undelegations.clone(),
             pending_operation_timeout_ms: self
@@ -344,8 +394,8 @@ where
             known_empty_eatas: Arc::new(PlMutex::new(LruCache::new(
                 KNOWN_EMPTY_EATAS_CAPACITY,
             ))),
-            seen_delegation_record_slots: Arc::new(PlMutex::new(
-                LruCache::new(SEEN_DELEGATION_RECORD_SLOTS_CAPACITY),
+            dlp_collision_tracker: Arc::new(PlMutex::new(
+                DlpCollisionTracker::new(),
             )),
             pending_clones: Arc::new(Mutex::new(hash_map::HashMap::new())),
             pending_undelegations: Arc::new(Mutex::new(HashSet::new())),
@@ -1519,42 +1569,6 @@ where
         });
     }
 
-    /// Records sightings of delegation-record-shaped program updates, then
-    /// reports whether this pubkey's own delegation record was sighted at or
-    /// after the update slot: a fresh delegation writes the account and its
-    /// record in one slot, so a sighting marks a delegated account whose app
-    /// data collides with an internal DLP discriminator. A short grace period
-    /// covers the record being delivered after the account update.
-    async fn is_freshly_delegated_collision(
-        &self,
-        update: &ForwardedSubscriptionUpdate,
-    ) -> bool {
-        let slot = update.account.slot();
-        if update
-            .account
-            .fresh_account()
-            .is_some_and(|account| is_delegation_record_data(account.data()))
-        {
-            self.seen_delegation_record_slots
-                .lock()
-                .put(update.pubkey, slot);
-        }
-
-        let record_pubkey =
-            delegation_record_pda_from_delegated_account(&update.pubkey);
-        let record_sighted = || {
-            self.seen_delegation_record_slots
-                .lock()
-                .get(&record_pubkey)
-                .is_some_and(|&record_slot| record_slot >= slot)
-        };
-        if record_sighted() {
-            return true;
-        }
-        tokio::time::sleep(DELEGATION_RECORD_SIGHTING_GRACE).await;
-        record_sighted()
-    }
-
     async fn process_subscription_update(
         &self,
         pubkey: Pubkey,
@@ -1563,20 +1577,44 @@ where
         // Internal DLP payloads (records/metadata/commit state) can never be
         // greedily cloned, so drop them before discovery issues remote
         // fetches. The exception is an account whose app data collides with
-        // an internal discriminator: its delegation also emits the
-        // delegation-record update, whose sighting routes it to discovery.
+        // an internal discriminator: its delegation also writes the
+        // delegation record, whose sighting routes the account update to
+        // discovery — immediately when the record arrived first, or by
+        // releasing the parked update once the record arrives later.
         if matches!(update.source, SubscriptionSource::Program)
             && update.account.is_owned_by_delegation_program()
             && update.account.fresh_account().is_some_and(|account| {
                 is_internal_dlp_account_data(account.data())
             })
-            && !self.is_freshly_delegated_collision(&update).await
         {
-            trace!(
-                pubkey = %pubkey,
-                "Dropping internal DLP program subscription update"
-            );
-            return;
+            let released = update
+                .account
+                .fresh_account()
+                .is_some_and(|account| {
+                    is_delegation_record_data(account.data())
+                })
+                .then(|| {
+                    self.dlp_collision_tracker
+                        .lock()
+                        .sight_record(pubkey, update.account.slot())
+                })
+                .flatten();
+            if let Some(released) = released {
+                // The parked update's deferred discovery continuation;
+                // discovery declining means drop, as for any internal update.
+                self.maybe_greedily_clone_discovered_delegated_account(
+                    released.pubkey,
+                    &released,
+                )
+                .await;
+            }
+            if !self.dlp_collision_tracker.lock().check_or_park(&update) {
+                trace!(
+                    pubkey = %pubkey,
+                    "Dropping internal DLP program subscription update"
+                );
+                return;
+            }
         }
 
         if self

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -212,11 +212,12 @@ const PARKED_COLLISION_UPDATES_CAPACITY: NonZeroUsize =
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum DlpProgramUpdateInterest {
-    DropIrrelevant,
+    DropRawEataNoProjectionInterest,
     DropLocalDelegatedAuthoritative,
     ProcessUndelegating,
     ProcessAtaProjection,
     ProcessDirectlyWatched,
+    DiscoverDelegatedAccount,
 }
 
 /// A parked internal-looking account update, reduced to pubkey + slot so
@@ -510,68 +511,81 @@ where
             return DlpProgramUpdateInterest::ProcessDirectlyWatched;
         }
 
-        if self
-            .has_local_ata_projection_interest(pubkey, account)
+        if let Some(has_projection_interest) = self
+            .raw_eata_has_local_projection_interest(pubkey, account)
             .await
         {
+            return if has_projection_interest {
+                DlpProgramUpdateInterest::ProcessAtaProjection
+            } else {
+                DlpProgramUpdateInterest::DropRawEataNoProjectionInterest
+            };
+        }
+
+        if self.base_ata_has_projection_interest(pubkey, account).await {
             return DlpProgramUpdateInterest::ProcessAtaProjection;
         }
 
-        DlpProgramUpdateInterest::DropIrrelevant
+        DlpProgramUpdateInterest::DiscoverDelegatedAccount
     }
 
-    async fn has_local_ata_projection_interest(
+    async fn raw_eata_has_local_projection_interest(
         &self,
         pubkey: Pubkey,
         account: &AccountSharedData,
-    ) -> bool {
-        if let Some(eata_pubkey) =
-            ata_projection::derive_eata_pubkey_from_ata_account(
+    ) -> Option<bool> {
+        let ata_pubkeys =
+            ata_projection::derive_supported_ata_pubkeys_from_raw_eata(
                 &pubkey, account,
-            )
-        {
-            if self
-                .remote_account_provider
-                .has_subscription_reason(
-                    &pubkey,
-                    SubscriptionReason::AtaProjection,
-                )
-                .await
+            )?;
+
+        for ata_pubkey in ata_pubkeys.iter() {
+            if self.accounts_bank.get_account(ata_pubkey).is_some()
                 || self
                     .remote_account_provider
                     .has_subscription_reason(
-                        &eata_pubkey,
+                        ata_pubkey,
                         SubscriptionReason::AtaProjection,
                     )
                     .await
             {
-                return true;
+                return Some(true);
             }
         }
 
-        if let Some(ata_pubkeys) =
-            ata_projection::derive_supported_ata_pubkeys_from_raw_eata(
+        Some(
+            self.remote_account_provider
+                .has_subscription_reason(
+                    &pubkey,
+                    SubscriptionReason::AtaProjection,
+                )
+                .await,
+        )
+    }
+
+    async fn base_ata_has_projection_interest(
+        &self,
+        pubkey: Pubkey,
+        account: &AccountSharedData,
+    ) -> bool {
+        let Some(eata_pubkey) =
+            ata_projection::derive_eata_pubkey_from_ata_account(
                 &pubkey, account,
             )
-        {
-            for ata_pubkey in ata_pubkeys.iter() {
-                if self.accounts_bank.get_account(ata_pubkey).is_some()
-                    || self
-                        .remote_account_provider
-                        .has_subscription_reason(
-                            ata_pubkey,
-                            SubscriptionReason::AtaProjection,
-                        )
-                        .await
-                {
-                    return true;
-                }
-            }
-        }
+        else {
+            return false;
+        };
 
         self.remote_account_provider
             .has_subscription_reason(&pubkey, SubscriptionReason::AtaProjection)
             .await
+            || self
+                .remote_account_provider
+                .has_subscription_reason(
+                    &eata_pubkey,
+                    SubscriptionReason::AtaProjection,
+                )
+                .await
     }
 
     #[instrument(skip(self, pubkeys))]
@@ -1742,14 +1756,12 @@ where
             };
 
         match dlp_program_interest {
-            Some(DlpProgramUpdateInterest::DropIrrelevant) => {
-                if !is_internal_dlp_update {
-                    trace!(
-                        pubkey = %pubkey,
-                        "Dropping irrelevant DLP program subscription update"
-                    );
-                    return;
-                }
+            Some(DlpProgramUpdateInterest::DropRawEataNoProjectionInterest) => {
+                trace!(
+                    pubkey = %pubkey,
+                    "Dropping raw eATA DLP program update without local projection interest"
+                );
+                return;
             }
             Some(DlpProgramUpdateInterest::DropLocalDelegatedAuthoritative) => {
                 self.cleanup_direct_subscription_for_delegated_account(pubkey)
@@ -1763,6 +1775,7 @@ where
             Some(DlpProgramUpdateInterest::ProcessUndelegating)
             | Some(DlpProgramUpdateInterest::ProcessAtaProjection)
             | Some(DlpProgramUpdateInterest::ProcessDirectlyWatched)
+            | Some(DlpProgramUpdateInterest::DiscoverDelegatedAccount)
             | None => {}
         }
 

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -96,7 +96,10 @@ use crate::{
         program_account::{
             get_loaderv3_get_program_data_address, LoadedProgram,
         },
-        pubsub_common::{is_internal_dlp_account_data, SubscriptionSource},
+        pubsub_common::{
+            is_delegation_record_data, is_internal_dlp_account_data,
+            SubscriptionSource,
+        },
         CapacityEvictionProtection, ChainPubsubClient, ChainRpcClient,
         ForwardedSubscriptionUpdate, MatchSlotsConfig, RemoteAccount,
         RemoteAccountProvider, ResolvedAccountSharedData, SubscriptionReason,
@@ -141,6 +144,11 @@ where
     /// Negative cache for derived eATAs confirmed missing on chain.
     known_empty_eatas: Arc<PlMutex<LruCache<Pubkey, ()>>>,
 
+    /// Slots at which delegation-record-shaped program updates were last
+    /// seen, used to recognize freshly delegated accounts whose app data
+    /// collides with an internal DLP discriminator.
+    seen_delegation_record_slots: Arc<PlMutex<LruCache<Pubkey, u64>>>,
+
     /// Tracks in-flight clone operations.
     /// The first caller to claim a key becomes the owner and performs
     /// the actual clone. Subsequent callers become waiters and receive
@@ -181,6 +189,19 @@ const KNOWN_EMPTY_EATAS_CAPACITY: NonZeroUsize =
         None => panic!("KNOWN_EMPTY_EATAS_CAPACITY must be non-zero"),
     };
 
+/// Capacity for recently sighted delegation-record update slots.
+const SEEN_DELEGATION_RECORD_SLOTS_CAPACITY: NonZeroUsize =
+    match NonZeroUsize::new(16_384) {
+        Some(n) => n,
+        None => {
+            panic!("SEEN_DELEGATION_RECORD_SLOTS_CAPACITY must be non-zero")
+        }
+    };
+
+/// Grace period for an account update to be matched with its same-slot
+/// delegation-record update when the record is delivered slightly later.
+const DELEGATION_RECORD_SIGHTING_GRACE: Duration = Duration::from_millis(250);
+
 /// A pending fetch+clone operation claimed by one dedup call, resolved by
 /// the batch worker spawned for that call.
 struct ClaimedOperation {
@@ -216,6 +237,9 @@ where
             allowed_programs: self.allowed_programs.clone(),
             programs_not_to_subscribe: self.programs_not_to_subscribe.clone(),
             known_empty_eatas: self.known_empty_eatas.clone(),
+            seen_delegation_record_slots: self
+                .seen_delegation_record_slots
+                .clone(),
             pending_clones: self.pending_clones.clone(),
             pending_undelegations: self.pending_undelegations.clone(),
             pending_operation_timeout_ms: self
@@ -320,6 +344,9 @@ where
             known_empty_eatas: Arc::new(PlMutex::new(LruCache::new(
                 KNOWN_EMPTY_EATAS_CAPACITY,
             ))),
+            seen_delegation_record_slots: Arc::new(PlMutex::new(
+                LruCache::new(SEEN_DELEGATION_RECORD_SLOTS_CAPACITY),
+            )),
             pending_clones: Arc::new(Mutex::new(hash_map::HashMap::new())),
             pending_undelegations: Arc::new(Mutex::new(HashSet::new())),
             pending_operation_timeout_ms: Arc::new(AtomicU64::new(
@@ -1492,18 +1519,58 @@ where
         });
     }
 
+    /// Records sightings of delegation-record-shaped program updates, then
+    /// reports whether this pubkey's own delegation record was sighted at or
+    /// after the update slot: a fresh delegation writes the account and its
+    /// record in one slot, so a sighting marks a delegated account whose app
+    /// data collides with an internal DLP discriminator. A short grace period
+    /// covers the record being delivered after the account update.
+    async fn is_freshly_delegated_collision(
+        &self,
+        update: &ForwardedSubscriptionUpdate,
+    ) -> bool {
+        let slot = update.account.slot();
+        if update
+            .account
+            .fresh_account()
+            .is_some_and(|account| is_delegation_record_data(account.data()))
+        {
+            self.seen_delegation_record_slots
+                .lock()
+                .put(update.pubkey, slot);
+        }
+
+        let record_pubkey =
+            delegation_record_pda_from_delegated_account(&update.pubkey);
+        let record_sighted = || {
+            self.seen_delegation_record_slots
+                .lock()
+                .get(&record_pubkey)
+                .is_some_and(|&record_slot| record_slot >= slot)
+        };
+        if record_sighted() {
+            return true;
+        }
+        tokio::time::sleep(DELEGATION_RECORD_SIGHTING_GRACE).await;
+        record_sighted()
+    }
+
     async fn process_subscription_update(
         &self,
         pubkey: Pubkey,
         update: ForwardedSubscriptionUpdate,
     ) {
         // Internal DLP payloads (records/metadata/commit state) can never be
-        // greedily cloned, so drop them before discovery issues remote fetches.
+        // greedily cloned, so drop them before discovery issues remote
+        // fetches. The exception is an account whose app data collides with
+        // an internal discriminator: its delegation also emits the
+        // delegation-record update, whose sighting routes it to discovery.
         if matches!(update.source, SubscriptionSource::Program)
             && update.account.is_owned_by_delegation_program()
             && update.account.fresh_account().is_some_and(|account| {
                 is_internal_dlp_account_data(account.data())
             })
+            && !self.is_freshly_delegated_collision(&update).await
         {
             trace!(
                 pubkey = %pubkey,

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -4624,6 +4624,607 @@ async fn test_discovered_dlp_owned_account_with_internal_record_prefix_is_droppe
     );
 }
 
+async fn drain_subscription_update_tasks(
+    fetch_cloner: &Arc<TestFetchCloner>,
+    timeout: Duration,
+) {
+    tokio::time::timeout(timeout, async {
+        while Arc::strong_count(fetch_cloner) > 1 {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("timed out waiting for subscription update task to drain");
+}
+
+#[tokio::test]
+async fn test_absent_unwatched_dlp_program_update_is_dropped_without_delegation_record_fetch(
+) {
+    init_logger();
+    let validator_keypair = Keypair::new();
+    let account_pubkey = random_pubkey();
+    const CURRENT_SLOT: u64 = 100;
+
+    let dlp_owned_account = Account {
+        lamports: 1_000_000,
+        data: vec![1, 2, 3, 4],
+        owner: dlp_api::id(),
+        executable: false,
+        rent_epoch: 0,
+    };
+
+    let FetcherTestCtx {
+        accounts_bank,
+        rpc_client,
+        subscription_tx,
+        fetch_cloner,
+        cloner,
+        ..
+    } = setup(
+        [(account_pubkey, dlp_owned_account.clone())],
+        CURRENT_SLOT,
+        validator_keypair.insecure_clone(),
+    )
+    .await;
+
+    let fetches_before = rpc_client.single_account_fetches()
+        + rpc_client.multi_account_fetches();
+
+    use crate::remote_account_provider::{
+        RemoteAccount, RemoteAccountUpdateSource,
+    };
+
+    subscription_tx
+        .send(ForwardedSubscriptionUpdate {
+            pubkey: account_pubkey,
+            account: RemoteAccount::from_fresh_account(
+                dlp_owned_account,
+                CURRENT_SLOT,
+                RemoteAccountUpdateSource::Subscription,
+            ),
+            source: SubscriptionSource::Program,
+        })
+        .await
+        .unwrap();
+    drop(subscription_tx);
+
+    drain_subscription_update_tasks(&fetch_cloner, Duration::from_secs(1))
+        .await;
+
+    assert!(accounts_bank.get_account(&account_pubkey).is_none());
+    assert_eq!(cloner.clone_request_count(), 0);
+    assert_eq!(
+        rpc_client.single_account_fetches()
+            + rpc_client.multi_account_fetches(),
+        fetches_before
+    );
+}
+
+#[tokio::test]
+async fn test_active_local_delegated_dlp_program_update_cleans_up_without_fetch_or_overwrite(
+) {
+    init_logger();
+    let validator_keypair = Keypair::new();
+    let validator_pubkey = validator_keypair.pubkey();
+    let account_pubkey = random_pubkey();
+    let account_owner = random_pubkey();
+    const CURRENT_SLOT: u64 = 101;
+
+    let remote_update = Account {
+        lamports: 1_000_000,
+        data: vec![9, 9, 9],
+        owner: dlp_api::id(),
+        executable: false,
+        rent_epoch: 0,
+    };
+
+    let FetcherTestCtx {
+        remote_account_provider,
+        accounts_bank,
+        rpc_client,
+        subscription_tx,
+        fetch_cloner,
+        cloner,
+        ..
+    } = setup(
+        [(account_pubkey, remote_update.clone())],
+        CURRENT_SLOT,
+        validator_keypair.insecure_clone(),
+    )
+    .await;
+
+    add_delegation_record_for(
+        &rpc_client,
+        account_pubkey,
+        validator_pubkey,
+        account_owner,
+    );
+
+    let mut local_delegated = AccountSharedData::from(Account {
+        lamports: 1_000_000,
+        data: vec![1, 2, 3],
+        owner: account_owner,
+        executable: false,
+        rent_epoch: 0,
+    });
+    local_delegated.set_delegated(true);
+    local_delegated.set_undelegating(false);
+    local_delegated.set_remote_slot(100);
+    accounts_bank.insert(account_pubkey, local_delegated.clone());
+
+    remote_account_provider
+        .acquire_subscription(
+            &account_pubkey,
+            SubscriptionReason::DirectAccount,
+        )
+        .await
+        .unwrap();
+
+    let fetches_before = rpc_client.single_account_fetches()
+        + rpc_client.multi_account_fetches();
+
+    use crate::remote_account_provider::{
+        RemoteAccount, RemoteAccountUpdateSource,
+    };
+
+    subscription_tx
+        .send(ForwardedSubscriptionUpdate {
+            pubkey: account_pubkey,
+            account: RemoteAccount::from_fresh_account(
+                remote_update,
+                CURRENT_SLOT,
+                RemoteAccountUpdateSource::Subscription,
+            ),
+            source: SubscriptionSource::Program,
+        })
+        .await
+        .unwrap();
+    drop(subscription_tx);
+
+    drain_subscription_update_tasks(&fetch_cloner, Duration::from_secs(1))
+        .await;
+
+    assert_eq!(
+        rpc_client.single_account_fetches()
+            + rpc_client.multi_account_fetches(),
+        fetches_before
+    );
+    assert_eq!(cloner.clone_request_count(), 0);
+    assert!(!remote_account_provider.is_watching(&account_pubkey));
+    assert_eq!(
+        accounts_bank.get_account(&account_pubkey),
+        Some(local_delegated)
+    );
+}
+
+#[tokio::test]
+async fn test_undelegating_internal_looking_dlp_program_update_reaches_completion_logic(
+) {
+    init_logger();
+    let validator_keypair = Keypair::new();
+    let account_pubkey = random_pubkey();
+    let account_owner = random_pubkey();
+    const CURRENT_SLOT: u64 = 101;
+
+    let mut app_data = vec![0; DelegationRecord::size_with_discriminator()];
+    app_data[..8].copy_from_slice(&100u64.to_le_bytes());
+    assert!(
+        crate::remote_account_provider::pubsub_common::is_internal_dlp_account_data(
+            &app_data
+        )
+    );
+
+    let remote_account = Account {
+        lamports: 1_000_000,
+        data: app_data.clone(),
+        owner: dlp_api::id(),
+        executable: false,
+        rent_epoch: 0,
+    };
+
+    let FetcherTestCtx {
+        remote_account_provider,
+        accounts_bank,
+        subscription_tx,
+        fetch_cloner,
+        ..
+    } = setup(
+        [(account_pubkey, remote_account.clone())],
+        CURRENT_SLOT,
+        validator_keypair.insecure_clone(),
+    )
+    .await;
+
+    let mut local_undelegating = AccountSharedData::from(Account {
+        lamports: 1_000_000,
+        data: app_data,
+        owner: account_owner,
+        executable: false,
+        rent_epoch: 0,
+    });
+    local_undelegating.set_delegated(true);
+    local_undelegating.set_undelegating(true);
+    local_undelegating.set_remote_slot(100);
+    accounts_bank.insert(account_pubkey, local_undelegating);
+
+    remote_account_provider
+        .acquire_subscription(
+            &account_pubkey,
+            SubscriptionReason::DirectAccount,
+        )
+        .await
+        .unwrap();
+
+    use crate::remote_account_provider::{
+        RemoteAccount, RemoteAccountUpdateSource,
+    };
+
+    subscription_tx
+        .send(ForwardedSubscriptionUpdate {
+            pubkey: account_pubkey,
+            account: RemoteAccount::from_fresh_account(
+                remote_account,
+                CURRENT_SLOT,
+                RemoteAccountUpdateSource::Subscription,
+            ),
+            source: SubscriptionSource::Program,
+        })
+        .await
+        .unwrap();
+    drop(subscription_tx);
+
+    drain_subscription_update_tasks(&fetch_cloner, Duration::from_secs(1))
+        .await;
+
+    let bank_account = accounts_bank
+        .get_account(&account_pubkey)
+        .expect("local account should remain observable after completion");
+    assert!(!bank_account.undelegating());
+    assert!(remote_account_provider.is_watching(&account_pubkey));
+}
+
+#[tokio::test]
+async fn test_raw_eata_program_update_without_projection_interest_is_dropped_without_fetch(
+) {
+    init_logger();
+    let validator_keypair = Keypair::new();
+    let wallet_owner = random_pubkey();
+    let mint = random_pubkey();
+    let eata_pubkey = derive_eata(&wallet_owner, &mint);
+    const CURRENT_SLOT: u64 = 100;
+    const AMOUNT: u64 = 777;
+
+    let eata_account = create_eata_account(&wallet_owner, &mint, AMOUNT, true);
+    let ata_pubkey = derive_ata(&wallet_owner, &mint);
+
+    let FetcherTestCtx {
+        accounts_bank,
+        rpc_client,
+        subscription_tx,
+        fetch_cloner,
+        cloner,
+        ..
+    } = setup(
+        [(eata_pubkey, eata_account.clone())],
+        CURRENT_SLOT,
+        validator_keypair.insecure_clone(),
+    )
+    .await;
+
+    let fetches_before = rpc_client.single_account_fetches()
+        + rpc_client.multi_account_fetches();
+
+    use crate::remote_account_provider::{
+        RemoteAccount, RemoteAccountUpdateSource,
+    };
+
+    subscription_tx
+        .send(ForwardedSubscriptionUpdate {
+            pubkey: eata_pubkey,
+            account: RemoteAccount::from_fresh_account(
+                eata_account,
+                CURRENT_SLOT,
+                RemoteAccountUpdateSource::Subscription,
+            ),
+            source: SubscriptionSource::Program,
+        })
+        .await
+        .unwrap();
+    drop(subscription_tx);
+
+    drain_subscription_update_tasks(&fetch_cloner, Duration::from_secs(1))
+        .await;
+
+    assert_eq!(
+        rpc_client.single_account_fetches()
+            + rpc_client.multi_account_fetches(),
+        fetches_before
+    );
+    assert_eq!(cloner.clone_request_count(), 0);
+    assert!(accounts_bank.get_account(&eata_pubkey).is_none());
+    assert!(accounts_bank.get_account(&ata_pubkey).is_none());
+}
+
+#[tokio::test]
+async fn test_raw_eata_program_update_with_projection_interest_processes_projection(
+) {
+    init_logger();
+    let validator_keypair = Keypair::new();
+    let validator_pubkey = validator_keypair.pubkey();
+    let wallet_owner = random_pubkey();
+    let mint = random_pubkey();
+    let eata_pubkey = derive_eata(&wallet_owner, &mint);
+    let ata_pubkey = derive_ata(&wallet_owner, &mint);
+    const CURRENT_SLOT: u64 = 101;
+    const AMOUNT: u64 = 777;
+
+    let base_ata_account = create_ata_account(&wallet_owner, &mint);
+    let eata_account = create_eata_account(&wallet_owner, &mint, AMOUNT, true);
+
+    let FetcherTestCtx {
+        accounts_bank,
+        rpc_client,
+        subscription_tx,
+        ..
+    } = setup(
+        [(eata_pubkey, eata_account.clone())],
+        CURRENT_SLOT,
+        validator_keypair.insecure_clone(),
+    )
+    .await;
+
+    let mut local_base_ata = AccountSharedData::from(base_ata_account.clone());
+    local_base_ata.set_remote_slot(100);
+    accounts_bank.insert(ata_pubkey, local_base_ata);
+
+    add_delegation_record_for(
+        &rpc_client,
+        eata_pubkey,
+        validator_pubkey,
+        EATA_PROGRAM_ID,
+    );
+
+    use crate::remote_account_provider::{
+        RemoteAccount, RemoteAccountUpdateSource,
+    };
+
+    subscription_tx
+        .send(ForwardedSubscriptionUpdate {
+            pubkey: eata_pubkey,
+            account: RemoteAccount::from_fresh_account(
+                eata_account,
+                CURRENT_SLOT,
+                RemoteAccountUpdateSource::Subscription,
+            ),
+            source: SubscriptionSource::Program,
+        })
+        .await
+        .unwrap();
+
+    tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            let projected =
+                accounts_bank
+                    .get_account(&ata_pubkey)
+                    .is_some_and(|account| {
+                        account.delegated()
+                            && account.remote_slot() == CURRENT_SLOT
+                    });
+            if projected {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("timed out waiting for raw eATA projection");
+
+    let projected_ata = accounts_bank
+        .get_account(&ata_pubkey)
+        .expect("projected ATA should be cloned into the base ATA pubkey");
+    assert!(projected_ata.delegated());
+    assert_eq!(projected_ata.owner(), &base_ata_account.owner);
+    assert_eq!(projected_ata.data().len(), base_ata_account.data.len());
+    assert_eq!(projected_ata.remote_slot(), CURRENT_SLOT);
+}
+
+#[tokio::test]
+async fn test_absent_unwatched_dlp_update_delegated_elsewhere_is_ignored_without_record_fetch(
+) {
+    init_logger();
+    let validator_keypair = Keypair::new();
+    let other_validator = random_pubkey();
+    let account_pubkey = random_pubkey();
+    let account_owner = random_pubkey();
+    const CURRENT_SLOT: u64 = 100;
+
+    let delegated_account = Account {
+        lamports: 1_000_000,
+        data: vec![1, 2, 3, 4],
+        owner: dlp_api::id(),
+        executable: false,
+        rent_epoch: 0,
+    };
+
+    let FetcherTestCtx {
+        accounts_bank,
+        rpc_client,
+        subscription_tx,
+        fetch_cloner,
+        cloner,
+        ..
+    } = setup(
+        [(account_pubkey, delegated_account.clone())],
+        CURRENT_SLOT,
+        validator_keypair.insecure_clone(),
+    )
+    .await;
+
+    add_delegation_record_for(
+        &rpc_client,
+        account_pubkey,
+        other_validator,
+        account_owner,
+    );
+
+    let fetches_before = rpc_client.single_account_fetches()
+        + rpc_client.multi_account_fetches();
+
+    use crate::remote_account_provider::{
+        RemoteAccount, RemoteAccountUpdateSource,
+    };
+
+    subscription_tx
+        .send(ForwardedSubscriptionUpdate {
+            pubkey: account_pubkey,
+            account: RemoteAccount::from_fresh_account(
+                delegated_account,
+                CURRENT_SLOT,
+                RemoteAccountUpdateSource::Subscription,
+            ),
+            source: SubscriptionSource::Program,
+        })
+        .await
+        .unwrap();
+    drop(subscription_tx);
+
+    drain_subscription_update_tasks(&fetch_cloner, Duration::from_secs(1))
+        .await;
+
+    assert_eq!(
+        rpc_client.single_account_fetches()
+            + rpc_client.multi_account_fetches(),
+        fetches_before
+    );
+    assert_eq!(cloner.clone_request_count(), 0);
+    assert!(accounts_bank.get_account(&account_pubkey).is_none());
+}
+
+#[tokio::test]
+async fn test_explicit_ensure_still_fetches_delegation_record_and_clones_delegated_account(
+) {
+    init_logger();
+    let validator_keypair = Keypair::new();
+    let validator_pubkey = validator_keypair.pubkey();
+    let account_pubkey = random_pubkey();
+    let account_owner = random_pubkey();
+    const CURRENT_SLOT: u64 = 100;
+
+    let app_data = vec![1, 2, 3, 4];
+    let delegated_account = Account {
+        lamports: 1_000_000,
+        data: app_data.clone(),
+        owner: dlp_api::id(),
+        executable: false,
+        rent_epoch: 0,
+    };
+
+    let FetcherTestCtx {
+        accounts_bank,
+        rpc_client,
+        fetch_cloner,
+        ..
+    } = setup(
+        [(account_pubkey, delegated_account.clone())],
+        CURRENT_SLOT,
+        validator_keypair.insecure_clone(),
+    )
+    .await;
+
+    add_delegation_record_for(
+        &rpc_client,
+        account_pubkey,
+        validator_pubkey,
+        account_owner,
+    );
+
+    let fetches_before = rpc_client.single_account_fetches()
+        + rpc_client.multi_account_fetches();
+
+    fetch_cloner
+        .fetch_and_clone_accounts_with_dedup(
+            &[account_pubkey],
+            None,
+            Some(CURRENT_SLOT),
+            AccountFetchContext::rpc_get_account(),
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        rpc_client.single_account_fetches()
+            + rpc_client.multi_account_fetches()
+            > fetches_before
+    );
+    let cloned_account = accounts_bank
+        .get_account(&account_pubkey)
+        .expect("delegated account should be cloned explicitly");
+    assert!(cloned_account.delegated());
+    assert_eq!(cloned_account.owner(), &account_owner);
+    assert_eq!(cloned_account.data(), app_data.as_slice());
+}
+
+#[tokio::test]
+async fn test_explicit_clone_executes_post_delegation_actions_after_prefilter_changes(
+) {
+    init_logger();
+    let validator_keypair = Keypair::new();
+    let validator_pubkey = validator_keypair.pubkey();
+    let account_pubkey = random_pubkey();
+    let account_owner = random_pubkey();
+    const CURRENT_SLOT: u64 = 100;
+
+    let delegated_account = Account {
+        lamports: 1_000_000,
+        data: vec![1, 2, 3, 4],
+        owner: dlp_api::id(),
+        executable: false,
+        rent_epoch: 0,
+    };
+
+    let FetcherTestCtx {
+        accounts_bank,
+        rpc_client,
+        fetch_cloner,
+        cloner,
+        ..
+    } = setup(
+        [(account_pubkey, delegated_account)],
+        CURRENT_SLOT,
+        validator_keypair.insecure_clone(),
+    )
+    .await;
+
+    add_delegation_record_with_actions_for(
+        &rpc_client,
+        account_pubkey,
+        validator_pubkey,
+        account_owner,
+        system_program::id(),
+    );
+
+    fetch_cloner
+        .fetch_and_clone_accounts_with_dedup(
+            &[account_pubkey],
+            None,
+            Some(CURRENT_SLOT),
+            AccountFetchContext::rpc_get_account(),
+        )
+        .await
+        .unwrap();
+
+    let clone_requests = cloner.clone_requests();
+    let delegated_clone_request = clone_requests
+        .iter()
+        .find(|request| request.pubkey == account_pubkey)
+        .expect("delegated account clone request should be recorded");
+    assert!(!delegated_clone_request.delegation_actions.is_empty());
+    let cloned_account = accounts_bank
+        .get_account(&account_pubkey)
+        .expect("delegated account should be cloned explicitly");
+    assert!(cloned_account.delegated());
+}
+
 // A freshly delegated account whose app data collides with an internal DLP
 // discriminator is still greedily cloned: the delegation-record update from
 // the same delegation routes it to discovery, in either delivery order.

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -675,7 +675,8 @@ async fn test_dlp_program_update_classifier_detects_ata_projection_interest() {
 }
 
 #[tokio::test]
-async fn test_dlp_program_update_classifier_drops_irrelevant_update() {
+async fn test_dlp_program_update_classifier_discovers_unwatched_non_eata_update(
+) {
     let validator_keypair = Keypair::new();
     let pubkey = random_pubkey();
     let mut remote_update =
@@ -693,7 +694,37 @@ async fn test_dlp_program_update_classifier_drops_irrelevant_update() {
         fetch_cloner
             .classify_dlp_program_update_interest(pubkey, &remote_update)
             .await,
-        DlpProgramUpdateInterest::DropIrrelevant
+        DlpProgramUpdateInterest::DiscoverDelegatedAccount
+    );
+}
+
+#[tokio::test]
+async fn test_dlp_program_update_classifier_drops_raw_eata_without_projection_interest(
+) {
+    let validator_keypair = Keypair::new();
+    let wallet_owner = random_pubkey();
+    let mint = random_pubkey();
+    let eata_pubkey = derive_eata(&wallet_owner, &mint);
+    let mut eata_account = AccountSharedData::from(create_eata_account(
+        &wallet_owner,
+        &mint,
+        777,
+        true,
+    ));
+    eata_account.set_remote_slot(101);
+
+    let FetcherTestCtx { fetch_cloner, .. } = setup(
+        std::iter::empty::<(Pubkey, Account)>(),
+        100,
+        validator_keypair,
+    )
+    .await;
+
+    assert_eq!(
+        fetch_cloner
+            .classify_dlp_program_update_interest(eata_pubkey, &eata_account)
+            .await,
+        DlpProgramUpdateInterest::DropRawEataNoProjectionInterest
     );
 }
 
@@ -4800,7 +4831,7 @@ async fn drain_subscription_update_tasks(
 }
 
 #[tokio::test]
-async fn test_absent_unwatched_dlp_program_update_is_dropped_without_delegation_record_fetch(
+async fn test_absent_unwatched_dlp_program_update_without_delegation_record_is_ignored_after_record_fetch(
 ) {
     init_logger();
     let validator_keypair = Keypair::new();
@@ -4851,10 +4882,11 @@ async fn test_absent_unwatched_dlp_program_update_is_dropped_without_delegation_
 
     assert!(accounts_bank.get_account(&account_pubkey).is_none());
     assert_eq!(cloner.clone_request_count(), 0);
-    assert_eq!(
+    assert!(
         rpc_client.single_account_fetches()
-            + rpc_client.multi_account_fetches(),
-        fetches_before
+            + rpc_client.multi_account_fetches()
+            > fetches_before,
+        "greedy discovery should attempt delegation-record resolution before ignoring the update"
     );
 }
 
@@ -5254,7 +5286,7 @@ async fn test_raw_eata_program_update_with_projection_interest_processes_project
 }
 
 #[tokio::test]
-async fn test_absent_unwatched_dlp_update_delegated_elsewhere_is_ignored_without_record_fetch(
+async fn test_absent_unwatched_dlp_update_delegated_elsewhere_is_ignored_after_record_fetch(
 ) {
     init_logger();
     let validator_keypair = Keypair::new();
@@ -5312,10 +5344,11 @@ async fn test_absent_unwatched_dlp_update_delegated_elsewhere_is_ignored_without
     drain_subscription_update_tasks(&fetch_cloner, Duration::from_secs(1))
         .await;
 
-    assert_eq!(
+    assert!(
         rpc_client.single_account_fetches()
-            + rpc_client.multi_account_fetches(),
-        fetches_before
+            + rpc_client.multi_account_fetches()
+            > fetches_before,
+        "greedy discovery should fetch the delegation record before ignoring other-validator authority"
     );
     assert_eq!(cloner.clone_request_count(), 0);
     assert!(accounts_bank.get_account(&account_pubkey).is_none());

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -4624,6 +4624,110 @@ async fn test_discovered_dlp_owned_account_with_internal_record_prefix_is_droppe
     );
 }
 
+// A freshly delegated account whose app data collides with an internal DLP
+// discriminator is still greedily cloned: the delegation-record update from
+// the same delegation routes it to discovery.
+#[tokio::test]
+async fn test_discovered_colliding_delegated_account_with_record_sighting_is_cloned(
+) {
+    init_logger();
+    let validator_keypair = Keypair::new();
+    let validator_pubkey = validator_keypair.pubkey();
+    let account_pubkey = random_pubkey();
+    let account_owner = random_pubkey();
+    const CURRENT_SLOT: u64 = 100;
+
+    let mut app_data = vec![0; DelegationRecord::size_with_discriminator()];
+    app_data[..8].copy_from_slice(&100u64.to_le_bytes());
+
+    let delegated_account = Account {
+        lamports: 1_000_000,
+        data: app_data.clone(),
+        owner: dlp_api::id(),
+        executable: false,
+        rent_epoch: 0,
+    };
+
+    let FetcherTestCtx {
+        accounts_bank,
+        rpc_client,
+        subscription_tx,
+        ..
+    } = setup(
+        [(account_pubkey, delegated_account.clone())],
+        CURRENT_SLOT,
+        validator_keypair.insecure_clone(),
+    )
+    .await;
+
+    add_delegation_record_for(
+        &rpc_client,
+        account_pubkey,
+        validator_pubkey,
+        account_owner,
+    );
+
+    let delegation_record_pubkey =
+        dlp_api::pda::delegation_record_pda_from_delegated_account(
+            &account_pubkey,
+        );
+    let delegation_record = DelegationRecord {
+        authority: validator_pubkey,
+        owner: account_owner,
+        delegation_slot: 1,
+        lamports: 1_000,
+        commit_frequency_ms: 2_000,
+    };
+    let delegation_record_account = Account {
+        lamports: 1_000_000,
+        data: delegation_record_to_vec(&delegation_record),
+        owner: dlp_api::id(),
+        executable: false,
+        rent_epoch: 0,
+    };
+
+    use crate::remote_account_provider::{
+        RemoteAccount, RemoteAccountUpdateSource,
+    };
+
+    for (pubkey, account) in [
+        (delegation_record_pubkey, delegation_record_account),
+        (account_pubkey, delegated_account),
+    ] {
+        subscription_tx
+            .send(ForwardedSubscriptionUpdate {
+                pubkey,
+                account: RemoteAccount::from_fresh_account(
+                    account,
+                    CURRENT_SLOT,
+                    RemoteAccountUpdateSource::Subscription,
+                ),
+                source: SubscriptionSource::Program,
+            })
+            .await
+            .unwrap();
+    }
+
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while !accounts_bank.get_account(&account_pubkey).is_some_and(
+            |account| {
+                account.delegated()
+                    && account.owner() == &account_owner
+                    && account.remote_slot() == CURRENT_SLOT
+            },
+        ) {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("timed out waiting for colliding delegated account clone");
+
+    let cloned_account = accounts_bank
+        .get_account(&account_pubkey)
+        .expect("account should be greedily cloned from program update");
+    assert_eq!(cloned_account.data(), app_data.as_slice());
+}
+
 #[tokio::test]
 async fn test_internal_dlp_pda_program_update_is_filtered_after_discovery_miss()
 {

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -509,6 +509,190 @@ async fn acquire_direct_subscription_for_update(
         .expect("failed to acquire direct subscription for update test");
 }
 
+#[tokio::test]
+async fn test_dlp_program_update_classifier_prefers_undelegating_local_state() {
+    let validator_keypair = Keypair::new();
+    let local_owner = random_pubkey();
+    let pubkey = random_pubkey();
+    let mut remote_update =
+        AccountSharedData::new(1_000_000, 0, &dlp_api::id());
+    remote_update.set_remote_slot(101);
+
+    let FetcherTestCtx {
+        fetch_cloner,
+        accounts_bank,
+        remote_account_provider,
+        ..
+    } = setup(
+        std::iter::empty::<(Pubkey, Account)>(),
+        100,
+        validator_keypair,
+    )
+    .await;
+
+    let mut local_account = AccountSharedData::new(1_000_000, 0, &local_owner);
+    local_account.set_delegated(true);
+    local_account.set_undelegating(true);
+    local_account.set_remote_slot(100);
+    accounts_bank.insert(pubkey, local_account);
+    acquire_direct_subscription_for_update(&remote_account_provider, &pubkey)
+        .await;
+
+    assert_eq!(
+        fetch_cloner
+            .classify_dlp_program_update_interest(pubkey, &remote_update)
+            .await,
+        DlpProgramUpdateInterest::ProcessUndelegating
+    );
+}
+
+#[tokio::test]
+async fn test_dlp_program_update_classifier_prefers_delegated_local_authority_before_watch(
+) {
+    let validator_keypair = Keypair::new();
+    let local_owner = random_pubkey();
+    let pubkey = random_pubkey();
+    let mut remote_update =
+        AccountSharedData::new(1_000_000, 0, &dlp_api::id());
+    remote_update.set_remote_slot(101);
+
+    let FetcherTestCtx {
+        fetch_cloner,
+        accounts_bank,
+        remote_account_provider,
+        ..
+    } = setup(
+        std::iter::empty::<(Pubkey, Account)>(),
+        100,
+        validator_keypair,
+    )
+    .await;
+
+    let mut local_account = AccountSharedData::new(1_000_000, 0, &local_owner);
+    local_account.set_delegated(true);
+    local_account.set_remote_slot(100);
+    accounts_bank.insert(pubkey, local_account);
+    acquire_direct_subscription_for_update(&remote_account_provider, &pubkey)
+        .await;
+
+    assert_eq!(
+        fetch_cloner
+            .classify_dlp_program_update_interest(pubkey, &remote_update)
+            .await,
+        DlpProgramUpdateInterest::DropLocalDelegatedAuthoritative
+    );
+}
+
+#[tokio::test]
+async fn test_dlp_program_update_classifier_returns_directly_watched_before_projection(
+) {
+    let validator_keypair = Keypair::new();
+    let wallet_owner = random_pubkey();
+    let mint = random_pubkey();
+    let eata_pubkey = derive_eata(&wallet_owner, &mint);
+    let mut eata_account = AccountSharedData::from(create_eata_account(
+        &wallet_owner,
+        &mint,
+        777,
+        true,
+    ));
+    eata_account.set_remote_slot(101);
+
+    let FetcherTestCtx {
+        fetch_cloner,
+        accounts_bank,
+        remote_account_provider,
+        ..
+    } = setup(
+        std::iter::empty::<(Pubkey, Account)>(),
+        100,
+        validator_keypair,
+    )
+    .await;
+    insert_plain_ata_in_bank(
+        &accounts_bank,
+        derive_ata(&wallet_owner, &mint),
+        &wallet_owner,
+        &mint,
+        100,
+    );
+    acquire_direct_subscription_for_update(
+        &remote_account_provider,
+        &eata_pubkey,
+    )
+    .await;
+
+    assert_eq!(
+        fetch_cloner
+            .classify_dlp_program_update_interest(eata_pubkey, &eata_account)
+            .await,
+        DlpProgramUpdateInterest::ProcessDirectlyWatched
+    );
+}
+
+#[tokio::test]
+async fn test_dlp_program_update_classifier_detects_ata_projection_interest() {
+    let validator_keypair = Keypair::new();
+    let wallet_owner = random_pubkey();
+    let mint = random_pubkey();
+    let eata_pubkey = derive_eata(&wallet_owner, &mint);
+    let mut eata_account = AccountSharedData::from(create_eata_account(
+        &wallet_owner,
+        &mint,
+        777,
+        true,
+    ));
+    eata_account.set_remote_slot(101);
+
+    let FetcherTestCtx {
+        fetch_cloner,
+        accounts_bank,
+        ..
+    } = setup(
+        std::iter::empty::<(Pubkey, Account)>(),
+        100,
+        validator_keypair,
+    )
+    .await;
+    insert_plain_ata_in_bank(
+        &accounts_bank,
+        derive_ata(&wallet_owner, &mint),
+        &wallet_owner,
+        &mint,
+        100,
+    );
+
+    assert_eq!(
+        fetch_cloner
+            .classify_dlp_program_update_interest(eata_pubkey, &eata_account)
+            .await,
+        DlpProgramUpdateInterest::ProcessAtaProjection
+    );
+}
+
+#[tokio::test]
+async fn test_dlp_program_update_classifier_drops_irrelevant_update() {
+    let validator_keypair = Keypair::new();
+    let pubkey = random_pubkey();
+    let mut remote_update =
+        AccountSharedData::new(1_000_000, 0, &dlp_api::id());
+    remote_update.set_remote_slot(101);
+
+    let FetcherTestCtx { fetch_cloner, .. } = setup(
+        std::iter::empty::<(Pubkey, Account)>(),
+        100,
+        validator_keypair,
+    )
+    .await;
+
+    assert_eq!(
+        fetch_cloner
+            .classify_dlp_program_update_interest(pubkey, &remote_update)
+            .await,
+        DlpProgramUpdateInterest::DropIrrelevant
+    );
+}
+
 async fn wait_for_pending_request(
     fetch_cloner: &Arc<
         FetchCloner<

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -4,6 +4,7 @@ use dlp_api::{
     pda::undelegation_request_pda_from_delegated_account,
     state::{DelegationRecord, UndelegationRequest},
 };
+use magicblock_core::token_programs::TOKEN_PROGRAM_ID;
 use magicblock_metrics::metrics::{
     chainlink_pending_fetch_accounts_value,
     chainlink_pending_fetch_waiters_gauge_value,
@@ -18,6 +19,7 @@ use solana_instruction::{AccountMeta, Instruction};
 use solana_keypair::Keypair;
 use solana_program::{program_option::COption, program_pack::Pack};
 use solana_rent::Rent;
+use solana_rpc_client_api::config::RpcAccountInfoConfig;
 use solana_sdk_ids::system_program;
 use solana_signer::Signer;
 use spl_token::state::{Account as SplAccount, AccountState};
@@ -37,8 +39,10 @@ use crate::{
     assert_subscribed_without_delegation_record,
     remote_account_provider::{
         chain_pubsub_client::mock::ChainPubsubClientMock,
-        chain_slot::ChainSlot, pubsub_common::SubscriptionSource,
-        RemoteAccountProvider, RemoteAccountUpdateSource,
+        chain_slot::ChainSlot,
+        program_account::{get_loaderv3_get_program_data_address, LOADER_V3},
+        pubsub_common::SubscriptionSource,
+        RemoteAccount, RemoteAccountProvider, RemoteAccountUpdateSource,
         SubscriptionReleaseMode,
     },
     testing::{
@@ -1932,9 +1936,6 @@ async fn test_delegated_discovered_after_direct_subscribe_releases_direct_withou
 
     // Send a newer plain update; delegated authoritative-skip path should
     // silently release direct subscription ownership.
-    use crate::remote_account_provider::{
-        RemoteAccount, RemoteAccountUpdateSource,
-    };
     let chain_update = Account {
         lamports: 900_000,
         data: vec![9, 9, 9, 9],
@@ -2404,7 +2405,6 @@ async fn test_delegated_subscription_update_keeps_externally_acquired_undelegati
 
     // Drive a delegated update through the subscription listener so the
     // delegated direct-subscription cleanup path is exercised end-to-end.
-    use crate::remote_account_provider::RemoteAccount;
     rpc_client.set_slot(CURRENT_SLOT + 1);
     let chain_update = Account {
         lamports: 900_000,
@@ -3397,8 +3397,6 @@ async fn test_overlapping_concurrent_ensures_share_inflight_keys_at_rpc_level()
 
 #[tokio::test]
 async fn test_mock_multi_account_fetch_increments_only_multi_counter() {
-    use solana_rpc_client_api::config::RpcAccountInfoConfig;
-
     init_logger();
     let account_owner = random_pubkey();
     const CURRENT_SLOT: u64 = 100;
@@ -3757,10 +3755,6 @@ async fn test_auto_airdrop_uses_chain_slot_when_account_not_in_bank() {
 
 #[tokio::test]
 async fn test_program_loader_resolver_error_releases_program_data_refs() {
-    use crate::remote_account_provider::program_account::{
-        get_loaderv3_get_program_data_address, LOADER_V3,
-    };
-
     init_logger();
     let validator_keypair = Keypair::new();
     let program_pubkey = random_pubkey();
@@ -4340,10 +4334,6 @@ async fn send_subscription_update_and_get_subscribed_programs(
     slot: u64,
     expected_program_id: Option<Pubkey>,
 ) -> std::collections::HashSet<Pubkey> {
-    use crate::remote_account_provider::{
-        RemoteAccount, RemoteAccountUpdateSource,
-    };
-
     accounts_bank.insert(account_pubkey, AccountSharedData::from(bank_account));
     acquire_direct_subscription_for_update(
         remote_account_provider,
@@ -4607,10 +4597,6 @@ async fn test_non_raw_eata_owned_account_subscription_update_stays_delegated() {
         EATA_PROGRAM_ID,
     );
 
-    use crate::remote_account_provider::{
-        RemoteAccount, RemoteAccountUpdateSource,
-    };
-
     acquire_direct_subscription_for_update(
         &remote_account_provider,
         &account_pubkey,
@@ -4679,10 +4665,6 @@ async fn test_discovered_dlp_owned_account_without_delegation_record_is_ignored(
         validator_keypair.insecure_clone(),
     )
     .await;
-
-    use crate::remote_account_provider::{
-        RemoteAccount, RemoteAccountUpdateSource,
-    };
 
     let mut dlp_owned_account_shared =
         AccountSharedData::from(dlp_owned_account.clone());
@@ -4773,10 +4755,6 @@ async fn test_discovered_dlp_owned_account_with_internal_record_prefix_is_droppe
     let fetches_before = rpc_client.single_account_fetches()
         + rpc_client.multi_account_fetches();
 
-    use crate::remote_account_provider::{
-        RemoteAccount, RemoteAccountUpdateSource,
-    };
-
     subscription_tx
         .send(ForwardedSubscriptionUpdate {
             pubkey: account_pubkey,
@@ -4853,10 +4831,6 @@ async fn test_absent_unwatched_dlp_program_update_is_dropped_without_delegation_
 
     let fetches_before = rpc_client.single_account_fetches()
         + rpc_client.multi_account_fetches();
-
-    use crate::remote_account_provider::{
-        RemoteAccount, RemoteAccountUpdateSource,
-    };
 
     subscription_tx
         .send(ForwardedSubscriptionUpdate {
@@ -4947,10 +4921,6 @@ async fn test_active_local_delegated_dlp_program_update_cleans_up_without_fetch_
     let fetches_before = rpc_client.single_account_fetches()
         + rpc_client.multi_account_fetches();
 
-    use crate::remote_account_provider::{
-        RemoteAccount, RemoteAccountUpdateSource,
-    };
-
     subscription_tx
         .send(ForwardedSubscriptionUpdate {
             pubkey: account_pubkey,
@@ -5039,10 +5009,6 @@ async fn test_undelegating_internal_looking_dlp_program_update_reaches_completio
         .await
         .unwrap();
 
-    use crate::remote_account_provider::{
-        RemoteAccount, RemoteAccountUpdateSource,
-    };
-
     subscription_tx
         .send(ForwardedSubscriptionUpdate {
             pubkey: account_pubkey,
@@ -5097,10 +5063,6 @@ async fn test_raw_eata_program_update_without_projection_interest_is_dropped_wit
 
     let fetches_before = rpc_client.single_account_fetches()
         + rpc_client.multi_account_fetches();
-
-    use crate::remote_account_provider::{
-        RemoteAccount, RemoteAccountUpdateSource,
-    };
 
     subscription_tx
         .send(ForwardedSubscriptionUpdate {
@@ -5167,10 +5129,6 @@ async fn test_raw_eata_program_update_with_projection_interest_processes_project
         validator_pubkey,
         EATA_PROGRAM_ID,
     );
-
-    use crate::remote_account_provider::{
-        RemoteAccount, RemoteAccountUpdateSource,
-    };
 
     subscription_tx
         .send(ForwardedSubscriptionUpdate {
@@ -5253,10 +5211,6 @@ async fn test_absent_unwatched_dlp_update_delegated_elsewhere_is_ignored_without
 
     let fetches_before = rpc_client.single_account_fetches()
         + rpc_client.multi_account_fetches();
-
-    use crate::remote_account_provider::{
-        RemoteAccount, RemoteAccountUpdateSource,
-    };
 
     subscription_tx
         .send(ForwardedSubscriptionUpdate {
@@ -5479,10 +5433,6 @@ async fn colliding_delegated_account_is_cloned(record_late: bool) {
         rent_epoch: 0,
     };
 
-    use crate::remote_account_provider::{
-        RemoteAccount, RemoteAccountUpdateSource,
-    };
-
     // With the record late, the account update parks awaiting its record and
     // the record update arriving later (e.g. debounced) must release it into
     // discovery.
@@ -5571,10 +5521,6 @@ async fn test_internal_dlp_pda_program_update_is_filtered_after_discovery_miss()
     )
     .await;
 
-    use crate::remote_account_provider::{
-        RemoteAccount, RemoteAccountUpdateSource,
-    };
-
     subscription_tx
         .send(ForwardedSubscriptionUpdate {
             pubkey: delegation_record_pubkey,
@@ -5648,10 +5594,6 @@ async fn test_same_slot_delegated_subscription_update_overrides_plain_bank_accou
     let mut plain_in_bank = AccountSharedData::from(plain_account);
     plain_in_bank.set_remote_slot(CURRENT_SLOT);
     accounts_bank.insert(account_pubkey, plain_in_bank);
-
-    use crate::remote_account_provider::{
-        RemoteAccount, RemoteAccountUpdateSource,
-    };
 
     acquire_direct_subscription_for_update(
         &remote_account_provider,
@@ -5738,10 +5680,6 @@ async fn test_same_slot_delegated_subscription_update_overrides_undelegating_ban
     undelegating_in_bank.set_undelegating(true);
     accounts_bank.insert(account_pubkey, undelegating_in_bank);
 
-    use crate::remote_account_provider::{
-        RemoteAccount, RemoteAccountUpdateSource,
-    };
-
     acquire_direct_subscription_for_update(
         &remote_account_provider,
         &account_pubkey,
@@ -5817,10 +5755,6 @@ async fn test_discovered_dlp_owned_account_delegated_elsewhere_is_ignored() {
         other_validator,
         account_owner,
     );
-
-    use crate::remote_account_provider::{
-        RemoteAccount, RemoteAccountUpdateSource,
-    };
 
     subscription_tx
         .send(ForwardedSubscriptionUpdate {
@@ -5900,10 +5834,6 @@ async fn test_out_of_order_delegated_eata_subscription_update_still_projects_ata
         &mint,
         CURRENT_SLOT,
     );
-
-    use crate::remote_account_provider::{
-        RemoteAccount, RemoteAccountUpdateSource,
-    };
 
     acquire_direct_subscription_for_update(
         &remote_account_provider,
@@ -6001,10 +5931,6 @@ async fn test_out_of_order_delegated_eata_update_clones_action_dependencies() {
         &mint,
         CURRENT_SLOT,
     );
-
-    use crate::remote_account_provider::{
-        RemoteAccount, RemoteAccountUpdateSource,
-    };
 
     acquire_direct_subscription_for_update(
         &remote_account_provider,
@@ -6104,10 +6030,6 @@ async fn test_subscription_update_with_delegation_actions_clones_dependencies()
     let mut stale_in_bank = AccountSharedData::from(delegated_account.clone());
     stale_in_bank.set_remote_slot(CURRENT_SLOT - 1);
     accounts_bank.insert(account_pubkey, stale_in_bank);
-
-    use crate::remote_account_provider::{
-        RemoteAccount, RemoteAccountUpdateSource,
-    };
 
     acquire_direct_subscription_for_update(
         &remote_account_provider,
@@ -6210,10 +6132,6 @@ async fn test_delegated_eata_subscription_update_clones_raw_eata_and_projects_at
         &mint,
         CURRENT_SLOT,
     );
-
-    use crate::remote_account_provider::{
-        RemoteAccount, RemoteAccountUpdateSource,
-    };
 
     acquire_direct_subscription_for_update(
         &remote_account_provider,
@@ -6330,10 +6248,6 @@ async fn test_raw_eata_subscription_update_without_actions_projects_remote_ata_o
         accounts_bank.get_account(&ata_pubkey).is_none(),
         "test must start without the ATA in bank"
     );
-
-    use crate::remote_account_provider::{
-        RemoteAccount, RemoteAccountUpdateSource,
-    };
 
     acquire_direct_subscription_for_update(
         &remote_account_provider,
@@ -6477,10 +6391,6 @@ async fn test_delegated_eata_subscription_update_projects_remote_ata() {
         "test must start without the ATA in bank"
     );
 
-    use crate::remote_account_provider::{
-        RemoteAccount, RemoteAccountUpdateSource,
-    };
-
     acquire_direct_subscription_for_update(
         &remote_account_provider,
         &eata_pubkey,
@@ -6576,10 +6486,6 @@ async fn test_ata_subscription_update_projects_eata_when_chain_slot_lags() {
         tokio::time::sleep(Duration::from_millis(800)).await;
         rpc_to_advance.set_slot(ATA_SLOT);
     });
-
-    use crate::remote_account_provider::{
-        RemoteAccount, RemoteAccountUpdateSource,
-    };
 
     acquire_direct_subscription_for_update(
         &remote_account_provider,
@@ -6697,10 +6603,6 @@ async fn test_delegated_eata_subscription_update_clones_action_dependencies() {
         &mint,
         CURRENT_SLOT,
     );
-
-    use crate::remote_account_provider::{
-        RemoteAccount, RemoteAccountUpdateSource,
-    };
 
     acquire_direct_subscription_for_update(
         &remote_account_provider,
@@ -7853,10 +7755,6 @@ async fn test_delegated_eata_update_does_not_override_delegated_ata_in_bank() {
     local_ata_shared.set_delegated(true);
     accounts_bank.insert(ata_pubkey, local_ata_shared);
 
-    use crate::remote_account_provider::{
-        RemoteAccount, RemoteAccountUpdateSource,
-    };
-
     // A newer chain update for delegated eATA must not override delegated ATA in bank.
     subscription_tx
         .send(ForwardedSubscriptionUpdate {
@@ -7940,10 +7838,6 @@ async fn test_delegated_eata_update_projects_existing_plain_ata_in_bank() {
     let mut plain_ata_shared = AccountSharedData::from(plain_ata);
     plain_ata_shared.set_remote_slot(PLAIN_ATA_SLOT);
     accounts_bank.insert(ata_pubkey, plain_ata_shared);
-
-    use crate::remote_account_provider::{
-        RemoteAccount, RemoteAccountUpdateSource,
-    };
 
     subscription_tx
         .send(ForwardedSubscriptionUpdate {
@@ -8050,10 +7944,6 @@ async fn test_delegated_eata_update_projects_existing_token_2022_ata_in_bank() {
     let mut legacy_ata_shared = AccountSharedData::from(legacy_ata);
     legacy_ata_shared.set_remote_slot(PLAIN_ATA_SLOT + 1);
     accounts_bank.insert(legacy_ata_pubkey, legacy_ata_shared);
-
-    use crate::remote_account_provider::{
-        RemoteAccount, RemoteAccountUpdateSource,
-    };
 
     subscription_tx
         .send(ForwardedSubscriptionUpdate {
@@ -8165,10 +8055,6 @@ async fn test_greedy_delegated_eata_update_projects_remote_token_2022_ata() {
         validator_pubkey,
         EATA_PROGRAM_ID,
     );
-
-    use crate::remote_account_provider::{
-        RemoteAccount, RemoteAccountUpdateSource,
-    };
 
     subscription_tx
         .send(ForwardedSubscriptionUpdate {
@@ -9008,10 +8894,6 @@ async fn test_undelegating_projected_ata_subscription_update_stays_locked() {
     accounts_bank.insert(ata_pubkey, local_ata_shared);
     assert_not_subscribed!(remote_account_provider, &[&eata_pubkey]);
 
-    use crate::remote_account_provider::{
-        RemoteAccount, RemoteAccountUpdateSource,
-    };
-
     acquire_direct_subscription_for_update(
         &remote_account_provider,
         &ata_pubkey,
@@ -9111,10 +8993,6 @@ async fn test_delegated_eata_update_does_not_override_undelegating_ata_in_bank()
     local_ata_shared.set_remote_slot(LOCAL_SLOT);
     local_ata_shared.set_undelegating(true);
     accounts_bank.insert(ata_pubkey, local_ata_shared);
-
-    use crate::remote_account_provider::{
-        RemoteAccount, RemoteAccountUpdateSource,
-    };
 
     subscription_tx
         .send(ForwardedSubscriptionUpdate {
@@ -10091,10 +9969,6 @@ async fn test_project_ata_skips_repeat_fetch_for_known_empty_eata() {
     .await;
     let eata_pubkey = derive_eata(&wallet_owner, &mint);
 
-    use crate::remote_account_provider::{
-        RemoteAccount, RemoteAccountUpdateSource,
-    };
-
     acquire_direct_subscription_for_update(
         &remote_account_provider,
         &ata_pubkey,
@@ -10169,8 +10043,6 @@ async fn test_project_ata_skips_repeat_fetch_for_known_empty_eata() {
 #[tokio::test]
 async fn test_delegated_account_owned_by_token_program_does_not_subscribe_program(
 ) {
-    use magicblock_core::token_programs::TOKEN_PROGRAM_ID;
-
     init_logger();
     let validator_keypair = Keypair::new();
     let validator_pubkey = validator_keypair.pubkey();

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -4859,6 +4859,89 @@ async fn test_absent_unwatched_dlp_program_update_is_dropped_without_delegation_
 }
 
 #[tokio::test]
+async fn test_absent_unwatched_dlp_program_update_delegated_to_us_is_greedily_cloned(
+) {
+    init_logger();
+    let validator_keypair = Keypair::new();
+    let validator_pubkey = validator_keypair.pubkey();
+    let account_pubkey = random_pubkey();
+    let account_owner = random_pubkey();
+    const CURRENT_SLOT: u64 = 100;
+
+    let app_data = vec![1, 2, 3, 4];
+    let delegated_account = Account {
+        lamports: 1_000_000,
+        data: app_data.clone(),
+        owner: dlp_api::id(),
+        executable: false,
+        rent_epoch: 0,
+    };
+
+    let FetcherTestCtx {
+        accounts_bank,
+        rpc_client,
+        subscription_tx,
+        fetch_cloner: _,
+        cloner,
+        ..
+    } = setup(
+        [(account_pubkey, delegated_account.clone())],
+        CURRENT_SLOT,
+        validator_keypair.insecure_clone(),
+    )
+    .await;
+
+    add_delegation_record_for(
+        &rpc_client,
+        account_pubkey,
+        validator_pubkey,
+        account_owner,
+    );
+
+    let fetches_before = rpc_client.single_account_fetches()
+        + rpc_client.multi_account_fetches();
+
+    subscription_tx
+        .send(ForwardedSubscriptionUpdate {
+            pubkey: account_pubkey,
+            account: RemoteAccount::from_fresh_account(
+                delegated_account,
+                CURRENT_SLOT,
+                RemoteAccountUpdateSource::Subscription,
+            ),
+            source: SubscriptionSource::Program,
+        })
+        .await
+        .unwrap();
+
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while accounts_bank.get_account(&account_pubkey).is_none() {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("timed out waiting for greedy DLP discovery clone");
+
+    assert!(
+        rpc_client.single_account_fetches()
+            + rpc_client.multi_account_fetches()
+            > fetches_before,
+        "greedy discovery must fetch the delegation record before cloning"
+    );
+    assert!(
+        cloner.clone_request_count() >= 1,
+        "delegated account should be cloned from program update"
+    );
+    let cloned_account = accounts_bank
+        .get_account(&account_pubkey)
+        .expect("delegated account should be cloned from program update");
+    assert!(cloned_account.delegated());
+    assert_eq!(cloned_account.owner(), &account_owner);
+    assert_eq!(cloned_account.data(), app_data.as_slice());
+    assert_eq!(cloned_account.remote_slot(), CURRENT_SLOT);
+}
+
+#[tokio::test]
 async fn test_active_local_delegated_dlp_program_update_cleans_up_without_fetch_or_overwrite(
 ) {
     init_logger();

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -4536,8 +4536,11 @@ async fn test_discovered_dlp_owned_account_without_delegation_record_is_ignored(
     assert!(accounts_bank.get_account(&account_pubkey).is_none());
 }
 
+// Accounts whose app data collides with an internal DLP discriminator are
+// dropped before discovery (no remote fetch); they are cloned lazily on
+// first use instead of greedily from the program update.
 #[tokio::test]
-async fn test_discovered_dlp_owned_account_with_internal_record_prefix_is_cloned(
+async fn test_discovered_dlp_owned_account_with_internal_record_prefix_is_dropped_without_fetch(
 ) {
     init_logger();
     let validator_keypair = Keypair::new();
@@ -4566,6 +4569,8 @@ async fn test_discovered_dlp_owned_account_with_internal_record_prefix_is_cloned
         accounts_bank,
         rpc_client,
         subscription_tx,
+        fetch_cloner,
+        cloner,
         ..
     } = setup(
         [(account_pubkey, delegated_account.clone())],
@@ -4580,6 +4585,9 @@ async fn test_discovered_dlp_owned_account_with_internal_record_prefix_is_cloned
         validator_pubkey,
         account_owner,
     );
+
+    let fetches_before = rpc_client.single_account_fetches()
+        + rpc_client.multi_account_fetches();
 
     use crate::remote_account_provider::{
         RemoteAccount, RemoteAccountUpdateSource,
@@ -4597,27 +4605,23 @@ async fn test_discovered_dlp_owned_account_with_internal_record_prefix_is_cloned
         })
         .await
         .unwrap();
+    drop(subscription_tx);
 
-    const POLL_INTERVAL: std::time::Duration = Duration::from_millis(10);
-    const TIMEOUT: std::time::Duration = Duration::from_millis(500);
-    tokio::time::timeout(TIMEOUT, async {
-        while !accounts_bank.get_account(&account_pubkey).is_some_and(
-            |account| {
-                account.delegated()
-                    && account.owner() == &account_owner
-                    && account.remote_slot() == CURRENT_SLOT
-            },
-        ) {
-            tokio::time::sleep(POLL_INTERVAL).await;
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while Arc::strong_count(&fetch_cloner) > 1 {
+            tokio::time::sleep(Duration::from_millis(10)).await;
         }
     })
     .await
-    .expect("timed out waiting for masquerading delegated account clone");
+    .expect("timed out waiting for internal DLP update to be dropped");
 
-    let cloned_account = accounts_bank
-        .get_account(&account_pubkey)
-        .expect("account should be greedily cloned from program update");
-    assert_eq!(cloned_account.data(), app_data.as_slice());
+    assert!(accounts_bank.get_account(&account_pubkey).is_none());
+    assert_eq!(cloner.clone_request_count(), 0);
+    assert_eq!(
+        rpc_client.single_account_fetches()
+            + rpc_client.multi_account_fetches(),
+        fetches_before
+    );
 }
 
 #[tokio::test]

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -4626,10 +4626,18 @@ async fn test_discovered_dlp_owned_account_with_internal_record_prefix_is_droppe
 
 // A freshly delegated account whose app data collides with an internal DLP
 // discriminator is still greedily cloned: the delegation-record update from
-// the same delegation routes it to discovery.
+// the same delegation routes it to discovery, in either delivery order.
 #[tokio::test]
-async fn test_discovered_colliding_delegated_account_with_record_sighting_is_cloned(
-) {
+async fn test_discovered_colliding_delegated_account_record_first_is_cloned() {
+    colliding_delegated_account_is_cloned(false).await;
+}
+
+#[tokio::test]
+async fn test_discovered_colliding_delegated_account_record_late_is_cloned() {
+    colliding_delegated_account_is_cloned(true).await;
+}
+
+async fn colliding_delegated_account_is_cloned(record_late: bool) {
     init_logger();
     let validator_keypair = Keypair::new();
     let validator_pubkey = validator_keypair.pubkey();
@@ -4690,10 +4698,17 @@ async fn test_discovered_colliding_delegated_account_with_record_sighting_is_clo
         RemoteAccount, RemoteAccountUpdateSource,
     };
 
-    for (pubkey, account) in [
+    // With the record late, the account update parks awaiting its record and
+    // the record update arriving later (e.g. debounced) must release it into
+    // discovery.
+    let mut updates = vec![
         (delegation_record_pubkey, delegation_record_account),
         (account_pubkey, delegated_account),
-    ] {
+    ];
+    if record_late {
+        updates.reverse();
+    }
+    for (pubkey, account) in updates {
         subscription_tx
             .send(ForwardedSubscriptionUpdate {
                 pubkey,
@@ -4706,6 +4721,7 @@ async fn test_discovered_colliding_delegated_account_with_record_sighting_is_clo
             })
             .await
             .unwrap();
+        tokio::time::sleep(Duration::from_millis(50)).await;
     }
 
     tokio::time::timeout(Duration::from_secs(2), async {

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -4085,14 +4085,6 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
 }
 
 impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
-    /// Check if an account is currently pending (being fetched).
-    pub(crate) fn is_pending(&self, pubkey: &Pubkey) -> bool {
-        let fetching = self
-            .fetching_accounts
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
-        fetching.contains_key(pubkey)
-    }
     pub(crate) async fn has_subscription_reason(
         &self,
         pubkey: &Pubkey,
@@ -4103,6 +4095,18 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
             .await
             .get(pubkey)
             .is_some_and(|ownership| ownership.contains(reason))
+    }
+}
+
+#[cfg(test)]
+impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
+    /// Check if an account is currently pending (being fetched).
+    pub(crate) fn is_pending(&self, pubkey: &Pubkey) -> bool {
+        let fetching = self
+            .fetching_accounts
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        fetching.contains_key(pubkey)
     }
 }
 

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -508,6 +508,7 @@ type CapacityEvictionProtectionPredicate =
 type SharedCapacityEvictionProtectionPredicate =
     Arc<RwLock<Option<Arc<CapacityEvictionProtectionPredicate>>>>;
 
+#[derive(Clone)]
 pub struct ForwardedSubscriptionUpdate {
     pub pubkey: Pubkey,
     pub account: RemoteAccount,

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -2902,14 +2902,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
     }
 }
 
-#[cfg(test)]
 impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
-    /// Check if an account is currently pending (being fetched).
-    pub(crate) fn is_pending(&self, pubkey: &Pubkey) -> bool {
-        let fetching = self.fetching_accounts.lock().unwrap();
-        fetching.contains_key(pubkey)
-    }
-
     pub(crate) async fn has_subscription_reason(
         &self,
         pubkey: &Pubkey,
@@ -2920,6 +2913,15 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
             .await
             .get(pubkey)
             .is_some_and(|ownership| ownership.contains(reason))
+    }
+}
+
+#[cfg(test)]
+impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
+    /// Check if an account is currently pending (being fetched).
+    pub(crate) fn is_pending(&self, pubkey: &Pubkey) -> bool {
+        let fetching = self.fetching_accounts.lock().unwrap();
+        fetching.contains_key(pubkey)
     }
 }
 

--- a/magicblock-chainlink/src/remote_account_provider/pubsub_common.rs
+++ b/magicblock-chainlink/src/remote_account_provider/pubsub_common.rs
@@ -84,15 +84,16 @@ impl SubscriptionUpdate {
     }
 }
 
-pub(crate) fn is_internal_dlp_account_data(data: &[u8]) -> bool {
-    let is_delegation_record = data.len()
-        >= DelegationRecord::size_with_discriminator()
+pub(crate) fn is_delegation_record_data(data: &[u8]) -> bool {
+    data.len() >= DelegationRecord::size_with_discriminator()
         && DelegationRecord::try_from_bytes_with_discriminator(
             &data[..DelegationRecord::size_with_discriminator()],
         )
-        .is_ok();
+        .is_ok()
+}
 
-    is_delegation_record
+pub(crate) fn is_internal_dlp_account_data(data: &[u8]) -> bool {
+    is_delegation_record_data(data)
         || DelegationMetadata::try_from_bytes_with_discriminator(data).is_ok()
         || CommitRecord::try_from_bytes_with_discriminator(data).is_ok()
         || ProgramConfig::try_from_bytes_with_discriminator(data).is_ok()

--- a/test-integration/test-cloning/tests/10_post_delegation_token_transfer.rs
+++ b/test-integration/test-cloning/tests/10_post_delegation_token_transfer.rs
@@ -33,7 +33,6 @@ use spl_associated_token_account_interface::instruction::create_associated_token
 use spl_token::{instruction as spl_token_ix, state::Mint};
 use test_kit::init_logger;
 
-const SOURCE_AUTHORITY_SEED: [u8; 32] = [7; 32];
 const SOURCE_EATA_BALANCE: u64 = 200;
 const DESTINATION_EATA_BALANCE: u64 = 100;
 const TRANSFER_AMOUNT: u64 = 100;
@@ -176,9 +175,9 @@ fn test_post_delegation_action_executes_spl_token_transfer_100() {
 
     let fee_payer = Keypair::new();
     let delegated_account = Keypair::new();
-    let source_authority = Keypair::new_from_array(SOURCE_AUTHORITY_SEED);
-    let destination_authority = Keypair::new_from_array([8; 32]);
-    let mint = Keypair::new_from_array([9; 32]);
+    let source_authority = Keypair::new();
+    let destination_authority = Keypair::new();
+    let mint = Keypair::new();
     let source_ata = derive_ata(&source_authority.pubkey(), &mint.pubkey());
     let destination_ata =
         derive_ata(&destination_authority.pubkey(), &mint.pubkey());


### PR DESCRIPTION
## Summary

Adds a local-interest gate for DLP-owned `programSubscribe` updates so the validator avoids delegation-record companion fetches for DLP firehose entries that cannot affect local state.

- Drops absent/unwatched DLP-owned program updates before delegation-record resolution.
- Treats existing local delegated, non-undelegating accounts as authoritative and avoids overwriting them from DLP program updates.
- Keeps undelegating and ATA/eATA projection paths locally observable and correctness-sensitive.
- Preserves explicit RPC/transaction ensure behavior so requested delegated accounts still resolve delegation records and clone normally.

PARTIALLY ADDRESSES: #1366

## Details

### magicblock-chainlink

The subscription-update path now classifies DLP-owned program updates by local interest before performing delegation-record companion fetches. The classifier uses bank state, direct subscription state, and ATA/eATA projection interest to distinguish irrelevant firehose traffic from updates that still need local processing.

For locally delegated accounts, DLP program updates now clean up direct subscription ownership without fetching a record or overwriting local delegated state. Locally undelegating accounts bypass the internal-DLP early-drop path so undelegation completion and redelegation handling remain observable.

Raw eATA program updates were also narrowed: they only fetch eATA delegation records or companion base ATA state when there is local projection interest, such as an existing base ATA or active projection subscription. Explicit ensure paths are intentionally not narrowed by this firehose prefilter.

### Tests and docs

Added focused regression coverage for DLP program-update branches, including absent/unwatched updates, delegated-local-authoritative updates, undelegating internal-looking updates, raw eATA projection interest, delegated-elsewhere firehose updates, explicit ensure cloning, and post-delegation actions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Tightened handling of subscription-driven program and DLP-owned updates, improving “drop without fetch” behavior and reducing unnecessary delegation lookups.
  - Preserved local delegated/undelegating authority to prevent unintended overwrites, while keeping undelegation completion/redelegation observable.
  - Strengthened ATA/eATA projection gating by deriving supported base ATAs from raw eATA and source-aware subscription processing.

- **Tests**
  - Expanded DLP/EATA classification and collision scenarios, including collision candidate release/locking and ensuring no clone requests while undelegation is pending.
  - Improved post-delegation transfer test setup with runtime-generated keypairs.

- **Documentation**
  - Updated chainlink projection/subscription rules to reflect the revised gating and filtering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->