### PR TITLE
Fix/committor transient retries refactor

### DIFF
--- a/magicblock-committor-service/src/intent_execution_manager/intent_execution_engine.rs
+++ b/magicblock-committor-service/src/intent_execution_manager/intent_execution_engine.rs
@@ -371,18 +371,10 @@ where
                 }
             });
 
-            // Retry only plausibly transient failures, and never once action
-            // callbacks fired: a retry would double-report the intent outcome
-            let send_stage_failure = matches!(
-                &result.inner,
-                Err(IntentExecutorError::FailedToCommitError { .. })
-                    | Err(IntentExecutorError::FailedToFinalizeError { .. })
-            );
-            let retriable = attempt < MAX_INTENT_ATTEMPTS
-                && result.callbacks_report.is_empty()
-                && matches!(&result.inner, Err(err) if err.is_transient())
-                && (has_dedup_guard || !send_stage_failure);
-            if !retriable {
+            // break early if we can't retry anymore
+            if attempt >= MAX_INTENT_ATTEMPTS
+                || !result.is_retriable(has_dedup_guard)
+            {
                 break result;
             }
 

--- a/magicblock-committor-service/src/intent_execution_manager/intent_execution_engine.rs
+++ b/magicblock-committor-service/src/intent_execution_manager/intent_execution_engine.rs
@@ -40,14 +40,14 @@ use crate::{
 const SEMAPHORE_CLOSED_MSG: &str = "Executors semaphore closed!";
 /// Max number of executors that can send messages in parallel to Base layer
 const MAX_EXECUTORS: u8 = 50;
+/// Max intents concurrently sleeping in retry backoff. Retries release their
+/// executor slot while sleeping; this cap keeps the total task population
+/// bounded when many intents fail together
+const MAX_SLEEPING_RETRIERS: usize = 5_000;
 /// Max executions of an intent whose failures were transient
 const MAX_INTENT_ATTEMPTS: u32 = 3;
 /// Backoff between intent attempts, scaled linearly by attempt number
 const INTENT_RETRY_BACKOFF: Duration = Duration::from_secs(1);
-/// Max intents concurrently sleeping in retry backoff. Retries release their
-/// executor slot while sleeping; this cap keeps the total task population
-/// bounded when many intents fail together
-const MAX_SLEEPING_RETRIES: u8 = 50;
 
 /// Concurrency limits shared between the engine and its executor tasks
 struct ExecutionLimits {
@@ -138,9 +138,7 @@ where
             executors_semaphore: Arc::new(Semaphore::new(
                 MAX_EXECUTORS as usize,
             )),
-            retries_semaphore: Arc::new(Semaphore::new(
-                MAX_SLEEPING_RETRIES as usize,
-            )),
+            retries_semaphore: Arc::new(Semaphore::new(MAX_SLEEPING_RETRIERS)),
             inner: Arc::new(Mutex::new(IntentScheduler::new())),
         }
     }

--- a/magicblock-committor-service/src/intent_execution_manager/intent_execution_engine.rs
+++ b/magicblock-committor-service/src/intent_execution_manager/intent_execution_engine.rs
@@ -308,15 +308,59 @@ where
         result_sender: broadcast::Sender<BroadcastedIntentExecutionResult>,
     ) {
         let instant = Instant::now();
-        let mut execution_permit = Some(execution_permit);
 
+        let (result, execution_permit) = Self::execute_with_retries(
+            executor_factory,
+            persister,
+            &intent,
+            limits,
+            execution_permit,
+        )
+        .await;
+
+        // Report
+        let _ = result.inner.as_ref().inspect_err(|err| {
+            error!(intent_id = intent.id, error = ?err, "Failed to execute intent bundle");
+        });
+        Self::execution_metrics(instant.elapsed(), &intent, &result.inner);
+        let broadcasted_result =
+            BroadcastedIntentExecutionResult::new(intent.id, result);
+        if let Err(err) = result_sender.send(broadcasted_result) {
+            warn!(error = ?err, "No result listeners");
+        }
+
+        // Unlock: remove executed task from Scheduler to unblock other intents
+        // SAFETY: Self::execute is called ONLY after IntentScheduler
+        // successfully is able to schedule execution of some Intent
+        // that means that the same Intent is SAFE to complete
+        inner_scheduler
+            .lock()
+            .expect(POISONED_INNER_MSG)
+            .complete(&intent)
+            .expect("Valid completion of previously scheduled message");
+
+        // Free worker
+        drop(execution_permit);
+    }
+
+    /// Executes an intent, retrying plausibly-transient failures with a
+    /// fresh executor. Returns the final result together with whichever
+    /// execution permit is still held (`None` only if the executors
+    /// semaphore closed mid-retry).
+    async fn execute_with_retries(
+        executor_factory: Arc<F>,
+        persister: Option<P>,
+        intent: &ScheduledIntentBundle,
+        limits: ExecutionLimits,
+        execution_permit: OwnedSemaphorePermit,
+    ) -> (IntentExecutionResult, Option<OwnedSemaphorePermit>) {
         // Commit tasks give on-chain dedup (commit nonce) to re-executed
         // sends; action-only intents can double-execute if their transaction
         // landed unobserved, so they only retry pre-send failures
         let has_dedup_guard = !intent.get_all_committed_pubkeys().is_empty();
 
-        // Execute an Intent
         let mut attempt = 0;
+        let mut execution_permit = Some(execution_permit);
         let result = loop {
             attempt += 1;
             let mut executor = executor_factory.create_instance();
@@ -382,32 +426,8 @@ where
                 };
             drop(retry_permit);
         };
-        let _ = result.inner.as_ref().inspect_err(|err| {
-            error!(intent_id = intent.id, error = ?err, "Failed to execute intent bundle");
-        });
 
-        // Record metrics after execution
-        Self::execution_metrics(instant.elapsed(), &intent, &result.inner);
-
-        // Broadcast result to subscribers
-        let broadcasted_result =
-            BroadcastedIntentExecutionResult::new(intent.id, result);
-        if let Err(err) = result_sender.send(broadcasted_result) {
-            warn!(error = ?err, "No result listeners");
-        }
-
-        // Remove executed task from Scheduler to unblock other intents
-        // SAFETY: Self::execute is called ONLY after IntentScheduler
-        // successfully is able to schedule execution of some Intent
-        // that means that the same Intent is SAFE to complete
-        inner_scheduler
-            .lock()
-            .expect(POISONED_INNER_MSG)
-            .complete(&intent)
-            .expect("Valid completion of previously scheduled message");
-
-        // Free worker
-        drop(execution_permit);
+        (result, execution_permit)
     }
 
     /// Records metrics related to intent execution

--- a/magicblock-committor-service/src/intent_executor/mod.rs
+++ b/magicblock-committor-service/src/intent_executor/mod.rs
@@ -94,6 +94,27 @@ pub struct IntentExecutionResult {
     pub callbacks_report: Vec<Result<Signature, CallbackScheduleError>>,
 }
 
+impl IntentExecutionResult {
+    /// Whether a failed execution is safe to retry with a fresh executor.
+    ///
+    /// Never retries once action callbacks have reported (a retry would
+    /// double-report the outcome), and only retries plausibly transient
+    /// errors. Commit tasks give on-chain dedup (commit nonce) to re-executed
+    /// sends; action-only intents (`has_dedup_guard == false`) have no such
+    /// guard and can double-execute if their transaction landed unobserved,
+    /// so they only retry pre-send failures.
+    pub fn is_retriable(&self, has_dedup_guard: bool) -> bool {
+        let send_stage_failure = matches!(
+            &self.inner,
+            Err(IntentExecutorError::FailedToCommitError { .. })
+                | Err(IntentExecutorError::FailedToFinalizeError { .. })
+        );
+        self.callbacks_report.is_empty()
+            && matches!(&self.inner, Err(err) if err.is_transient())
+            && (has_dedup_guard || !send_stage_failure)
+    }
+}
+
 #[async_trait]
 pub trait IntentExecutor: Send + Sync + 'static {
     /// Executes Message on Base layer

--- a/magicblock-committor-service/src/intent_executor/single_stage_executor.rs
+++ b/magicblock-committor-service/src/intent_executor/single_stage_executor.rs
@@ -84,8 +84,6 @@ where
             self.current_attempt += 1;
 
             // Prepare & execute message
-            // Preparation failures here happen before anything landed, so
-            // they are commit-stage errors (safe to re-execute the intent)
             let execution_result = prepare_and_execute_strategy(
                 &self.intent_client,
                 &self.authority,
@@ -94,7 +92,7 @@ where
                 persister,
             )
             .await
-            .map_err(IntentExecutorError::FailedCommitPreparationError)?;
+            .map_err(IntentExecutorError::FailedFinalizePreparationError)?;
 
             // Process error: Ok - return, Err - handle further
             let execution_err = match execution_result {
@@ -295,7 +293,7 @@ where
             &None::<IntentPersisterImpl>,
         )
         .await
-        .map_err(IntentExecutorError::FailedCommitPreparationError)?
+        .map_err(IntentExecutorError::FailedFinalizePreparationError)?
         .map_err(|err| IntentExecutorError::FailedToFinalizeError {
             err,
             commit_signature: None,

--- a/magicblock-committor-service/src/intent_executor/task_info_fetcher.rs
+++ b/magicblock-committor-service/src/intent_executor/task_info_fetcher.rs
@@ -658,11 +658,11 @@ impl TaskInfoFetcherError {
     /// RPC-side fetch failures are transient; malformed or absent
     /// delegation accounts are deterministic.
     pub fn is_transient(&self) -> bool {
-        matches!(
-            self,
-            Self::MinContextSlotNotReachedError(_, _)
-                | Self::MagicBlockRpcClientError(_)
-        )
+        match self {
+            Self::MinContextSlotNotReachedError(_, _) => true,
+            Self::MagicBlockRpcClientError(err) => err.is_transient(),
+            _ => false,
+        }
     }
 
     pub fn map_client_error(

--- a/magicblock-committor-service/src/intent_executor/two_stage_executor.rs
+++ b/magicblock-committor-service/src/intent_executor/two_stage_executor.rs
@@ -116,7 +116,7 @@ where
             self.state.current_attempt += 1;
 
             // Prepare & execute message
-            let execution_result = match prepare_and_execute_strategy(
+            let execution_result = prepare_and_execute_strategy(
                 &self.intent_client,
                 &self.authority,
                 transaction_preparator,
@@ -124,23 +124,19 @@ where
                 persister,
             )
             .await
-            {
-                Ok(value) => value,
-                Err(err) => {
-                    // Preparation may have reserved ALTs or initialized
-                    // buffers already - surrender strategies for cleanup
-                    self.dispose_strategies();
-                    return Err(
-                        IntentExecutorError::FailedCommitPreparationError(err),
-                    );
-                }
-            };
+            .map_err(IntentExecutorError::FailedCommitPreparationError)
+            .inspect_err(|_| {
+                // Preparation may have reserved ALTs or initialized
+                // buffers already - surrender strategies for cleanup
+                self.dispose_strategies();
+            })?;
+
             let execution_err = match execution_result {
                 Ok(value) => break Ok(value),
                 Err(err) => err,
             };
 
-            let flow = match self
+            let flow = self
                 .patch_commit_strategy(
                     &execution_err,
                     task_info_fetcher,
@@ -148,13 +144,9 @@ where
                     committed_pubkeys,
                 )
                 .await
-            {
-                Ok(value) => value,
-                Err(err) => {
+                .inspect_err(|_| {
                     self.dispose_strategies();
-                    return Err(err);
-                }
-            };
+                })?;
             let cleanup = match flow {
                 ControlFlow::Continue(value) => value,
                 ControlFlow::Break(()) => {
@@ -426,7 +418,7 @@ where
             self.state.current_attempt += 1;
 
             // Prepare & execute message
-            let execution_result = match prepare_and_execute_strategy(
+            let execution_result = prepare_and_execute_strategy(
                 &self.intent_client,
                 &self.authority,
                 transaction_preparator,
@@ -434,33 +426,23 @@ where
                 persister,
             )
             .await
-            {
-                Ok(value) => value,
-                Err(err) => {
-                    // Preparation may have reserved ALTs or initialized
-                    // buffers already - surrender strategy for cleanup
-                    self.dispose_strategy();
-                    return Err(
-                        IntentExecutorError::FailedFinalizePreparationError(
-                            err,
-                        ),
-                    );
-                }
-            };
+            .map_err(IntentExecutorError::FailedFinalizePreparationError)
+            .inspect_err(|_| {
+                // Preparation may have reserved ALTs or initialized
+                // buffers already - surrender strategy for cleanup
+                self.dispose_strategy();
+            })?;
             let execution_err = match execution_result {
                 Ok(value) => break Ok(value),
                 Err(err) => err,
             };
 
-            let flow = match self.patch_finalize_strategy(&execution_err).await
-            {
-                Ok(value) => value,
-                Err(err) => {
+            let flow = self
+                .patch_finalize_strategy(&execution_err)
+                .await
+                .inspect_err(|_| {
                     self.dispose_strategy();
-                    return Err(err);
-                }
-            };
-
+                })?;
             let cleanup = match flow {
                 ControlFlow::Continue(cleanup) => cleanup,
                 ControlFlow::Break(()) => {


### PR DESCRIPTION
<!--
PR title must match: type(scope): summary
Types: feat|fix|docs|chore|refactor|test|perf|ci|build
Examples:
  fix: avoid panic on empty slot
  feat(rpc): add getFoo endpoint
-->

## Summary
<!-- One sentence. Link to issue if applicable. -->
Resolving comments on main PR

## Breaking Changes
- [ ] None
- [ ] Yes — migration path described below


## Test Plan
<!-- How you verified this works. e.g., "unit tests", "ran locally against testnet", "existing tests pass" -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retry handling for transient intent execution failures.
  * Increased capacity for concurrent sleeping retries.
  * Corrected commit and finalize failure classification.
  * Ensured execution strategies are properly cleaned up after preparation or patch failures.
  * Preserved safer retry behavior when callback outcomes have already been reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->