### PR TITLE
fix: Relax redsuite workflow requirements

### DIFF
--- a/.github/workflows/ci-redsuite.yml
+++ b/.github/workflows/ci-redsuite.yml
@@ -29,8 +29,6 @@ on:
       - '.github/workflows/ci-redsuite.yml'
       - '.github/actions/setup-build-env/**'
       - '.github/actions/setup-solana/**'
-  pull_request_review:
-    types: [submitted]
 
 permissions:
   contents: read
@@ -43,61 +41,7 @@ env:
   BENCHER_PROJECT: magicblock-validator-redsuite
 
 jobs:
-  review_gate:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    name: Review Gate
-    timeout-minutes: 5
-    permissions:
-      contents: read
-      pull-requests: read
-    outputs:
-      run: ${{ steps.decide.outputs.run }}
-    steps:
-      - name: Check review state
-        id: decide
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          PR: ${{ github.event.pull_request.number }}
-        run: |
-          set -euo pipefail
-          allow() { echo "run=$1" >> "$GITHUB_OUTPUT"; echo "$2" | tee -a "$GITHUB_STEP_SUMMARY"; }
-          if [ "$GITHUB_EVENT_NAME" = "push" ]; then
-            allow true "push run — no review gate"
-            exit 0
-          fi
-
-          if [ "$GITHUB_EVENT_NAME" != "pull_request" ]; then
-            # review-triggered: GitHub applied no paths filter here
-            if ! gh api "repos/$REPO/pulls/$PR/files" --paginate --jq '.[].filename' \
-              | grep -qE '\.(rs|proto)$|(^|/)Cargo\.(toml|lock)$|^rust-toolchain\.toml$|^\.github/workflows/ci-redsuite\.yml$|^\.github/actions/(setup-build-env|setup-solana)/'; then
-              allow false "PR touches no redsuite-relevant paths"
-              exit 0
-            fi
-          fi
-
-          reviews=$(gh api "repos/$REPO/pulls/$PR/reviews" --paginate \
-            --jq '[.[] | select(.user.login | startswith("coderabbit"))] | length')
-          if [ "$reviews" -eq 0 ]; then
-            allow false "CodeRabbit has not reviewed yet — the suite starts once it has"
-            exit 0
-          fi
-
-          unresolved=$(gh api graphql --paginate \
-            -f query='query($owner:String!,$name:String!,$pr:Int!,$endCursor:String){repository(owner:$owner,name:$name){pullRequest(number:$pr){reviewThreads(first:100,after:$endCursor){pageInfo{hasNextPage endCursor} nodes{isResolved}}}}}' \
-            -f owner="${REPO%%/*}" -f name="${REPO##*/}" -F pr="$PR" \
-            --jq '.data.repository.pullRequest.reviewThreads.nodes[].isResolved' \
-            | grep -c false || true)
-          if [ "$unresolved" -gt 0 ]; then
-            allow false "$unresolved unresolved review thread(s) — resolve them, then re-run this workflow or push an update"
-            exit 0
-          fi
-          allow true "CodeRabbit reviewed and all review threads resolved"
-        shell: bash
-
   build_er:
-    needs: review_gate
-    if: needs.review_gate.outputs.run == 'true'
     runs-on: blacksmith-32vcpu-ubuntu-2404
     name: Build ER Release Artifact
     timeout-minutes: 90

--- a/.github/workflows/ci-redsuite.yml
+++ b/.github/workflows/ci-redsuite.yml
@@ -38,7 +38,6 @@ env:
   REDSUITE_REV: 91abdd5e44db88d922cba8a5d22ed2cfa0e63951
   SOLANA_VERSION: v4.0.3
   RUST_TOOLCHAIN: "1.94.1"
-  BENCHER_PROJECT: magicblock-validator-redsuite
 
 jobs:
   build_er:
@@ -232,49 +231,3 @@ jobs:
         shell: bash
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
-
-      - name: Export Bencher Metric Format
-        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-        run: ./redsuite-dist/redsuite report bmf --out redsuite-bmf.json
-        shell: bash
-
-      - uses: bencherdev/bencher@v0.6.8
-        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-
-      - name: Track results with Bencher
-        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-        run: |
-          set -euo pipefail
-          if [ -z "${BENCHER_API_TOKEN:-}" ]; then
-            echo "BENCHER_API_TOKEN not set — skipping Bencher tracking"
-            exit 0
-          fi
-          if [ "$GITHUB_EVENT_NAME" = "push" ]; then
-            bencher run \
-              --project "$BENCHER_PROJECT" \
-              --token "$BENCHER_API_TOKEN" \
-              --branch "$GITHUB_REF_NAME" \
-              --testbed blacksmith-8vcpu-ubuntu-2404 \
-              --adapter json \
-              --file redsuite-bmf.json
-          else
-            bencher run \
-              --project "$BENCHER_PROJECT" \
-              --token "$BENCHER_API_TOKEN" \
-              --branch "$HEAD_REF" \
-              --start-point "$BASE_REF" \
-              --start-point-hash "$BASE_SHA" \
-              --start-point-clone-thresholds \
-              --start-point-reset \
-              --testbed blacksmith-8vcpu-ubuntu-2404 \
-              --adapter json \
-              --github-actions "$GH_TOKEN" \
-              --file redsuite-bmf.json
-          fi
-        shell: bash
-        env:
-          BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
-          HEAD_REF: ${{ github.event.pull_request.head.ref }}
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Redsuite was only run when all CodeRabbit comments got resolved and it looked as if it was never run or cancelled many times (deliberate behaviour). This was confusing so now Redsuite is run with every PR update regardless of unresolved comments. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified continuous integration workflow triggers.
  * Removed the review-based approval gate from the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->