### PR TITLE
fix: don't cap laserstream reconnects at 4 attempts

### DIFF
--- a/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/actor.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/actor.rs
@@ -152,7 +152,10 @@ impl ChainLaserActor<super::StreamHandleImpl, super::StreamFactoryImpl> {
         let laser_client_config = LaserstreamConfig {
             api_key: api_key.to_string(),
             endpoint: pubsub_url.to_string(),
-            max_reconnect_attempts: Some(4),
+            // None defers to the SDK hard cap (240 attempts / 20 min, counter
+            // resets on every successful connect). A low cap turns a transient
+            // provider flap into permanent stream death until restart.
+            max_reconnect_attempts: None,
             channel_options,
             replay: true,
         };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when connecting to the Laser service by allowing reconnection attempts to continue according to the underlying service’s limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->