### PR TITLE
fix: keep rate-limited ledger I/O out of the post-RPC shutdown window

### DIFF
--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -1227,12 +1227,6 @@ impl MagicValidator {
         log_timing("shutdown", "accountsdb_flush", step_start);
 
         let step_start = Instant::now();
-        if let Err(err) = self.ledger.flush() {
-            error!(error = ?err, "Failed to flush ledger");
-        }
-        log_timing("shutdown", "ledger_flush", step_start);
-
-        let step_start = Instant::now();
         if let Err(err) = self.ledger.shutdown(true) {
             error!(error = ?err, "Failed to shutdown ledger");
         }
@@ -1268,6 +1262,11 @@ impl MagicValidator {
         self.ledger.cancel_manual_compactions();
         if let Err(err) = self.ledger.flush() {
             error!(error = ?err, "Failed to flush during shutdown preparation");
+        }
+        // Stop background jobs while the RPC is still serving; writes landing
+        // after this point are WAL-backed and recovered on the next open.
+        if let Err(err) = self.ledger.shutdown(true) {
+            error!(error = ?err, "Failed to stop ledger background work");
         }
         log_timing("shutdown", "prepare_ledger_for_shutdown", step_start);
     }

--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -1263,10 +1263,10 @@ impl MagicValidator {
         if let Err(err) = self.ledger.flush() {
             error!(error = ?err, "Failed to flush during shutdown preparation");
         }
-        // Stop background jobs while the RPC is still serving; writes landing
-        // after this point are WAL-backed and recovered on the next open.
-        if let Err(err) = self.ledger.shutdown(true) {
-            error!(error = ?err, "Failed to stop ledger background work");
+        // Second pass drains auto-flushes started while the first one ran, so
+        // the rate-limited waiting happens here, while the RPC still serves.
+        if let Err(err) = self.ledger.flush() {
+            error!(error = ?err, "Failed to flush during shutdown preparation");
         }
         log_timing("shutdown", "prepare_ledger_for_shutdown", step_start);
     }


### PR DESCRIPTION
## Problem

During shutdown, the final ledger flush and `cancel_all_background_work` run **after** the RPC/WS servers have stopped, and both are metered by the ledger rate limiter (48 MiB/s, kAllIo). This stretches the window between the RPC going dark and the restarted process becoming ready by several seconds, during which requests fail with connection refused.

## Fix

- `prepare_ledger_for_shutdown` (which runs while the RPC is still serving) now flushes twice: the second pass drains any auto-flush that started while the first, long pass ran — previously that straddling job was waited on by `cancel_all_background_work` after the servers had stopped.
- Drop the explicit ledger flush from `stop()`: the small delta written during the drain is WAL-backed (all ledger writes use default WriteOptions) and is picked up by the flush inside `cancel_all_background_work`, which stays in its original position after `transaction_execution_join` — so flush threads remain alive for the whole execution drain.

Net effect: the ledger contributes ~0.1s to the post-RPC window; user-visible downtime on restart shrinks to process swap + init (~1.4s).
