### PR TITLE
fix: bound RPC runtime teardown so a stuck task cannot hang shutdown

### DIFF
--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -432,7 +432,7 @@ impl MagicValidator {
             log_timing("startup", "rpc_runtime_build", step_start);
             runtime.block_on(rpc.run());
 
-            drop(runtime);
+            runtime.shutdown_timeout(Duration::from_secs(2));
             info!("RPC runtime shutdown");
         });
 


### PR DESCRIPTION
Dropping the RPC runtime blocks indefinitely on its worker/blocking threads. A single task stuck in a blocking poll prevents `rpc_handle.join()` from returning, so shutdown hangs until the systemd kill timeout (SIGKILL), skipping the ledger/accountsdb flush steps that follow.

Replace `drop(runtime)` with `shutdown_timeout(2s)`: teardown becomes bounded, the stuck thread is leaked for the process's final moments instead of holding the shutdown hostage, and the remaining shutdown sequence runs cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RPC worker shutdown handling by allowing a graceful shutdown with a maximum wait of two seconds.
  * Helps prevent abrupt termination while avoiding indefinite shutdown delays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->