### PR TITLE
fix: MinContextSlotNotReachedError error mapping in TaskInfoFetcher.

### DIFF
--- a/magicblock-committor-service/src/intent_executor/task_info_fetcher.rs
+++ b/magicblock-committor-service/src/intent_executor/task_info_fetcher.rs
@@ -671,6 +671,11 @@ impl TaskInfoFetcherError {
     ) -> Self {
         const MIN_CONTEXT_SLOT_MSG1: &str =
             "Minimum context slot has not been reached";
+        const MIN_CONTEXT_SLOT_MSG2: &str = "Min context slot not reached";
+        fn is_min_context_slot_msg(msg: &str) -> bool {
+            msg.contains(MIN_CONTEXT_SLOT_MSG1)
+                || msg.contains(MIN_CONTEXT_SLOT_MSG2)
+        }
 
         let orig = e;
         let err = match &orig {
@@ -684,13 +689,26 @@ impl TaskInfoFetcherError {
 
         match &*err.kind {
             ErrorKind::RpcError(rpc_err) => match rpc_err {
-                RpcError::ForUser(msg)
-                if msg.contains(MIN_CONTEXT_SLOT_MSG1) => {
-                    Self::MinContextSlotNotReachedError(min_context_slot, Box::new(orig))
-                },
-                RpcError::RpcResponseError { code, .. }
-                if *code == JSON_RPC_SERVER_ERROR_MIN_CONTEXT_SLOT_NOT_REACHED => {
-                    Self::MinContextSlotNotReachedError(min_context_slot, Box::new(orig))
+                RpcError::ForUser(msg) if is_min_context_slot_msg(msg) => {
+                    Self::MinContextSlotNotReachedError(
+                        min_context_slot,
+                        Box::new(orig),
+                    )
+                }
+                RpcError::RpcResponseError {
+                    code: JSON_RPC_SERVER_ERROR_MIN_CONTEXT_SLOT_NOT_REACHED,
+                    ..
+                } => Self::MinContextSlotNotReachedError(
+                    min_context_slot,
+                    Box::new(orig),
+                ),
+                RpcError::RpcResponseError { message, .. }
+                    if is_min_context_slot_msg(message) =>
+                {
+                    Self::MinContextSlotNotReachedError(
+                        min_context_slot,
+                        Box::new(orig),
+                    )
                 }
                 _ => Self::MagicBlockRpcClientError(Box::new(orig)),
             },


### PR DESCRIPTION
<!--
PR title must match: type(scope): summary
Types: feat|fix|docs|chore|refactor|test|perf|ci|build
Examples:
  fix: avoid panic on empty slot
  feat(rpc): add getFoo endpoint
-->

## Summary
<!-- One sentence. Link to issue if applicable. -->
Helius RPC returns a different message & code if min context slot isn't reached. Added a support for them. Now this gets mapped correctly and thus we will have a longer retry time

## Breaking Changes
- [ ] None
- [ ] Yes — migration path described below


## Test Plan
<!-- How you verified this works. e.g., "unit tests", "ran locally against testnet", "existing tests pass" -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of RPC errors related to minimum context slot requirements.
  * These errors are now recognized consistently across additional response formats, providing more accurate error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->