### PR TITLE
fix: sync ledger WAL during shutdown

### DIFF
--- a/.agents/context/crates/magicblock-api.md
+++ b/.agents/context/crates/magicblock-api.md
@@ -65,7 +65,7 @@ The exported public API is intentionally small for production use:
 - `magic_validator::MagicValidator`
   - `try_from_config(ValidatorParams) -> ApiResult<MagicValidator>` builds the service graph and spawns some long-lived components such as transaction execution and the RPC runtime.
   - `start(&mut self) -> ApiResult<()>` performs ledger replay/reset/recovery, switches scheduler/replication mode, and starts post-start services such as slot ticking, ledger truncation, claim-fees, and the task scheduler.
-  - `stop(self)` consumes the validator and shuts down services, joins threads/tasks where available, flushes AccountsDb and ledger, and performs ledger shutdown.
+  - `stop(self)` consumes the validator and shuts down services, joins threads/tasks where available, flushes AccountsDb, syncs the ledger WAL, and performs ledger shutdown.
   - `start_unregister_validator_on_chain(&mut self)` sends a best-effort unregister transaction for standalone ephemeral validators that use on-chain coordination.
   - `prepare_ledger_for_shutdown(&mut self)` stops truncation, cancels manual compactions, and flushes the ledger before final shutdown.
   - `ledger(&self) -> &Ledger` exposes the ledger for the binary to lock and report paths.
@@ -172,10 +172,10 @@ This service is started only for non-replica validators.
 4. Stop claim-fees task.
 5. Join RPC thread, slot ticker, ledger truncator, replication thread, and transaction execution thread.
 6. Flush AccountsDb.
-7. Flush and shut down ledger.
+7. Sync the ledger WAL and shut down ledger.
 8. Join unregister confirmation thread only if it has already finished; shutdown does not wait for that confirmation.
 
-Durable state is flushed only after workers that can admit, commit, truncate, or replicate state are stopped.
+Durable state is flushed or synced only after workers that can admit, commit, truncate, or replicate state are stopped.
 
 ### Domain registry and base-layer operator flow
 

--- a/.agents/context/crates/magicblock-ledger.md
+++ b/.agents/context/crates/magicblock-ledger.md
@@ -81,7 +81,7 @@ Important constructors and accessors:
 
 - `Ledger::open(path)` and `Ledger::open_with_options(path, LedgerOptions)` create `path/rocksdb`, adjust `ulimit -n` when enabled, open RocksDB, initialize `LatestBlock` from the highest stored blockhash, and initialize the lowest cleanup slot.
 - `ledger_path()`, `banking_trace_path()`, `storage_size()`, `db(self)`, `latest_block()`, and `latest_blockhash()` expose operational handles.
-- `flush()`, `shutdown(wait)`, and `cancel_manual_compactions()` are used during shutdown and maintenance.
+- `flush()`, `sync_wal()`, `shutdown(wait)`, and `cancel_manual_compactions()` are used during shutdown and maintenance.
 
 Primary data APIs:
 
@@ -215,7 +215,7 @@ Preserve compatibility for existing ledger directories unless the change explici
 5. **Preserve on-disk compatibility.** Deprecated key decoders and protobuf/bincode choices must not be removed without an explicit migration strategy.
 6. **Do not replay failed transactions.** Ledger replay must only re-run successful transactions and must use `persist: false`.
 7. **Do not block execution/RPC unnecessarily.** Avoid long compactions, full-column scans, excessive serialization, or unbounded iterator work on hot request or transaction paths.
-8. **Shutdown must protect durability.** Flush and RocksDB background-work cancellation behavior must stay compatible with validator shutdown ordering.
+8. **Shutdown must protect durability.** Flush, WAL sync, and RocksDB background-work cancellation behavior must stay compatible with validator shutdown ordering.
 9. **Metrics labels must stay bounded.** RocksDB/ledger datapoints should use fixed column/operation labels, not pubkeys, signatures, paths, or other high-cardinality values.
 
 ## Common change areas and what to inspect

--- a/.agents/specs/validator-specification.md
+++ b/.agents/specs/validator-specification.md
@@ -411,4 +411,4 @@ Shutdown ordering matters:
 2. Stop services while preserving in-flight intent safety.
 3. Stop committor service last among services where needed for in-flight intents.
 4. Join threads.
-5. Flush AccountsDb and ledger.
+5. Flush AccountsDb and durably sync the ledger WAL.

--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -1227,10 +1227,10 @@ impl MagicValidator {
         log_timing("shutdown", "accountsdb_flush", step_start);
 
         let step_start = Instant::now();
-        if let Err(err) = self.ledger.flush() {
-            error!(error = ?err, "Failed to flush ledger");
+        if let Err(err) = self.ledger.sync_wal() {
+            error!(error = ?err, "Failed to sync ledger WAL");
         }
-        log_timing("shutdown", "ledger_flush", step_start);
+        log_timing("shutdown", "ledger_wal_sync", step_start);
 
         let step_start = Instant::now();
         if let Err(err) = self.ledger.shutdown(true) {

--- a/magicblock-ledger/src/store/api.rs
+++ b/magicblock-ledger/src/store/api.rs
@@ -1389,6 +1389,11 @@ impl Ledger {
             .flush_cfs_opt(&cfs, &FlushOptions::default())
     }
 
+    /// Syncs all outstanding WAL writes to disk.
+    pub fn sync_wal(&self) -> LedgerResult<()> {
+        Ok(self.db.backend.db.flush_wal(true)?)
+    }
+
     /// Graceful db shutdown
     pub fn shutdown(&self, wait: bool) -> LedgerResult<()> {
         let _guard = MeasureGuard {


### PR DESCRIPTION
## Summary

- keep the bulk ledger flush in shutdown preparation while RPC is live
- replace the post-join rate-limited full flush with a durable WAL sync
- document the shutdown durability ordering

## Why

Writers can still dirty the ledger after any pre-shutdown flush. Syncing the WAL after all writers join preserves a checked durability barrier without putting a rate-limited SST flush in the RPC-dark window.

## Validation

- `make fmt`
- `make lint`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo nextest run -p magicblock-ledger -p magicblock-api` (24 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit ledger WAL synchronization during validator shutdown to improve durability.
  * Exposed ledger WAL synchronization as a maintenance and shutdown operation.

* **Documentation**
  * Updated shutdown procedures and durability guidance to reflect WAL synchronization, state flushing, and background-work cancellation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->