### PR TITLE
fix: speed up the replication stream drain by batching

### DIFF
--- a/magicblock-processor/src/scheduler/mod.rs
+++ b/magicblock-processor/src/scheduler/mod.rs
@@ -313,6 +313,11 @@ impl TransactionScheduler {
         if self.coordinator.is_primary() {
             self.advance_primary_slot().await;
         }
+        // No later shutdown step emits replication messages. Release the
+        // producer endpoint as soon as the final Block/SuperBlock is queued so
+        // the replication service can finish draining independently of executor
+        // teardown.
+        self.replication_tx.take();
         // Shutdown: drop executor channels to signal workers to stop,
         // then drain remaining ready notifications
         drop(self.executors);

--- a/magicblock-replicator/src/service/primary.rs
+++ b/magicblock-replicator/src/service/primary.rs
@@ -189,14 +189,10 @@ impl Primary {
         let _timing = ShutdownTiming::new("replication_service_drain");
 
         let deadline = Instant::now() + SHUTDOWN_DRAIN_TIMEOUT;
-        if !self.confirm_transactions(Some(deadline)).await {
-            warn!("failed to confirm published transactions during shutdown");
-            return;
-        }
-        // Every message is confirmed here, so this counts messages known to be
-        // persisted. `confirmation_for` trades confirmation for publish
-        // throughput, but there is no throughput left to protect once we are
-        // stopping, and this is the last chance to notice a loss.
+        // Transactions remain pipelined while the producer finishes. Block
+        // fences and the final flush below still guarantee that a successful
+        // drain has confirmed every message without paying one NATS round trip
+        // per queued transaction.
         let mut drained = 0_u64;
 
         if let Some(msg) = pending.take() {
@@ -220,6 +216,13 @@ impl Primary {
                     drained += 1;
                 }
                 DrainNext::ProducerFinished => {
+                    if !self.confirm_transactions(Some(deadline)).await {
+                        warn!(
+                            drained,
+                            "failed to confirm drained replication messages"
+                        );
+                        return;
+                    }
                     info!(drained, "replication shutdown drain complete");
                     return;
                 }
@@ -231,14 +234,13 @@ impl Primary {
         }
     }
 
-    /// Publishes during shutdown, confirming regardless of message kind.
+    /// Publishes during shutdown using the normal ordering fences.
     async fn drain_publish(
         &mut self,
         msg: &Message,
         deadline: Instant,
     ) -> bool {
-        self.publish_with_retry_until(msg, Some(deadline), Confirm::Yes)
-            .await
+        self.publish_ordered_until(msg, Some(deadline)).await
     }
 
     async fn release_producer_lock(&self, lock_state: LockState) {
@@ -290,14 +292,22 @@ impl Primary {
     }
 
     async fn publish_with_retry(&mut self, msg: &Message) -> bool {
+        self.publish_ordered_until(msg, None).await
+    }
+
+    async fn publish_ordered_until(
+        &mut self,
+        msg: &Message,
+        deadline: Option<Instant>,
+    ) -> bool {
         let fence = matches!(msg, Message::Block(_))
             || (matches!(msg, Message::Transaction(_))
                 && self.unconfirmed_transactions.len()
                     >= MAX_DEFERRED_TRANSACTION_ACKS);
-        if fence && !self.confirm_transactions(None).await {
+        if fence && !self.confirm_transactions(deadline).await {
             return false;
         }
-        self.publish_with_retry_until(msg, None, confirmation_for(msg))
+        self.publish_with_retry_until(msg, deadline, confirmation_for(msg))
             .await
     }
 

--- a/test-integration/test-task-scheduler/src/lib.rs
+++ b/test-integration/test-task-scheduler/src/lib.rs
@@ -25,6 +25,7 @@ use magicblock_config::{
     ValidatorParams,
 };
 use magicblock_program::Pubkey;
+use magicblock_task_scheduler::SchedulerDatabase;
 use program_flexi_counter::{
     instruction::{
         create_delegate_ix_with_commit_frequency_ms, create_init_ix,
@@ -36,6 +37,7 @@ use solana_sdk::{
     signature::Keypair, signer::Signer, transaction::Transaction,
 };
 use tempfile::TempDir;
+use tokio::runtime::Runtime;
 
 pub const TASK_SCHEDULER_TICK_MILLIS: u64 = 50;
 
@@ -159,6 +161,30 @@ pub fn wait_for_incremented_counter(
         false,
         cleanup(validator),
         "Failed to wait for incremented counter"
+    );
+}
+
+/// Waits for asynchronous crank completion to remove a task from storage.
+pub fn wait_for_task_removed(
+    ctx: &IntegrationTestContext,
+    db: &SchedulerDatabase,
+    runtime: &Runtime,
+    task_id: i64,
+    max_timeout: Duration,
+    validator: &mut Child,
+) {
+    let now = Instant::now();
+    while now.elapsed() < max_timeout {
+        let task = expect!(runtime.block_on(db.get_task(task_id)), validator);
+        if task.is_none() {
+            return;
+        }
+        expect!(ctx.wait_for_next_slot_ephem(), validator);
+    }
+    assert!(
+        false,
+        cleanup(validator),
+        "Failed to wait for task {task_id} to be removed"
     );
 }
 

--- a/test-integration/test-task-scheduler/tests/test_reschedule_task.rs
+++ b/test-integration/test-task-scheduler/tests/test_reschedule_task.rs
@@ -13,6 +13,7 @@ use solana_sdk::{
 };
 use test_task_scheduler::{
     create_delegated_counter, setup_validator, wait_for_incremented_counter,
+    wait_for_task_removed,
 };
 use tokio::runtime::Runtime;
 
@@ -113,6 +114,14 @@ fn test_reschedule_task() {
     // Check that the completed task was removed from the database
     let db = expect!(SchedulerDatabase::new(db_path), validator);
     let runtime = expect!(Runtime::new(), validator);
+    wait_for_task_removed(
+        &ctx,
+        &db,
+        &runtime,
+        task_id,
+        Duration::from_secs(10),
+        &mut validator,
+    );
 
     let failed_scheduling =
         expect!(runtime.block_on(db.get_failed_schedulings()), validator);

--- a/test-integration/test-task-scheduler/tests/test_schedule_task.rs
+++ b/test-integration/test-task-scheduler/tests/test_schedule_task.rs
@@ -13,6 +13,7 @@ use solana_sdk::{
 };
 use test_task_scheduler::{
     create_delegated_counter, setup_validator, wait_for_incremented_counter,
+    wait_for_task_removed,
 };
 use tokio::runtime::Runtime;
 
@@ -80,6 +81,14 @@ fn test_schedule_task() {
     // Check that the completed task was removed from the database
     let db = expect!(SchedulerDatabase::new(db_path), validator);
     let runtime = expect!(Runtime::new(), validator);
+    wait_for_task_removed(
+        &ctx,
+        &db,
+        &runtime,
+        task_id,
+        Duration::from_secs(10),
+        &mut validator,
+    );
 
     let failed_scheduling =
         expect!(runtime.block_on(db.get_failed_schedulings()), validator);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown draining for replication to prevent late replication emission during shutdown cleanup.
  * Updated shutdown confirmation flow so transaction confirmation happens after producer completion is observed.
  * Aligned shutdown publishing with normal ordered behavior and improved retry/confirmation handling, including respecting shutdown deadlines.
* **Tests**
  * Added a helper to wait until scheduler tasks are removed from the database.
  * Strengthened task scheduling/rescheduling integration tests with explicit task-removal verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->