### PR TITLE
Revert "fix: MinContextSlotNotReachedError error mapping in TaskInfoFetcher."

### DIFF
--- a/magicblock-committor-service/src/intent_executor/task_info_fetcher.rs
+++ b/magicblock-committor-service/src/intent_executor/task_info_fetcher.rs
@@ -671,11 +671,6 @@ impl TaskInfoFetcherError {
     ) -> Self {
         const MIN_CONTEXT_SLOT_MSG1: &str =
             "Minimum context slot has not been reached";
-        const MIN_CONTEXT_SLOT_MSG2: &str = "Min context slot not reached";
-        fn is_min_context_slot_msg(msg: &str) -> bool {
-            msg.contains(MIN_CONTEXT_SLOT_MSG1)
-                || msg.contains(MIN_CONTEXT_SLOT_MSG2)
-        }
 
         let orig = e;
         let err = match &orig {
@@ -689,26 +684,13 @@ impl TaskInfoFetcherError {
 
         match &*err.kind {
             ErrorKind::RpcError(rpc_err) => match rpc_err {
-                RpcError::ForUser(msg) if is_min_context_slot_msg(msg) => {
-                    Self::MinContextSlotNotReachedError(
-                        min_context_slot,
-                        Box::new(orig),
-                    )
-                }
-                RpcError::RpcResponseError {
-                    code: JSON_RPC_SERVER_ERROR_MIN_CONTEXT_SLOT_NOT_REACHED,
-                    ..
-                } => Self::MinContextSlotNotReachedError(
-                    min_context_slot,
-                    Box::new(orig),
-                ),
-                RpcError::RpcResponseError { message, .. }
-                    if is_min_context_slot_msg(message) =>
-                {
-                    Self::MinContextSlotNotReachedError(
-                        min_context_slot,
-                        Box::new(orig),
-                    )
+                RpcError::ForUser(msg)
+                if msg.contains(MIN_CONTEXT_SLOT_MSG1) => {
+                    Self::MinContextSlotNotReachedError(min_context_slot, Box::new(orig))
+                },
+                RpcError::RpcResponseError { code, .. }
+                if *code == JSON_RPC_SERVER_ERROR_MIN_CONTEXT_SLOT_NOT_REACHED => {
+                    Self::MinContextSlotNotReachedError(min_context_slot, Box::new(orig))
                 }
                 _ => Self::MagicBlockRpcClientError(Box::new(orig)),
             },


### PR DESCRIPTION
Reverts magicblock-labs/magicblock-validator#1468