### PR TITLE
fix: deflake test_schedule_task task removal assertion

### DIFF
--- a/test-integration/test-task-scheduler/tests/test_schedule_task.rs
+++ b/test-integration/test-task-scheduler/tests/test_schedule_task.rs
@@ -1,4 +1,7 @@
-use std::time::Duration;
+use std::{
+    thread::sleep,
+    time::{Duration, Instant},
+};
 
 use cleanass::assert_eq;
 use integration_test_tools::{expect, validator::cleanup};
@@ -101,7 +104,16 @@ fn test_schedule_task() {
         failed_tasks
     );
 
-    let tasks = expect!(runtime.block_on(db.get_task_ids()), validator);
+    // The task row is deleted asynchronously after the last crank is sent,
+    // so poll for the removal instead of asserting on the first read
+    let started = Instant::now();
+    let tasks = loop {
+        let tasks = expect!(runtime.block_on(db.get_task_ids()), validator);
+        if tasks.is_empty() || started.elapsed() >= Duration::from_secs(10) {
+            break tasks;
+        }
+        sleep(Duration::from_millis(100));
+    };
     assert_eq!(
         tasks.len(),
         0,


### PR DESCRIPTION
## Problem

`test_schedule_task` intermittently fails in CI with `assertion left == right failed: tasks: [1]` and takes the whole integration matrix down via fail-fast (this is what failed the v0.13.13 release run, and what previously got #1468/#1371 reverted — neither was the cause, the failure reproduced without them).

The test waits for the counter to reach 3 by polling RPC, then immediately asserts the scheduler's SQLite `tasks` table is empty. But the row delete is asynchronous to on-chain visibility: `send_crank_batch` fire-and-forgets `send_transaction`, and the delete happens later on the main loop (`crank_rx` → `on_crank_batch_completed` → batched SQLite commit), while the transaction executes on an independent path. There is no happens-before between counter == 3 and the row removal. On slow runners the delete consistently loses the race, so all 4 retry attempts fail; on fast runners it always wins — which is why the failure flip-flops between runs with identical code.

## Fix

Poll the DB for the row removal with a 10s deadline instead of asserting on the first read, mirroring the existing `failed_tasks` polling loop in `test_schedule_error`. The existing assertions are kept unchanged and still fail with the same message if the row never disappears.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated scheduler integration coverage to account for asynchronous task deletion.
  * Added polling with a timeout to improve test reliability and reduce timing-related failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->