### PR TITLE
fix: proceed with a single confirmed pubsub subscription

### DIFF
--- a/magicblock-chainlink/src/submux/mod.rs
+++ b/magicblock-chainlink/src/submux/mod.rs
@@ -1127,12 +1127,9 @@ where
     }
 
     /// Number of clients that must confirm an account subscription for it to be considered active.
-    /// 2/3 of connected clients subscribing immediately.
+    /// One connected transport suffices; the reconciler repairs the rest.
     fn required_account_subscription_confirmations(&self) -> usize {
-        let n = self
-            .connected_clients_subscribing_immediately
-            .load(Ordering::SeqCst) as usize;
-        cmp::max(1, (n * 2) / 3)
+        1
     }
 
     /// Number of clients that must confirm a program subscription for it to be considered

--- a/magicblock-config/src/lib.rs
+++ b/magicblock-config/src/lib.rs
@@ -145,11 +145,12 @@ impl ValidatorParams {
     /// If no WebSocket remote is present, derives one from the first HTTP remote.
     /// This satisfies the requirement for a subscription-capable endpoint.
     fn ensure_websocket(&mut self) {
-        // Check if a websocket remote already exists
+        // Skip if a subscription-capable remote (websocket or gRPC) exists;
+        // HTTP-only providers may not serve websocket on the same host
         if self
             .remotes
             .iter()
-            .any(|r| matches!(r, Remote::Websocket(_)))
+            .any(|r| matches!(r, Remote::Websocket(_) | Remote::Grpc(_)))
         {
             return;
         }


### PR DESCRIPTION
## Problem

A degraded pubsub provider can fail account subscriptions through the 2/3 confirmation quorum even when a healthy transport has already confirmed. Since subscription setup is in the account-fetch path, this fails every fetch (and `sendTransaction` account ensures) on the node until restart.

Additionally, when no `wss` remote is configured, a websocket remote is derived from the HTTP remote even if gRPC coverage exists. HTTP-only providers (e.g. Ironforge) don't serve websocket, so the derived client can never connect and only degrades the mux.

## Solution

- `required_account_subscription_confirmations` → 1: one confirmation from any connected ws/gRPC client suffices. Remaining clients still subscribe in the background and the reconciler repairs failures. Zero connected clients still fails the operation.
- `ensure_websocket` treats gRPC remotes as subscription-capable and only derives a websocket from HTTP as a last resort.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account subscription handling by consistently requiring a single confirmation.
  * Prevented unnecessary WebSocket endpoints from being added when a gRPC endpoint is already configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->