### PR TITLE
Revert "perf: prefilter DLP program updates"

### DIFF
--- a/.agents/context/crates/magicblock-chainlink.md
+++ b/.agents/context/crates/magicblock-chainlink.md
@@ -265,11 +265,9 @@ Chainlink has special handling for associated token accounts and ephemeral ATAs:
 - For each ATA, Chainlink derives the companion eATA PDA with `try_derive_eata_address_and_bump`.
 - It subscribes to both ATA and eATA using `SubscriptionReason::AtaProjection`.
 - If the eATA exists, has a delegation record for this validator, and can be projected, Chainlink clones a projected delegated ATA into the local bank.
-- Raw eATA program-subscription updates are projection candidates only when there is local projection interest: a watched ATA/eATA projection subscription, a watched raw eATA, or a supported base ATA already present locally. Without that interest, Chainlink drops the update without fetching the eATA's delegation record or companion base ATA state.
 - Projection preserves the base ATA's owner and data length, which is important for Token-2022 extensions.
 - Missing eATAs can be remembered in `known_empty_eatas`, but only after confirmed `NotFound` while an eATA subscription is live.
 - Raw eATA PDAs are not marked delegated directly; their state is projected into the corresponding base ATA.
-- Explicit RPC/transaction ensure paths still resolve eATA delegation records and project delegated ATAs normally when the requested account requires it; the local-interest narrowing applies to program-subscription firehose updates.
 
 Pitfalls:
 
@@ -299,10 +297,7 @@ Key behavior:
 - Non-clock updates become `ForwardedSubscriptionUpdate` with a `SubscriptionSource` (`Account` or program source).
 - If a subscription update arrives while an RPC fetch is pending, it resolves the pending fetch waiters only when its slot is at least the fetch start slot and does not regress the retained per-account classification.
 - Account-subscription updates for pubkeys no longer watched are dropped and can enqueue a removal update if stale local state exists.
-- Program-subscription updates are allowed even if the pubkey is not in the direct-account LRU, but DLP-owned program updates are first classified for local interest before any delegation-record companion fetch.
-- Absent and unwatched DLP-owned program updates are not dropped solely for lacking local interest. Ordinary non-internal DLP-owned user-account updates still reach greedy discovery so Chainlink can resolve a valid delegation record and execute post-delegation actions. Only updates that are provably irrelevant without delegation-record resolution, such as true internal DLP payloads or raw eATA projection updates without local ATA/eATA projection interest, are dropped before discovery.
-- Existing local delegated non-undelegating accounts are authoritative. DLP program updates for them clean up direct subscriptions and must not fetch a delegation record, clone, or overwrite local state.
-- Existing local undelegating accounts bypass the internal-DLP early drop and continue undelegation completion/redelegation processing so completion remains observable.
+- Program-subscription updates are allowed even if the pubkey is not in the direct-account LRU; delegated accounts may be tracked only by owner-program subscriptions.
 - Non-advancing updates are ignored unless they represent a same-slot delegated refresh needed for undelegate/redelegate recovery.
 - Delegated updates cause direct subscription cleanup; undelegation-completion updates retain/directly ensure subscriptions as appropriate and release `UndelegationTracking` ownership.
 
@@ -317,28 +312,19 @@ The scan uses Base64Zstd account encoding and gets a nearby base-chain slot for 
 
 ### Greedy discovery
 
-For DLP-owned program-subscription firehose updates, Chainlink first classifies the pubkey using local bank state, direct-watch state, and ATA/eATA projection interest.
-
-Greedy discovery remains enabled for ordinary non-internal DLP-owned user-account updates, even when the account is absent locally and not directly watched. This preserves clone-time post-delegation action execution for new delegations discovered from the DLP program subscription. The prefilter may only skip delegation-record resolution for updates that are provably irrelevant from local state and payload shape, including internal DLP records/metadata/commit state and raw eATA updates with no local projection interest.
-
-Updates for directly watched accounts or locally relevant ATA/eATA projection state may still greedily fetch and clone if the delegation record says the account belongs to this validator (or is confined). Explicit RPC/transaction ensure paths are not narrowed by this prefilter: they still fetch delegation records and clone delegated accounts normally.
+If a subscription update discovers a DLP-owned account absent from the bank, Chainlink may greedily fetch and clone it if the delegation record says it belongs to this validator (or is confined). This is especially important for delegated eATA discovery and owner-program subscriptions.
 
 Updates delegated to other validators are ignored after discovery so this validator does not clone state it cannot execute against.
 
 ### Internal DLP update filtering and collision sighting
 
-DLP-owned program-subscription updates are classified before internal-DLP payload filtering or collision handling. Updates for existing local delegated non-undelegating accounts clean up direct subscriptions and return without overwriting locally authoritative state. Updates for existing local undelegating accounts and locally relevant ATA/eATA projections continue past the internal-DLP early drop so undelegation completion and projection processing can run.
-
-Program-subscription updates whose payload parses as an internal DLP account (delegation record, delegation metadata, commit record, program config) are then dropped in `FetchCloner::process_subscription_update` **before** greedy discovery, with zero remote fetches — their derived "record of a record" PDA never exists, and these updates dominate the DLP program-subscription firehose.
-
-The internal-DLP fast path must not classify ordinary non-internal user-account updates as irrelevant merely because they are absent locally; those updates must fall through to greedy discovery so valid same-slot delegation records can trigger clone and post-delegation action handling.
+Program-subscription updates whose payload parses as an internal DLP account (delegation record, delegation metadata, commit record, program config) are dropped in `FetchCloner::process_subscription_update` **before** greedy discovery, with zero remote fetches — their derived "record of a record" PDA never exists, and these updates dominate the DLP program-subscription firehose.
 
 The exception is a delegated account whose app data byte-collides with an internal DLP discriminator (LE u64 100–103). Such accounts must still reach greedy discovery so their post-delegation actions execute. `DlpCollisionTracker` (single lock, so check-then-park is atomic against sight-then-release) resolves this without a fetch:
 
 - Every delegation-record-shaped update records a monotonic sighting (`record pubkey -> max slot`), from either subscription source. Only program-subscription updates are dropped/parked; account-subscription updates always continue into normal processing.
 - An internal-looking account update whose derived delegation-record PDA was sighted at or after its own slot proceeds to greedy discovery (a fresh delegation writes both accounts in one slot).
 - Otherwise the update is parked (pubkey + slot, keyed by its derived record PDA); a later record sighting releases it into an authority-gated, deduped fetch+clone that retries until the bank reflects the sighted delegation.
-- Before each released-candidate clone attempt, Chainlink rechecks local undelegating state against the sighted delegation record. A still-pending undelegation remains locked and retains its tracking subscription rather than being overwritten by the deferred collision update.
 - Genuine internal PDAs always miss the sighting cache and are dropped. A missed sighting degrades to lazy on-demand cloning via the normal getAccount/send-transaction paths — never to incorrect state.
 
 ## RemoteAccountProvider internals

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/ata_projection.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/ata_projection.rs
@@ -22,9 +22,8 @@ use super::{
 use crate::{
     cloner::{AccountCloneRequest, Cloner, DelegationActions},
     remote_account_provider::{
-        pubsub_common::SubscriptionSource, ChainPubsubClient, ChainRpcClient,
-        MatchSlotsConfig, RemoteAccount, ResolvedAccountSharedData,
-        SubscriptionReason,
+        ChainPubsubClient, ChainRpcClient, MatchSlotsConfig, RemoteAccount,
+        ResolvedAccountSharedData, SubscriptionReason,
     },
 };
 
@@ -40,29 +39,6 @@ pub(crate) fn derive_eata_pubkey_from_ata_layout(
     ata_account: &AccountSharedData,
 ) -> Option<Pubkey> {
     derive_eata_pubkey(ata_info_from_layout(ata_pubkey, ata_account)?)
-}
-
-pub(crate) fn derive_supported_ata_pubkeys(
-    owner: &Pubkey,
-    mint: &Pubkey,
-) -> Vec<Pubkey> {
-    try_derive_supported_ata_pubkeys(owner, mint)
-        .token_2022_first()
-        .into_iter()
-        .flatten()
-        .collect::<Vec<_>>()
-}
-
-pub(crate) fn derive_supported_ata_pubkeys_from_raw_eata(
-    eata_pubkey: &Pubkey,
-    eata_account: &AccountSharedData,
-) -> Option<Vec<Pubkey>> {
-    let (wallet_owner, mint) = delegation::parse_raw_eata_pda(
-        eata_pubkey,
-        eata_account.data(),
-        EATA_PROGRAM_ID,
-    )?;
-    Some(derive_supported_ata_pubkeys(&wallet_owner, &mint))
 }
 
 fn derive_eata_pubkey(ata_info: AtaInfo) -> Option<Pubkey> {
@@ -127,7 +103,6 @@ pub(crate) async fn maybe_build_projected_ata_clone_request_from_subscription_up
     this: &FetchCloner<T, U, V, C>,
     eata_pubkey: Pubkey,
     eata_account: &AccountSharedData,
-    update_source: SubscriptionSource,
     deleg_record: Option<&DelegationRecord>,
     delegation_actions: &DelegationActions,
     companion_fetch_log_context: &CompanionFetchLogContext,
@@ -150,19 +125,11 @@ where
         .await;
     }
 
-    let ata_pubkeys =
-        derive_supported_ata_pubkeys_from_raw_eata(&eata_pubkey, eata_account)?;
-    if ata_pubkeys.is_empty() {
-        return None;
-    }
-
-    if matches!(update_source, SubscriptionSource::Program)
-        && !this
-            .raw_eata_has_local_projection_interest(eata_pubkey, eata_account)
-            .await?
-    {
-        return None;
-    }
+    delegation::parse_raw_eata_pda(
+        &eata_pubkey,
+        eata_account.data(),
+        EATA_PROGRAM_ID,
+    )?;
 
     let (deleg_record, delegation_actions) =
         delegation::fetch_and_parse_delegation_record(
@@ -208,7 +175,12 @@ where
         eata_account.data(),
         deleg_record.owner,
     )?;
-    let ata_pubkeys = derive_supported_ata_pubkeys(&wallet_owner, &mint);
+    let ata_pubkeys = try_derive_supported_ata_pubkeys(&wallet_owner, &mint);
+    let ata_pubkeys = ata_pubkeys
+        .token_2022_first()
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
 
     // eATA updates only carry the projected balance fields. The base ATA is
     // required so the clone preserves the actual token program owner and any

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -20,7 +20,8 @@ use magicblock_accounts_db::traits::AccountsBank;
 use magicblock_aml::RiskService;
 use magicblock_config::config::AllowedProgram;
 use magicblock_core::token_programs::{
-    is_ata, normalize_native_token_account_for_local_clone, EATA_PROGRAM_ID,
+    is_ata, normalize_native_token_account_for_local_clone,
+    try_derive_supported_ata_pubkeys, EATA_PROGRAM_ID,
 };
 use magicblock_metrics::metrics::{
     self, AccountFetchContext, AccountFetchReason, BankPrecheckOutcome,
@@ -209,16 +210,6 @@ const PARKED_COLLISION_UPDATES_CAPACITY: NonZeroUsize =
             panic!("PARKED_COLLISION_UPDATES_CAPACITY must be non-zero")
         }
     };
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum DlpProgramUpdateInterest {
-    DropRawEataNoProjectionInterest,
-    DropLocalDelegatedAuthoritative,
-    ProcessUndelegating,
-    ProcessAtaProjection,
-    ProcessDirectlyWatched,
-    DiscoverDelegatedAccount,
-}
 
 /// A parked internal-looking account update, reduced to pubkey + slot so
 /// the firehose cannot pin account payloads in memory.
@@ -482,6 +473,7 @@ where
                     })
             },
         );
+
         me.clone()
             .start_subscription_listener(subscription_updates_rx);
 
@@ -491,101 +483,6 @@ where
     /// Get the current fetch count
     pub fn fetch_count(&self) -> u64 {
         self.fetch_count.load(Ordering::Relaxed)
-    }
-
-    async fn classify_dlp_program_update_interest(
-        &self,
-        pubkey: Pubkey,
-        account: &AccountSharedData,
-    ) -> DlpProgramUpdateInterest {
-        if let Some(local_account) = self.accounts_bank.get_account(&pubkey) {
-            if local_account.undelegating() {
-                return DlpProgramUpdateInterest::ProcessUndelegating;
-            }
-            if local_account.delegated() {
-                return DlpProgramUpdateInterest::DropLocalDelegatedAuthoritative;
-            }
-        }
-
-        if self.remote_account_provider.is_watching(&pubkey) {
-            return DlpProgramUpdateInterest::ProcessDirectlyWatched;
-        }
-
-        if let Some(has_projection_interest) = self
-            .raw_eata_has_local_projection_interest(pubkey, account)
-            .await
-        {
-            return if has_projection_interest {
-                DlpProgramUpdateInterest::ProcessAtaProjection
-            } else {
-                DlpProgramUpdateInterest::DropRawEataNoProjectionInterest
-            };
-        }
-
-        if self.base_ata_has_projection_interest(pubkey, account).await {
-            return DlpProgramUpdateInterest::ProcessAtaProjection;
-        }
-
-        DlpProgramUpdateInterest::DiscoverDelegatedAccount
-    }
-
-    async fn raw_eata_has_local_projection_interest(
-        &self,
-        pubkey: Pubkey,
-        account: &AccountSharedData,
-    ) -> Option<bool> {
-        let ata_pubkeys =
-            ata_projection::derive_supported_ata_pubkeys_from_raw_eata(
-                &pubkey, account,
-            )?;
-
-        for ata_pubkey in ata_pubkeys.iter() {
-            if self.accounts_bank.get_account(ata_pubkey).is_some()
-                || self
-                    .remote_account_provider
-                    .has_subscription_reason(
-                        ata_pubkey,
-                        SubscriptionReason::AtaProjection,
-                    )
-                    .await
-            {
-                return Some(true);
-            }
-        }
-
-        Some(
-            self.remote_account_provider
-                .has_subscription_reason(
-                    &pubkey,
-                    SubscriptionReason::AtaProjection,
-                )
-                .await,
-        )
-    }
-
-    async fn base_ata_has_projection_interest(
-        &self,
-        pubkey: Pubkey,
-        account: &AccountSharedData,
-    ) -> bool {
-        let Some(eata_pubkey) =
-            ata_projection::derive_eata_pubkey_from_ata_account(
-                &pubkey, account,
-            )
-        else {
-            return false;
-        };
-
-        self.remote_account_provider
-            .has_subscription_reason(&pubkey, SubscriptionReason::AtaProjection)
-            .await
-            || self
-                .remote_account_provider
-                .has_subscription_reason(
-                    &eata_pubkey,
-                    SubscriptionReason::AtaProjection,
-                )
-                .await
     }
 
     #[instrument(skip(self, pubkeys))]
@@ -1729,71 +1626,13 @@ where
         pubkey: Pubkey,
         update: ForwardedSubscriptionUpdate,
     ) {
-        let fresh_update_account = update.account.fresh_account();
-        let is_dlp_owned_update = fresh_update_account
-            .as_ref()
-            .is_some_and(|account| account.owner() == &dlp_api::id());
-        let is_internal_dlp_update =
-            fresh_update_account.as_ref().is_some_and(|account| {
-                is_internal_dlp_account_data(account.data())
-            });
-
-        let dlp_program_interest =
-            if matches!(update.source, SubscriptionSource::Program)
-                && is_dlp_owned_update
-            {
-                match fresh_update_account.as_ref() {
-                    Some(account) => Some(
-                        self.classify_dlp_program_update_interest(
-                            pubkey, account,
-                        )
-                        .await,
-                    ),
-                    None => None,
-                }
-            } else {
-                None
-            };
-
-        match dlp_program_interest {
-            Some(DlpProgramUpdateInterest::DropRawEataNoProjectionInterest) => {
-                trace!(
-                    pubkey = %pubkey,
-                    "Dropping raw eATA DLP program update without local projection interest"
-                );
-                return;
-            }
-            Some(DlpProgramUpdateInterest::DropLocalDelegatedAuthoritative) => {
-                self.cleanup_direct_subscription_for_delegated_account(pubkey)
-                    .await;
-                trace!(
-                    pubkey = %pubkey,
-                    "Dropping DLP program update for locally authoritative delegated account"
-                );
-                return;
-            }
-            Some(DlpProgramUpdateInterest::ProcessUndelegating)
-            | Some(DlpProgramUpdateInterest::ProcessAtaProjection)
-            | Some(DlpProgramUpdateInterest::ProcessDirectlyWatched)
-            | Some(DlpProgramUpdateInterest::DiscoverDelegatedAccount)
-            | None => {}
-        }
-
-        // Internal DLP payloads (records/metadata/commit state) can never be
-        // greedily cloned, so drop them before discovery issues remote
-        // fetches. The exception is an account whose app data collides with
-        // an internal discriminator: its delegation also writes the
-        // delegation record, whose sighting routes the account update to
-        // discovery — immediately when the record arrived first, or by
-        // releasing the parked update once the record arrives later.
-        if !matches!(
-            dlp_program_interest,
-            Some(DlpProgramUpdateInterest::ProcessUndelegating)
-                | Some(DlpProgramUpdateInterest::ProcessAtaProjection)
-        ) && is_dlp_owned_update
-        {
-            if let Some(account) = fresh_update_account.as_ref() {
-                if is_internal_dlp_update {
+        // Internal DLP payloads can never be greedily cloned, so drop them
+        // before discovery issues remote fetches; an account whose app data
+        // collides with an internal discriminator is routed to discovery
+        // via its delegation-record sighting instead.
+        if update.account.is_owned_by_delegation_program() {
+            if let Some(account) = update.account.fresh_account() {
+                if is_internal_dlp_account_data(account.data()) {
                     // Sight records from either source: SubMux dedup can
                     // deliver a directly watched record account-sourced.
                     let released = is_delegation_record_data(account.data())
@@ -1829,6 +1668,7 @@ where
         {
             return;
         }
+
         // A late forwarded update can arrive after an account was removed from
         // the provider watch set. If a new subscription already won the race,
         // is_watching is true and this update can be processed normally. If this
@@ -1878,7 +1718,6 @@ where
             context_slot: update_slot,
         };
 
-        let update_source = update.source;
         let (resolved_account, deleg_record, delegation_actions) = self
             .resolve_account_to_clone_from_forwarded_sub_with_unsubscribe(
                 update,
@@ -1893,10 +1732,9 @@ where
                 AccountFetchReason::SubscriptionUpdateClone,
             );
         let projected_ata_clone_request = self
-            .maybe_build_projected_ata_clone_request_from_subscription_update_with_source(
+            .maybe_build_projected_ata_clone_request_from_subscription_update(
                 pubkey,
                 &account,
-                update_source,
                 deleg_record.as_ref(),
                 &delegation_actions,
                 &companion_fetch_log_context,
@@ -2325,31 +2163,6 @@ where
         // (at the sighted slot itself only a delegated copy settles).
         const MAX_RELEASE_CLONE_ATTEMPTS: usize = 3;
         for _ in 0..MAX_RELEASE_CLONE_ATTEMPTS {
-            // The candidate may have been parked before local undelegation
-            // started. Do not let its later record sighting bypass the normal
-            // confirmation check and overwrite protected local state.
-            if self
-                .accounts_bank
-                .get_account(&candidate.pubkey)
-                .is_some_and(|in_bank| {
-                    in_bank.undelegating()
-                        && account_still_undelegating_on_chain(
-                            &candidate.pubkey,
-                            true,
-                            in_bank.remote_slot(),
-                            Some(deleg_record),
-                            &self.validator_pubkey,
-                        )
-                })
-            {
-                trace!(
-                    pubkey = %candidate.pubkey,
-                    slot = candidate.slot,
-                    "Ignoring released collision candidate while local undelegation remains pending"
-                );
-                return;
-            }
-
             let result = match self
                 .fetch_and_clone_accounts_with_dedup_forced_refresh(
                     &[candidate.pubkey],
@@ -2472,7 +2285,11 @@ where
             deleg_record.owner,
         )
         .map(|(wallet_owner, mint)| {
-            ata_projection::derive_supported_ata_pubkeys(&wallet_owner, &mint)
+            try_derive_supported_ata_pubkeys(&wallet_owner, &mint)
+                .token_2022_first()
+                .into_iter()
+                .flatten()
+                .collect::<Vec<_>>()
         })
         .unwrap_or_default();
         let mut pubkeys_to_clone =
@@ -2969,31 +2786,10 @@ where
         delegation_actions: &DelegationActions,
         companion_fetch_log_context: &CompanionFetchLogContext,
     ) -> Option<AccountCloneRequest> {
-        self.maybe_build_projected_ata_clone_request_from_subscription_update_with_source(
-            eata_pubkey,
-            eata_account,
-            SubscriptionSource::Account,
-            deleg_record,
-            delegation_actions,
-            companion_fetch_log_context,
-        )
-        .await
-    }
-
-    async fn maybe_build_projected_ata_clone_request_from_subscription_update_with_source(
-        &self,
-        eata_pubkey: Pubkey,
-        eata_account: &AccountSharedData,
-        update_source: SubscriptionSource,
-        deleg_record: Option<&DelegationRecord>,
-        delegation_actions: &DelegationActions,
-        companion_fetch_log_context: &CompanionFetchLogContext,
-    ) -> Option<AccountCloneRequest> {
         ata_projection::maybe_build_projected_ata_clone_request_from_subscription_update(
             self,
             eata_pubkey,
             eata_account,
-            update_source,
             deleg_record,
             delegation_actions,
             companion_fetch_log_context,

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -4,7 +4,6 @@ use dlp_api::{
     pda::undelegation_request_pda_from_delegated_account,
     state::{DelegationRecord, UndelegationRequest},
 };
-use magicblock_core::token_programs::TOKEN_PROGRAM_ID;
 use magicblock_metrics::metrics::{
     chainlink_pending_fetch_accounts_value,
     chainlink_pending_fetch_waiters_gauge_value,
@@ -19,7 +18,6 @@ use solana_instruction::{AccountMeta, Instruction};
 use solana_keypair::Keypair;
 use solana_program::{program_option::COption, program_pack::Pack};
 use solana_rent::Rent;
-use solana_rpc_client_api::config::RpcAccountInfoConfig;
 use solana_sdk_ids::system_program;
 use solana_signer::Signer;
 use spl_token::state::{Account as SplAccount, AccountState};
@@ -39,10 +37,8 @@ use crate::{
     assert_subscribed_without_delegation_record,
     remote_account_provider::{
         chain_pubsub_client::mock::ChainPubsubClientMock,
-        chain_slot::ChainSlot,
-        program_account::{get_loaderv3_get_program_data_address, LOADER_V3},
-        pubsub_common::SubscriptionSource,
-        RemoteAccount, RemoteAccountProvider, RemoteAccountUpdateSource,
+        chain_slot::ChainSlot, pubsub_common::SubscriptionSource,
+        RemoteAccountProvider, RemoteAccountUpdateSource,
         SubscriptionReleaseMode,
     },
     testing::{
@@ -511,221 +507,6 @@ async fn acquire_direct_subscription_for_update(
         .acquire_subscription(pubkey, SubscriptionReason::DirectAccount)
         .await
         .expect("failed to acquire direct subscription for update test");
-}
-
-#[tokio::test]
-async fn test_dlp_program_update_classifier_prefers_undelegating_local_state() {
-    let validator_keypair = Keypair::new();
-    let local_owner = random_pubkey();
-    let pubkey = random_pubkey();
-    let mut remote_update =
-        AccountSharedData::new(1_000_000, 0, &dlp_api::id());
-    remote_update.set_remote_slot(101);
-
-    let FetcherTestCtx {
-        fetch_cloner,
-        accounts_bank,
-        remote_account_provider,
-        ..
-    } = setup(
-        std::iter::empty::<(Pubkey, Account)>(),
-        100,
-        validator_keypair,
-    )
-    .await;
-
-    let mut local_account = AccountSharedData::new(1_000_000, 0, &local_owner);
-    local_account.set_delegated(true);
-    local_account.set_undelegating(true);
-    local_account.set_remote_slot(100);
-    accounts_bank.insert(pubkey, local_account);
-    acquire_direct_subscription_for_update(&remote_account_provider, &pubkey)
-        .await;
-
-    assert_eq!(
-        fetch_cloner
-            .classify_dlp_program_update_interest(pubkey, &remote_update)
-            .await,
-        DlpProgramUpdateInterest::ProcessUndelegating
-    );
-}
-
-#[tokio::test]
-async fn test_dlp_program_update_classifier_prefers_delegated_local_authority_before_watch(
-) {
-    let validator_keypair = Keypair::new();
-    let local_owner = random_pubkey();
-    let pubkey = random_pubkey();
-    let mut remote_update =
-        AccountSharedData::new(1_000_000, 0, &dlp_api::id());
-    remote_update.set_remote_slot(101);
-
-    let FetcherTestCtx {
-        fetch_cloner,
-        accounts_bank,
-        remote_account_provider,
-        ..
-    } = setup(
-        std::iter::empty::<(Pubkey, Account)>(),
-        100,
-        validator_keypair,
-    )
-    .await;
-
-    let mut local_account = AccountSharedData::new(1_000_000, 0, &local_owner);
-    local_account.set_delegated(true);
-    local_account.set_remote_slot(100);
-    accounts_bank.insert(pubkey, local_account);
-    acquire_direct_subscription_for_update(&remote_account_provider, &pubkey)
-        .await;
-
-    assert_eq!(
-        fetch_cloner
-            .classify_dlp_program_update_interest(pubkey, &remote_update)
-            .await,
-        DlpProgramUpdateInterest::DropLocalDelegatedAuthoritative
-    );
-}
-
-#[tokio::test]
-async fn test_dlp_program_update_classifier_returns_directly_watched_before_projection(
-) {
-    let validator_keypair = Keypair::new();
-    let wallet_owner = random_pubkey();
-    let mint = random_pubkey();
-    let eata_pubkey = derive_eata(&wallet_owner, &mint);
-    let mut eata_account = AccountSharedData::from(create_eata_account(
-        &wallet_owner,
-        &mint,
-        777,
-        true,
-    ));
-    eata_account.set_remote_slot(101);
-
-    let FetcherTestCtx {
-        fetch_cloner,
-        accounts_bank,
-        remote_account_provider,
-        ..
-    } = setup(
-        std::iter::empty::<(Pubkey, Account)>(),
-        100,
-        validator_keypair,
-    )
-    .await;
-    insert_plain_ata_in_bank(
-        &accounts_bank,
-        derive_ata(&wallet_owner, &mint),
-        &wallet_owner,
-        &mint,
-        100,
-    );
-    acquire_direct_subscription_for_update(
-        &remote_account_provider,
-        &eata_pubkey,
-    )
-    .await;
-
-    assert_eq!(
-        fetch_cloner
-            .classify_dlp_program_update_interest(eata_pubkey, &eata_account)
-            .await,
-        DlpProgramUpdateInterest::ProcessDirectlyWatched
-    );
-}
-
-#[tokio::test]
-async fn test_dlp_program_update_classifier_detects_ata_projection_interest() {
-    let validator_keypair = Keypair::new();
-    let wallet_owner = random_pubkey();
-    let mint = random_pubkey();
-    let eata_pubkey = derive_eata(&wallet_owner, &mint);
-    let mut eata_account = AccountSharedData::from(create_eata_account(
-        &wallet_owner,
-        &mint,
-        777,
-        true,
-    ));
-    eata_account.set_remote_slot(101);
-
-    let FetcherTestCtx {
-        fetch_cloner,
-        accounts_bank,
-        ..
-    } = setup(
-        std::iter::empty::<(Pubkey, Account)>(),
-        100,
-        validator_keypair,
-    )
-    .await;
-    insert_plain_ata_in_bank(
-        &accounts_bank,
-        derive_ata(&wallet_owner, &mint),
-        &wallet_owner,
-        &mint,
-        100,
-    );
-
-    assert_eq!(
-        fetch_cloner
-            .classify_dlp_program_update_interest(eata_pubkey, &eata_account)
-            .await,
-        DlpProgramUpdateInterest::ProcessAtaProjection
-    );
-}
-
-#[tokio::test]
-async fn test_dlp_program_update_classifier_discovers_unwatched_non_eata_update(
-) {
-    let validator_keypair = Keypair::new();
-    let pubkey = random_pubkey();
-    let mut remote_update =
-        AccountSharedData::new(1_000_000, 0, &dlp_api::id());
-    remote_update.set_remote_slot(101);
-
-    let FetcherTestCtx { fetch_cloner, .. } = setup(
-        std::iter::empty::<(Pubkey, Account)>(),
-        100,
-        validator_keypair,
-    )
-    .await;
-
-    assert_eq!(
-        fetch_cloner
-            .classify_dlp_program_update_interest(pubkey, &remote_update)
-            .await,
-        DlpProgramUpdateInterest::DiscoverDelegatedAccount
-    );
-}
-
-#[tokio::test]
-async fn test_dlp_program_update_classifier_drops_raw_eata_without_projection_interest(
-) {
-    let validator_keypair = Keypair::new();
-    let wallet_owner = random_pubkey();
-    let mint = random_pubkey();
-    let eata_pubkey = derive_eata(&wallet_owner, &mint);
-    let mut eata_account = AccountSharedData::from(create_eata_account(
-        &wallet_owner,
-        &mint,
-        777,
-        true,
-    ));
-    eata_account.set_remote_slot(101);
-
-    let FetcherTestCtx { fetch_cloner, .. } = setup(
-        std::iter::empty::<(Pubkey, Account)>(),
-        100,
-        validator_keypair,
-    )
-    .await;
-
-    assert_eq!(
-        fetch_cloner
-            .classify_dlp_program_update_interest(eata_pubkey, &eata_account)
-            .await,
-        DlpProgramUpdateInterest::DropRawEataNoProjectionInterest
-    );
 }
 
 async fn wait_for_pending_request(
@@ -1967,6 +1748,9 @@ async fn test_delegated_discovered_after_direct_subscribe_releases_direct_withou
 
     // Send a newer plain update; delegated authoritative-skip path should
     // silently release direct subscription ownership.
+    use crate::remote_account_provider::{
+        RemoteAccount, RemoteAccountUpdateSource,
+    };
     let chain_update = Account {
         lamports: 900_000,
         data: vec![9, 9, 9, 9],
@@ -2436,6 +2220,7 @@ async fn test_delegated_subscription_update_keeps_externally_acquired_undelegati
 
     // Drive a delegated update through the subscription listener so the
     // delegated direct-subscription cleanup path is exercised end-to-end.
+    use crate::remote_account_provider::RemoteAccount;
     rpc_client.set_slot(CURRENT_SLOT + 1);
     let chain_update = Account {
         lamports: 900_000,
@@ -3428,6 +3213,8 @@ async fn test_overlapping_concurrent_ensures_share_inflight_keys_at_rpc_level()
 
 #[tokio::test]
 async fn test_mock_multi_account_fetch_increments_only_multi_counter() {
+    use solana_rpc_client_api::config::RpcAccountInfoConfig;
+
     init_logger();
     let account_owner = random_pubkey();
     const CURRENT_SLOT: u64 = 100;
@@ -3786,6 +3573,10 @@ async fn test_auto_airdrop_uses_chain_slot_when_account_not_in_bank() {
 
 #[tokio::test]
 async fn test_program_loader_resolver_error_releases_program_data_refs() {
+    use crate::remote_account_provider::program_account::{
+        get_loaderv3_get_program_data_address, LOADER_V3,
+    };
+
     init_logger();
     let validator_keypair = Keypair::new();
     let program_pubkey = random_pubkey();
@@ -4365,6 +4156,10 @@ async fn send_subscription_update_and_get_subscribed_programs(
     slot: u64,
     expected_program_id: Option<Pubkey>,
 ) -> std::collections::HashSet<Pubkey> {
+    use crate::remote_account_provider::{
+        RemoteAccount, RemoteAccountUpdateSource,
+    };
+
     accounts_bank.insert(account_pubkey, AccountSharedData::from(bank_account));
     acquire_direct_subscription_for_update(
         remote_account_provider,
@@ -4628,6 +4423,10 @@ async fn test_non_raw_eata_owned_account_subscription_update_stays_delegated() {
         EATA_PROGRAM_ID,
     );
 
+    use crate::remote_account_provider::{
+        RemoteAccount, RemoteAccountUpdateSource,
+    };
+
     acquire_direct_subscription_for_update(
         &remote_account_provider,
         &account_pubkey,
@@ -4696,6 +4495,10 @@ async fn test_discovered_dlp_owned_account_without_delegation_record_is_ignored(
         validator_keypair.insecure_clone(),
     )
     .await;
+
+    use crate::remote_account_provider::{
+        RemoteAccount, RemoteAccountUpdateSource,
+    };
 
     let mut dlp_owned_account_shared =
         AccountSharedData::from(dlp_owned_account.clone());
@@ -4786,6 +4589,10 @@ async fn test_discovered_dlp_owned_account_with_internal_record_prefix_is_droppe
     let fetches_before = rpc_client.single_account_fetches()
         + rpc_client.multi_account_fetches();
 
+    use crate::remote_account_provider::{
+        RemoteAccount, RemoteAccountUpdateSource,
+    };
+
     subscription_tx
         .send(ForwardedSubscriptionUpdate {
             pubkey: account_pubkey,
@@ -4817,668 +4624,6 @@ async fn test_discovered_dlp_owned_account_with_internal_record_prefix_is_droppe
     );
 }
 
-async fn drain_subscription_update_tasks(
-    fetch_cloner: &Arc<TestFetchCloner>,
-    timeout: Duration,
-) {
-    tokio::time::timeout(timeout, async {
-        while Arc::strong_count(fetch_cloner) > 1 {
-            tokio::time::sleep(Duration::from_millis(10)).await;
-        }
-    })
-    .await
-    .expect("timed out waiting for subscription update task to drain");
-}
-
-#[tokio::test]
-async fn test_absent_unwatched_dlp_program_update_without_delegation_record_is_ignored_after_record_fetch(
-) {
-    init_logger();
-    let validator_keypair = Keypair::new();
-    let account_pubkey = random_pubkey();
-    const CURRENT_SLOT: u64 = 100;
-
-    let dlp_owned_account = Account {
-        lamports: 1_000_000,
-        data: vec![1, 2, 3, 4],
-        owner: dlp_api::id(),
-        executable: false,
-        rent_epoch: 0,
-    };
-
-    let FetcherTestCtx {
-        accounts_bank,
-        rpc_client,
-        subscription_tx,
-        fetch_cloner,
-        cloner,
-        ..
-    } = setup(
-        [(account_pubkey, dlp_owned_account.clone())],
-        CURRENT_SLOT,
-        validator_keypair.insecure_clone(),
-    )
-    .await;
-
-    let fetches_before = rpc_client.single_account_fetches()
-        + rpc_client.multi_account_fetches();
-
-    subscription_tx
-        .send(ForwardedSubscriptionUpdate {
-            pubkey: account_pubkey,
-            account: RemoteAccount::from_fresh_account(
-                dlp_owned_account,
-                CURRENT_SLOT,
-                RemoteAccountUpdateSource::Subscription,
-            ),
-            source: SubscriptionSource::Program,
-        })
-        .await
-        .unwrap();
-    drop(subscription_tx);
-
-    drain_subscription_update_tasks(&fetch_cloner, Duration::from_secs(1))
-        .await;
-
-    assert!(accounts_bank.get_account(&account_pubkey).is_none());
-    assert_eq!(cloner.clone_request_count(), 0);
-    assert!(
-        rpc_client.single_account_fetches()
-            + rpc_client.multi_account_fetches()
-            > fetches_before,
-        "greedy discovery should attempt delegation-record resolution before ignoring the update"
-    );
-}
-
-#[tokio::test]
-async fn test_absent_unwatched_dlp_program_update_delegated_to_us_is_greedily_cloned(
-) {
-    init_logger();
-    let validator_keypair = Keypair::new();
-    let validator_pubkey = validator_keypair.pubkey();
-    let account_pubkey = random_pubkey();
-    let account_owner = random_pubkey();
-    const CURRENT_SLOT: u64 = 100;
-
-    let app_data = vec![1, 2, 3, 4];
-    let delegated_account = Account {
-        lamports: 1_000_000,
-        data: app_data.clone(),
-        owner: dlp_api::id(),
-        executable: false,
-        rent_epoch: 0,
-    };
-
-    let FetcherTestCtx {
-        accounts_bank,
-        rpc_client,
-        subscription_tx,
-        fetch_cloner: _,
-        cloner,
-        ..
-    } = setup(
-        [(account_pubkey, delegated_account.clone())],
-        CURRENT_SLOT,
-        validator_keypair.insecure_clone(),
-    )
-    .await;
-
-    add_delegation_record_for(
-        &rpc_client,
-        account_pubkey,
-        validator_pubkey,
-        account_owner,
-    );
-
-    let fetches_before = rpc_client.single_account_fetches()
-        + rpc_client.multi_account_fetches();
-
-    subscription_tx
-        .send(ForwardedSubscriptionUpdate {
-            pubkey: account_pubkey,
-            account: RemoteAccount::from_fresh_account(
-                delegated_account,
-                CURRENT_SLOT,
-                RemoteAccountUpdateSource::Subscription,
-            ),
-            source: SubscriptionSource::Program,
-        })
-        .await
-        .unwrap();
-
-    tokio::time::timeout(Duration::from_secs(1), async {
-        while accounts_bank.get_account(&account_pubkey).is_none() {
-            tokio::time::sleep(Duration::from_millis(10)).await;
-        }
-    })
-    .await
-    .expect("timed out waiting for greedy DLP discovery clone");
-
-    assert!(
-        rpc_client.single_account_fetches()
-            + rpc_client.multi_account_fetches()
-            > fetches_before,
-        "greedy discovery must fetch the delegation record before cloning"
-    );
-    assert!(
-        cloner.clone_request_count() >= 1,
-        "delegated account should be cloned from program update"
-    );
-    let cloned_account = accounts_bank
-        .get_account(&account_pubkey)
-        .expect("delegated account should be cloned from program update");
-    assert!(cloned_account.delegated());
-    assert_eq!(cloned_account.owner(), &account_owner);
-    assert_eq!(cloned_account.data(), app_data.as_slice());
-    assert_eq!(cloned_account.remote_slot(), CURRENT_SLOT);
-}
-
-#[tokio::test]
-async fn test_active_local_delegated_dlp_program_update_cleans_up_without_fetch_or_overwrite(
-) {
-    init_logger();
-    let validator_keypair = Keypair::new();
-    let validator_pubkey = validator_keypair.pubkey();
-    let account_pubkey = random_pubkey();
-    let account_owner = random_pubkey();
-    const CURRENT_SLOT: u64 = 101;
-
-    let remote_update = Account {
-        lamports: 1_000_000,
-        data: vec![9, 9, 9],
-        owner: dlp_api::id(),
-        executable: false,
-        rent_epoch: 0,
-    };
-
-    let FetcherTestCtx {
-        remote_account_provider,
-        accounts_bank,
-        rpc_client,
-        subscription_tx,
-        fetch_cloner,
-        cloner,
-        ..
-    } = setup(
-        [(account_pubkey, remote_update.clone())],
-        CURRENT_SLOT,
-        validator_keypair.insecure_clone(),
-    )
-    .await;
-
-    add_delegation_record_for(
-        &rpc_client,
-        account_pubkey,
-        validator_pubkey,
-        account_owner,
-    );
-
-    let mut local_delegated = AccountSharedData::from(Account {
-        lamports: 1_000_000,
-        data: vec![1, 2, 3],
-        owner: account_owner,
-        executable: false,
-        rent_epoch: 0,
-    });
-    local_delegated.set_delegated(true);
-    local_delegated.set_undelegating(false);
-    local_delegated.set_remote_slot(100);
-    accounts_bank.insert(account_pubkey, local_delegated.clone());
-
-    remote_account_provider
-        .acquire_subscription(
-            &account_pubkey,
-            SubscriptionReason::DirectAccount,
-        )
-        .await
-        .unwrap();
-
-    let fetches_before = rpc_client.single_account_fetches()
-        + rpc_client.multi_account_fetches();
-
-    subscription_tx
-        .send(ForwardedSubscriptionUpdate {
-            pubkey: account_pubkey,
-            account: RemoteAccount::from_fresh_account(
-                remote_update,
-                CURRENT_SLOT,
-                RemoteAccountUpdateSource::Subscription,
-            ),
-            source: SubscriptionSource::Program,
-        })
-        .await
-        .unwrap();
-    drop(subscription_tx);
-
-    drain_subscription_update_tasks(&fetch_cloner, Duration::from_secs(1))
-        .await;
-
-    assert_eq!(
-        rpc_client.single_account_fetches()
-            + rpc_client.multi_account_fetches(),
-        fetches_before
-    );
-    assert_eq!(cloner.clone_request_count(), 0);
-    assert!(!remote_account_provider.is_watching(&account_pubkey));
-    assert_eq!(
-        accounts_bank.get_account(&account_pubkey),
-        Some(local_delegated)
-    );
-}
-
-#[tokio::test]
-async fn test_undelegating_internal_looking_dlp_program_update_reaches_completion_logic(
-) {
-    init_logger();
-    let validator_keypair = Keypair::new();
-    let account_pubkey = random_pubkey();
-    let account_owner = random_pubkey();
-    const CURRENT_SLOT: u64 = 101;
-
-    let mut app_data = vec![0; DelegationRecord::size_with_discriminator()];
-    app_data[..8].copy_from_slice(&100u64.to_le_bytes());
-    assert!(
-        crate::remote_account_provider::pubsub_common::is_internal_dlp_account_data(
-            &app_data
-        )
-    );
-
-    let remote_account = Account {
-        lamports: 1_000_000,
-        data: app_data.clone(),
-        owner: dlp_api::id(),
-        executable: false,
-        rent_epoch: 0,
-    };
-
-    let FetcherTestCtx {
-        remote_account_provider,
-        accounts_bank,
-        subscription_tx,
-        fetch_cloner,
-        ..
-    } = setup(
-        [(account_pubkey, remote_account.clone())],
-        CURRENT_SLOT,
-        validator_keypair.insecure_clone(),
-    )
-    .await;
-
-    let mut local_undelegating = AccountSharedData::from(Account {
-        lamports: 1_000_000,
-        data: app_data,
-        owner: account_owner,
-        executable: false,
-        rent_epoch: 0,
-    });
-    local_undelegating.set_delegated(true);
-    local_undelegating.set_undelegating(true);
-    local_undelegating.set_remote_slot(100);
-    accounts_bank.insert(account_pubkey, local_undelegating);
-
-    remote_account_provider
-        .acquire_subscription(
-            &account_pubkey,
-            SubscriptionReason::DirectAccount,
-        )
-        .await
-        .unwrap();
-
-    subscription_tx
-        .send(ForwardedSubscriptionUpdate {
-            pubkey: account_pubkey,
-            account: RemoteAccount::from_fresh_account(
-                remote_account,
-                CURRENT_SLOT,
-                RemoteAccountUpdateSource::Subscription,
-            ),
-            source: SubscriptionSource::Program,
-        })
-        .await
-        .unwrap();
-    drop(subscription_tx);
-
-    drain_subscription_update_tasks(&fetch_cloner, Duration::from_secs(1))
-        .await;
-
-    let bank_account = accounts_bank
-        .get_account(&account_pubkey)
-        .expect("local account should remain observable after completion");
-    assert!(!bank_account.undelegating());
-    assert!(remote_account_provider.is_watching(&account_pubkey));
-}
-
-#[tokio::test]
-async fn test_raw_eata_program_update_without_projection_interest_is_dropped_without_fetch(
-) {
-    init_logger();
-    let validator_keypair = Keypair::new();
-    let wallet_owner = random_pubkey();
-    let mint = random_pubkey();
-    let eata_pubkey = derive_eata(&wallet_owner, &mint);
-    const CURRENT_SLOT: u64 = 100;
-    const AMOUNT: u64 = 777;
-
-    let eata_account = create_eata_account(&wallet_owner, &mint, AMOUNT, true);
-    let ata_pubkey = derive_ata(&wallet_owner, &mint);
-
-    let FetcherTestCtx {
-        accounts_bank,
-        rpc_client,
-        subscription_tx,
-        fetch_cloner,
-        cloner,
-        ..
-    } = setup(
-        [(eata_pubkey, eata_account.clone())],
-        CURRENT_SLOT,
-        validator_keypair.insecure_clone(),
-    )
-    .await;
-
-    let fetches_before = rpc_client.single_account_fetches()
-        + rpc_client.multi_account_fetches();
-
-    subscription_tx
-        .send(ForwardedSubscriptionUpdate {
-            pubkey: eata_pubkey,
-            account: RemoteAccount::from_fresh_account(
-                eata_account,
-                CURRENT_SLOT,
-                RemoteAccountUpdateSource::Subscription,
-            ),
-            source: SubscriptionSource::Program,
-        })
-        .await
-        .unwrap();
-    drop(subscription_tx);
-
-    drain_subscription_update_tasks(&fetch_cloner, Duration::from_secs(1))
-        .await;
-
-    assert_eq!(
-        rpc_client.single_account_fetches()
-            + rpc_client.multi_account_fetches(),
-        fetches_before
-    );
-    assert_eq!(cloner.clone_request_count(), 0);
-    assert!(accounts_bank.get_account(&eata_pubkey).is_none());
-    assert!(accounts_bank.get_account(&ata_pubkey).is_none());
-}
-
-#[tokio::test]
-async fn test_raw_eata_program_update_with_projection_interest_processes_projection(
-) {
-    init_logger();
-    let validator_keypair = Keypair::new();
-    let validator_pubkey = validator_keypair.pubkey();
-    let wallet_owner = random_pubkey();
-    let mint = random_pubkey();
-    let eata_pubkey = derive_eata(&wallet_owner, &mint);
-    let ata_pubkey = derive_ata(&wallet_owner, &mint);
-    const CURRENT_SLOT: u64 = 101;
-    const AMOUNT: u64 = 777;
-
-    let base_ata_account = create_ata_account(&wallet_owner, &mint);
-    let eata_account = create_eata_account(&wallet_owner, &mint, AMOUNT, true);
-
-    let FetcherTestCtx {
-        accounts_bank,
-        rpc_client,
-        subscription_tx,
-        ..
-    } = setup(
-        [(eata_pubkey, eata_account.clone())],
-        CURRENT_SLOT,
-        validator_keypair.insecure_clone(),
-    )
-    .await;
-
-    let mut local_base_ata = AccountSharedData::from(base_ata_account.clone());
-    local_base_ata.set_remote_slot(100);
-    accounts_bank.insert(ata_pubkey, local_base_ata);
-
-    add_delegation_record_for(
-        &rpc_client,
-        eata_pubkey,
-        validator_pubkey,
-        EATA_PROGRAM_ID,
-    );
-
-    subscription_tx
-        .send(ForwardedSubscriptionUpdate {
-            pubkey: eata_pubkey,
-            account: RemoteAccount::from_fresh_account(
-                eata_account,
-                CURRENT_SLOT,
-                RemoteAccountUpdateSource::Subscription,
-            ),
-            source: SubscriptionSource::Program,
-        })
-        .await
-        .unwrap();
-
-    tokio::time::timeout(Duration::from_secs(1), async {
-        loop {
-            let projected =
-                accounts_bank
-                    .get_account(&ata_pubkey)
-                    .is_some_and(|account| {
-                        account.delegated()
-                            && account.remote_slot() == CURRENT_SLOT
-                    });
-            if projected {
-                break;
-            }
-            tokio::time::sleep(Duration::from_millis(10)).await;
-        }
-    })
-    .await
-    .expect("timed out waiting for raw eATA projection");
-
-    let projected_ata = accounts_bank
-        .get_account(&ata_pubkey)
-        .expect("projected ATA should be cloned into the base ATA pubkey");
-    assert!(projected_ata.delegated());
-    assert_eq!(projected_ata.owner(), &base_ata_account.owner);
-    assert_eq!(projected_ata.data().len(), base_ata_account.data.len());
-    assert_eq!(projected_ata.remote_slot(), CURRENT_SLOT);
-}
-
-#[tokio::test]
-async fn test_absent_unwatched_dlp_update_delegated_elsewhere_is_ignored_after_record_fetch(
-) {
-    init_logger();
-    let validator_keypair = Keypair::new();
-    let other_validator = random_pubkey();
-    let account_pubkey = random_pubkey();
-    let account_owner = random_pubkey();
-    const CURRENT_SLOT: u64 = 100;
-
-    let delegated_account = Account {
-        lamports: 1_000_000,
-        data: vec![1, 2, 3, 4],
-        owner: dlp_api::id(),
-        executable: false,
-        rent_epoch: 0,
-    };
-
-    let FetcherTestCtx {
-        accounts_bank,
-        rpc_client,
-        subscription_tx,
-        fetch_cloner,
-        cloner,
-        ..
-    } = setup(
-        [(account_pubkey, delegated_account.clone())],
-        CURRENT_SLOT,
-        validator_keypair.insecure_clone(),
-    )
-    .await;
-
-    add_delegation_record_for(
-        &rpc_client,
-        account_pubkey,
-        other_validator,
-        account_owner,
-    );
-
-    let fetches_before = rpc_client.single_account_fetches()
-        + rpc_client.multi_account_fetches();
-
-    subscription_tx
-        .send(ForwardedSubscriptionUpdate {
-            pubkey: account_pubkey,
-            account: RemoteAccount::from_fresh_account(
-                delegated_account,
-                CURRENT_SLOT,
-                RemoteAccountUpdateSource::Subscription,
-            ),
-            source: SubscriptionSource::Program,
-        })
-        .await
-        .unwrap();
-    drop(subscription_tx);
-
-    drain_subscription_update_tasks(&fetch_cloner, Duration::from_secs(1))
-        .await;
-
-    assert!(
-        rpc_client.single_account_fetches()
-            + rpc_client.multi_account_fetches()
-            > fetches_before,
-        "greedy discovery should fetch the delegation record before ignoring other-validator authority"
-    );
-    assert_eq!(cloner.clone_request_count(), 0);
-    assert!(accounts_bank.get_account(&account_pubkey).is_none());
-}
-
-#[tokio::test]
-async fn test_explicit_ensure_still_fetches_delegation_record_and_clones_delegated_account(
-) {
-    init_logger();
-    let validator_keypair = Keypair::new();
-    let validator_pubkey = validator_keypair.pubkey();
-    let account_pubkey = random_pubkey();
-    let account_owner = random_pubkey();
-    const CURRENT_SLOT: u64 = 100;
-
-    let app_data = vec![1, 2, 3, 4];
-    let delegated_account = Account {
-        lamports: 1_000_000,
-        data: app_data.clone(),
-        owner: dlp_api::id(),
-        executable: false,
-        rent_epoch: 0,
-    };
-
-    let FetcherTestCtx {
-        accounts_bank,
-        rpc_client,
-        fetch_cloner,
-        ..
-    } = setup(
-        [(account_pubkey, delegated_account.clone())],
-        CURRENT_SLOT,
-        validator_keypair.insecure_clone(),
-    )
-    .await;
-
-    add_delegation_record_for(
-        &rpc_client,
-        account_pubkey,
-        validator_pubkey,
-        account_owner,
-    );
-
-    let fetches_before = rpc_client.single_account_fetches()
-        + rpc_client.multi_account_fetches();
-
-    fetch_cloner
-        .fetch_and_clone_accounts_with_dedup(
-            &[account_pubkey],
-            None,
-            Some(CURRENT_SLOT),
-            AccountFetchContext::rpc_get_account(),
-        )
-        .await
-        .unwrap();
-
-    assert!(
-        rpc_client.single_account_fetches()
-            + rpc_client.multi_account_fetches()
-            > fetches_before
-    );
-    let cloned_account = accounts_bank
-        .get_account(&account_pubkey)
-        .expect("delegated account should be cloned explicitly");
-    assert!(cloned_account.delegated());
-    assert_eq!(cloned_account.owner(), &account_owner);
-    assert_eq!(cloned_account.data(), app_data.as_slice());
-}
-
-#[tokio::test]
-async fn test_explicit_clone_executes_post_delegation_actions_after_prefilter_changes(
-) {
-    init_logger();
-    let validator_keypair = Keypair::new();
-    let validator_pubkey = validator_keypair.pubkey();
-    let account_pubkey = random_pubkey();
-    let account_owner = random_pubkey();
-    const CURRENT_SLOT: u64 = 100;
-
-    let delegated_account = Account {
-        lamports: 1_000_000,
-        data: vec![1, 2, 3, 4],
-        owner: dlp_api::id(),
-        executable: false,
-        rent_epoch: 0,
-    };
-
-    let FetcherTestCtx {
-        accounts_bank,
-        rpc_client,
-        fetch_cloner,
-        cloner,
-        ..
-    } = setup(
-        [(account_pubkey, delegated_account)],
-        CURRENT_SLOT,
-        validator_keypair.insecure_clone(),
-    )
-    .await;
-
-    add_delegation_record_with_actions_for(
-        &rpc_client,
-        account_pubkey,
-        validator_pubkey,
-        account_owner,
-        system_program::id(),
-    );
-
-    fetch_cloner
-        .fetch_and_clone_accounts_with_dedup(
-            &[account_pubkey],
-            None,
-            Some(CURRENT_SLOT),
-            AccountFetchContext::rpc_get_account(),
-        )
-        .await
-        .unwrap();
-
-    let clone_requests = cloner.clone_requests();
-    let delegated_clone_request = clone_requests
-        .iter()
-        .find(|request| request.pubkey == account_pubkey)
-        .expect("delegated account clone request should be recorded");
-    assert!(!delegated_clone_request.delegation_actions.is_empty());
-    let cloned_account = accounts_bank
-        .get_account(&account_pubkey)
-        .expect("delegated account should be cloned explicitly");
-    assert!(cloned_account.delegated());
-}
-
 // A freshly delegated account whose app data collides with an internal DLP
 // discriminator is still greedily cloned: the delegation-record update from
 // the same delegation routes it to discovery, in either delivery order.
@@ -5507,126 +4652,6 @@ async fn test_discovered_colliding_delegated_account_record_late_refreshes_stale
 async fn test_discovered_colliding_delegated_account_account_sourced_record_releases(
 ) {
     colliding_delegated_account_is_cloned(true, false, true).await;
-}
-
-// A candidate can be parked before local undelegation starts. Its later
-// record sighting must not bypass undelegation confirmation or release the
-// tracking subscription.
-#[tokio::test]
-async fn test_released_collision_candidate_keeps_pending_undelegation_locked() {
-    init_logger();
-    let validator_keypair = Keypair::new();
-    let validator_pubkey = validator_keypair.pubkey();
-    let account_pubkey = random_pubkey();
-    let account_owner = random_pubkey();
-    const CURRENT_SLOT: u64 = 100;
-    const LOCAL_SLOT: u64 = CURRENT_SLOT - 1;
-
-    let mut app_data = vec![0; DelegationRecord::size_with_discriminator()];
-    app_data[..8].copy_from_slice(&100u64.to_le_bytes());
-    let delegated_account = Account {
-        lamports: 1_000_000,
-        data: app_data.clone(),
-        owner: dlp_api::id(),
-        executable: false,
-        rent_epoch: 0,
-    };
-
-    let FetcherTestCtx {
-        remote_account_provider,
-        accounts_bank,
-        rpc_client,
-        subscription_tx,
-        cloner,
-        ..
-    } = setup(
-        [(account_pubkey, delegated_account.clone())],
-        CURRENT_SLOT,
-        validator_keypair.insecure_clone(),
-    )
-    .await;
-
-    add_delegation_record_for(
-        &rpc_client,
-        account_pubkey,
-        validator_pubkey,
-        account_owner,
-    );
-    let delegation_record_pubkey =
-        dlp_api::pda::delegation_record_pda_from_delegated_account(
-            &account_pubkey,
-        );
-    let delegation_record = DelegationRecord {
-        authority: validator_pubkey,
-        owner: account_owner,
-        delegation_slot: 1,
-        lamports: 1_000,
-        commit_frequency_ms: 2_000,
-    };
-    let delegation_record_account = Account {
-        lamports: 1_000_000,
-        data: delegation_record_to_vec(&delegation_record),
-        owner: dlp_api::id(),
-        executable: false,
-        rent_epoch: 0,
-    };
-
-    subscription_tx
-        .send(ForwardedSubscriptionUpdate {
-            pubkey: account_pubkey,
-            account: RemoteAccount::from_fresh_account(
-                delegated_account,
-                CURRENT_SLOT,
-                RemoteAccountUpdateSource::Subscription,
-            ),
-            source: SubscriptionSource::Program,
-        })
-        .await
-        .unwrap();
-    tokio::time::sleep(Duration::from_millis(50)).await;
-
-    let mut local_undelegating =
-        AccountSharedData::new(1_000_000, app_data.len(), &dlp_api::id());
-    local_undelegating.set_data_from_slice(&app_data);
-    local_undelegating.set_remote_slot(LOCAL_SLOT);
-    local_undelegating.set_undelegating(true);
-    accounts_bank.insert(account_pubkey, local_undelegating.clone());
-    remote_account_provider
-        .acquire_subscription(
-            &account_pubkey,
-            SubscriptionReason::UndelegationTracking,
-        )
-        .await
-        .expect("failed to acquire undelegation tracking");
-
-    subscription_tx
-        .send(ForwardedSubscriptionUpdate {
-            pubkey: delegation_record_pubkey,
-            account: RemoteAccount::from_fresh_account(
-                delegation_record_account,
-                CURRENT_SLOT,
-                RemoteAccountUpdateSource::Subscription,
-            ),
-            source: SubscriptionSource::Program,
-        })
-        .await
-        .unwrap();
-    tokio::time::sleep(Duration::from_millis(300)).await;
-
-    let account_after = accounts_bank
-        .get_account(&account_pubkey)
-        .expect("undelegating account must remain in bank");
-    assert_eq!(account_after, local_undelegating);
-    assert_eq!(cloner.clone_request_count(), 0);
-    assert!(
-        remote_account_provider
-            .has_subscription_reason(
-                &account_pubkey,
-                SubscriptionReason::UndelegationTracking,
-            )
-            .await,
-        "pending undelegation tracking must remain held"
-    );
 }
 
 // A release pass that settles on pre-delegation state (e.g. joining an
@@ -6154,6 +5179,10 @@ async fn test_internal_dlp_pda_program_update_is_filtered_after_discovery_miss()
     )
     .await;
 
+    use crate::remote_account_provider::{
+        RemoteAccount, RemoteAccountUpdateSource,
+    };
+
     subscription_tx
         .send(ForwardedSubscriptionUpdate {
             pubkey: delegation_record_pubkey,
@@ -6227,6 +5256,10 @@ async fn test_same_slot_delegated_subscription_update_overrides_plain_bank_accou
     let mut plain_in_bank = AccountSharedData::from(plain_account);
     plain_in_bank.set_remote_slot(CURRENT_SLOT);
     accounts_bank.insert(account_pubkey, plain_in_bank);
+
+    use crate::remote_account_provider::{
+        RemoteAccount, RemoteAccountUpdateSource,
+    };
 
     acquire_direct_subscription_for_update(
         &remote_account_provider,
@@ -6313,6 +5346,10 @@ async fn test_same_slot_delegated_subscription_update_overrides_undelegating_ban
     undelegating_in_bank.set_undelegating(true);
     accounts_bank.insert(account_pubkey, undelegating_in_bank);
 
+    use crate::remote_account_provider::{
+        RemoteAccount, RemoteAccountUpdateSource,
+    };
+
     acquire_direct_subscription_for_update(
         &remote_account_provider,
         &account_pubkey,
@@ -6388,6 +5425,10 @@ async fn test_discovered_dlp_owned_account_delegated_elsewhere_is_ignored() {
         other_validator,
         account_owner,
     );
+
+    use crate::remote_account_provider::{
+        RemoteAccount, RemoteAccountUpdateSource,
+    };
 
     subscription_tx
         .send(ForwardedSubscriptionUpdate {
@@ -6467,6 +5508,10 @@ async fn test_out_of_order_delegated_eata_subscription_update_still_projects_ata
         &mint,
         CURRENT_SLOT,
     );
+
+    use crate::remote_account_provider::{
+        RemoteAccount, RemoteAccountUpdateSource,
+    };
 
     acquire_direct_subscription_for_update(
         &remote_account_provider,
@@ -6564,6 +5609,10 @@ async fn test_out_of_order_delegated_eata_update_clones_action_dependencies() {
         &mint,
         CURRENT_SLOT,
     );
+
+    use crate::remote_account_provider::{
+        RemoteAccount, RemoteAccountUpdateSource,
+    };
 
     acquire_direct_subscription_for_update(
         &remote_account_provider,
@@ -6663,6 +5712,10 @@ async fn test_subscription_update_with_delegation_actions_clones_dependencies()
     let mut stale_in_bank = AccountSharedData::from(delegated_account.clone());
     stale_in_bank.set_remote_slot(CURRENT_SLOT - 1);
     accounts_bank.insert(account_pubkey, stale_in_bank);
+
+    use crate::remote_account_provider::{
+        RemoteAccount, RemoteAccountUpdateSource,
+    };
 
     acquire_direct_subscription_for_update(
         &remote_account_provider,
@@ -6765,6 +5818,10 @@ async fn test_delegated_eata_subscription_update_clones_raw_eata_and_projects_at
         &mint,
         CURRENT_SLOT,
     );
+
+    use crate::remote_account_provider::{
+        RemoteAccount, RemoteAccountUpdateSource,
+    };
 
     acquire_direct_subscription_for_update(
         &remote_account_provider,
@@ -6881,6 +5938,10 @@ async fn test_raw_eata_subscription_update_without_actions_projects_remote_ata_o
         accounts_bank.get_account(&ata_pubkey).is_none(),
         "test must start without the ATA in bank"
     );
+
+    use crate::remote_account_provider::{
+        RemoteAccount, RemoteAccountUpdateSource,
+    };
 
     acquire_direct_subscription_for_update(
         &remote_account_provider,
@@ -7024,6 +6085,10 @@ async fn test_delegated_eata_subscription_update_projects_remote_ata() {
         "test must start without the ATA in bank"
     );
 
+    use crate::remote_account_provider::{
+        RemoteAccount, RemoteAccountUpdateSource,
+    };
+
     acquire_direct_subscription_for_update(
         &remote_account_provider,
         &eata_pubkey,
@@ -7119,6 +6184,10 @@ async fn test_ata_subscription_update_projects_eata_when_chain_slot_lags() {
         tokio::time::sleep(Duration::from_millis(800)).await;
         rpc_to_advance.set_slot(ATA_SLOT);
     });
+
+    use crate::remote_account_provider::{
+        RemoteAccount, RemoteAccountUpdateSource,
+    };
 
     acquire_direct_subscription_for_update(
         &remote_account_provider,
@@ -7236,6 +6305,10 @@ async fn test_delegated_eata_subscription_update_clones_action_dependencies() {
         &mint,
         CURRENT_SLOT,
     );
+
+    use crate::remote_account_provider::{
+        RemoteAccount, RemoteAccountUpdateSource,
+    };
 
     acquire_direct_subscription_for_update(
         &remote_account_provider,
@@ -8388,6 +7461,10 @@ async fn test_delegated_eata_update_does_not_override_delegated_ata_in_bank() {
     local_ata_shared.set_delegated(true);
     accounts_bank.insert(ata_pubkey, local_ata_shared);
 
+    use crate::remote_account_provider::{
+        RemoteAccount, RemoteAccountUpdateSource,
+    };
+
     // A newer chain update for delegated eATA must not override delegated ATA in bank.
     subscription_tx
         .send(ForwardedSubscriptionUpdate {
@@ -8471,6 +7548,10 @@ async fn test_delegated_eata_update_projects_existing_plain_ata_in_bank() {
     let mut plain_ata_shared = AccountSharedData::from(plain_ata);
     plain_ata_shared.set_remote_slot(PLAIN_ATA_SLOT);
     accounts_bank.insert(ata_pubkey, plain_ata_shared);
+
+    use crate::remote_account_provider::{
+        RemoteAccount, RemoteAccountUpdateSource,
+    };
 
     subscription_tx
         .send(ForwardedSubscriptionUpdate {
@@ -8577,6 +7658,10 @@ async fn test_delegated_eata_update_projects_existing_token_2022_ata_in_bank() {
     let mut legacy_ata_shared = AccountSharedData::from(legacy_ata);
     legacy_ata_shared.set_remote_slot(PLAIN_ATA_SLOT + 1);
     accounts_bank.insert(legacy_ata_pubkey, legacy_ata_shared);
+
+    use crate::remote_account_provider::{
+        RemoteAccount, RemoteAccountUpdateSource,
+    };
 
     subscription_tx
         .send(ForwardedSubscriptionUpdate {
@@ -8688,6 +7773,10 @@ async fn test_greedy_delegated_eata_update_projects_remote_token_2022_ata() {
         validator_pubkey,
         EATA_PROGRAM_ID,
     );
+
+    use crate::remote_account_provider::{
+        RemoteAccount, RemoteAccountUpdateSource,
+    };
 
     subscription_tx
         .send(ForwardedSubscriptionUpdate {
@@ -9527,6 +8616,10 @@ async fn test_undelegating_projected_ata_subscription_update_stays_locked() {
     accounts_bank.insert(ata_pubkey, local_ata_shared);
     assert_not_subscribed!(remote_account_provider, &[&eata_pubkey]);
 
+    use crate::remote_account_provider::{
+        RemoteAccount, RemoteAccountUpdateSource,
+    };
+
     acquire_direct_subscription_for_update(
         &remote_account_provider,
         &ata_pubkey,
@@ -9626,6 +8719,10 @@ async fn test_delegated_eata_update_does_not_override_undelegating_ata_in_bank()
     local_ata_shared.set_remote_slot(LOCAL_SLOT);
     local_ata_shared.set_undelegating(true);
     accounts_bank.insert(ata_pubkey, local_ata_shared);
+
+    use crate::remote_account_provider::{
+        RemoteAccount, RemoteAccountUpdateSource,
+    };
 
     subscription_tx
         .send(ForwardedSubscriptionUpdate {
@@ -10602,6 +9699,10 @@ async fn test_project_ata_skips_repeat_fetch_for_known_empty_eata() {
     .await;
     let eata_pubkey = derive_eata(&wallet_owner, &mint);
 
+    use crate::remote_account_provider::{
+        RemoteAccount, RemoteAccountUpdateSource,
+    };
+
     acquire_direct_subscription_for_update(
         &remote_account_provider,
         &ata_pubkey,
@@ -10676,6 +9777,8 @@ async fn test_project_ata_skips_repeat_fetch_for_known_empty_eata() {
 #[tokio::test]
 async fn test_delegated_account_owned_by_token_program_does_not_subscribe_program(
 ) {
+    use magicblock_core::token_programs::TOKEN_PROGRAM_ID;
+
     init_logger();
     let validator_keypair = Keypair::new();
     let validator_pubkey = validator_keypair.pubkey();

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -4084,7 +4084,17 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
     }
 }
 
+#[cfg(test)]
 impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
+    /// Check if an account is currently pending (being fetched).
+    pub(crate) fn is_pending(&self, pubkey: &Pubkey) -> bool {
+        let fetching = self
+            .fetching_accounts
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        fetching.contains_key(pubkey)
+    }
+
     pub(crate) async fn has_subscription_reason(
         &self,
         pubkey: &Pubkey,
@@ -4095,18 +4105,6 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
             .await
             .get(pubkey)
             .is_some_and(|ownership| ownership.contains(reason))
-    }
-}
-
-#[cfg(test)]
-impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
-    /// Check if an account is currently pending (being fetched).
-    pub(crate) fn is_pending(&self, pubkey: &Pubkey) -> bool {
-        let fetching = self
-            .fetching_accounts
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
-        fetching.contains_key(pubkey)
     }
 }
 

--- a/test-integration/test-cloning/tests/10_post_delegation_token_transfer.rs
+++ b/test-integration/test-cloning/tests/10_post_delegation_token_transfer.rs
@@ -33,6 +33,7 @@ use spl_associated_token_account_interface::instruction::create_associated_token
 use spl_token::{instruction as spl_token_ix, state::Mint};
 use test_kit::init_logger;
 
+const SOURCE_AUTHORITY_SEED: [u8; 32] = [7; 32];
 const SOURCE_EATA_BALANCE: u64 = 200;
 const DESTINATION_EATA_BALANCE: u64 = 100;
 const TRANSFER_AMOUNT: u64 = 100;
@@ -175,9 +176,9 @@ fn test_post_delegation_action_executes_spl_token_transfer_100() {
 
     let fee_payer = Keypair::new();
     let delegated_account = Keypair::new();
-    let source_authority = Keypair::new();
-    let destination_authority = Keypair::new();
-    let mint = Keypair::new();
+    let source_authority = Keypair::new_from_array(SOURCE_AUTHORITY_SEED);
+    let destination_authority = Keypair::new_from_array([8; 32]);
+    let mint = Keypair::new_from_array([9; 32]);
     let source_ata = derive_ata(&source_authority.pubkey(), &mint.pubkey());
     let destination_ata =
         derive_ata(&destination_authority.pubkey(), &mint.pubkey());


### PR DESCRIPTION
Reverts magicblock-labs/magicblock-validator#1455

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of subscription updates for delegated accounts, including accounts discovered through owner-program subscriptions.
  - Refined projected ATA/eATA processing to preserve supported ATA relationships and improve companion account discovery.
  - Prevented updates for accounts delegated to other validators from being incorrectly processed.
  - Improved handling of internal account updates and collision cases during account discovery.

- **Documentation**
  - Updated Chainlink behavior documentation to reflect the revised subscription, delegation, and collision-handling rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->