### PR TITLE
fix: do not populate the block cache during the replay

### DIFF
--- a/magicblock-aperture/src/error.rs
+++ b/magicblock-aperture/src/error.rs
@@ -169,6 +169,14 @@ impl RpcError {
         }
     }
 
+    pub(crate) fn unavailable<E: Display>(error: E) -> Self {
+        Self {
+            code: INTERNAL_ERROR,
+            message: error.to_string(),
+            http_status: 503,
+        }
+    }
+
     pub(crate) fn custom<E: Display>(error: E, code: i16) -> Self {
         Self {
             code,

--- a/magicblock-aperture/src/lib.rs
+++ b/magicblock-aperture/src/lib.rs
@@ -3,7 +3,7 @@ use std::net::SocketAddr;
 use error::{ApertureError, RpcError};
 use magicblock_config::config::aperture::ApertureConfig;
 use magicblock_core::link::DispatchEndpoints;
-use processor::EventProcessor;
+pub use processor::EventProcessors;
 use server::{http::HttpServer, websocket::WebsocketServer};
 use state::SharedState;
 use tokio::net::TcpListener;
@@ -19,13 +19,27 @@ pub async fn initialize_aperture(
     dispatch: &DispatchEndpoints,
     cancel: CancellationToken,
 ) -> ApertureResult<JsonRpcServer> {
+    let (server, events) =
+        prepare_aperture(config, state, dispatch, cancel).await?;
+    events.start();
+    Ok(server)
+}
+
+/// Initializes Aperture without subscribing its event processors.
+///
+/// Validator startup uses this form so ledger-replay block broadcasts are not
+/// admitted into the RPC blockhash cache.
+pub async fn prepare_aperture(
+    config: &ApertureConfig,
+    state: SharedState,
+    dispatch: &DispatchEndpoints,
+    cancel: CancellationToken,
+) -> ApertureResult<(JsonRpcServer, EventProcessors)> {
     let server =
         JsonRpcServer::new(config, state.clone(), dispatch, cancel.clone())
             .await?;
-    // Start event processors only after the server has bound its sockets so a
-    // bind failure cannot leak background tasks during retries in tests/startup.
-    EventProcessor::start(config, &state, dispatch, cancel)?;
-    Ok(server)
+    let events = EventProcessors::try_new(config, state, dispatch, cancel)?;
+    Ok((server, events))
 }
 
 /// An entrypoint to startup JSON-RPC server, for both HTTP and WS requests

--- a/magicblock-aperture/src/processor.rs
+++ b/magicblock-aperture/src/processor.rs
@@ -56,57 +56,90 @@ pub(crate) struct EventProcessor {
     geyser: Arc<GeyserPluginManager>,
 }
 
-impl EventProcessor {
-    /// Creates a new `EventProcessor` instance by cloning handles to shared state and channels.
-    fn new(
+/// Event-processing service prepared during RPC initialization and started only
+/// after validator recovery is complete.
+///
+/// Deferring the block subscription keeps blockhashes broadcast during ledger
+/// replay out of the RPC cache while preserving those broadcasts for the
+/// execution runtime.
+pub struct EventProcessors {
+    config: ApertureConfig,
+    state: SharedState,
+    account_update_rx: AccountUpdateRx,
+    transaction_status_rx: TransactionStatusRx,
+    cancel: CancellationToken,
+    geyser: Arc<GeyserPluginManager>,
+}
+
+impl EventProcessors {
+    pub(crate) fn try_new(
+        config: &ApertureConfig,
+        state: SharedState,
         channels: &DispatchEndpoints,
-        state: &SharedState,
-        geyser: Arc<GeyserPluginManager>,
+        cancel: CancellationToken,
     ) -> ApertureResult<Self> {
-        let latest_block = state.ledger.latest_block().clone();
-        // Subscribe to block updates immediately to ensure we don't miss any
-        // notifications that might be sent before the `run()` method is polled.
-        let block_update_rx = latest_block.subscribe();
+        // SAFETY:
+        // Geyser plugins use FFI. Operators must ensure each configured plugin
+        // is compatible with this validator.
+        let geyser =
+            unsafe { GeyserPluginManager::new(&config.geyser_plugins) }?.into();
         Ok(Self {
-            subscriptions: state.subscriptions.clone(),
-            transactions: state.transactions.clone(),
-            blocks: state.blocks.clone(),
+            config: config.clone(),
+            state,
             account_update_rx: channels.account_update.clone(),
             transaction_status_rx: channels.transaction_status.clone(),
-            block_update_rx,
+            cancel,
             geyser,
         })
     }
 
-    /// Spawns a specified number of `EventProcessor` workers.
+    /// Starts workers and subscribes them to block updates.
     ///
-    /// Each worker runs in its own Tokio task and will gracefully shut down when the
-    /// provided `CancellationToken` is triggered.
-    ///
-    /// # Arguments
-    /// * `state` - The shared global state of the RPC service.
-    /// * `channels` - The endpoints for receiving validator events.
-    /// * `instances` - The number of concurrent worker tasks to spawn.
-    /// * `cancel` - The token used for graceful shutdown.
-    pub(crate) fn start(
-        config: &ApertureConfig,
-        state: &SharedState,
-        channels: &DispatchEndpoints,
-        cancel: CancellationToken,
-    ) -> ApertureResult<()> {
-        // SAFETY:
-        // Geyser plugin system works with the FFI, and is inherently unsafe,
-        // the plugin must be 100% compatible with the validator to be used
-        // without any memory violations, and it is the responsibility of the
-        // node operator to ensure that loaded plugin is correct and safe to use.
-        let geyser: Arc<_> =
-            unsafe { GeyserPluginManager::new(&config.geyser_plugins) }?.into();
+    /// Call this after ledger replay. Broadcast receivers only observe updates
+    /// sent after subscription, so replayed blockhashes cannot become valid RPC
+    /// blockhashes.
+    pub fn start(self) {
+        let Self {
+            config,
+            state,
+            account_update_rx,
+            transaction_status_rx,
+            cancel,
+            geyser,
+        } = self;
         for id in 0..config.event_processors {
-            let geyser = geyser.clone();
-            let processor = EventProcessor::new(channels, state, geyser)?;
+            let processor = EventProcessor::new(
+                &state,
+                account_update_rx.clone(),
+                transaction_status_rx.clone(),
+                geyser.clone(),
+            );
             tokio::spawn(processor.run(id, cancel.clone()));
         }
-        Ok(())
+    }
+}
+
+impl EventProcessor {
+    /// Creates a new `EventProcessor` instance by cloning handles to shared state and channels.
+    fn new(
+        state: &SharedState,
+        account_update_rx: AccountUpdateRx,
+        transaction_status_rx: TransactionStatusRx,
+        geyser: Arc<GeyserPluginManager>,
+    ) -> Self {
+        let latest_block = state.ledger.latest_block().clone();
+        // Subscribe to block updates immediately to ensure we don't miss any
+        // notifications that might be sent before the `run()` method is polled.
+        let block_update_rx = latest_block.subscribe();
+        Self {
+            subscriptions: state.subscriptions.clone(),
+            transactions: state.transactions.clone(),
+            blocks: state.blocks.clone(),
+            account_update_rx,
+            transaction_status_rx,
+            block_update_rx,
+            geyser,
+        }
     }
 
     /// The main event processing loop for a single worker instance.

--- a/magicblock-aperture/src/requests/http/get_latest_blockhash.rs
+++ b/magicblock-aperture/src/requests/http/get_latest_blockhash.rs
@@ -11,6 +11,11 @@ impl HttpDispatcher {
         &self,
         request: &JsonRequest,
     ) -> HandlerResult {
+        if !self.blocks.is_ready() {
+            return Err(RpcError::unavailable(
+                "blockhash unavailable until the first post-recovery block",
+            ));
+        }
         let info = self.blocks.get_latest();
         let slot = info.slot;
         let response = RpcBlockhash::from(info);

--- a/magicblock-aperture/src/requests/http/mod.rs
+++ b/magicblock-aperture/src/requests/http/mod.rs
@@ -129,13 +129,17 @@ impl HttpDispatcher {
         &self,
         method: &'static str,
     ) -> RpcResult<()> {
-        if self.needs_onchain_interactions() {
-            Ok(())
-        } else {
-            Err(RpcError::transaction_verification(format!(
+        if !self.needs_onchain_interactions() {
+            return Err(RpcError::transaction_verification(format!(
                 "{method} is only available while validator is primary"
-            )))
+            )));
         }
+        if !self.blocks.is_ready() {
+            return Err(RpcError::unavailable(format!(
+                "{method} is unavailable until the first post-recovery block"
+            )));
+        }
+        Ok(())
     }
 
     /// Fetches an account's data from the `AccountsDb` filling it in from chain

--- a/magicblock-aperture/src/server/http/dispatch.rs
+++ b/magicblock-aperture/src/server/http/dispatch.rs
@@ -96,7 +96,7 @@ impl HttpDispatcher {
         self: Arc<Self>,
         request: Request<Incoming>,
     ) -> Result<Response<JsonBody>, Infallible> {
-        if let Some(response) = Self::handle_special_request(&request) {
+        if let Some(response) = self.handle_special_request(&request) {
             return Ok(response);
         }
         // A local macro to simplify error handling. If a Result is an Err,
@@ -233,6 +233,7 @@ impl HttpDispatcher {
     }
 
     fn handle_special_request(
+        &self,
         request: &Request<Incoming>,
     ) -> Option<Response<JsonBody>> {
         if request.method() == Method::OPTIONS {
@@ -242,7 +243,9 @@ impl HttpDispatcher {
         } else if request.uri() == "/health/primary" {
             let mut response = Response::new(JsonBody::from(""));
             Self::set_access_control_headers(&mut response);
-            if CoordinationMode::current() != CoordinationMode::Primary {
+            if CoordinationMode::current() != CoordinationMode::Primary
+                || !self.blocks.is_ready()
+            {
                 *response.status_mut() = StatusCode::SERVICE_UNAVAILABLE
             }
             return Some(response);

--- a/magicblock-aperture/src/state/blocks.rs
+++ b/magicblock-aperture/src/state/blocks.rs
@@ -1,4 +1,11 @@
-use std::{ops::Deref, sync::Arc, time::Duration};
+use std::{
+    ops::Deref,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
 
 use arc_swap::ArcSwapAny;
 use magicblock_core::{
@@ -25,6 +32,8 @@ pub(crate) struct BlocksCache {
     block_validity: u64,
     /// Latest observed block (updated whenever the ledger transitions to new slot)
     latest: ArcSwapAny<Arc<LastCachedBlock>>,
+    /// Whether RPC observed a block after event processing started.
+    ready: AtomicBool,
     /// An underlying time-based cache for storing `BlockHash` to `BlockMeta` mappings.
     cache: ExpiringCache<BlockHash, Slot>,
 }
@@ -61,10 +70,9 @@ impl BlocksCache {
         let blocktime_ratio = SOLANA_BLOCK_TIME / blocktime as f64;
         let block_validity = blocktime_ratio * MAX_VALID_BLOCKHASH_SLOTS;
         let cache = ExpiringCache::new(BLOCK_CACHE_TTL);
-        // Add the initial blockhash to the cache so it's recognized as valid
-        cache.push(latest.blockhash, latest.slot);
         Self {
             latest: ArcSwapAny::new(latest.into()),
+            ready: AtomicBool::new(false),
             block_validity: block_validity as u64,
             cache,
         }
@@ -81,6 +89,12 @@ impl BlocksCache {
         self.cache.push(latest.blockhash, latest.slot);
         // And mark it as latest observed
         self.latest.swap(last.into());
+        self.ready.store(true, Ordering::Release);
+    }
+
+    /// Returns whether a post-recovery block is available to RPC clients.
+    pub(crate) fn is_ready(&self) -> bool {
+        self.ready.load(Ordering::Acquire)
     }
 
     /// Retrieves information about the latest block, including its calculated validity period.

--- a/magicblock-aperture/src/tests.rs
+++ b/magicblock-aperture/src/tests.rs
@@ -25,7 +25,7 @@ use crate::{
     server::websocket::dispatch::WsConnectionChannel,
     state::{ChainlinkImpl, InnerChainlinkImpl, SharedState},
     utils::ProgramFilters,
-    EventProcessor,
+    EventProcessors,
 };
 
 const LAMPORTS_PER_SOL: u64 = 1_000_000_000;
@@ -49,6 +49,7 @@ mod event_processor {
     use magicblock_config::{
         config::ApertureConfig, consts::DEFAULT_LEDGER_BLOCK_TIME_MS,
     };
+    use magicblock_core::link::blocks::{BlockHash, LatestBlockInner};
 
     use super::*;
     use crate::state::NodeContext;
@@ -72,10 +73,69 @@ mod event_processor {
         );
         let cancel = CancellationToken::new();
         let config = ApertureConfig::default();
-        EventProcessor::start(&config, &state, &env.dispatch, cancel)
-            .expect("failed to start an event processor");
+        let events = EventProcessors::try_new(
+            &config,
+            state.clone(),
+            &env.dispatch,
+            cancel,
+        )
+        .expect("failed to initialize event processors");
+        events.start();
         env.advance_slot();
         (state, env)
+    }
+
+    #[tokio::test]
+    async fn block_updates_before_event_start_are_not_cached() {
+        let env = ExecutionTestEnv::new_with_config(
+            ExecutionTestEnv::BASE_FEE,
+            1,
+            true,
+        );
+        env.advance_slot();
+        let state = SharedState::new(
+            NodeContext {
+                identity: env.get_payer().pubkey,
+                blocktime: DEFAULT_LEDGER_BLOCK_TIME_MS,
+                ..Default::default()
+            },
+            env.accountsdb.clone(),
+            env.ledger.clone(),
+            Arc::new(chainlink(&env.accountsdb)),
+        );
+        let recovered = LatestBlockInner::new(2, BlockHash::new_unique(), 1);
+        env.ledger.latest_block().store(recovered.clone());
+
+        assert!(!state.blocks.is_ready());
+        assert!(!state.blocks.contains(&recovered.blockhash));
+
+        let events = EventProcessors::try_new(
+            &ApertureConfig::default(),
+            state.clone(),
+            &env.dispatch,
+            CancellationToken::new(),
+        )
+        .expect("failed to initialize event processors");
+        events.start();
+
+        tokio::task::yield_now().await;
+        assert!(
+            !state.blocks.is_ready(),
+            "subscribing after recovery must not expose the recovered blockhash"
+        );
+
+        let live = LatestBlockInner::new(3, BlockHash::new_unique(), 2);
+        env.ledger.latest_block().store(live.clone());
+        timeout(Duration::from_secs(1), async {
+            while !state.blocks.is_ready() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("fresh block was not cached");
+
+        assert!(state.blocks.contains(&live.blockhash));
+        assert!(!state.blocks.contains(&recovered.blockhash));
     }
 
     /// Awaits a message from a receiver with a timeout, panicking if no message

--- a/magicblock-aperture/tests/setup.rs
+++ b/magicblock-aperture/tests/setup.rs
@@ -126,6 +126,10 @@ impl RpcTestEnv {
             initialize_aperture(&config, state, &execution.dispatch, cancel)
                 .await
                 .expect("failed to initialize aperture test server");
+        // Blocks produced before the event processors subscribe are deliberately
+        // not valid for RPC. Produce one after subscription to make the test RPC
+        // transaction-ready.
+        execution.advance_slot();
 
         let rpc_url = format!("http://{}", server.http_addr());
         let pubsub_url = format!("ws://{}", server.ws_addr());

--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -11,8 +11,9 @@ use std::{
 use magicblock_account_cloner::ChainlinkCloner;
 use magicblock_accounts_db::{traits::AccountsBank, AccountsDb};
 use magicblock_aperture::{
-    initialize_aperture,
+    prepare_aperture,
     state::{NodeContext, SharedState},
+    EventProcessors,
 };
 use magicblock_chainlink::{
     config::ChainlinkConfig, remote_account_provider::Endpoints, ProdChainlink,
@@ -117,6 +118,7 @@ pub struct MagicValidator {
     intent_execution_service: IntentExecutionServiceImpl,
     replication_service: Option<ReplicationService>,
     undelegation_request_service: Option<Arc<UndelegationRequestService>>,
+    aperture_events: Option<EventProcessors>,
     rpc_handle: thread::JoinHandle<()>,
     identity: Pubkey,
     transaction_scheduler: TransactionSchedulerHandle,
@@ -412,7 +414,7 @@ impl MagicValidator {
             chainlink.clone(),
         );
         let step_start = Instant::now();
-        let rpc = initialize_aperture(
+        let (rpc, aperture_events) = prepare_aperture(
             &config.aperture,
             shared_state,
             &dispatch,
@@ -464,6 +466,7 @@ impl MagicValidator {
             intent_execution_service,
             replication_service,
             undelegation_request_service,
+            aperture_events: Some(aperture_events),
             token,
             ledger,
             ledger_truncator,
@@ -1047,6 +1050,14 @@ impl MagicValidator {
                     })?;
             }
         }
+
+        // Subscribe Aperture only after ledger replay and local bank cleanup.
+        // Executors still receive replay-time block broadcasts, while RPC starts
+        // with no valid blockhash and waits for the next live block.
+        self.aperture_events
+            .take()
+            .expect("Aperture event processors should only start once")
+            .start();
 
         // Notify the scheduler that ledger replay and bank cleanup is complete.
         if self.is_standalone {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added readiness tracking so RPC endpoints become available only after the first post-recovery block.
  - Added consistent “temporarily unavailable” responses via HTTP 503 for transient RPC conditions.
  - Improved startup sequencing by starting event processors before RPC becomes usable.

- **Bug Fixes**
  - Latest blockhash requests are now rejected until the blocks cache is ready, avoiding incomplete recovery data.
  - The primary health endpoint now reports unavailable (503) until the node is ready.
  - Ensured recovered blockhashes aren’t cached until the live event flow begins.

- **Tests**
  - Added coverage for cache readiness/correctness around recovered vs live blocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->