### PR TITLE
fix: lift ledger IO throttle during shutdown flush

### DIFF
--- a/.agents/context/crates/magicblock-api.md
+++ b/.agents/context/crates/magicblock-api.md
@@ -67,7 +67,7 @@ The exported public API is intentionally small for production use:
   - `start(&mut self) -> ApiResult<()>` performs ledger replay/reset/recovery, switches scheduler/replication mode, and starts post-start services such as slot ticking, ledger truncation, claim-fees, and the task scheduler.
   - `stop(self)` consumes the validator and shuts down services, joins threads/tasks where available, flushes AccountsDb and ledger, and performs ledger shutdown.
   - `start_unregister_validator_on_chain(&mut self)` sends a best-effort unregister transaction for standalone ephemeral validators that use on-chain coordination.
-  - `prepare_ledger_for_shutdown(&mut self)` stops truncation, cancels manual compactions, disables automatic compactions, lifts the ledger's background IO rate limit (safe only once compactions are stopped), and flushes the ledger before final shutdown. Ordering matters: lifting the throttle earlier would let compaction IO saturate the disk while the RPC still serves.
+  - `prepare_ledger_for_shutdown(&mut self)` stops truncation, cancels manual compactions, disables automatic compactions, waits (bounded) for in-flight compactions to quiesce, lifts the ledger's background IO rate limit, and flushes the ledger before final shutdown. Ordering matters: lifting the throttle before compactions stop would let compaction IO saturate the disk while the RPC still serves.
   - `ledger(&self) -> &Ledger` exposes the ledger for the binary to lock and report paths.
 - `domain_registry_manager::DomainRegistryManager`
   - builds Solana RPC clients for the Magic Domain Program;

--- a/.agents/context/crates/magicblock-api.md
+++ b/.agents/context/crates/magicblock-api.md
@@ -67,7 +67,7 @@ The exported public API is intentionally small for production use:
   - `start(&mut self) -> ApiResult<()>` performs ledger replay/reset/recovery, switches scheduler/replication mode, and starts post-start services such as slot ticking, ledger truncation, claim-fees, and the task scheduler.
   - `stop(self)` consumes the validator and shuts down services, joins threads/tasks where available, flushes AccountsDb and ledger, and performs ledger shutdown.
   - `start_unregister_validator_on_chain(&mut self)` sends a best-effort unregister transaction for standalone ephemeral validators that use on-chain coordination.
-  - `prepare_ledger_for_shutdown(&mut self)` stops truncation, cancels manual compactions, and flushes the ledger before final shutdown.
+  - `prepare_ledger_for_shutdown(&mut self)` stops truncation, cancels manual compactions, disables automatic compactions, lifts the ledger's background IO rate limit (safe only once compactions are stopped), and flushes the ledger before final shutdown. Ordering matters: lifting the throttle earlier would let compaction IO saturate the disk while the RPC still serves.
   - `ledger(&self) -> &Ledger` exposes the ledger for the binary to lock and report paths.
 - `domain_registry_manager::DomainRegistryManager`
   - builds Solana RPC clients for the Magic Domain Program;

--- a/.agents/context/crates/magicblock-ledger.md
+++ b/.agents/context/crates/magicblock-ledger.md
@@ -81,7 +81,7 @@ Important constructors and accessors:
 
 - `Ledger::open(path)` and `Ledger::open_with_options(path, LedgerOptions)` create `path/rocksdb`, adjust `ulimit -n` when enabled, open RocksDB, initialize `LatestBlock` from the highest stored blockhash, and initialize the lowest cleanup slot.
 - `ledger_path()`, `banking_trace_path()`, `storage_size()`, `db(self)`, `latest_block()`, and `latest_blockhash()` expose operational handles.
-- `flush()`, `shutdown(wait)`, and `cancel_manual_compactions()` are used during shutdown and maintenance.
+- `flush()`, `shutdown(wait)`, `cancel_manual_compactions()`, `disable_auto_compactions()`, and `lift_rate_limit()` are used during shutdown and maintenance. Each `Rocks` owns a handle to its DB-wide 48 MiB/s kAllIo rate limiter (`rocksdb_options.rs`); the limiter charges flush writes as well as compaction IO, so shutdown lifts it — only after compactions are stopped — to keep the final flush from stretching into restart downtime.
 
 Primary data APIs:
 

--- a/.agents/context/crates/magicblock-ledger.md
+++ b/.agents/context/crates/magicblock-ledger.md
@@ -81,7 +81,7 @@ Important constructors and accessors:
 
 - `Ledger::open(path)` and `Ledger::open_with_options(path, LedgerOptions)` create `path/rocksdb`, adjust `ulimit -n` when enabled, open RocksDB, initialize `LatestBlock` from the highest stored blockhash, and initialize the lowest cleanup slot.
 - `ledger_path()`, `banking_trace_path()`, `storage_size()`, `db(self)`, `latest_block()`, and `latest_blockhash()` expose operational handles.
-- `flush()`, `shutdown(wait)`, `cancel_manual_compactions()`, `disable_auto_compactions()`, and `lift_rate_limit()` are used during shutdown and maintenance. Each `Rocks` owns a handle to its DB-wide 48 MiB/s kAllIo rate limiter (`rocksdb_options.rs`); the limiter charges flush writes as well as compaction IO, so shutdown lifts it — only after compactions are stopped — to keep the final flush from stretching into restart downtime.
+- `flush()`, `shutdown(wait)`, `cancel_manual_compactions()`, `disable_auto_compactions()`, `wait_for_quiescent_compactions(timeout)`, and `lift_rate_limit()` are used during shutdown and maintenance. Each `Rocks` owns a handle to its DB-wide 48 MiB/s kAllIo rate limiter (`rocksdb_options.rs`); the limiter charges flush writes as well as compaction IO, so shutdown lifts it — only after compactions are stopped and given a bounded window to quiesce — to keep the final flush from stretching into restart downtime.
 
 Primary data APIs:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -777,7 +777,7 @@ dependencies = [
  "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -3209,7 +3209,7 @@ dependencies = [
 [[package]]
 name = "librocksdb-sys"
 version = "0.18.0+10.7.5"
-source = "git+https://github.com/magicblock-labs/rust-rocksdb.git?rev=50c94dc2#50c94dc2c29cc27d8e1214eb56b6bc2d1cd73857"
+source = "git+https://github.com/magicblock-labs/rust-rocksdb.git?rev=c6a3f91f#c6a3f91fbf9d89c718e223cb1ea856589738b8e1"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -5009,7 +5009,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "petgraph",
@@ -5030,7 +5030,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -5662,7 +5662,7 @@ checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 [[package]]
 name = "rocksdb"
 version = "0.24.0"
-source = "git+https://github.com/magicblock-labs/rust-rocksdb.git?rev=50c94dc2#50c94dc2c29cc27d8e1214eb56b6bc2d1cd73857"
+source = "git+https://github.com/magicblock-labs/rust-rocksdb.git?rev=c6a3f91f#c6a3f91fbf9d89c718e223cb1ea856589738b8e1"
 dependencies = [
  "libc",
  "librocksdb-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,12 +168,12 @@ spl-token-2022 = { package = "spl-token-2022-interface", version = "2.1" }
 
 
 # Avoid the vendored bzip2 within rocksdb-sys that can cause linker conflicts
-librocksdb-sys = { git = "https://github.com/magicblock-labs/rust-rocksdb.git", rev = "50c94dc2" }
+librocksdb-sys = { git = "https://github.com/magicblock-labs/rust-rocksdb.git", rev = "c6a3f91f" }
 prost = "0.14"
 protobuf-src = "1.1"
 rand = "0.9"
 reqwest = "0.12"
-rocksdb = { git = "https://github.com/magicblock-labs/rust-rocksdb.git", rev = "50c94dc2", features = [
+rocksdb = { git = "https://github.com/magicblock-labs/rust-rocksdb.git", rev = "c6a3f91f", features = [
     "raw-ptr"
 ] }
 rusqlite = { version = "0.37.0", features = ["bundled"] } # bundled sqlite 3.44
@@ -269,4 +269,4 @@ solana-transaction-context = { git = "https://github.com/magicblock-labs/magicbl
 # (disable_manual_compaction, mode-aware rate limiter) are reached through
 # the `raw-ptr` feature + librocksdb-sys directly.
 libsodium-rs = { git = "https://github.com/jedisct1/libsodium-rs.git", rev = "0397a6c5785233f9f2ac91f3eedc3cceb74e0060" }
-rocksdb = { git = "https://github.com/magicblock-labs/rust-rocksdb.git", rev = "50c94dc2" }
+rocksdb = { git = "https://github.com/magicblock-labs/rust-rocksdb.git", rev = "c6a3f91f" }

--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -1260,19 +1260,26 @@ impl MagicValidator {
         self.ledger_truncator.stop();
         // Calls & awaits until manual compaction is canceled
         self.ledger.cancel_manual_compactions();
-        // Stop auto compactions too: with the throttle lifted below, a
+        // Stop auto compactions too: with the throttle lifted, a
         // flush-triggered compaction would otherwise run at full disk speed
         // while the RPC still serves.
-        if let Err(err) = self.ledger.disable_auto_compactions() {
-            error!(error = ?err, "Failed to disable auto compactions during shutdown preparation");
+        match self.ledger.disable_auto_compactions() {
+            Ok(()) => {
+                // Disabling does not cancel a compaction already mid-run;
+                // give it a bounded window to finish before handing it full
+                // disk bandwidth.
+                self.ledger
+                    .wait_for_quiescent_compactions(Duration::from_secs(2));
+                // Compactions are stopped; unthrottled flushes only compete
+                // with foreground work for the few seconds before exit.
+                self.ledger.lift_rate_limit();
+            }
+            Err(err) => {
+                // Some column may still schedule compactions: keep the
+                // throttle and accept a slower flush over disk saturation.
+                error!(error = ?err, "Failed to disable auto compactions; keeping IO throttle for shutdown flush");
+            }
         }
-        // Disabling does not cancel a compaction already mid-run; give it a
-        // bounded window to finish before handing it full disk bandwidth.
-        self.ledger
-            .wait_for_quiescent_compactions(Duration::from_secs(2));
-        // Compactions are stopped; unthrottled flushes only compete with
-        // foreground work for the few seconds before exit.
-        self.ledger.lift_rate_limit();
         if let Err(err) = self.ledger.flush() {
             error!(error = ?err, "Failed to flush during shutdown preparation");
         }

--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -1260,7 +1260,13 @@ impl MagicValidator {
         self.ledger_truncator.stop();
         // Calls & awaits until manual compaction is canceled
         self.ledger.cancel_manual_compactions();
-        // Compactions are canceled; unthrottled flushes only compete with
+        // Stop auto compactions too: with the throttle lifted below, a
+        // flush-triggered compaction would otherwise run at full disk speed
+        // while the RPC still serves.
+        if let Err(err) = self.ledger.disable_auto_compactions() {
+            error!(error = ?err, "Failed to disable auto compactions during shutdown preparation");
+        }
+        // Compactions are stopped; unthrottled flushes only compete with
         // foreground work for the few seconds before exit.
         self.ledger.lift_rate_limit();
         if let Err(err) = self.ledger.flush() {

--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -1266,6 +1266,10 @@ impl MagicValidator {
         if let Err(err) = self.ledger.disable_auto_compactions() {
             error!(error = ?err, "Failed to disable auto compactions during shutdown preparation");
         }
+        // Disabling does not cancel a compaction already mid-run; give it a
+        // bounded window to finish before handing it full disk bandwidth.
+        self.ledger
+            .wait_for_quiescent_compactions(Duration::from_secs(2));
         // Compactions are stopped; unthrottled flushes only compete with
         // foreground work for the few seconds before exit.
         self.ledger.lift_rate_limit();

--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -1260,6 +1260,9 @@ impl MagicValidator {
         self.ledger_truncator.stop();
         // Calls & awaits until manual compaction is canceled
         self.ledger.cancel_manual_compactions();
+        // Compactions are canceled; unthrottled flushes only compete with
+        // foreground work for the few seconds before exit.
+        self.ledger.lift_rate_limit();
         if let Err(err) = self.ledger.flush() {
             error!(error = ?err, "Failed to flush during shutdown preparation");
         }

--- a/magicblock-ledger/src/database/mod.rs
+++ b/magicblock-ledger/src/database/mod.rs
@@ -8,5 +8,5 @@ pub mod ledger_column;
 pub mod meta;
 pub mod options;
 mod rocks_db;
-pub(crate) mod rocksdb_options;
+mod rocksdb_options;
 pub mod write_batch;

--- a/magicblock-ledger/src/database/mod.rs
+++ b/magicblock-ledger/src/database/mod.rs
@@ -8,5 +8,5 @@ pub mod ledger_column;
 pub mod meta;
 pub mod options;
 mod rocks_db;
-mod rocksdb_options;
+pub(crate) mod rocksdb_options;
 pub mod write_batch;

--- a/magicblock-ledger/src/database/rocks_db.rs
+++ b/magicblock-ledger/src/database/rocks_db.rs
@@ -19,7 +19,7 @@ use super::{
     columns::Column,
     iterator::IteratorMode,
     options::{AccessType, LedgerOptions},
-    rocksdb_options::get_rocksdb_options,
+    rocksdb_options::{get_rocksdb_options, RateLimiterHandle},
 };
 use crate::errors::{LedgerError, LedgerResult};
 
@@ -32,6 +32,8 @@ pub struct Rocks {
     access_type: AccessType,
     /// Oldest slot we want to keep in DB, slots before will be removed
     oldest_slot: Arc<AtomicU64>,
+    /// This DB's background IO rate limiter; kept so shutdown can lift it.
+    rate_limiter: RateLimiterHandle,
 }
 
 impl Rocks {
@@ -42,7 +44,7 @@ impl Rocks {
         fs::create_dir_all(path)?;
 
         let oldest_slot = Arc::new(DEFAULT_OLD_SLOT.into());
-        let db_options = get_rocksdb_options(&access_type);
+        let (db_options, rate_limiter) = get_rocksdb_options(&access_type);
         let descriptors = cf_descriptors(path, &options, &oldest_slot);
 
         let db = match access_type {
@@ -56,7 +58,15 @@ impl Rocks {
             db,
             access_type,
             oldest_slot,
+            rate_limiter,
         })
+    }
+
+    /// Raises the background IO rate limit to effectively unlimited so
+    /// shutdown flushes run at disk speed; call only after compactions
+    /// have been stopped.
+    pub fn lift_rate_limit(&self) {
+        self.rate_limiter.lift();
     }
 
     pub fn destroy(path: &Path) -> LedgerResult<()> {

--- a/magicblock-ledger/src/database/rocksdb_options.rs
+++ b/magicblock-ledger/src/database/rocksdb_options.rs
@@ -1,30 +1,41 @@
-use std::sync::atomic::{AtomicPtr, Ordering};
-
 use rocksdb::{AsRawPtr, Options};
 
 use super::options::AccessType;
 
-/// Handle to the ledger's rate limiter, kept alive for the process lifetime
-/// so shutdown can lift the throttle for the final memtable flush.
-static RATE_LIMITER: AtomicPtr<librocksdb_sys::rocksdb_ratelimiter_t> =
-    AtomicPtr::new(std::ptr::null_mut());
+/// Owned reference to this DB's rate limiter, kept so shutdown can lift the
+/// throttle for the final memtable flush.
+#[derive(Debug)]
+pub(crate) struct RateLimiterHandle(*mut librocksdb_sys::rocksdb_ratelimiter_t);
 
-/// Raises the background IO rate limit to effectively unlimited. Once
-/// truncation compactions are canceled at shutdown, throttling only
-/// stretches the final flush into restart downtime.
-pub fn lift_rate_limit() {
-    let limiter = RATE_LIMITER.load(Ordering::Acquire);
-    if !limiter.is_null() {
+// SAFETY: the underlying RateLimiter is internally synchronized;
+// SetBytesPerSecond and destroy are safe from any thread.
+unsafe impl Send for RateLimiterHandle {}
+unsafe impl Sync for RateLimiterHandle {}
+
+impl RateLimiterHandle {
+    /// Raises the background IO rate limit to effectively unlimited. Once
+    /// compactions are stopped at shutdown, throttling only stretches the
+    /// final flush into restart downtime.
+    pub(crate) fn lift(&self) {
         unsafe {
             librocksdb_sys::rocksdb_ratelimiter_set_bytes_per_second(
-                limiter,
+                self.0,
                 i64::MAX,
             );
         }
     }
 }
 
-pub fn get_rocksdb_options(access_type: &AccessType) -> Options {
+impl Drop for RateLimiterHandle {
+    fn drop(&mut self) {
+        // Drops our shared_ptr reference; the DB keeps its own while open.
+        unsafe { librocksdb_sys::rocksdb_ratelimiter_destroy(self.0) }
+    }
+}
+
+pub fn get_rocksdb_options(
+    access_type: &AccessType,
+) -> (Options, RateLimiterHandle) {
     let mut options = Options::default();
 
     // Create missing items to support a clean start
@@ -87,7 +98,7 @@ pub fn get_rocksdb_options(access_type: &AccessType) -> Options {
     // The safe wrapper only exposes kWritesOnly, so go through the C API.
     // RateLimiter parameters: rate_bytes_per_sec, refill_period_us, fairness
     const RATE_LIMITER_MODE_ALL_IO: std::ffi::c_int = 2; // RateLimiter::Mode::kAllIo
-    unsafe {
+    let rate_limiter = unsafe {
         let ratelimiter = librocksdb_sys::rocksdb_ratelimiter_create_with_mode(
             48 * 1024 * 1024,
             100 * 1000,
@@ -99,16 +110,16 @@ pub fn get_rocksdb_options(access_type: &AccessType) -> Options {
             options.as_raw_ptr(),
             ratelimiter,
         );
-        // Keep our reference instead of destroying it so lift_rate_limit
-        // can adjust the limiter at shutdown.
-        RATE_LIMITER.store(ratelimiter, Ordering::Release);
-    }
+        // Keep our reference instead of destroying it so shutdown can lift
+        // the throttle for this DB's final flush.
+        RateLimiterHandle(ratelimiter)
+    };
 
     // Dynamic level bytes is a good default to balance levels
     options.set_level_compaction_dynamic_level_bytes(true);
     options.set_report_bg_io_stats(true);
 
-    options
+    (options, rate_limiter)
 }
 
 // Returns whether automatic compactions should be disabled for the entire

--- a/magicblock-ledger/src/database/rocksdb_options.rs
+++ b/magicblock-ledger/src/database/rocksdb_options.rs
@@ -1,6 +1,28 @@
+use std::sync::atomic::{AtomicPtr, Ordering};
+
 use rocksdb::{AsRawPtr, Options};
 
 use super::options::AccessType;
+
+/// Handle to the ledger's rate limiter, kept alive for the process lifetime
+/// so shutdown can lift the throttle for the final memtable flush.
+static RATE_LIMITER: AtomicPtr<librocksdb_sys::rocksdb_ratelimiter_t> =
+    AtomicPtr::new(std::ptr::null_mut());
+
+/// Raises the background IO rate limit to effectively unlimited. Once
+/// truncation compactions are canceled at shutdown, throttling only
+/// stretches the final flush into restart downtime.
+pub fn lift_rate_limit() {
+    let limiter = RATE_LIMITER.load(Ordering::Acquire);
+    if !limiter.is_null() {
+        unsafe {
+            librocksdb_sys::rocksdb_ratelimiter_set_bytes_per_second(
+                limiter,
+                i64::MAX,
+            );
+        }
+    }
+}
 
 pub fn get_rocksdb_options(access_type: &AccessType) -> Options {
     let mut options = Options::default();
@@ -77,7 +99,9 @@ pub fn get_rocksdb_options(access_type: &AccessType) -> Options {
             options.as_raw_ptr(),
             ratelimiter,
         );
-        librocksdb_sys::rocksdb_ratelimiter_destroy(ratelimiter);
+        // Keep our reference instead of destroying it so lift_rate_limit
+        // can adjust the limiter at shutdown.
+        RATE_LIMITER.store(ratelimiter, Ordering::Release);
     }
 
     // Dynamic level bytes is a good default to balance levels

--- a/magicblock-ledger/src/store/api.rs
+++ b/magicblock-ledger/src/store/api.rs
@@ -1401,9 +1401,32 @@ impl Ledger {
     }
 
     /// Lifts the background IO rate limit so shutdown flushes run at disk
-    /// speed; call only after manual compactions have been canceled.
+    /// speed; call only after compactions have been stopped.
     pub fn lift_rate_limit(&self) {
-        crate::database::rocksdb_options::lift_rate_limit();
+        self.db.backend.lift_rate_limit();
+    }
+
+    /// Disables automatic compactions on all columns; used at shutdown so
+    /// flush-induced L0 growth cannot schedule compactions that would run
+    /// unthrottled once the rate limit is lifted.
+    pub fn disable_auto_compactions(&self) -> LedgerResult<()> {
+        let cfs = [
+            self.transaction_status_cf.handle(),
+            self.address_signatures_cf.handle(),
+            self.slot_signatures_cf.handle(),
+            self.blocktime_cf.handle(),
+            self.blockhash_cf.handle(),
+            self.transaction_cf.handle(),
+            self.transaction_memos_cf.handle(),
+            self.perf_samples_cf.handle(),
+        ];
+        for cf in cfs {
+            self.db
+                .backend
+                .db
+                .set_options_cf(cf, &[("disable_auto_compactions", "true")])?;
+        }
+        Ok(())
     }
 
     /// Cancels manual compaction

--- a/magicblock-ledger/src/store/api.rs
+++ b/magicblock-ledger/src/store/api.rs
@@ -6,6 +6,7 @@ use std::{
         atomic::{AtomicI64, Ordering},
         Arc, RwLock,
     },
+    time::{Duration, Instant},
 };
 
 use bincode::{deserialize, serialize};
@@ -1404,6 +1405,34 @@ impl Ledger {
     /// speed; call only after compactions have been stopped.
     pub fn lift_rate_limit(&self) {
         self.db.backend.lift_rate_limit();
+    }
+
+    /// Best-effort wait until no compactions are running, so lifting the
+    /// rate limit cannot hand an in-flight compaction full disk bandwidth.
+    /// Bounded: a throttled job mid-run may need minutes, and shutdown must
+    /// not stall on it.
+    pub fn wait_for_quiescent_compactions(&self, timeout: Duration) {
+        const RUNNING_COMPACTIONS: &str = "rocksdb.num-running-compactions";
+        let deadline = Instant::now() + timeout;
+        loop {
+            match self.db.backend.db.property_int_value(RUNNING_COMPACTIONS) {
+                Ok(Some(running)) if running > 0 => {
+                    if Instant::now() >= deadline {
+                        warn!(
+                            running,
+                            "Compactions still running after quiesce timeout"
+                        );
+                        return;
+                    }
+                    std::thread::sleep(Duration::from_millis(50));
+                }
+                Ok(_) => return,
+                Err(err) => {
+                    warn!(error = ?err, "Failed to query running compactions");
+                    return;
+                }
+            }
+        }
     }
 
     /// Disables automatic compactions on all columns; used at shutdown so

--- a/magicblock-ledger/src/store/api.rs
+++ b/magicblock-ledger/src/store/api.rs
@@ -1400,6 +1400,12 @@ impl Ledger {
         Ok(())
     }
 
+    /// Lifts the background IO rate limit so shutdown flushes run at disk
+    /// speed; call only after manual compactions have been canceled.
+    pub fn lift_rate_limit(&self) {
+        crate::database::rocksdb_options::lift_rate_limit();
+    }
+
     /// Cancels manual compaction
     /// Here we utilize the internal of `disable_manual_compaction`
     /// Which not only disables future manual compaction,

--- a/test-integration/Cargo.lock
+++ b/test-integration/Cargo.lock
@@ -795,7 +795,7 @@ dependencies = [
  "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -3246,7 +3246,7 @@ dependencies = [
 [[package]]
 name = "librocksdb-sys"
 version = "0.18.0+10.7.5"
-source = "git+https://github.com/magicblock-labs/rust-rocksdb.git?rev=50c94dc2#50c94dc2c29cc27d8e1214eb56b6bc2d1cd73857"
+source = "git+https://github.com/magicblock-labs/rust-rocksdb.git?rev=c6a3f91f#c6a3f91fbf9d89c718e223cb1ea856589738b8e1"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -5064,7 +5064,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "petgraph",
@@ -5085,7 +5085,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -5716,7 +5716,7 @@ checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 [[package]]
 name = "rocksdb"
 version = "0.24.0"
-source = "git+https://github.com/magicblock-labs/rust-rocksdb.git?rev=50c94dc2#50c94dc2c29cc27d8e1214eb56b6bc2d1cd73857"
+source = "git+https://github.com/magicblock-labs/rust-rocksdb.git?rev=c6a3f91f#c6a3f91fbf9d89c718e223cb1ea856589738b8e1"
 dependencies = [
  "libc",
  "librocksdb-sys",

--- a/test-integration/Cargo.toml
+++ b/test-integration/Cargo.toml
@@ -114,7 +114,7 @@ url = "2.5.0"
 # and we use protobuf-src v2.1.1. Otherwise compilation fails
 solana-storage-proto = { path = "../storage-proto" }
 # same reason as above
-rocksdb = { git = "https://github.com/magicblock-labs/rust-rocksdb.git", rev = "50c94dc2" }
+rocksdb = { git = "https://github.com/magicblock-labs/rust-rocksdb.git", rev = "c6a3f91f" }
 solana-account = { git = "https://github.com/magicblock-labs/magicblock-svm.git", rev = "03950095887b011818886b68e06fde6a1a94def1" }
 solana-program-runtime = { git = "https://github.com/magicblock-labs/magicblock-svm.git", rev = "03950095887b011818886b68e06fde6a1a94def1" }
 solana-svm = { git = "https://github.com/magicblock-labs/magicblock-svm.git", rev = "03950095887b011818886b68e06fde6a1a94def1" }


### PR DESCRIPTION
## Problem

Keep a handle to the rate limiter and raise it to unlimited at the start of `prepare_ledger_for_shutdown`, right after `cancel_manual_compactions()`. At that point truncation IO can no longer saturate the disk, so throttling the flush only stretches it into restart downtime.

Uses `rocksdb_ratelimiter_set_bytes_per_second` (thread-safe `RateLimiter::SetBytesPerSecond`), added to the fork in magicblock-labs/rust-rocksdb#2; the rev bump picks it up.

## Expected impact

Shutdown flush drops from 5–30s to disk speed (~1s for the observed volumes); total restart wall time returns to ~2s. Steady-state throttling of truncation compactions is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved ledger shutdown reliability by stopping automatic compactions and waiting for active compactions to finish before final flushing.
  - Reduced potential disk I/O contention during shutdown while RPC services remain active.
  - Enabled the final ledger flush to run without the background I/O throttle, helping minimize restart downtime.

- **Documentation**
  - Clarified shutdown ordering, compaction behavior, and I/O rate-limiting details in the maintenance guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->