### PR TITLE
fix(committor): propagate tx assembly errors in prepare_for_strategy

### DIFF
--- a/magicblock-committor-service/src/transaction_preparator/mod.rs
+++ b/magicblock-committor-service/src/transaction_preparator/mod.rs
@@ -101,14 +101,15 @@ impl TransactionPreparator for TransactionPreparatorImpl {
             .await?;
         metrics::observe_committor_intent_alt_count(lookup_tables.len());
 
-        let message = TransactionUtils::assemble_tasks_tx_with_uniqueness_nonce(
-            authority,
-            &tx_strategy.optimized_tasks,
-            self.compute_budget_config.compute_unit_price,
-            &lookup_tables,
-            tx_strategy.uniqueness_nonce,
-        )?
-        .message;
+        let message =
+            TransactionUtils::assemble_tasks_tx_with_uniqueness_nonce(
+                authority,
+                &tx_strategy.optimized_tasks,
+                self.compute_budget_config.compute_unit_price,
+                &lookup_tables,
+                tx_strategy.uniqueness_nonce,
+            )?
+            .message;
 
         Ok(message)
     }

--- a/magicblock-committor-service/src/transaction_preparator/mod.rs
+++ b/magicblock-committor-service/src/transaction_preparator/mod.rs
@@ -101,16 +101,14 @@ impl TransactionPreparator for TransactionPreparatorImpl {
             .await?;
         metrics::observe_committor_intent_alt_count(lookup_tables.len());
 
-        let message =
-            TransactionUtils::assemble_tasks_tx_with_uniqueness_nonce(
-                authority,
-                &tx_strategy.optimized_tasks,
-                self.compute_budget_config.compute_unit_price,
-                &lookup_tables,
-                tx_strategy.uniqueness_nonce,
-            )
-            .expect("Possibility to assemble checked above")
-            .message;
+        let message = TransactionUtils::assemble_tasks_tx_with_uniqueness_nonce(
+            authority,
+            &tx_strategy.optimized_tasks,
+            self.compute_budget_config.compute_unit_price,
+            &lookup_tables,
+            tx_strategy.uniqueness_nonce,
+        )?
+        .message;
 
         Ok(message)
     }


### PR DESCRIPTION
## Summary

`TransactionPreparatorImpl::prepare_for_strategy` used `.expect()` when assembling the final transaction message. A prior feasibility check runs against dummy lookup tables, so assembly can still fail with the real prepared data — causing the committor worker to panic.

This change replaces `.expect()` with `?` so assembly failures are propagated as errors instead of panicking.

Fixes #1018

## Test plan

- [x] `cargo check -p magicblock-committor-service`
- [x] `cargo test -p magicblock-committor-service`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Transaction preparation now reports message assembly errors gracefully instead of terminating unexpectedly.
  * Improved error propagation allows callers to handle failed transaction preparation safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->