### PR TITLE
fix(committor): report shared signature on single-stage finalize failure

### DIFF
--- a/magicblock-committor-service/src/intent_executor/error.rs
+++ b/magicblock-committor-service/src/intent_executor/error.rs
@@ -657,6 +657,33 @@ mod tests {
     }
 
     #[test]
+    fn single_stage_finalize_failure_reports_shared_signature() {
+        let signature = solana_signature::Signature::new_unique();
+        let err = TransactionStrategyExecutionError::InternalError(
+            InternalError::MagicBlockRpcClientError(Box::new(
+                MagicBlockRpcClientError::SentTransactionError(
+                    solana_transaction_error::TransactionError::InstructionError(
+                        0,
+                        solana_instruction::error::InstructionError::Custom(1),
+                    ),
+                    signature,
+                ),
+            )),
+        );
+
+        let wrapped =
+            super::IntentExecutorError::from_finalize_execution_error(
+                err,
+                Some(signature),
+            );
+        assert_eq!(
+            wrapped.signatures(),
+            Some((signature, Some(signature)))
+        );
+        assert!(!wrapped.is_transient());
+    }
+
+    #[test]
     fn unrelated_internal_errors_do_not_trigger_single_stage_split() {
         let err = TransactionStrategyExecutionError::InternalError(
             InternalError::MagicBlockRpcClientError(Box::new(

--- a/magicblock-committor-service/src/intent_executor/error.rs
+++ b/magicblock-committor-service/src/intent_executor/error.rs
@@ -129,7 +129,18 @@ impl IntentExecutorError {
             finalize_signature,
         }
     }
+}
 
+/// Maps a single-stage execution failure to [`IntentExecutorError`], using the
+/// same signature for commit and finalize (one transaction for both stages).
+pub(crate) fn single_stage_finalize_execution_error(
+    err: TransactionStrategyExecutionError,
+) -> IntentExecutorError {
+    let signature = err.signature();
+    IntentExecutorError::from_finalize_execution_error(err, signature)
+}
+
+impl IntentExecutorError {
     /// True when re-executing the whole intent from scratch may succeed:
     /// the failure was transport/RPC-side rather than deterministic.
     /// Once a commit landed (two-stage finalize failures) re-execution would
@@ -671,11 +682,7 @@ mod tests {
             )),
         );
 
-        let wrapped =
-            super::IntentExecutorError::from_finalize_execution_error(
-                err,
-                Some(signature),
-            );
+        let wrapped = super::single_stage_finalize_execution_error(err);
         assert_eq!(
             wrapped.signatures(),
             Some((signature, Some(signature)))

--- a/magicblock-committor-service/src/intent_executor/error.rs
+++ b/magicblock-committor-service/src/intent_executor/error.rs
@@ -131,13 +131,15 @@ impl IntentExecutorError {
     }
 }
 
-/// Maps a single-stage execution failure to [`IntentExecutorError`], using the
-/// same signature for commit and finalize (one transaction for both stages).
+/// Maps a single-stage execution failure to [`IntentExecutorError`].
+///
+/// `commit_signature` stays `None` so retry semantics remain unchanged for
+/// transient send failures. The failed transaction signature is still exposed
+/// via [`IntentExecutorError::signatures`].
 pub(crate) fn single_stage_finalize_execution_error(
     err: TransactionStrategyExecutionError,
 ) -> IntentExecutorError {
-    let signature = err.signature();
-    IntentExecutorError::from_finalize_execution_error(err, signature)
+    IntentExecutorError::from_finalize_execution_error(err, None)
 }
 
 impl IntentExecutorError {
@@ -179,7 +181,11 @@ impl IntentExecutorError {
                 err: _,
                 commit_signature,
                 finalize_signature,
-            } => commit_signature.map(|el| (el, *finalize_signature)),
+            } => match (*commit_signature, *finalize_signature) {
+                (Some(commit), finalize) => Some((commit, finalize)),
+                (None, Some(finalize)) => Some((finalize, Some(finalize))),
+                _ => None,
+            },
             IntentExecutorError::EmptyIntentError
             | IntentExecutorError::FailedToFitError
             | IntentExecutorError::SignerError(_) => None,
@@ -683,11 +689,25 @@ mod tests {
         );
 
         let wrapped = super::single_stage_finalize_execution_error(err);
-        assert_eq!(
-            wrapped.signatures(),
-            Some((signature, Some(signature)))
-        );
+        assert_eq!(wrapped.signatures(), Some((signature, Some(signature))));
         assert!(!wrapped.is_transient());
+    }
+
+    #[test]
+    fn single_stage_blockhash_not_found_failure_stays_transient() {
+        let signature = solana_signature::Signature::new_unique();
+        let err = TransactionStrategyExecutionError::InternalError(
+            InternalError::MagicBlockRpcClientError(Box::new(
+                MagicBlockRpcClientError::SentTransactionError(
+                    solana_transaction_error::TransactionError::BlockhashNotFound,
+                    signature,
+                ),
+            )),
+        );
+
+        let wrapped = super::single_stage_finalize_execution_error(err);
+        assert_eq!(wrapped.signatures(), Some((signature, Some(signature))));
+        assert!(wrapped.is_transient());
     }
 
     #[test]

--- a/magicblock-committor-service/src/intent_executor/single_stage_executor.rs
+++ b/magicblock-committor-service/src/intent_executor/single_stage_executor.rs
@@ -134,11 +134,10 @@ where
         };
 
         result.map_err(|err| {
-            IntentExecutorError::from_finalize_execution_error(
-                err,
-                // TODO(edwin): shall one stage have same signature for commit & finalize
-                None,
-            )
+            // Single-stage executes commit+finalize in one transaction; mirror the
+            // success-path semantics in `commit_persister::finalize_base_intent`.
+            let signature = err.signature();
+            IntentExecutorError::from_finalize_execution_error(err, signature)
         })
     }
 

--- a/magicblock-committor-service/src/intent_executor/single_stage_executor.rs
+++ b/magicblock-committor-service/src/intent_executor/single_stage_executor.rs
@@ -10,8 +10,8 @@ use tracing::{error, instrument};
 use crate::{
     intent_executor::{
         error::{
-            IntentExecutorError, IntentExecutorResult,
-            TransactionStrategyExecutionError,
+            single_stage_finalize_execution_error, IntentExecutorError,
+            IntentExecutorResult, TransactionStrategyExecutionError,
         },
         intent_execution_client::IntentExecutionClient,
         task_info_fetcher::{CacheTaskInfoFetcher, TaskInfoFetcher},
@@ -133,12 +133,7 @@ where
             }
         };
 
-        result.map_err(|err| {
-            // Single-stage executes commit+finalize in one transaction; mirror the
-            // success-path semantics in `commit_persister::finalize_base_intent`.
-            let signature = err.signature();
-            IntentExecutorError::from_finalize_execution_error(err, signature)
-        })
+        result.map_err(single_stage_finalize_execution_error)
     }
 
     pub fn has_callbacks(&self) -> bool {


### PR DESCRIPTION
## Summary
Single-stage intent execution commits and finalizes in a single transaction. On the success path, `commit_persister::finalize_base_intent` already stores the same signature for both stages (`(signature, signature)`).

On failure, `SingleStageExecutor` passed `commit_signature: None` into `from_finalize_execution_error`, so `IntentExecutorError::signatures()` returned `None` even when the failed transaction had a signature. This made downstream error reporting inconsistent with the success path.

This change passes `err.signature()` as the commit signature on single-stage failures, matching the success-path semantics.

## Test plan
- [x] `cargo test -p magicblock-committor-service single_stage_finalize_failure_reports_shared_signature`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for failed single-stage executions by consistently preserving transaction signatures across execution and finalization errors.
  * Classified deterministic single-stage failures as non-transient, enabling more reliable error handling and reducing unnecessary retries.
  * Standardized reporting for transient and deterministic failures to provide clearer finalization results.

* **Tests**
  * Added coverage for transaction signature reporting and failure classification across single-stage execution scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->