### PR TITLE
fix: prevent slow ledger reads from starving the RPC runtime

### DIFF
--- a/magicblock-aperture/src/requests/http/get_block_time.rs
+++ b/magicblock-aperture/src/requests/http/get_block_time.rs
@@ -7,6 +7,10 @@ impl HttpDispatcher {
     /// Returns the estimated production time of a block, as a Unix timestamp.
     /// If the block is not found in the ledger (e.g., the slot was skipped),
     /// this method returns a `BLOCK_NOT_FOUND` error.
+    ///
+    /// Reads the blocktime column directly — a single-key get that stays
+    /// cheap even while truncation tombstones make slot iteration slow —
+    /// instead of assembling the full block.
     pub(crate) fn get_block_time(
         &self,
         request: &mut JsonRequest,
@@ -14,15 +18,14 @@ impl HttpDispatcher {
         let block = parse_params!(request.params()?, Slot);
         let block = some_or_err!(block);
 
-        let block = self.ledger.get_block(block)?.ok_or_else(|| {
-            let error =
-                format!("Slot {block} was skipped, or is not yet available");
-            RpcError::custom(error, BLOCK_NOT_FOUND)
-        })?;
+        let block_time =
+            self.ledger.get_block_time(block)?.ok_or_else(|| {
+                let error = format!(
+                    "Slot {block} was skipped, or is not yet available"
+                );
+                RpcError::custom(error, BLOCK_NOT_FOUND)
+            })?;
 
-        Ok(ResponsePayload::encode_no_context(
-            &request.id,
-            block.block_time,
-        ))
+        Ok(ResponsePayload::encode_no_context(&request.id, block_time))
     }
 }

--- a/magicblock-aperture/src/requests/http/get_signature_statuses.rs
+++ b/magicblock-aperture/src/requests/http/get_signature_statuses.rs
@@ -18,11 +18,7 @@ impl HttpDispatcher {
     /// checks a hot in-memory cache of recent transactions before falling back to the
     /// persistent ledger. The returned list has the same length as the input, with
     /// `null` entries for signatures that are not found.
-    ///
-    /// Only the ledger fallbacks run under the blocking-read gate: cache hits
-    /// (clients polling recently submitted transactions) must stay responsive
-    /// even when degraded ledger reads hold every permit.
-    pub(crate) async fn get_signature_statuses(
+    pub(crate) fn get_signature_statuses(
         &self,
         request: &mut JsonRequest,
     ) -> HandlerResult {
@@ -34,11 +30,8 @@ impl HttpDispatcher {
             ));
         }
         let mut statuses = Vec::with_capacity(signatures.len());
-        let mut misses = Vec::new();
 
-        for (index, signature) in
-            signatures.into_iter().map(Into::into).enumerate()
-        {
+        for signature in signatures.into_iter().map(Into::into) {
             // Level 1: Check the hot in-memory cache first.
             if let Some(Some(cached_status)) = self.transactions.get(&signature)
             {
@@ -46,31 +39,18 @@ impl HttpDispatcher {
                     cached_status.slot,
                     cached_status.result.clone(),
                 )));
-            } else {
-                statuses.push(None);
-                misses.push((index, signature));
+                continue;
             }
-        }
 
-        // Level 2: Fall back to the persistent ledger for historical lookups.
-        if !misses.is_empty() {
-            let resolved = self
-                .run_blocking(|| {
-                    misses
-                        .into_iter()
-                        .map(|(index, signature)| {
-                            self.ledger
-                                .get_transaction_status(signature, Slot::MAX)
-                                .map(|status| (index, status))
-                        })
-                        .collect::<Result<Vec<_>, _>>()
-                })
-                .await?;
-            for (index, ledger_status) in resolved {
-                if let Some((slot, meta)) = ledger_status {
-                    statuses[index] =
-                        Some(build_transaction_status(slot, meta.status));
-                }
+            // Level 2: Fall back to the persistent ledger for historical lookups.
+            let ledger_status =
+                self.ledger.get_transaction_status(signature, Slot::MAX)?;
+            if let Some((slot, meta)) = ledger_status {
+                let status = build_transaction_status(slot, meta.status);
+                statuses.push(Some(status));
+            } else {
+                // The signature was not found in the cache or the ledger.
+                statuses.push(None);
             }
         }
 

--- a/magicblock-aperture/src/requests/http/get_signature_statuses.rs
+++ b/magicblock-aperture/src/requests/http/get_signature_statuses.rs
@@ -18,7 +18,11 @@ impl HttpDispatcher {
     /// checks a hot in-memory cache of recent transactions before falling back to the
     /// persistent ledger. The returned list has the same length as the input, with
     /// `null` entries for signatures that are not found.
-    pub(crate) fn get_signature_statuses(
+    ///
+    /// Only the ledger fallbacks run under the blocking-read gate: cache hits
+    /// (clients polling recently submitted transactions) must stay responsive
+    /// even when degraded ledger reads hold every permit.
+    pub(crate) async fn get_signature_statuses(
         &self,
         request: &mut JsonRequest,
     ) -> HandlerResult {
@@ -30,8 +34,11 @@ impl HttpDispatcher {
             ));
         }
         let mut statuses = Vec::with_capacity(signatures.len());
+        let mut misses = Vec::new();
 
-        for signature in signatures.into_iter().map(Into::into) {
+        for (index, signature) in
+            signatures.into_iter().map(Into::into).enumerate()
+        {
             // Level 1: Check the hot in-memory cache first.
             if let Some(Some(cached_status)) = self.transactions.get(&signature)
             {
@@ -39,18 +46,31 @@ impl HttpDispatcher {
                     cached_status.slot,
                     cached_status.result.clone(),
                 )));
-                continue;
-            }
-
-            // Level 2: Fall back to the persistent ledger for historical lookups.
-            let ledger_status =
-                self.ledger.get_transaction_status(signature, Slot::MAX)?;
-            if let Some((slot, meta)) = ledger_status {
-                let status = build_transaction_status(slot, meta.status);
-                statuses.push(Some(status));
             } else {
-                // The signature was not found in the cache or the ledger.
                 statuses.push(None);
+                misses.push((index, signature));
+            }
+        }
+
+        // Level 2: Fall back to the persistent ledger for historical lookups.
+        if !misses.is_empty() {
+            let resolved = self
+                .run_blocking(|| {
+                    misses
+                        .into_iter()
+                        .map(|(index, signature)| {
+                            self.ledger
+                                .get_transaction_status(signature, Slot::MAX)
+                                .map(|status| (index, status))
+                        })
+                        .collect::<Result<Vec<_>, _>>()
+                })
+                .await?;
+            for (index, ledger_status) in resolved {
+                if let Some((slot, meta)) = ledger_status {
+                    statuses[index] =
+                        Some(build_transaction_status(slot, meta.status));
+                }
             }
         }
 

--- a/magicblock-aperture/src/server/http/dispatch.rs
+++ b/magicblock-aperture/src/server/http/dispatch.rs
@@ -177,10 +177,10 @@ impl HttpDispatcher {
         match request.method {
             GetAccountInfo => self.get_account_info(request).await,
             GetBalance => self.get_balance(request).await,
-            GetBlock => self.get_block(request),
+            GetBlock => run_blocking(|| self.get_block(request)),
             GetBlockCommitment => self.get_block_commitment(request),
             GetBlockHeight => self.get_block_height(request),
-            GetBlockTime => self.get_block_time(request),
+            GetBlockTime => run_blocking(|| self.get_block_time(request)),
             GetBlocks => self.get_blocks(request),
             GetBlocksWithLimit => self.get_blocks_with_limit(request),
             GetClusterNodes => self.get_cluster_nodes(request),
@@ -199,8 +199,12 @@ impl HttpDispatcher {
             GetRecentPerformanceSamples => {
                 self.get_recent_performance_samples(request)
             }
-            GetSignatureStatuses => self.get_signature_statuses(request),
-            GetSignaturesForAddress => self.get_signatures_for_address(request),
+            GetSignatureStatuses => {
+                run_blocking(|| self.get_signature_statuses(request))
+            }
+            GetSignaturesForAddress => {
+                run_blocking(|| self.get_signatures_for_address(request))
+            }
             GetSlot => self.get_slot(request),
             GetSlotLeader => self.get_slot_leader(request),
             GetSlotLeaders => self.get_slot_leaders(request),
@@ -216,7 +220,7 @@ impl HttpDispatcher {
             }
             GetTokenLargestAccounts => self.get_token_largest_accounts(request),
             GetTokenSupply => self.get_token_supply(request),
-            GetTransaction => self.get_transaction(request),
+            GetTransaction => run_blocking(|| self.get_transaction(request)),
             GetTransactionCount => self.get_transaction_count(request),
             GetVersion => self.get_version(request),
             GetVoteAccounts => self.get_vote_accounts(request),
@@ -265,5 +269,23 @@ impl HttpDispatcher {
         headers.insert(ACCESS_CONTROL_ALLOW_METHODS, hv("POST, OPTIONS, GET"));
         headers.insert(ACCESS_CONTROL_ALLOW_HEADERS, hv("*"));
         headers.insert(ACCESS_CONTROL_MAX_AGE, hv("86400"));
+    }
+}
+
+/// Runs a ledger (RocksDB) reading handler via `block_in_place`: a slow read
+/// (e.g. scanning range tombstones left behind by the ledger truncator) must
+/// never pin an RPC runtime worker and starve every other request.
+///
+/// Falls back to running inline on current-thread runtimes (tests), where
+/// `block_in_place` would panic.
+fn run_blocking<T>(f: impl FnOnce() -> T) -> T {
+    use tokio::runtime::{Handle, RuntimeFlavor};
+    let multi_threaded = Handle::try_current()
+        .map(|h| h.runtime_flavor() == RuntimeFlavor::MultiThread)
+        .unwrap_or_default();
+    if multi_threaded {
+        tokio::task::block_in_place(f)
+    } else {
+        f()
     }
 }

--- a/magicblock-aperture/src/server/http/dispatch.rs
+++ b/magicblock-aperture/src/server/http/dispatch.rs
@@ -59,7 +59,7 @@ pub(crate) struct HttpDispatcher {
     /// A handle to the transaction scheduler for processing
     /// `sendTransaction` and `simulateTransaction`.
     pub(crate) transactions_scheduler: TransactionSchedulerHandle,
-    /// Bounds concurrent blocking ledger reads so a burst of degraded
+    /// Bounds concurrent iterator-based ledger scans so a burst of degraded
     /// (e.g. tombstone-scanning) queries cannot exhaust threads or the DB.
     blocking_reads: Semaphore,
 }
@@ -73,12 +73,12 @@ impl HttpDispatcher {
         state: SharedState,
         channels: &DispatchEndpoints,
     ) -> Arc<Self> {
-        // Mirror the runtime's worker count: the same ledger-read concurrency
+        // Mirror the runtime's worker count: the same ledger-scan concurrency
         // the workers previously allowed implicitly, now without starving them.
         let permits = std::thread::available_parallelism()
             .map(|n| (n.get() / 2).saturating_sub(1))
             .unwrap_or(1)
-            .max(1);
+            .max(2);
         Arc::new(Self {
             context: state.context,
             accountsdb: state.accountsdb.clone(),
@@ -191,9 +191,7 @@ impl HttpDispatcher {
             GetBlock => self.run_blocking(|| self.get_block(request)).await,
             GetBlockCommitment => self.get_block_commitment(request),
             GetBlockHeight => self.get_block_height(request),
-            GetBlockTime => {
-                self.run_blocking(|| self.get_block_time(request)).await
-            }
+            GetBlockTime => self.get_block_time(request),
             GetBlocks => self.get_blocks(request),
             GetBlocksWithLimit => self.get_blocks_with_limit(request),
             GetClusterNodes => self.get_cluster_nodes(request),
@@ -212,8 +210,7 @@ impl HttpDispatcher {
             GetRecentPerformanceSamples => {
                 self.get_recent_performance_samples(request)
             }
-            // Gates only its ledger fallbacks; cache hits answer inline.
-            GetSignatureStatuses => self.get_signature_statuses(request).await,
+            GetSignatureStatuses => self.get_signature_statuses(request),
             GetSignaturesForAddress => {
                 self.run_blocking(|| self.get_signatures_for_address(request))
                     .await
@@ -233,9 +230,7 @@ impl HttpDispatcher {
             }
             GetTokenLargestAccounts => self.get_token_largest_accounts(request),
             GetTokenSupply => self.get_token_supply(request),
-            GetTransaction => {
-                self.run_blocking(|| self.get_transaction(request)).await
-            }
+            GetTransaction => self.get_transaction(request),
             GetTransactionCount => self.get_transaction_count(request),
             GetVersion => self.get_version(request),
             GetVoteAccounts => self.get_vote_accounts(request),
@@ -288,15 +283,20 @@ impl HttpDispatcher {
 }
 
 impl HttpDispatcher {
-    /// Runs a ledger (RocksDB) reading handler via `block_in_place`: a slow
-    /// read (e.g. scanning range tombstones left behind by the ledger
-    /// truncator) must never pin an RPC runtime worker and starve every other
-    /// request. The `blocking_reads` semaphore bounds how many such reads run
-    /// at once; waiters queue in async land without occupying any thread.
+    /// Runs an iterator-based ledger scan (`getBlock`,
+    /// `getSignaturesForAddress`) via `block_in_place`: such scans crawl the
+    /// range tombstones left behind by the ledger truncator and must never
+    /// pin an RPC runtime worker and starve every other request. The
+    /// `blocking_reads` semaphore bounds how many run at once; waiters queue
+    /// in async land without occupying any thread.
+    ///
+    /// Single-key ledger gets stay inline: they remain cheap under tombstones
+    /// (signature-keyed columns are never range-deleted), and the per-call
+    /// `block_in_place` core handoff is too costly for hot point lookups.
     ///
     /// Falls back to running inline on current-thread runtimes (tests), where
     /// `block_in_place` would panic.
-    pub(crate) async fn run_blocking<T>(&self, f: impl FnOnce() -> T) -> T {
+    async fn run_blocking<T>(&self, f: impl FnOnce() -> T) -> T {
         use tokio::runtime::{Handle, RuntimeFlavor};
         // The semaphore is never closed, so acquisition cannot fail.
         let _permit = self.blocking_reads.acquire().await.ok();

--- a/magicblock-aperture/src/server/http/dispatch.rs
+++ b/magicblock-aperture/src/server/http/dispatch.rs
@@ -20,6 +20,7 @@ use magicblock_ledger::Ledger;
 use magicblock_metrics::metrics::{
     RPC_REQUESTS_COUNT, RPC_REQUEST_HANDLING_TIME,
 };
+use tokio::sync::Semaphore;
 
 use crate::{
     requests::{
@@ -58,6 +59,9 @@ pub(crate) struct HttpDispatcher {
     /// A handle to the transaction scheduler for processing
     /// `sendTransaction` and `simulateTransaction`.
     pub(crate) transactions_scheduler: TransactionSchedulerHandle,
+    /// Bounds concurrent blocking ledger reads so a burst of degraded
+    /// (e.g. tombstone-scanning) queries cannot exhaust threads or the DB.
+    blocking_reads: Semaphore,
 }
 
 impl HttpDispatcher {
@@ -69,6 +73,12 @@ impl HttpDispatcher {
         state: SharedState,
         channels: &DispatchEndpoints,
     ) -> Arc<Self> {
+        // Mirror the runtime's worker count: the same ledger-read concurrency
+        // the workers previously allowed implicitly, now without starving them.
+        let permits = std::thread::available_parallelism()
+            .map(|n| (n.get() / 2).saturating_sub(1))
+            .unwrap_or(1)
+            .max(1);
         Arc::new(Self {
             context: state.context,
             accountsdb: state.accountsdb.clone(),
@@ -77,6 +87,7 @@ impl HttpDispatcher {
             transactions: state.transactions.clone(),
             blocks: state.blocks.clone(),
             transactions_scheduler: channels.transaction_scheduler.clone(),
+            blocking_reads: Semaphore::new(permits),
         })
     }
 
@@ -177,10 +188,12 @@ impl HttpDispatcher {
         match request.method {
             GetAccountInfo => self.get_account_info(request).await,
             GetBalance => self.get_balance(request).await,
-            GetBlock => run_blocking(|| self.get_block(request)),
+            GetBlock => self.run_blocking(|| self.get_block(request)).await,
             GetBlockCommitment => self.get_block_commitment(request),
             GetBlockHeight => self.get_block_height(request),
-            GetBlockTime => run_blocking(|| self.get_block_time(request)),
+            GetBlockTime => {
+                self.run_blocking(|| self.get_block_time(request)).await
+            }
             GetBlocks => self.get_blocks(request),
             GetBlocksWithLimit => self.get_blocks_with_limit(request),
             GetClusterNodes => self.get_cluster_nodes(request),
@@ -200,10 +213,12 @@ impl HttpDispatcher {
                 self.get_recent_performance_samples(request)
             }
             GetSignatureStatuses => {
-                run_blocking(|| self.get_signature_statuses(request))
+                self.run_blocking(|| self.get_signature_statuses(request))
+                    .await
             }
             GetSignaturesForAddress => {
-                run_blocking(|| self.get_signatures_for_address(request))
+                self.run_blocking(|| self.get_signatures_for_address(request))
+                    .await
             }
             GetSlot => self.get_slot(request),
             GetSlotLeader => self.get_slot_leader(request),
@@ -220,7 +235,9 @@ impl HttpDispatcher {
             }
             GetTokenLargestAccounts => self.get_token_largest_accounts(request),
             GetTokenSupply => self.get_token_supply(request),
-            GetTransaction => run_blocking(|| self.get_transaction(request)),
+            GetTransaction => {
+                self.run_blocking(|| self.get_transaction(request)).await
+            }
             GetTransactionCount => self.get_transaction_count(request),
             GetVersion => self.get_version(request),
             GetVoteAccounts => self.get_vote_accounts(request),
@@ -272,20 +289,26 @@ impl HttpDispatcher {
     }
 }
 
-/// Runs a ledger (RocksDB) reading handler via `block_in_place`: a slow read
-/// (e.g. scanning range tombstones left behind by the ledger truncator) must
-/// never pin an RPC runtime worker and starve every other request.
-///
-/// Falls back to running inline on current-thread runtimes (tests), where
-/// `block_in_place` would panic.
-fn run_blocking<T>(f: impl FnOnce() -> T) -> T {
-    use tokio::runtime::{Handle, RuntimeFlavor};
-    let multi_threaded = Handle::try_current()
-        .map(|h| h.runtime_flavor() == RuntimeFlavor::MultiThread)
-        .unwrap_or_default();
-    if multi_threaded {
-        tokio::task::block_in_place(f)
-    } else {
-        f()
+impl HttpDispatcher {
+    /// Runs a ledger (RocksDB) reading handler via `block_in_place`: a slow
+    /// read (e.g. scanning range tombstones left behind by the ledger
+    /// truncator) must never pin an RPC runtime worker and starve every other
+    /// request. The `blocking_reads` semaphore bounds how many such reads run
+    /// at once; waiters queue in async land without occupying any thread.
+    ///
+    /// Falls back to running inline on current-thread runtimes (tests), where
+    /// `block_in_place` would panic.
+    async fn run_blocking<T>(&self, f: impl FnOnce() -> T) -> T {
+        use tokio::runtime::{Handle, RuntimeFlavor};
+        // The semaphore is never closed, so acquisition cannot fail.
+        let _permit = self.blocking_reads.acquire().await.ok();
+        let multi_threaded = Handle::try_current()
+            .map(|h| h.runtime_flavor() == RuntimeFlavor::MultiThread)
+            .unwrap_or_default();
+        if multi_threaded {
+            tokio::task::block_in_place(f)
+        } else {
+            f()
+        }
     }
 }

--- a/magicblock-aperture/src/server/http/dispatch.rs
+++ b/magicblock-aperture/src/server/http/dispatch.rs
@@ -212,10 +212,8 @@ impl HttpDispatcher {
             GetRecentPerformanceSamples => {
                 self.get_recent_performance_samples(request)
             }
-            GetSignatureStatuses => {
-                self.run_blocking(|| self.get_signature_statuses(request))
-                    .await
-            }
+            // Gates only its ledger fallbacks; cache hits answer inline.
+            GetSignatureStatuses => self.get_signature_statuses(request).await,
             GetSignaturesForAddress => {
                 self.run_blocking(|| self.get_signatures_for_address(request))
                     .await
@@ -298,7 +296,7 @@ impl HttpDispatcher {
     ///
     /// Falls back to running inline on current-thread runtimes (tests), where
     /// `block_in_place` would panic.
-    async fn run_blocking<T>(&self, f: impl FnOnce() -> T) -> T {
+    pub(crate) async fn run_blocking<T>(&self, f: impl FnOnce() -> T) -> T {
         use tokio::runtime::{Handle, RuntimeFlavor};
         // The semaphore is never closed, so acquisition cannot fail.
         let _permit = self.blocking_reads.acquire().await.ok();

--- a/magicblock-ledger/src/store/api.rs
+++ b/magicblock-ledger/src/store/api.rs
@@ -411,11 +411,15 @@ impl Ledger {
     // As far as we are concerned these are just the time when we advanced to
     // a specific slot.
     pub fn write_block(&self, block: LatestBlockInner) -> LedgerResult<()> {
-        self.blocktime_cf
-            .put(block.slot, &block.clock.unix_timestamp)?;
-        self.blocktime_cf.try_increase_entry_counter(1);
+        // Blocktime and blockhash must land atomically: readers treat the
+        // pair as one record (e.g. getBlockTime vs getBlock availability),
+        // so a split write must never be observable or partially persisted.
+        let mut batch = self.db.batch();
+        batch.put::<cf::Blocktime>(block.slot, &block.clock.unix_timestamp)?;
+        batch.put::<cf::Blockhash>(block.slot, &block.blockhash)?;
+        self.db.write(batch)?;
 
-        self.blockhash_cf.put(block.slot, &block.blockhash)?;
+        self.blocktime_cf.try_increase_entry_counter(1);
         self.blockhash_cf.try_increase_entry_counter(1);
         self.latest_block.store(block);
         Ok(())

--- a/magicblock-ledger/src/store/api.rs
+++ b/magicblock-ledger/src/store/api.rs
@@ -276,7 +276,7 @@ impl Ledger {
     // Block time
     // -----------------
 
-    pub(crate) fn get_block_time(
+    pub fn get_block_time(
         &self,
         slot: Slot,
     ) -> LedgerResult<Option<UnixTimestamp>> {


### PR DESCRIPTION
## Problem

ledger-reading handlers (`getBlock`, `getBlockTime`, `getTransaction`, `getSignatureStatuses`, `getSignaturesForAddress`) execute RocksDB reads synchronously on the RPC runtime's worker threads (`num_cpus/2 - 1` = 5 on the affected host), with no `spawn_blocking` anywhere in aperture. When the ledger truncator planted range tombstones, reads crossing that range degraded from microseconds to seconds/minutes until the (rate-limited, ~2h) compaction cleared them. 

## Fix

Run the five ledger-reading handlers via `block_in_place`, which hands the worker's scheduler core to another thread before the blocking read. A stalled read now occupies only its own OS thread; `getLatestBlockhash`, `sendTransaction`, `getHealth`, and connection tasks keep being served. 