### PR TITLE
docs: update PR workflow policy

### DIFF
--- a/.agents/context/crate-map.md
+++ b/.agents/context/crate-map.md
@@ -82,5 +82,5 @@ The validator is performance-sensitive. When changing any crate on RPC, account 
 - For commit or undelegation bugs, start with `magicblock-program`, `magicblock-committor-service`, and `magicblock-services` for request-triggered scheduling.
 - For RPC behavior, start with `magicblock-aperture`; check `magicblock-chainlink` if reads trigger cloning.
 - For validator lifecycle/startup/shutdown, start with `magicblock-api` and `magicblock-validator`.
-- When adding, removing, renaming, or repurposing a crate, update this file and `AGENTS.md` in the same change.
+- When adding, removing, renaming, or repurposing a crate, queue updates to this file and `AGENTS.md` for the weekly documentation-maintenance task.
 - When changing crate responsibilities, note whether performance-sensitive work moved onto or off of a hot path and document any expected regression or mitigation.

--- a/.agents/context/crates/magicblock-account-cloner.md
+++ b/.agents/context/crates/magicblock-account-cloner.md
@@ -19,7 +19,7 @@ This crate is on the account-availability path for transaction submission, RPC r
 
 ## Update requirement
 
-Update this document in the same change whenever behavior in `magicblock-account-cloner` changes, or whenever another crate changes the clone requests or Magic Program instructions this crate consumes. Update it for changes to:
+Queue an update to this document for the weekly documentation-maintenance task whenever behavior in `magicblock-account-cloner` changes, or whenever another crate changes the clone requests or Magic Program instructions this crate consumes. Include changes to:
 
 - the `ChainlinkCloner` public constructor or its `Cloner` trait implementation,
 - account clone sizing, chunking, cleanup, post-delegation action handling, or transaction-size limits,

--- a/.agents/context/crates/magicblock-accounts-db.md
+++ b/.agents/context/crates/magicblock-accounts-db.md
@@ -17,7 +17,7 @@ This crate is on multiple performance-sensitive paths: transaction execution acc
 
 ## Update requirement
 
-Whenever behavior in `magicblock-accounts-db` changes, or another crate changes AccountsDb flows/contracts, update this document in the same change for changes to:
+Whenever behavior in `magicblock-accounts-db` changes, or another crate changes AccountsDb flows or contracts, queue an update to this document for the weekly documentation-maintenance task for changes to:
 
 - storage layout, mmap header fields, block sizing, allocation/recycling, or serialized account representation,
 - LMDB tables, key/value encodings, owner/program indexes, or cursor/iterator lifetime handling,

--- a/.agents/context/crates/magicblock-accounts.md
+++ b/.agents/context/crates/magicblock-accounts.md
@@ -32,7 +32,7 @@ Do not add new runtime services here just because the crate name says
 
 ## Update Requirement
 
-Update this document in the same change when:
+Queue an update to this document for the weekly documentation-maintenance task when:
 
 - this crate gains or loses exports;
 - the legacy `ScheduledCommitsProcessor` trait or account error surface changes;

--- a/.agents/context/crates/magicblock-aml.md
+++ b/.agents/context/crates/magicblock-aml.md
@@ -17,7 +17,7 @@ This crate sits on the `magicblock-chainlink` account synchronization path for a
 
 ## Update requirement
 
-Update this document in the same change whenever `magicblock-aml` behavior, public APIs, configuration contract, persistence layout, error semantics, or Chainlink integration changes. Update it for changes to:
+Queue an update to this document for the weekly documentation-maintenance task whenever `magicblock-aml` behavior, public APIs, configuration contract, persistence layout, error semantics, or Chainlink integration changes. Include changes to:
 
 - `RiskService`, `RiskError`, `RiskResult`, cache aliases, or other exported API shape;
 - Range endpoint path, query parameters, auth scheme, response parsing, or expected JSON fields;
@@ -213,7 +213,7 @@ The Range response parser accepts any JSON document with top-level unsigned inte
 
 1. Disabled risk config must return `Ok(None)` and must not require an API key, open SQLite, or spawn background tasks.
 2. Enabled risk config must fail fast without an API key and when `risk_score_threshold > 10`.
-3. The cache file must remain under the validator ledger path as `risk-cache.db` unless a migration and documentation update are included.
+3. The cache file must remain under the validator ledger path as `risk-cache.db` unless a migration is included and the documentation update is queued for weekly maintenance.
 4. SQLite reads/writes must not run directly on async runtime worker threads; keep them behind `spawn_blocking` or an equivalent non-hot-path boundary.
 5. Cached scores and fetched scores must use the same high-risk comparison: `score >= risk_score_threshold`.
 6. Concurrent requests for the same uncached address must remain deduplicated to avoid avoidable Range API amplification.

--- a/.agents/context/crates/magicblock-aperture.md
+++ b/.agents/context/crates/magicblock-aperture.md
@@ -19,7 +19,7 @@ Aperture sits directly on performance-sensitive RPC, PubSub, event-processing, a
 
 ## Update requirement
 
-Update this document in the same change whenever `magicblock-aperture` behavior, public APIs, request/response compatibility, configuration contract, event flow, cache behavior, Geyser integration, metrics, tests, or performance characteristics change. Update it for changes to:
+Queue an update to this document for the weekly documentation-maintenance task whenever `magicblock-aperture` behavior, public APIs, request/response compatibility, configuration contract, event flow, cache behavior, Geyser integration, metrics, tests, or performance characteristics change. Include changes to:
 
 - `initialize_aperture`, `JsonRpcServer`, `SharedState`, `NodeContext`, exported modules, or startup/shutdown ordering;
 - HTTP or WebSocket method inventories in `JsonRpcHttpMethod` / `JsonRpcWsMethod`;
@@ -294,7 +294,7 @@ Subscription grouping depends on encoders implementing stable ordering/equality.
 
 ### JSON and Solana compatibility
 
-The crate intentionally implements a subset of Solana JSON-RPC behavior plus MagicBlock-specific methods. Some methods are mocked for compatibility. Do not silently change method names, response context slots, JSON-RPC error codes, or unsupported-encoding behavior without updating tests and operator/client documentation.
+The crate intentionally implements a subset of Solana JSON-RPC behavior plus MagicBlock-specific methods. Some methods are mocked for compatibility. Do not silently change method names, response context slots, JSON-RPC error codes, or unsupported-encoding behavior without updating tests and queuing the operator/client documentation update for weekly maintenance.
 
 ### Geyser FFI safety
 

--- a/.agents/context/crates/magicblock-api.md
+++ b/.agents/context/crates/magicblock-api.md
@@ -19,7 +19,7 @@ This crate sits directly on startup and shutdown paths and coordinates hot-path 
 
 ## Update requirement
 
-Update this document in the same change whenever `magicblock-api` behavior or contracts change. Update it for changes to:
+Queue an update to this document for the weekly documentation-maintenance task whenever `magicblock-api` behavior or contracts change. Include changes to:
 
 - `MagicValidator::try_from_config`, `start`, `stop`, `prepare_ledger_for_shutdown`, or validator registration/unregistration behavior;
 - startup/shutdown ordering, service ownership, cancellation semantics, or thread/runtime spawning;

--- a/.agents/context/crates/magicblock-chainlink.md
+++ b/.agents/context/crates/magicblock-chainlink.md
@@ -19,7 +19,7 @@ Chainlink is on the account-availability hot path for RPC reads and transaction 
 
 ## Update requirement
 
-Whenever behavior in `magicblock-chainlink` changes, or another crate changes Chainlink flows, update this document in the same change for changes to:
+Whenever behavior in `magicblock-chainlink` changes, or another crate changes Chainlink flows, queue an update to this document for the weekly documentation-maintenance task for changes to:
 
 - account fetch/clone classification,
 - delegation-record resolution or local delegated/confined/undelegating flags,

--- a/.agents/context/crates/magicblock-committor-program.md
+++ b/.agents/context/crates/magicblock-committor-program.md
@@ -18,7 +18,7 @@ End-to-end commit/undelegation semantics live in .agents/specs/validator-specifi
 
 ## Update requirement
 
-Update this guide in the same change whenever behavior or contracts in `magicblock-committor-program` change. In particular, update it for changes to:
+Queue an update to this guide for the weekly documentation-maintenance task whenever behavior or contracts in `magicblock-committor-program` change. Include changes to:
 
 - `CommittorInstruction` variants, account order, Borsh layout, instruction-size constants, or program id;
 - PDA seed strings, seed order, bump handling, authority scoping, or `commit_id` encoding;

--- a/.agents/context/crates/magicblock-committor-service.md
+++ b/.agents/context/crates/magicblock-committor-service.md
@@ -20,7 +20,7 @@ End-to-end commit/undelegation semantics live in .agents/specs/validator-specifi
 
 ## Update requirement
 
-Update this guide in the same change whenever behavior or contracts in `magicblock-committor-service` change. In particular, update it for changes to:
+Queue an update to this guide for the weekly documentation-maintenance task whenever behavior or contracts in `magicblock-committor-service` change. Include changes to:
 
 - `CommittorService`, `BaseIntentCommittor`, `CommittorServiceExt`, channel messages, startup/shutdown, or cancellation semantics;
 - `ChainConfig`, `ComputeBudgetConfig`, action timeout behavior, RPC/websocket construction, or configured commitment assumptions;

--- a/.agents/context/crates/magicblock-config.md
+++ b/.agents/context/crates/magicblock-config.md
@@ -16,7 +16,7 @@ This crate sits on the startup/configuration path rather than a per-transaction 
 
 ## Update requirement
 
-Update this document in the same change whenever `magicblock-config` behavior or contracts change.
+Queue an update to this document for the weekly documentation-maintenance task whenever `magicblock-config` behavior or contracts change.
 
 Update it for changes to:
 
@@ -175,7 +175,7 @@ Do not introduce aliases casually. Operator docs, `config.example.toml`, integra
 
 ### Strict unknown-field behavior
 
-Most config structs use `deny_unknown_fields`. This catches typos and stale config but makes renames/removals breaking for operators. If a field is renamed, include migration notes and update tests/example config in the same change.
+Most config structs use `deny_unknown_fields`. This catches typos and stale config but makes renames/removals breaking for operators. If a field is renamed, update tests in the code change and queue migration notes and example-config updates for the weekly documentation-maintenance task.
 
 ### Secrets and debug output
 

--- a/.agents/context/crates/magicblock-core.md
+++ b/.agents/context/crates/magicblock-core.md
@@ -16,7 +16,7 @@ Keep `magicblock-core` dependency-light and protocol-neutral where possible. It 
 
 ## Update requirement
 
-Update this guide in the same change whenever behavior or contracts in `magicblock-core` change. In particular, update it for changes to:
+Queue an update to this guide for the weekly documentation-maintenance task whenever behavior or contracts in `magicblock-core` change. Include changes to:
 
 - endpoint/channel topology, channel capacity, backpressure semantics, or scheduler pause behavior in `src/link.rs` and `src/link/transactions.rs`;
 - public transaction modes, replay/block-boundary ordering, replication message layout, or bincode payload compatibility;

--- a/.agents/context/crates/magicblock-ledger.md
+++ b/.agents/context/crates/magicblock-ledger.md
@@ -17,7 +17,7 @@ This crate sits on storage, RPC-history, startup/recovery, replication, and exec
 
 ## Update requirement
 
-Update this guide in the same change whenever behavior or contracts in `magicblock-ledger` change. In particular, update it for changes to:
+Queue an update to this guide for the weekly documentation-maintenance task whenever behavior or contracts in `magicblock-ledger` change. Include changes to:
 
 - `Ledger`, `LatestBlock`, `LatestBlockInner`, `SignatureInfosForAddress`, or exported error/API types;
 - RocksDB column families, key encodings, serialization formats, protobuf/bincode compatibility, or column options;

--- a/.agents/context/crates/magicblock-magic-program-api.md
+++ b/.agents/context/crates/magicblock-magic-program-api.md
@@ -21,7 +21,7 @@ Do not put Magic Program execution logic, validation policy, persistence, RPC be
 
 ## Update requirement
 
-Update this guide in the same change whenever behavior or contracts in `magicblock-magic-program-api` change. In particular, update it for changes to:
+Queue an update to this guide for the weekly documentation-maintenance task whenever behavior or contracts in `magicblock-magic-program-api` change. Include changes to:
 
 - any public constant, program ID, fixed account, PDA seed, PDA derivation, or rent/context-size constant;
 - `MagicBlockInstruction`, `CallbackInstruction`, `PostDelegationActionExecutorInstruction`, `AccountCloneFields`, account-modification types, or serialization behavior;

--- a/.agents/context/crates/magicblock-metrics.md
+++ b/.agents/context/crates/magicblock-metrics.md
@@ -18,7 +18,7 @@ This crate is intentionally dependency-light and has no dependency on other work
 
 ## Update requirement
 
-Whenever an agent changes behavior in `magicblock-metrics`, or changes another crate in a way that changes metrics exposed by this crate, this document must be updated in the same change.
+Whenever behavior in `magicblock-metrics` changes, or another crate changes the metrics exposed by this crate, queue an update to this document for the weekly documentation-maintenance task.
 
 Update this file for changes to:
 
@@ -315,7 +315,7 @@ Current counters include:
 - `inc_rpc_client_signature_status_batch_count()`,
 - `inc_rpc_client_signature_status_batch_signatures_count(count)`.
 
-Some names/help strings are investigation-oriented (`*_a_count`, "Get mupltiple account count"). Treat them as current implementation, but if you formalize or rename them, update dashboards/alerts and this guide in the same change.
+Some names/help strings are investigation-oriented (`*_a_count`, "Get mupltiple account count"). Treat them as current implementation, but if you formalize or rename them, queue dashboard, alert, and guide updates for the weekly documentation-maintenance task.
 
 ### Pubsub clients and gRPC streams
 

--- a/.agents/context/crates/magicblock-rpc-client.md
+++ b/.agents/context/crates/magicblock-rpc-client.md
@@ -20,7 +20,7 @@ End-to-end commit/undelegation semantics live in .agents/specs/validator-specifi
 
 ## Update requirement
 
-Update this guide in the same change whenever behavior or contracts in `magicblock-rpc-client` change. In particular, update it for changes to:
+Queue an update to this guide for the weekly documentation-maintenance task whenever behavior or contracts in `magicblock-rpc-client` change. Include changes to:
 
 - `MagicblockRpcClient` constructors, cached blockhash/slot behavior, commitment handling, or `chain_slot` observation;
 - `SEND_TRANSACTION_CONFIG`, send/confirm defaults, timeout intervals, or `MagicBlockSendTransactionConfig` semantics;

--- a/.agents/context/crates/magicblock-services.md
+++ b/.agents/context/crates/magicblock-services.md
@@ -19,7 +19,7 @@ End-to-end commit/undelegation semantics live in .agents/specs/validator-specifi
 
 ## Update requirement
 
-Update this guide in the same change whenever behavior or contracts in `magicblock-services` change. In particular, update it for changes to:
+Queue an update to this guide for the weekly documentation-maintenance task whenever behavior or contracts in `magicblock-services` change. Include changes to:
 
 - exported modules or public constructors in `magicblock-services/src/lib.rs`, `actions_callback_service.rs`, or `undelegation_request_service.rs`;
 - the `ActionsCallbackService` transaction layout, signer handling, blockhash source, or callback response encoding;

--- a/.agents/context/crates/magicblock-table-mania.md
+++ b/.agents/context/crates/magicblock-table-mania.md
@@ -19,7 +19,7 @@ End-to-end commit/undelegation semantics live in .agents/specs/validator-specifi
 
 ## Update requirement
 
-Update this guide in the same change whenever behavior or contracts in `magicblock-table-mania` change. In particular, update it for changes to:
+Queue an update to this guide for the weekly documentation-maintenance task whenever behavior or contracts in `magicblock-table-mania` change. Include changes to:
 
 - public exports in `src/lib.rs`, `TableMania`, `LookupTableRc`, `GarbageCollectorConfig`, `TableManiaComputeBudgets`, or `TableManiaError`;
 - reservation/release semantics, reference-count behavior, or active/released table lifecycle;

--- a/.agents/context/crates/magicblock-task-scheduler.md
+++ b/.agents/context/crates/magicblock-task-scheduler.md
@@ -18,7 +18,7 @@ This crate sits on the scheduled-task/crank path and can affect transaction exec
 
 ## Update requirement
 
-Update this guide in the same change whenever behavior or contracts in `magicblock-task-scheduler` change. In particular, update it for changes to:
+Queue an update to this guide for the weekly documentation-maintenance task whenever behavior or contracts in `magicblock-task-scheduler` change. Include changes to:
 
 - public exports in `src/lib.rs`, `SchedulerDatabase`, `TaskSchedulerService`, or `TaskSchedulerError`;
 - SQLite schema, database path, WAL/PRAGMA settings, retention behavior, optimistic `updated_at` concurrency, or restart recovery semantics;

--- a/.agents/context/crates/magicblock-validator-admin.md
+++ b/.agents/context/crates/magicblock-validator-admin.md
@@ -16,7 +16,7 @@ This crate sits on validator startup, background administration, and base-layer 
 
 ## Update requirement
 
-Update this guide in the same change whenever behavior or contracts in `magicblock-validator-admin` change. In particular, update it for changes to:
+Queue an update to this guide for the weekly documentation-maintenance task whenever behavior or contracts in `magicblock-validator-admin` change. Include changes to:
 
 - public exports in `src/lib.rs` or `src/claim_fees.rs`;
 - `ClaimFeesTask` lifecycle, cancellation, tick scheduling, duplicate-start behavior, or shutdown timeout;

--- a/.agents/context/crates/magicblock-validator.md
+++ b/.agents/context/crates/magicblock-validator.md
@@ -19,7 +19,7 @@ This crate sits on startup and shutdown paths, not on per-transaction execution 
 
 ## Update requirement
 
-Update this guide in the same change whenever `magicblock-validator` behavior or contracts change. In particular, update it for changes to:
+Queue an update to this guide for the weekly documentation-maintenance task whenever `magicblock-validator` behavior or contracts change. Include changes to:
 
 - CLI invocation, feature flags, `--no-tui` semantics, or logging behavior;
 - main Tokio runtime construction, worker-thread sizing, or runtime/thread names;
@@ -181,7 +181,7 @@ The binary obtains the lock after `MagicValidator` is constructed because it nee
 
 ### Operator-facing output is compatibility-sensitive
 
-Startup output in `run_no_tui` is useful for local development, automation, and debugging. If changing labels, hiding fields, or routing output differently, update operator docs and consider tests or manual validation of both `RUST_LOG` modes.
+Startup output in `run_no_tui` is useful for local development, automation, and debugging. If changing labels, hiding fields, or routing output differently, queue the operator-doc update for weekly maintenance and consider tests or manual validation of both `RUST_LOG` modes.
 
 ## Important invariants
 

--- a/.agents/context/crates/magicblock-version.md
+++ b/.agents/context/crates/magicblock-version.md
@@ -16,7 +16,7 @@ This crate is small and dependency-light. It is not on the transaction execution
 
 ## Update requirement
 
-Update this guide in the same change whenever `magicblock-version` behavior or contracts change. In particular, update it for changes to:
+Queue an update to this guide for the weekly documentation-maintenance task whenever `magicblock-version` behavior or contracts change. Include changes to:
 
 - `Version` fields, serialization behavior, `Display` / `Debug` formatting, or the `semver!` / `version!` macros;
 - how `major`, `minor`, `patch`, `commit`, `feature_set`, `client`, `solana_core`, or `git_version` are computed;
@@ -119,7 +119,7 @@ HTTP getVersion request
        magicblock-core = version.to_string()
 ```
 
-The RPC field names are external compatibility surface. Do not rename them or swap `git-commit` from `git_version` to the numeric `commit` field without updating RPC tests, docs, and downstream tooling expectations.
+The RPC field names are external compatibility surface. Do not rename them or swap `git-commit` from `git_version` to the numeric `commit` field without updating RPC tests and downstream tooling expectations and queuing the documentation update for weekly maintenance.
 
 ### Validator/TUI display flow
 

--- a/.agents/context/crates/storage-proto.md
+++ b/.agents/context/crates/storage-proto.md
@@ -16,7 +16,7 @@ This crate is on the ledger persistence/read path through `magicblock-ledger`. I
 
 ## Update requirement
 
-Update this guide in the same change whenever `storage-proto` behavior or contracts change. In particular, update it for changes to:
+Queue an update to this guide for the weekly documentation-maintenance task whenever `storage-proto` behavior or contracts change. Include changes to:
 
 - protobuf files under `storage-proto/proto/`, field numbers, enum values, optionality, or package names;
 - build-time code generation in `storage-proto/build.rs`, including generated module names or `tonic_prost_build` options;

--- a/.agents/context/crates/test-kit.md
+++ b/.agents/context/crates/test-kit.md
@@ -17,7 +17,7 @@ This crate is not production runtime code, but it wraps performance- and correct
 
 ## Update requirement
 
-Update this guide in the same change whenever `test-kit` behavior or contracts change. In particular, update it for changes to:
+Queue an update to this guide for the weekly documentation-maintenance task whenever `test-kit` behavior or contracts change. Include changes to:
 
 - `ExecutionTestEnv` construction, scheduler startup/mode handling, shutdown behavior, default fee, block time, or superblock sizing;
 - helper semantics that mark accounts delegated, fund payers, advance slots, load programs, or write directly to `AccountsDb`/`Ledger`;

--- a/.agents/memory/agent-memory-and-docs.md
+++ b/.agents/memory/agent-memory-and-docs.md
@@ -1,20 +1,20 @@
 # Agent Memory and Documentation Stewardship
 
-This file defines how agents keep repository knowledge current. Treat the files in `./.agents/` as the repository's persistent agent memory: when an agent discovers durable information that future agents should rely on, the agent must update these documents in the same change whenever practical.
+This file defines how agents keep repository knowledge current. Treat the files in `./.agents/` as the repository's persistent agent memory. Documentation updates are batched into a dedicated weekly maintenance task, which is currently started manually.
 
 `AGENTS.md`, `.agents/README.md`, overview docs, and crate guides should point here instead of restating this policy.
 
 ## Core rule
 
-Whenever you discover that the current `./.agents/` guidance is missing, incomplete, inaccurate, or stale, update it before finishing the task.
+Do not update documentation in a feature, fix, refactor, or other code pull request. When current guidance is missing, incomplete, inaccurate, or stale, identify the exact documentation follow-up in the task handoff so it can be handled by the weekly documentation-maintenance task.
 
-This applies even when the discovery is incidental to another task. Do not leave known gaps for a future agent unless you are blocked from editing documentation; if blocked, report the exact missing update and where it should go.
+This applies even when the discovery is incidental to another task. Dedicated documentation tasks, including the weekly maintenance task and explicit instruction-policy changes, may update documentation in documentation-only pull requests.
 
-**Documented elsewhere is not an excuse to skip the update.** A durable fact being present in the source code, a code comment, an unrelated `.agents/` file, an external repo, or any other location does *not* satisfy this rule. The test is not "does this fact exist somewhere?" — it is "would an agent who opens the single most relevant `.agents/` document for this concern find it there?" If the answer is no, you must capture it in that document, even if a related or partial mention already lives in a different file. Each `.agents/` document must be self-sufficient for an agent working in the area it covers; never rely on the reader having read another file. When the same fact is genuinely relevant in two places, put the full explanation in the most specific canonical file and add a short pointer (not a silent omission) from the other.
+**Documented elsewhere is not an excuse to omit the follow-up.** A durable fact being present in the source code, a code comment, an unrelated `.agents/` file, an external repo, or any other location does *not* make the relevant agent guidance complete. The test is "would an agent who opens the single most relevant `.agents/` document for this concern find it there?" If the answer is no, name that document and the missing information in the handoff. During weekly maintenance, put the full explanation in the most specific canonical file and add a short pointer from other relevant files.
 
-Concretely: if you investigate code to answer a question and find that the mechanism, behavior, or invariant you relied on is *not* spelled out in the crate/spec/rules document an agent would consult for that area, document it there now — regardless of whether a higher-level or differently-scoped file happens to mention it.
+Concretely: if you investigate code and find that the mechanism, behavior, or invariant you relied on is not spelled out in the crate, specification, or rules document an agent would consult, queue that exact update for the weekly documentation task rather than adding it to the code pull request.
 
-**This rule applies to read-only and question-answering tasks too, not only code changes.** If you investigate the code to answer a question and learn a durable fact — especially a divergence from agave/Solana upstream behavior (e.g. a missing limit, different default, or relaxed validation) — capture it before finishing, then report it per the Final response requirement below.
+**This rule applies to read-only and question-answering tasks too, not only code changes.** If you learn a durable fact — especially a divergence from agave/Solana upstream behavior, such as a missing limit, different default, or relaxed validation — include the documentation follow-up in the handoff.
 
 ## What must be captured
 
@@ -45,6 +45,8 @@ If no suitable document exists, create a new focused file in `.agents/` or `.age
 
 ## How to update
 
+Apply these steps during the dedicated weekly documentation-maintenance task or another explicitly requested documentation-only task:
+
 Keep updates concise and operational:
 
 1. State the behavior or workflow future agents need to know.
@@ -53,8 +55,8 @@ Keep updates concise and operational:
 4. Call out performance-sensitive paths and tradeoffs if relevant.
 5. Avoid duplicating large blocks across files; link or point to the canonical file instead.
 
-When behavior changes in code, update the docs in the same change as the implementation. When the task is documentation-only, verify that file paths and cross-references remain accurate.
+The weekly task should review the durable documentation follow-ups and merged code changes since the previous pass, update the relevant documentation, and submit only documentation changes. Verify that file paths and cross-references remain accurate.
 
 ## Final response requirement
 
-When finishing a task, report whether agent documentation was updated. If it was not updated, state why no durable agent-memory update was needed, or list the blocked documentation follow-up explicitly.
+When finishing a task, report whether agent documentation was updated. For code tasks, state either that no durable documentation follow-up was needed or list the exact follow-up for the weekly maintenance task.

--- a/.agents/rules/testing-and-validation.md
+++ b/.agents/rules/testing-and-validation.md
@@ -1,10 +1,10 @@
 # Testing and Validation
 
-This file tells agents how to validate changes. Keep it focused on commands and workflow. If validation behavior changes, update this file in the same change.
+This file tells agents how to validate changes. Keep it focused on commands and workflow. If validation behavior changes, queue an update to this file for the weekly documentation-maintenance task.
 
 ## Baseline rule
 
-Every code change must be validated. Use the repository-local `mbv-check` skill for Rust changes once it is available in the agent environment. The intent of that skill is to run this validator's standard Rust quality gate and help fix any failures.
+Every code change must be validated. Use the repository-local `mbv-check` skill for Rust changes only when full local validation is explicitly requested or appropriate outside a GitHub push workflow. The intent of that skill is to run this validator's standard Rust quality gate and help fix any failures.
 
 Crate guides should name relevant packages/suites and validation intent, but exact command syntax belongs here or in executable skills.
 
@@ -12,7 +12,9 @@ The validator is performance-sensitive. When a change touches critical RPC, acco
 
 For correctness, security, and protocol invariants, read `.agents/rules/invariants.md`, `.agents/rules/validator-goals.md`, and `.agents/specs/validator-specification.md`; this file only defines how to validate changes against those invariants. When a change touches signer/authority checks, account-sync correctness, lock acquisition/ordering, or any path driven by untrusted RPC/transaction input, add or run the test that exercises the security-relevant behavior (for example concurrency/race tests, delegation/sync ordering tests, or auth-rejection tests). If you cannot validate a security-relevant path, say so and call out the residual risk explicitly — do not treat it as low priority.
 
-Until or unless the skill provides a more specific command set, treat the required baseline as:
+For local validation before any GitHub push, run only tests targeted to the touched behavior; do not run a full workspace or integration suite. When fixing an existing pull request, run exactly one relevant unit test or one relevant integration test. Let CI provide the broader test coverage.
+
+For explicitly requested full local validation and for CI, use:
 
 ```bash
 make fmt
@@ -22,11 +24,11 @@ cargo nextest run --workspace
 
 Run tests with `cargo nextest`. If `nextest` is not available in the environment, fall back to `cargo test` for the same scope (for example `cargo test --workspace`). This is the single source of truth for that choice; other sections assume it.
 
-For small or targeted changes, run the smallest relevant test first, then run the broader checks before handing off if time allows.
+For work that will not be pushed to GitHub, run the smallest relevant test first and run broader checks only when explicitly requested or justified by the task.
 
 For documentation-only changes, at minimum verify the changed files are in the right location and that links/filenames mentioned in `AGENTS.md` and `.agents/` stay in sync.
 
-When you discover a new reliable way to test, debug, benchmark, or validate the codebase, update this file or the relevant crate-specific guide before finishing. If the approach is specific to one crate, prefer `.agents/context/crates/<crate>.md` and link from broader docs only when needed.
+When you discover a new reliable way to test, debug, benchmark, or validate the codebase, identify the documentation follow-up for the weekly maintenance task. If the approach is specific to one crate, target `.agents/context/crates/<crate>.md`; otherwise target this file.
 
 ## Choosing what to run
 
@@ -42,7 +44,10 @@ Use the crate map and touched files to pick tests:
 
 Always report exactly which commands were run and whether they passed. Also report any performance-sensitive paths touched, what performance validation was performed, and any unavoidable performance tradeoff or unmeasured risk.
 
-## Workspace checks
+## Full workspace checks
+
+Run these only when full local validation is explicitly requested or in CI, not
+as part of a GitHub push workflow.
 
 Common root-level commands:
 
@@ -226,4 +231,4 @@ When finishing a task, include:
 - any remaining risk, especially for integration tests that require validators or long-running suites,
 - any performance-sensitive paths touched and whether performance regression risk was measured, reasoned about, or left unmeasured,
 - any security-relevant paths touched (signer/authority enforcement, base-layer sync, locking/concurrency, untrusted-input handling), confirmation that no security property was weakened, and how that was checked or what residual risk remains,
-- whether agent documentation was updated for any durable discovery, or why no update was needed.
+- whether a durable documentation follow-up was queued for the weekly maintenance task, or why none was needed.

--- a/.agents/rules/validator-goals.md
+++ b/.agents/rules/validator-goals.md
@@ -138,7 +138,7 @@ Do not bypass delegation records, access validation, commit nonces, or intent pe
 
 Do not trade away any security property — signer/authority enforcement, base-layer sync integrity, or resistance to attacker-triggerable conditions — for performance, simplicity, or compatibility. There is no acceptable tradeoff here.
 
-Do not add protocol behavior in an isolated crate without updating the docs and checking the cross-crate architecture.
+Do not add protocol behavior in an isolated crate without checking the cross-crate architecture and identifying the corresponding documentation follow-up for the weekly maintenance task.
 
 ## Change checklist
 
@@ -152,5 +152,5 @@ Before finishing a feature, bug fix, or refactor, ask:
 5. Did I avoid blocking critical scheduler/RPC/executor paths?
 6. Did I avoid degrading critical-path latency, throughput, memory use, lock contention, and I/O behavior?
 7. If a performance tradeoff was unavoidable, did I explicitly call out why, the expected impact, and mitigation?
-8. Did I update the relevant file in `.agents/` if behavior changed?
-9. Did I update or create agent documentation for any newly discovered durable behavior, workflow, pitfall, invariant, crate responsibility, validation approach, or stale/missing guidance?
+8. Did I identify the relevant `.agents/` documentation follow-up if behavior changed?
+9. Did I queue any newly discovered durable behavior, workflow, pitfall, invariant, crate responsibility, validation approach, or stale/missing guidance for the weekly documentation-maintenance task?

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,24 @@ approve, or recommend merging the pull request until the violation is resolved.
 In the final reply, explicitly state whether the invariant review found any
 violation and identify the validation or evidence used for that conclusion.
 
+## Pull request and GitHub policy
+
+- Do not mix documentation updates into feature, fix, refactor, or other code
+  pull requests. Documentation updates are handled in a dedicated weekly
+  documentation-maintenance task, which is currently started manually. See
+  `.agents/memory/agent-memory-and-docs.md`.
+- Before pushing to GitHub, follow `.github/PULL_REQUEST_TEMPLATE.md` and the
+  repository's existing pull request convention. Use a
+  `type(scope): summary` title where the scope is optional, and keep the
+  `Summary`, `Breaking Changes`, and `Test Plan` structure.
+- Run only targeted tests locally before a GitHub push. When fixing an existing
+  pull request, run one relevant unit test or one relevant integration test
+  instead of a full suite. Broader validation belongs in CI. See
+  `.agents/rules/testing-and-validation.md`.
+- Never mention or include the name of an agent, assistant, model, or automation
+  tool in branch names, commit messages, pull request titles or bodies, review
+  replies, or any other GitHub-visible metadata.
+
 ## Directory layout
 
 - `.agents/rules/` — invariant behavioral and decision-making rules agents must follow.
@@ -53,6 +71,8 @@ Before changing code, consult the matching `./.agents` material so the change do
 
 The validator is performance-sensitive infrastructure. Changes must not degrade critical-path performance unless there is no viable alternative; if a tradeoff is unavoidable, call it out explicitly with the reason, expected impact, and any mitigation.
 
-For durable-knowledge and documentation-stewardship requirements, follow `.agents/memory/agent-memory-and-docs.md`. In every task's final reply, state whether agent docs were updated, or why no update was needed.
+For durable-knowledge and documentation-stewardship requirements, follow `.agents/memory/agent-memory-and-docs.md`. In every task's final reply, state whether agent docs were updated or whether a follow-up was queued for weekly maintenance.
 
-If anything is added to, removed from, renamed, or reorganized inside `./.agents/`, update this `AGENTS.md` file in the same change so this entrypoint remains accurate.
+During a documentation-only change, if anything is added to, removed from,
+renamed, or reorganized inside `./.agents/`, update this `AGENTS.md` file in the
+same change so this entrypoint remains accurate.


### PR DESCRIPTION
## Summary
Separates code pull requests from the manually started weekly documentation-maintenance workflow, requires targeted local tests for pull request follow-ups, and codifies the repository's existing pull request format and neutral GitHub metadata requirements.

## Breaking Changes
- [x] None
- [ ] Yes — migration path described below

## Test Plan
- `git diff --check`
- Verified that all changed files are Markdown guidance and that referenced policy and template paths exist.
- Rust tests were not run because this is a documentation-only change.