### PR TITLE
feat(rpc): expose remote account claim counts

### DIFF
--- a/magicblock-aperture/src/requests/http/get_account_info.rs
+++ b/magicblock-aperture/src/requests/http/get_account_info.rs
@@ -1,3 +1,5 @@
+use std::sync::{atomic::AtomicU64, Arc};
+
 use solana_rpc_client_api::config::RpcAccountInfoConfig;
 use tracing::*;
 
@@ -13,6 +15,7 @@ impl HttpDispatcher {
     pub(crate) async fn get_account_info(
         &self,
         request: &mut JsonRequest,
+        remote_account_claims: Arc<AtomicU64>,
     ) -> HandlerResult {
         let (pubkey, config) = parse_params!(
             request.params()?,
@@ -30,8 +33,10 @@ impl HttpDispatcher {
         debug!("Getting account info");
 
         // `read_account_with_ensure` guarantees the account is clone from chain if not in database.
+        let fetch_context =
+            Self::rpc_get_account_context(remote_account_claims);
         let account = self
-            .read_account_with_ensure(&pubkey)
+            .read_account_with_ensure(&pubkey, fetch_context)
             .await
             .filter(|acc| !Self::account_should_render_as_null(acc))
             // `LockedAccount` provides a race-free read of the account data before encoding.

--- a/magicblock-aperture/src/requests/http/get_balance.rs
+++ b/magicblock-aperture/src/requests/http/get_balance.rs
@@ -1,3 +1,5 @@
+use std::sync::{atomic::AtomicU64, Arc};
+
 use super::prelude::*;
 
 impl HttpDispatcher {
@@ -9,12 +11,15 @@ impl HttpDispatcher {
     pub(crate) async fn get_balance(
         &self,
         request: &mut JsonRequest,
+        remote_account_claims: Arc<AtomicU64>,
     ) -> HandlerResult {
         let pubkey_bytes = parse_params!(request.params()?, Serde32Bytes);
         let pubkey = some_or_err!(pubkey_bytes);
 
+        let fetch_context =
+            Self::rpc_get_account_context(remote_account_claims);
         let balance = self
-            .read_account_with_ensure(&pubkey)
+            .read_account_with_ensure(&pubkey, fetch_context)
             .await
             .map(|a| a.lamports())
             .unwrap_or_default(); // Default to 0 if account not found

--- a/magicblock-aperture/src/requests/http/get_delegation_status.rs
+++ b/magicblock-aperture/src/requests/http/get_delegation_status.rs
@@ -1,3 +1,5 @@
+use std::sync::{atomic::AtomicU64, Arc};
+
 use super::prelude::*;
 
 impl HttpDispatcher {
@@ -12,6 +14,7 @@ impl HttpDispatcher {
     pub(crate) async fn get_delegation_status(
         &self,
         request: &mut JsonRequest,
+        remote_account_claims: Arc<AtomicU64>,
     ) -> HandlerResult {
         // Parse the first positional parameter (account pubkey) using the
         // standard helper macro, mirroring `get_account_info`.
@@ -20,7 +23,10 @@ impl HttpDispatcher {
 
         // Ensure the account is present in the local AccountsDb, cloning it
         // from the reference cluster if necessary.
-        let account = self.read_account_with_ensure(&pubkey).await;
+        let fetch_context =
+            Self::rpc_get_account_context(remote_account_claims);
+        let account =
+            self.read_account_with_ensure(&pubkey, fetch_context).await;
 
         let is_delegated =
             account.as_ref().map(|acc| acc.delegated()).unwrap_or(false);

--- a/magicblock-aperture/src/requests/http/get_multiple_accounts.rs
+++ b/magicblock-aperture/src/requests/http/get_multiple_accounts.rs
@@ -36,12 +36,9 @@ impl HttpDispatcher {
         let accounts = pubkeys
             .iter()
             .zip(
-                self.read_accounts_with_ensure_with_context(
-                    &pubkeys,
-                    fetch_context,
-                )
-                .await
-                .into_iter(),
+                self.read_accounts_with_ensure(&pubkeys, fetch_context)
+                    .await
+                    .into_iter(),
             )
             .map(|(pubkey, acc)| {
                 acc.filter(|account| {

--- a/magicblock-aperture/src/requests/http/get_multiple_accounts.rs
+++ b/magicblock-aperture/src/requests/http/get_multiple_accounts.rs
@@ -1,3 +1,5 @@
+use std::sync::{atomic::AtomicU64, Arc};
+
 use solana_rpc_client_api::config::RpcAccountInfoConfig;
 
 use super::prelude::*;
@@ -13,6 +15,7 @@ impl HttpDispatcher {
     pub(crate) async fn get_multiple_accounts(
         &self,
         request: &mut JsonRequest,
+        remote_account_claims: Arc<AtomicU64>,
     ) -> HandlerResult {
         let (pubkeys, config) = parse_params!(
             request.params()?,
@@ -28,9 +31,18 @@ impl HttpDispatcher {
         let encoding = config.encoding.unwrap_or(UiAccountEncoding::Base58);
         let slice = config.data_slice;
 
+        let fetch_context =
+            Self::rpc_get_multiple_accounts_context(remote_account_claims);
         let accounts = pubkeys
             .iter()
-            .zip(self.read_accounts_with_ensure(&pubkeys).await.into_iter())
+            .zip(
+                self.read_accounts_with_ensure_with_context(
+                    &pubkeys,
+                    fetch_context,
+                )
+                .await
+                .into_iter(),
+            )
             .map(|(pubkey, acc)| {
                 acc.filter(|account| {
                     !Self::account_should_render_as_null(account)

--- a/magicblock-aperture/src/requests/http/get_token_account_balance.rs
+++ b/magicblock-aperture/src/requests/http/get_token_account_balance.rs
@@ -1,4 +1,7 @@
-use std::mem::size_of;
+use std::{
+    mem::size_of,
+    sync::{atomic::AtomicU64, Arc},
+};
 
 use solana_account::AccountSharedData;
 use solana_account_decoder::{
@@ -20,13 +23,17 @@ impl HttpDispatcher {
     pub(crate) async fn get_token_account_balance(
         &self,
         request: &mut JsonRequest,
+        remote_account_claims: Arc<AtomicU64>,
     ) -> HandlerResult {
         let pubkey = parse_params!(request.params()?, Serde32Bytes);
         let pubkey: Pubkey = some_or_err!(pubkey);
 
         // Fetch the target token account.
+        let token_account_fetch_context =
+            Self::rpc_get_account_context(remote_account_claims.clone());
         let token_account: AccountSharedData = some_or_err!(
-            self.read_account_with_ensure(&pubkey).await,
+            self.read_account_with_ensure(&pubkey, token_account_fetch_context)
+                .await,
             "token account not found or is not a token account"
         );
 
@@ -41,8 +48,11 @@ impl HttpDispatcher {
             })?;
 
         // Fetch the mint account to get the token's decimals.
+        let mint_fetch_context =
+            Self::rpc_get_account_context(remote_account_claims);
         let mint_account: AccountSharedData = some_or_err!(
-            self.read_account_with_ensure(&mint_pubkey).await,
+            self.read_account_with_ensure(&mint_pubkey, mint_fetch_context)
+                .await,
             "mint account not found"
         );
         let decimals =

--- a/magicblock-aperture/src/requests/http/mod.rs
+++ b/magicblock-aperture/src/requests/http/mod.rs
@@ -25,6 +25,7 @@ use magicblock_metrics::metrics::{
 use prelude::JsonBody;
 use solana_account::{AccountSharedData, ReadableAccount};
 use solana_pubkey::Pubkey;
+use solana_signature::Signature;
 use solana_transaction::{
     sanitized::SanitizedTransaction, versioned::VersionedTransaction,
 };
@@ -165,6 +166,17 @@ impl HttpDispatcher {
     ) -> AccountFetchContext {
         AccountFetchContext::new_with_claims_counter(
             AccountFetchEntrypoint::RpcGetMultipleAccounts,
+            AccountFetchReason::RequestedAccount,
+            remote_account_claims,
+        )
+    }
+
+    fn send_transaction_context(
+        signature: Signature,
+        remote_account_claims: Arc<AtomicU64>,
+    ) -> AccountFetchContext {
+        AccountFetchContext::new_with_claims_counter(
+            AccountFetchEntrypoint::SendTransaction(signature),
             AccountFetchReason::RequestedAccount,
             remote_account_claims,
         )

--- a/magicblock-aperture/src/requests/http/mod.rs
+++ b/magicblock-aperture/src/requests/http/mod.rs
@@ -236,14 +236,6 @@ impl HttpDispatcher {
             .collect()
     }
 
-    async fn read_accounts_with_ensure_with_context(
-        &self,
-        pubkeys: &[Pubkey],
-        fetch_context: AccountFetchContext,
-    ) -> Vec<Option<AccountSharedData>> {
-        self.read_accounts_with_ensure(pubkeys, fetch_context).await
-    }
-
     /// Decodes, validates, and sanitizes a transaction from its string representation.
     ///
     /// This is a crucial pre-processing step for both `sendTransaction` and

--- a/magicblock-aperture/src/requests/http/mod.rs
+++ b/magicblock-aperture/src/requests/http/mod.rs
@@ -1,5 +1,10 @@
 use core::str;
-use std::{mem::size_of, ops::Range, time::Duration};
+use std::{
+    mem::size_of,
+    ops::Range,
+    sync::{atomic::AtomicU64, Arc},
+    time::Duration,
+};
 
 use base64::{prelude::BASE64_STANDARD, Engine};
 use http_body_util::BodyExt;
@@ -13,7 +18,10 @@ use magicblock_core::{
     coordination_mode::CoordinationMode,
     link::transactions::{SanitizeableTransaction, WithEncoded},
 };
-use magicblock_metrics::metrics::{AccountFetchContext, ENSURE_ACCOUNTS_TIME};
+use magicblock_metrics::metrics::{
+    AccountFetchContext, AccountFetchEntrypoint, AccountFetchReason,
+    ENSURE_ACCOUNTS_TIME,
+};
 use prelude::JsonBody;
 use solana_account::{AccountSharedData, ReadableAccount};
 use solana_pubkey::Pubkey;
@@ -142,12 +150,33 @@ impl HttpDispatcher {
         Ok(())
     }
 
+    fn rpc_get_account_context(
+        remote_account_claims: Arc<AtomicU64>,
+    ) -> AccountFetchContext {
+        AccountFetchContext::new_with_claims_counter(
+            AccountFetchEntrypoint::RpcGetAccount,
+            AccountFetchReason::RequestedAccount,
+            remote_account_claims,
+        )
+    }
+
+    fn rpc_get_multiple_accounts_context(
+        remote_account_claims: Arc<AtomicU64>,
+    ) -> AccountFetchContext {
+        AccountFetchContext::new_with_claims_counter(
+            AccountFetchEntrypoint::RpcGetMultipleAccounts,
+            AccountFetchReason::RequestedAccount,
+            remote_account_claims,
+        )
+    }
+
     /// Fetches an account's data from the `AccountsDb` filling it in from chain
     /// as needed.
     #[instrument(skip_all)]
     async fn read_account_with_ensure(
         &self,
         pubkey: &Pubkey,
+        fetch_context: AccountFetchContext,
     ) -> Option<AccountSharedData> {
         if !self.needs_onchain_interactions() {
             return self.accountsdb.get_account(pubkey);
@@ -162,7 +191,7 @@ impl HttpDispatcher {
             .ensure_accounts(
                 &[*pubkey],
                 Some(&mark_empty_if_not_found),
-                AccountFetchContext::rpc_get_account(),
+                fetch_context,
             )
             .await
             .inspect_err(|e| {
@@ -180,6 +209,18 @@ impl HttpDispatcher {
         &self,
         pubkeys: &[Pubkey],
     ) -> Vec<Option<AccountSharedData>> {
+        self.read_accounts_with_ensure_with_context(
+            pubkeys,
+            AccountFetchContext::rpc_get_multiple_accounts(),
+        )
+        .await
+    }
+
+    async fn read_accounts_with_ensure_with_context(
+        &self,
+        pubkeys: &[Pubkey],
+        fetch_context: AccountFetchContext,
+    ) -> Vec<Option<AccountSharedData>> {
         if !self.needs_onchain_interactions() {
             return pubkeys
                 .iter()
@@ -193,11 +234,7 @@ impl HttpDispatcher {
             .start_timer();
         let _ = self
             .chainlink
-            .ensure_accounts(
-                pubkeys,
-                Some(pubkeys),
-                AccountFetchContext::rpc_get_multiple_accounts(),
-            )
+            .ensure_accounts(pubkeys, Some(pubkeys), fetch_context)
             .await
             .inspect_err(|e| {
                 // There is nothing we can do if fetching the accounts fails

--- a/magicblock-aperture/src/requests/http/mod.rs
+++ b/magicblock-aperture/src/requests/http/mod.rs
@@ -208,17 +208,6 @@ impl HttpDispatcher {
     async fn read_accounts_with_ensure(
         &self,
         pubkeys: &[Pubkey],
-    ) -> Vec<Option<AccountSharedData>> {
-        self.read_accounts_with_ensure_with_context(
-            pubkeys,
-            AccountFetchContext::rpc_get_multiple_accounts(),
-        )
-        .await
-    }
-
-    async fn read_accounts_with_ensure_with_context(
-        &self,
-        pubkeys: &[Pubkey],
         fetch_context: AccountFetchContext,
     ) -> Vec<Option<AccountSharedData>> {
         if !self.needs_onchain_interactions() {
@@ -245,6 +234,14 @@ impl HttpDispatcher {
             .iter()
             .map(|pubkey| self.accountsdb.get_account(pubkey))
             .collect()
+    }
+
+    async fn read_accounts_with_ensure_with_context(
+        &self,
+        pubkeys: &[Pubkey],
+        fetch_context: AccountFetchContext,
+    ) -> Vec<Option<AccountSharedData>> {
+        self.read_accounts_with_ensure(pubkeys, fetch_context).await
     }
 
     /// Decodes, validates, and sanitizes a transaction from its string representation.
@@ -310,6 +307,7 @@ impl HttpDispatcher {
     async fn ensure_transaction_accounts(
         &self,
         transaction: &SanitizedTransaction,
+        fetch_context: AccountFetchContext,
     ) -> RpcResult<()> {
         // Hard bound on account preparation: if the cloning pipeline is
         // degraded the transaction must fail with an error instead of
@@ -323,7 +321,10 @@ impl HttpDispatcher {
             .start_timer();
         match tokio::time::timeout(
             ENSURE_ACCOUNTS_TIMEOUT,
-            self.chainlink.ensure_transaction_accounts(transaction),
+            self.chainlink.ensure_transaction_accounts_with_context(
+                transaction,
+                fetch_context,
+            ),
         )
         .await
         .unwrap_or_else(|_elapsed| {

--- a/magicblock-aperture/src/requests/http/send_transaction.rs
+++ b/magicblock-aperture/src/requests/http/send_transaction.rs
@@ -1,4 +1,7 @@
+use std::sync::{atomic::AtomicU64, Arc};
+
 use magicblock_metrics::metrics::{
+    AccountFetchContext, AccountFetchEntrypoint, AccountFetchReason,
     TRANSACTION_PROCESSING_TIME, TRANSACTION_SKIP_PREFLIGHT,
 };
 use solana_rpc_client_api::config::RpcSendTransactionConfig;
@@ -18,6 +21,7 @@ impl HttpDispatcher {
     pub(crate) async fn send_transaction(
         &self,
         request: &mut JsonRequest,
+        remote_account_claims: Arc<AtomicU64>,
     ) -> HandlerResult {
         self.require_primary_rpc_method("sendTransaction")?;
         let _timer = TRANSACTION_PROCESSING_TIME.start_timer();
@@ -42,7 +46,13 @@ impl HttpDispatcher {
             return Err(TransactionError::AlreadyProcessed.into());
         }
 
-        self.ensure_transaction_accounts(&transaction.txn).await?;
+        let fetch_context = AccountFetchContext::new_with_claims_counter(
+            AccountFetchEntrypoint::SendTransaction(signature),
+            AccountFetchReason::RequestedAccount,
+            remote_account_claims,
+        );
+        self.ensure_transaction_accounts(&transaction.txn, fetch_context)
+            .await?;
 
         // Based on the preflight flag, either execute and await the result,
         // or schedule (fire-and-forget) for background processing.

--- a/magicblock-aperture/src/requests/http/send_transaction.rs
+++ b/magicblock-aperture/src/requests/http/send_transaction.rs
@@ -1,7 +1,6 @@
 use std::sync::{atomic::AtomicU64, Arc};
 
 use magicblock_metrics::metrics::{
-    AccountFetchContext, AccountFetchEntrypoint, AccountFetchReason,
     TRANSACTION_PROCESSING_TIME, TRANSACTION_SKIP_PREFLIGHT,
 };
 use solana_rpc_client_api::config::RpcSendTransactionConfig;
@@ -46,11 +45,8 @@ impl HttpDispatcher {
             return Err(TransactionError::AlreadyProcessed.into());
         }
 
-        let fetch_context = AccountFetchContext::new_with_claims_counter(
-            AccountFetchEntrypoint::SendTransaction(signature),
-            AccountFetchReason::RequestedAccount,
-            remote_account_claims,
-        );
+        let fetch_context =
+            Self::send_transaction_context(signature, remote_account_claims);
         self.ensure_transaction_accounts(&transaction.txn, fetch_context)
             .await?;
 

--- a/magicblock-aperture/src/requests/http/simulate_transaction.rs
+++ b/magicblock-aperture/src/requests/http/simulate_transaction.rs
@@ -4,9 +4,6 @@ use std::{
 };
 
 use magicblock_core::link::transactions::TransactionSimulationResult;
-use magicblock_metrics::metrics::{
-    AccountFetchContext, AccountFetchEntrypoint, AccountFetchReason,
-};
 use solana_message::inner_instruction::InnerInstructions;
 use solana_rpc_client_api::{
     config::RpcSimulateTransactionConfig,
@@ -55,11 +52,8 @@ impl HttpDispatcher {
             .inspect_err(|err| {
                 debug!(error = ?err, "Failed to prepare transaction to simulate")
             })?;
-        let fetch_context = AccountFetchContext::new_with_claims_counter(
-            AccountFetchEntrypoint::SendTransaction(
-                *transaction.txn.signature(),
-            ),
-            AccountFetchReason::RequestedAccount,
+        let fetch_context = Self::send_transaction_context(
+            *transaction.txn.signature(),
             remote_account_claims.clone(),
         );
         self.ensure_transaction_accounts(&transaction.txn, fetch_context)

--- a/magicblock-aperture/src/requests/http/simulate_transaction.rs
+++ b/magicblock-aperture/src/requests/http/simulate_transaction.rs
@@ -1,6 +1,12 @@
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    sync::{atomic::AtomicU64, Arc},
+};
 
 use magicblock_core::link::transactions::TransactionSimulationResult;
+use magicblock_metrics::metrics::{
+    AccountFetchContext, AccountFetchEntrypoint, AccountFetchReason,
+};
 use solana_message::inner_instruction::InnerInstructions;
 use solana_rpc_client_api::{
     config::RpcSimulateTransactionConfig,
@@ -25,6 +31,7 @@ impl HttpDispatcher {
     pub(crate) async fn simulate_transaction(
         &self,
         request: &mut JsonRequest,
+        remote_account_claims: Arc<AtomicU64>,
     ) -> HandlerResult {
         self.require_primary_rpc_method("simulateTransaction")?;
 
@@ -48,7 +55,15 @@ impl HttpDispatcher {
             .inspect_err(|err| {
                 debug!(error = ?err, "Failed to prepare transaction to simulate")
             })?;
-        self.ensure_transaction_accounts(&transaction.txn).await?;
+        let fetch_context = AccountFetchContext::new_with_claims_counter(
+            AccountFetchEntrypoint::SendTransaction(
+                *transaction.txn.signature(),
+            ),
+            AccountFetchReason::RequestedAccount,
+            remote_account_claims.clone(),
+        );
+        self.ensure_transaction_accounts(&transaction.txn, fetch_context)
+            .await?;
         let number_of_accounts = transaction.txn.message().account_keys().len();
 
         let replacement_blockhash = config
@@ -102,8 +117,12 @@ impl HttpDispatcher {
                             .map_err(RpcError::invalid_params)
                     })
                     .collect::<Result<Vec<_>, _>>()?;
-                let current_accounts =
-                    self.read_accounts_with_ensure(&pubkeys).await;
+                let fetch_context = Self::rpc_get_multiple_accounts_context(
+                    remote_account_claims.clone(),
+                );
+                let current_accounts = self
+                    .read_accounts_with_ensure(&pubkeys, fetch_context)
+                    .await;
                 let post_simulation_accounts = post_simulation_accounts
                     .into_iter()
                     .collect::<HashMap<_, _>>();

--- a/magicblock-aperture/src/server/http/dispatch.rs
+++ b/magicblock-aperture/src/server/http/dispatch.rs
@@ -1,11 +1,17 @@
 use core::str;
-use std::{convert::Infallible, sync::Arc};
+use std::{
+    convert::Infallible,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+};
 
 use futures::{stream::FuturesOrdered, StreamExt};
 use hyper::{
     body::Incoming,
     header::{
-        HeaderValue, ACCESS_CONTROL_ALLOW_HEADERS,
+        HeaderName, HeaderValue, ACCESS_CONTROL_ALLOW_HEADERS,
         ACCESS_CONTROL_ALLOW_METHODS, ACCESS_CONTROL_ALLOW_ORIGIN,
         ACCESS_CONTROL_MAX_AGE,
     },
@@ -111,6 +117,9 @@ impl HttpDispatcher {
         if let Some(response) = self.handle_special_request(&request) {
             return Ok(response);
         }
+
+        let remote_account_claims = Arc::new(AtomicU64::new(0));
+
         // A local macro to simplify error handling. If a Result is an Err,
         // it immediately formats it into a JSON-RPC error response and returns.
         macro_rules! unwrap {
@@ -120,6 +129,10 @@ impl HttpDispatcher {
                     Err(error) => {
                         let mut resp = ResponseErrorPayload::encode($id, error);
                         Self::set_access_control_headers(&mut resp);
+                        Self::set_remote_account_claims_header(
+                            &mut resp,
+                            &remote_account_claims,
+                        );
                         return Ok(resp);
                     }
                 }
@@ -130,6 +143,10 @@ impl HttpDispatcher {
                     Err(error) => {
                         let mut resp = ResponseErrorPayload::encode($id, error);
                         Self::set_access_control_headers(&mut resp);
+                        Self::set_remote_account_claims_header(
+                            &mut resp,
+                            &remote_account_claims,
+                        );
                         resp
                     }
                 }
@@ -143,7 +160,8 @@ impl HttpDispatcher {
         // Resolve the handler for request and process it
         let (response, id) = match request {
             RpcRequest::Single(mut r) => {
-                let response = self.process(&mut r).await;
+                let response =
+                    self.process(&mut r, remote_account_claims.clone()).await;
                 (response, Some(r.id))
             }
             RpcRequest::Multi(requests) => {
@@ -152,8 +170,10 @@ impl HttpDispatcher {
                 const CLOSE_BR: u8 = b']';
                 let mut jobs = FuturesOrdered::new();
                 for mut r in requests {
-                    let j = async {
-                        let response = self.process(&mut r).await;
+                    let claims = remote_account_claims.clone();
+                    let dispatcher = self.clone();
+                    let j = async move {
+                        let response = dispatcher.process(&mut r, claims).await;
                         (response, r)
                     };
                     jobs.push_back(j);
@@ -174,10 +194,18 @@ impl HttpDispatcher {
         // Handle any errors from the handling stage
         let mut response = unwrap!(response, id.as_ref());
         Self::set_access_control_headers(&mut response);
+        Self::set_remote_account_claims_header(
+            &mut response,
+            &remote_account_claims,
+        );
         Ok(response)
     }
 
-    async fn process(&self, request: &mut JsonHttpRequest) -> HandlerResult {
+    async fn process(
+        &self,
+        request: &mut JsonHttpRequest,
+        _remote_account_claims: Arc<AtomicU64>,
+    ) -> HandlerResult {
         // Route the request to the correct handler based on the method name.
         use crate::requests::JsonRpcHttpMethod::*;
         let method = request.method.as_str();
@@ -267,6 +295,21 @@ impl HttpDispatcher {
             return Some(response);
         }
         None
+    }
+
+    const REMOTE_ACCOUNT_CLAIMS_HEADER: HeaderName =
+        HeaderName::from_static("x-mb-remote-account-claims");
+
+    fn set_remote_account_claims_header(
+        response: &mut Response<JsonBody>,
+        remote_account_claims: &AtomicU64,
+    ) {
+        let claims = remote_account_claims.load(Ordering::Relaxed).to_string();
+        let value = HeaderValue::from_str(&claims)
+            .expect("u64 remote account claims header value should be valid");
+        response
+            .headers_mut()
+            .insert(Self::REMOTE_ACCOUNT_CLAIMS_HEADER, value);
     }
 
     /// Set CORS/Access control related headers (required by explorers/web apps)

--- a/magicblock-aperture/src/server/http/dispatch.rs
+++ b/magicblock-aperture/src/server/http/dispatch.rs
@@ -204,7 +204,7 @@ impl HttpDispatcher {
     async fn process(
         &self,
         request: &mut JsonHttpRequest,
-        _remote_account_claims: Arc<AtomicU64>,
+        remote_account_claims: Arc<AtomicU64>,
     ) -> HandlerResult {
         // Route the request to the correct handler based on the method name.
         use crate::requests::JsonRpcHttpMethod::*;
@@ -215,8 +215,14 @@ impl HttpDispatcher {
             .start_timer();
 
         match request.method {
-            GetAccountInfo => self.get_account_info(request).await,
-            GetBalance => self.get_balance(request).await,
+            GetAccountInfo => {
+                self.get_account_info(request, remote_account_claims.clone())
+                    .await
+            }
+            GetBalance => {
+                self.get_balance(request, remote_account_claims.clone())
+                    .await
+            }
             GetBlock => self.run_blocking(|| self.get_block(request)).await,
             GetBlockCommitment => self.get_block_commitment(request),
             GetBlockHeight => self.get_block_height(request),
@@ -234,7 +240,13 @@ impl HttpDispatcher {
             GetIdentity => self.get_identity(request),
             GetLargestAccounts => self.get_largest_accounts(request),
             GetLatestBlockhash => self.get_latest_blockhash(request),
-            GetMultipleAccounts => self.get_multiple_accounts(request).await,
+            GetMultipleAccounts => {
+                self.get_multiple_accounts(
+                    request,
+                    remote_account_claims.clone(),
+                )
+                .await
+            }
             GetProgramAccounts => self.get_program_accounts(request),
             GetRecentPerformanceSamples => {
                 self.get_recent_performance_samples(request)
@@ -249,7 +261,11 @@ impl HttpDispatcher {
             GetSlotLeaders => self.get_slot_leaders(request),
             GetSupply => self.get_supply(request),
             GetTokenAccountBalance => {
-                self.get_token_account_balance(request).await
+                self.get_token_account_balance(
+                    request,
+                    remote_account_claims.clone(),
+                )
+                .await
             }
             GetTokenAccountsByDelegate => {
                 self.get_token_accounts_by_delegate(request)
@@ -271,7 +287,13 @@ impl HttpDispatcher {
             GetRoutes => self.get_routes(request),
             // Alias for getLatestBlockhash; exists for Magic Router SDK compatibility.
             GetBlockhashForAccounts => self.get_latest_blockhash(request),
-            GetDelegationStatus => self.get_delegation_status(request).await,
+            GetDelegationStatus => {
+                self.get_delegation_status(
+                    request,
+                    remote_account_claims.clone(),
+                )
+                .await
+            }
             MethodNotFound => Err(RpcError::method_not_found()),
         }
     }

--- a/magicblock-aperture/src/server/http/dispatch.rs
+++ b/magicblock-aperture/src/server/http/dispatch.rs
@@ -337,6 +337,7 @@ impl HttpDispatcher {
     ) {
         let claims = remote_account_claims.load(Ordering::Relaxed).to_string();
         let value = HeaderValue::from_str(&claims)
+            // SAFETY: a stringified u64 is always a valid header value
             .expect("u64 remote account claims header value should be valid");
         response
             .headers_mut()

--- a/magicblock-aperture/src/server/http/dispatch.rs
+++ b/magicblock-aperture/src/server/http/dispatch.rs
@@ -282,8 +282,17 @@ impl HttpDispatcher {
             IsBlockhashValid => self.is_blockhash_valid(request),
             MinimumLedgerSlot => self.get_first_available_block(request),
             RequestAirdrop => self.request_airdrop(request).await,
-            SendTransaction => self.send_transaction(request).await,
-            SimulateTransaction => self.simulate_transaction(request).await,
+            SendTransaction => {
+                self.send_transaction(request, remote_account_claims.clone())
+                    .await
+            }
+            SimulateTransaction => {
+                self.simulate_transaction(
+                    request,
+                    remote_account_claims.clone(),
+                )
+                .await
+            }
             GetRoutes => self.get_routes(request),
             // Alias for getLatestBlockhash; exists for Magic Router SDK compatibility.
             GetBlockhashForAccounts => self.get_latest_blockhash(request),

--- a/magicblock-aperture/tests/accounts.rs
+++ b/magicblock-aperture/tests/accounts.rs
@@ -102,10 +102,13 @@ async fn test_get_account_info_emits_remote_account_claims_header_zero_for_bank_
 
     assert!(response.status().is_success());
     assert_eq!(remote_account_claims_header(&response), 0);
-    let body: json::Value = response
-        .json()
-        .await
-        .expect("getAccountInfo response body should decode");
+    let body: json::Value = json::from_str(
+        &response
+            .text()
+            .await
+            .expect("getAccountInfo response body should decode"),
+    )
+    .expect("getAccountInfo response body should be valid JSON");
     assert!(body["result"].is_object(), "response should contain result");
 }
 
@@ -201,10 +204,13 @@ async fn test_get_multiple_accounts_emits_remote_account_claims_header_zero_for_
 
     assert!(response.status().is_success());
     assert_eq!(remote_account_claims_header(&response), 0);
-    let body: json::Value = response
-        .json()
-        .await
-        .expect("getMultipleAccounts response body should decode");
+    let body: json::Value = json::from_str(
+        &response
+            .text()
+            .await
+            .expect("getMultipleAccounts response body should decode"),
+    )
+    .expect("getMultipleAccounts response body should be valid JSON");
     assert!(body["result"].is_object(), "response should contain result");
 }
 
@@ -238,6 +244,38 @@ async fn test_get_balance() {
     );
 }
 
+#[tokio::test]
+async fn test_get_balance_emits_remote_account_claims_header_zero_for_bank_hit()
+{
+    let env = RpcTestEnv::new().await;
+    let acc = env.create_account();
+    let client = reqwest::Client::new();
+    let request = json::json!({
+        "jsonrpc": "2.0",
+        "method": "getBalance",
+        "params": [acc.pubkey.to_string()],
+        "id": 1,
+    });
+
+    let response = client
+        .post(env.rpc.url())
+        .json(&request)
+        .send()
+        .await
+        .expect("getBalance HTTP request should succeed");
+
+    assert!(response.status().is_success());
+    assert_eq!(remote_account_claims_header(&response), 0);
+    let body: json::Value = json::from_str(
+        &response
+            .text()
+            .await
+            .expect("getBalance response body should decode"),
+    )
+    .expect("getBalance response body should be valid JSON");
+    assert!(body["result"].is_object(), "response should contain result");
+}
+
 /// Verifies `getTokenAccountBalance` for both existing and non-existent token accounts.
 #[tokio::test]
 async fn test_get_token_account_balance() {
@@ -265,6 +303,71 @@ async fn test_get_token_account_balance() {
         nonexistent_result.is_err(),
         "fetching balance of a non-token account should result in an error"
     );
+}
+
+#[tokio::test]
+async fn test_get_token_account_balance_emits_remote_account_claims_header_zero_for_bank_hit(
+) {
+    let env = RpcTestEnv::new().await;
+    let token_account =
+        env.create_token_account(Pubkey::new_unique(), Pubkey::new_unique());
+    let client = reqwest::Client::new();
+    let request = json::json!({
+        "jsonrpc": "2.0",
+        "method": "getTokenAccountBalance",
+        "params": [token_account.pubkey.to_string()],
+        "id": 1,
+    });
+
+    let response = client
+        .post(env.rpc.url())
+        .json(&request)
+        .send()
+        .await
+        .expect("getTokenAccountBalance HTTP request should succeed");
+
+    assert!(response.status().is_success());
+    assert_eq!(remote_account_claims_header(&response), 0);
+    let body: json::Value = json::from_str(
+        &response
+            .text()
+            .await
+            .expect("getTokenAccountBalance response body should decode"),
+    )
+    .expect("getTokenAccountBalance response body should be valid JSON");
+    assert!(body["result"].is_object(), "response should contain result");
+}
+
+#[tokio::test]
+async fn test_get_delegation_status_emits_remote_account_claims_header_zero_for_bank_hit(
+) {
+    let env = RpcTestEnv::new().await;
+    let acc = env.create_account();
+    let client = reqwest::Client::new();
+    let request = json::json!({
+        "jsonrpc": "2.0",
+        "method": "getDelegationStatus",
+        "params": [acc.pubkey.to_string()],
+        "id": 1,
+    });
+
+    let response = client
+        .post(env.rpc.url())
+        .json(&request)
+        .send()
+        .await
+        .expect("getDelegationStatus HTTP request should succeed");
+
+    assert!(response.status().is_success());
+    assert_eq!(remote_account_claims_header(&response), 0);
+    let body: json::Value = json::from_str(
+        &response
+            .text()
+            .await
+            .expect("getDelegationStatus response body should decode"),
+    )
+    .expect("getDelegationStatus response body should be valid JSON");
+    assert!(body["result"].is_object(), "response should contain result");
 }
 
 /// Verifies `getProgramAccounts` finds all accounts owned by a program.

--- a/magicblock-aperture/tests/accounts.rs
+++ b/magicblock-aperture/tests/accounts.rs
@@ -1,24 +1,11 @@
 use std::collections::HashSet;
 
 use json::JsonValueTrait;
-use setup::{RpcTestEnv, TOKEN_PROGRAM_ID};
+use setup::{remote_account_claims_header, RpcTestEnv, TOKEN_PROGRAM_ID};
 use solana_account::{accounts_equal, ReadableAccount};
 use solana_pubkey::Pubkey;
 use solana_rpc_client_api::request::TokenAccountsFilter;
 use test_kit::guinea;
-
-const REMOTE_ACCOUNT_CLAIMS_HEADER: &str = "X-MB-Remote-Account-Claims";
-
-fn remote_account_claims_header(response: &reqwest::Response) -> u64 {
-    response
-        .headers()
-        .get(REMOTE_ACCOUNT_CLAIMS_HEADER)
-        .expect("remote account claims header should be present")
-        .to_str()
-        .expect("remote account claims header should be valid ASCII")
-        .parse::<u64>()
-        .expect("remote account claims header should be an integer")
-}
 
 mod setup;
 

--- a/magicblock-aperture/tests/accounts.rs
+++ b/magicblock-aperture/tests/accounts.rs
@@ -1,10 +1,24 @@
 use std::collections::HashSet;
 
+use json::JsonValueTrait;
 use setup::{RpcTestEnv, TOKEN_PROGRAM_ID};
 use solana_account::{accounts_equal, ReadableAccount};
 use solana_pubkey::Pubkey;
 use solana_rpc_client_api::request::TokenAccountsFilter;
 use test_kit::guinea;
+
+const REMOTE_ACCOUNT_CLAIMS_HEADER: &str = "X-MB-Remote-Account-Claims";
+
+fn remote_account_claims_header(response: &reqwest::Response) -> u64 {
+    response
+        .headers()
+        .get(REMOTE_ACCOUNT_CLAIMS_HEADER)
+        .expect("remote account claims header should be present")
+        .to_str()
+        .expect("remote account claims header should be valid ASCII")
+        .parse::<u64>()
+        .expect("remote account claims header should be an integer")
+}
 
 mod setup;
 
@@ -64,6 +78,35 @@ async fn test_get_account_info() {
         second_miss.value, None,
         "repeated lookup should still return null"
     );
+}
+
+#[tokio::test]
+async fn test_get_account_info_emits_remote_account_claims_header_zero_for_bank_hit(
+) {
+    let env = RpcTestEnv::new().await;
+    let acc = env.create_account();
+    let client = reqwest::Client::new();
+    let request = json::json!({
+        "jsonrpc": "2.0",
+        "method": "getAccountInfo",
+        "params": [acc.pubkey.to_string()],
+        "id": 1,
+    });
+
+    let response = client
+        .post(env.rpc.url())
+        .json(&request)
+        .send()
+        .await
+        .expect("getAccountInfo HTTP request should succeed");
+
+    assert!(response.status().is_success());
+    assert_eq!(remote_account_claims_header(&response), 0);
+    let body: json::Value = response
+        .json()
+        .await
+        .expect("getAccountInfo response body should decode");
+    assert!(body["result"].is_object(), "response should contain result");
 }
 
 /// Verifies `getMultipleAccounts` for both existing and non-existent accounts.
@@ -133,6 +176,36 @@ async fn test_get_multiple_accounts() {
         ),
         "last result should match the last requested account"
     );
+}
+
+#[tokio::test]
+async fn test_get_multiple_accounts_emits_remote_account_claims_header_zero_for_bank_hits(
+) {
+    let env = RpcTestEnv::new().await;
+    let acc1 = env.create_account();
+    let acc2 = env.create_account();
+    let client = reqwest::Client::new();
+    let request = json::json!({
+        "jsonrpc": "2.0",
+        "method": "getMultipleAccounts",
+        "params": [[acc1.pubkey.to_string(), acc2.pubkey.to_string()]],
+        "id": 1,
+    });
+
+    let response = client
+        .post(env.rpc.url())
+        .json(&request)
+        .send()
+        .await
+        .expect("getMultipleAccounts HTTP request should succeed");
+
+    assert!(response.status().is_success());
+    assert_eq!(remote_account_claims_header(&response), 0);
+    let body: json::Value = response
+        .json()
+        .await
+        .expect("getMultipleAccounts response body should decode");
+    assert!(body["result"].is_object(), "response should contain result");
 }
 
 /// Verifies `getBalance` for both existing and non-existent accounts.

--- a/magicblock-aperture/tests/batches.rs
+++ b/magicblock-aperture/tests/batches.rs
@@ -1,18 +1,5 @@
 use json::{JsonContainerTrait, JsonValueTrait, Value};
-use setup::RpcTestEnv;
-
-const REMOTE_ACCOUNT_CLAIMS_HEADER: &str = "X-MB-Remote-Account-Claims";
-
-fn remote_account_claims_header(response: &reqwest::Response) -> u64 {
-    response
-        .headers()
-        .get(REMOTE_ACCOUNT_CLAIMS_HEADER)
-        .expect("remote account claims header should be present")
-        .to_str()
-        .expect("remote account claims header should be valid ASCII")
-        .parse::<u64>()
-        .expect("remote account claims header should be an integer")
-}
+use setup::{remote_account_claims_header, RpcTestEnv};
 
 mod setup;
 

--- a/magicblock-aperture/tests/batches.rs
+++ b/magicblock-aperture/tests/batches.rs
@@ -94,9 +94,52 @@ async fn test_batch_requests_emit_remote_account_claims_header_zero_when_no_fetc
 
     assert!(response.status().is_success());
     assert_eq!(remote_account_claims_header(&response), 0);
-    let body: json::Value = response
-        .json()
-        .await
-        .expect("batch response body should decode");
+    let body: json::Value = json::from_str(
+        &response
+            .text()
+            .await
+            .expect("batch response body should decode"),
+    )
+    .expect("batch response body should be valid JSON");
     assert!(body.is_array(), "batch response should be an array");
+}
+
+#[tokio::test]
+async fn test_mixed_batch_requests_emit_remote_account_claims_header_zero() {
+    let env = RpcTestEnv::new().await;
+    let account = env.create_account();
+    let batch_request = json::json!([
+        {"jsonrpc": "2.0", "method": "getVersion", "id": 1},
+        {
+            "jsonrpc": "2.0",
+            "method": "getAccountInfo",
+            "params": [account.pubkey.to_string()],
+            "id": 2
+        },
+        {
+            "jsonrpc": "2.0",
+            "method": "getBalance",
+            "params": [account.pubkey.to_string()],
+            "id": 3
+        }
+    ]);
+
+    let response = reqwest::Client::new()
+        .post(env.rpc.url())
+        .json(&batch_request)
+        .send()
+        .await
+        .expect("mixed batch HTTP request should succeed");
+
+    assert!(response.status().is_success());
+    assert_eq!(remote_account_claims_header(&response), 0);
+    let body: json::Value = json::from_str(
+        &response
+            .text()
+            .await
+            .expect("mixed batch response body should decode"),
+    )
+    .expect("mixed batch response body should be valid JSON");
+    assert!(body.is_array(), "mixed batch response should be an array");
+    assert_eq!(body.as_array().unwrap().len(), 3);
 }

--- a/magicblock-aperture/tests/batches.rs
+++ b/magicblock-aperture/tests/batches.rs
@@ -1,6 +1,19 @@
 use json::{JsonContainerTrait, JsonValueTrait, Value};
 use setup::RpcTestEnv;
 
+const REMOTE_ACCOUNT_CLAIMS_HEADER: &str = "X-MB-Remote-Account-Claims";
+
+fn remote_account_claims_header(response: &reqwest::Response) -> u64 {
+    response
+        .headers()
+        .get(REMOTE_ACCOUNT_CLAIMS_HEADER)
+        .expect("remote account claims header should be present")
+        .to_str()
+        .expect("remote account claims header should be valid ASCII")
+        .parse::<u64>()
+        .expect("remote account claims header should be an integer")
+}
+
 mod setup;
 
 #[tokio::test]
@@ -59,4 +72,31 @@ async fn test_batch_requests() {
         res2["result"].is_object(),
         "getIdentity should return an object"
     );
+}
+
+#[tokio::test]
+async fn test_batch_requests_emit_remote_account_claims_header_zero_when_no_fetches_triggered(
+) {
+    let env = RpcTestEnv::new().await;
+    let client = reqwest::Client::new();
+    let rpc_url = env.rpc.url();
+    let batch_request = json::json!([
+        {"jsonrpc": "2.0", "method": "getVersion", "id": 1},
+        {"jsonrpc": "2.0", "method": "getIdentity", "id": 2}
+    ]);
+
+    let response = client
+        .post(rpc_url)
+        .json(&batch_request)
+        .send()
+        .await
+        .expect("batch HTTP request should succeed");
+
+    assert!(response.status().is_success());
+    assert_eq!(remote_account_claims_header(&response), 0);
+    let body: json::Value = response
+        .json()
+        .await
+        .expect("batch response body should decode");
+    assert!(body.is_array(), "batch response should be an array");
 }

--- a/magicblock-aperture/tests/setup.rs
+++ b/magicblock-aperture/tests/setup.rs
@@ -40,6 +40,18 @@ use tokio_util::sync::CancellationToken;
 
 pub const TOKEN_PROGRAM_ID: Pubkey =
     Pubkey::from_str_const("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
+pub const REMOTE_ACCOUNT_CLAIMS_HEADER: &str = "X-MB-Remote-Account-Claims";
+
+pub fn remote_account_claims_header(response: &reqwest::Response) -> u64 {
+    response
+        .headers()
+        .get(REMOTE_ACCOUNT_CLAIMS_HEADER)
+        .expect("remote account claims header should be present")
+        .to_str()
+        .expect("remote account claims header should be valid ASCII")
+        .parse::<u64>()
+        .expect("remote account claims header should be an integer")
+}
 
 /// An end-to-end integration testing environment for the RPC server.
 ///

--- a/magicblock-aperture/tests/transactions.rs
+++ b/magicblock-aperture/tests/transactions.rs
@@ -1,5 +1,6 @@
 use std::time::{Duration, Instant};
 
+use json::JsonValueTrait;
 use magicblock_accounts_db::traits::AccountsBank;
 use magicblock_core::link::blocks::BlockHash;
 use setup::RpcTestEnv;
@@ -14,6 +15,19 @@ use solana_rpc_client_api::config::{
 use solana_signature::Signature;
 use solana_transaction_status::UiTransactionEncoding;
 use test_kit::guinea;
+
+const REMOTE_ACCOUNT_CLAIMS_HEADER: &str = "X-MB-Remote-Account-Claims";
+
+fn remote_account_claims_header(response: &reqwest::Response) -> u64 {
+    response
+        .headers()
+        .get(REMOTE_ACCOUNT_CLAIMS_HEADER)
+        .expect("remote account claims header should be present")
+        .to_str()
+        .expect("remote account claims header should be valid ASCII")
+        .parse::<u64>()
+        .expect("remote account claims header should be an integer")
+}
 
 mod setup;
 
@@ -61,6 +75,40 @@ async fn test_send_transaction_success() {
         RpcTestEnv::INIT_ACCOUNT_BALANCE + RpcTestEnv::TRANSFER_AMOUNT,
         "recipient account balance was not properly credited"
     );
+}
+
+#[tokio::test]
+async fn test_send_transaction_emits_remote_account_claims_header_zero() {
+    let env = RpcTestEnv::new().await;
+    let transaction = env.build_transfer_txn();
+    let encoded = bs58::encode(
+        bincode::serialize(&transaction).expect("transaction should serialize"),
+    )
+    .into_string();
+    let request = json::json!({
+        "jsonrpc": "2.0",
+        "method": "sendTransaction",
+        "params": [encoded],
+        "id": 1,
+    });
+
+    let response = reqwest::Client::new()
+        .post(env.rpc.url())
+        .json(&request)
+        .send()
+        .await
+        .expect("sendTransaction HTTP request should succeed");
+
+    assert!(response.status().is_success());
+    assert_eq!(remote_account_claims_header(&response), 0);
+    let body: json::Value = json::from_str(
+        &response
+            .text()
+            .await
+            .expect("sendTransaction response body should decode"),
+    )
+    .expect("sendTransaction response body should be valid JSON");
+    assert!(body["result"].is_str(), "response should contain signature");
 }
 
 /// Verifies the higher-level `send_and_confirm_transaction` method works correctly,
@@ -207,6 +255,90 @@ async fn test_simulate_transaction_success() {
         RpcTestEnv::INIT_ACCOUNT_BALANCE,
         "recipient balance should not change after simulation"
     );
+}
+
+#[tokio::test]
+async fn test_simulate_transaction_emits_remote_account_claims_header_zero() {
+    let env = RpcTestEnv::new().await;
+    let transaction = env.build_transfer_txn();
+    let encoded = bs58::encode(
+        bincode::serialize(&transaction).expect("transaction should serialize"),
+    )
+    .into_string();
+    let request = json::json!({
+        "jsonrpc": "2.0",
+        "method": "simulateTransaction",
+        "params": [encoded],
+        "id": 1,
+    });
+
+    let response = reqwest::Client::new()
+        .post(env.rpc.url())
+        .json(&request)
+        .send()
+        .await
+        .expect("simulateTransaction HTTP request should succeed");
+
+    assert!(response.status().is_success());
+    assert_eq!(remote_account_claims_header(&response), 0);
+    let body: json::Value = json::from_str(
+        &response
+            .text()
+            .await
+            .expect("simulateTransaction response body should decode"),
+    )
+    .expect("simulateTransaction response body should be valid JSON");
+    assert!(body["result"].is_object(), "response should contain result");
+}
+
+#[tokio::test]
+async fn test_simulate_transaction_with_requested_accounts_emits_remote_account_claims_header_zero(
+) {
+    let env = RpcTestEnv::new().await;
+    let sender = Pubkey::new_unique();
+    let recipient = Pubkey::new_unique();
+    let transaction =
+        env.build_transfer_txn_with_params(sender, recipient, false);
+    let encoded = bs58::encode(
+        bincode::serialize(&transaction).expect("transaction should serialize"),
+    )
+    .into_string();
+    let request = json::json!({
+        "jsonrpc": "2.0",
+        "method": "simulateTransaction",
+        "params": [
+            encoded,
+            {
+                "accounts": {
+                    "encoding": "base64",
+                    "addresses": [
+                        sender.to_string(),
+                        recipient.to_string(),
+                        guinea::ID.to_string()
+                    ]
+                }
+            }
+        ],
+        "id": 1,
+    });
+
+    let response = reqwest::Client::new()
+        .post(env.rpc.url())
+        .json(&request)
+        .send()
+        .await
+        .expect("simulateTransaction HTTP request should succeed");
+
+    assert!(response.status().is_success());
+    assert_eq!(remote_account_claims_header(&response), 0);
+    let body: json::Value = json::from_str(
+        &response
+            .text()
+            .await
+            .expect("simulateTransaction response body should decode"),
+    )
+    .expect("simulateTransaction response body should be valid JSON");
+    assert!(body["result"].is_object(), "response should contain result");
 }
 
 #[tokio::test]

--- a/magicblock-aperture/tests/transactions.rs
+++ b/magicblock-aperture/tests/transactions.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, Instant};
 use json::JsonValueTrait;
 use magicblock_accounts_db::traits::AccountsBank;
 use magicblock_core::link::blocks::BlockHash;
-use setup::RpcTestEnv;
+use setup::{remote_account_claims_header, RpcTestEnv};
 use solana_account::ReadableAccount;
 use solana_account_decoder::UiAccountEncoding;
 use solana_pubkey::Pubkey;
@@ -15,19 +15,6 @@ use solana_rpc_client_api::config::{
 use solana_signature::Signature;
 use solana_transaction_status::UiTransactionEncoding;
 use test_kit::guinea;
-
-const REMOTE_ACCOUNT_CLAIMS_HEADER: &str = "X-MB-Remote-Account-Claims";
-
-fn remote_account_claims_header(response: &reqwest::Response) -> u64 {
-    response
-        .headers()
-        .get(REMOTE_ACCOUNT_CLAIMS_HEADER)
-        .expect("remote account claims header should be present")
-        .to_str()
-        .expect("remote account claims header should be valid ASCII")
-        .parse::<u64>()
-        .expect("remote account claims header should be an integer")
-}
 
 mod setup;
 

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/ata_projection.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/ata_projection.rs
@@ -459,8 +459,9 @@ where
 
     let mut accounts_to_clone = vec![];
     let mut ata_join_set = JoinSet::new();
-    let ata_projection_context =
-        fetch_context.with_reason(metrics::AccountFetchReason::AtaProjection);
+    let ata_projection_context = fetch_context
+        .clone()
+        .with_reason(metrics::AccountFetchReason::AtaProjection);
     let delegation_record_context = fetch_context
         .with_reason(metrics::AccountFetchReason::DelegationRecord);
 
@@ -490,7 +491,7 @@ where
                     ata_pubkey,
                     eata,
                     effective_slot,
-                    ata_projection_context,
+                    ata_projection_context.clone(),
                     ChainlinkCompanionFetchKind::AtaProjection,
                 )
                 .map(move |res| (ata_pubkey, eata, effective_slot, res)),
@@ -508,7 +509,7 @@ where
                     ata_pubkey,
                     companion_pubkey,
                     effective_slot,
-                    ata_projection_context,
+                    ata_projection_context.clone(),
                     ChainlinkCompanionFetchKind::AtaProjection,
                 )
                 .map(move |res| {
@@ -569,7 +570,7 @@ where
             }
             (ata_pubkey, eata_pubkey, effective_slot, Ok(Err(err))) => {
                 let companion_fetch_log_context = CompanionFetchLogContext {
-                    origin: ata_projection_context,
+                    origin: ata_projection_context.clone(),
                     primary_pubkey: ata_pubkey,
                     context_slot: effective_slot,
                 };
@@ -582,7 +583,7 @@ where
             }
             (ata_pubkey, eata_pubkey, effective_slot, Err(join_err)) => {
                 let companion_fetch_log_context = CompanionFetchLogContext {
-                    origin: ata_projection_context,
+                    origin: ata_projection_context.clone(),
                     primary_pubkey: ata_pubkey,
                     context_slot: effective_slot,
                 };
@@ -598,10 +599,11 @@ where
 
     // Phase 2: Fetch delegation records in parallel for all eATAs
     let deleg_futures = ata_inputs.iter().filter_map(|input| {
+        let delegation_record_context = delegation_record_context.clone();
         input.eata_shared.as_ref().map(|_| async move {
             let context_slot = this.remote_account_provider.chain_slot();
             let companion_fetch_log_context = CompanionFetchLogContext {
-                origin: delegation_record_context,
+                origin: delegation_record_context.clone(),
                 primary_pubkey: input.eata_pubkey,
                 context_slot,
             };
@@ -609,7 +611,7 @@ where
                 this,
                 input.eata_pubkey,
                 context_slot,
-                delegation_record_context,
+                delegation_record_context.clone(),
                 &companion_fetch_log_context,
             )
             .await

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/ata_projection.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/ata_projection.rs
@@ -611,7 +611,7 @@ where
                 this,
                 input.eata_pubkey,
                 context_slot,
-                delegation_record_context.clone(),
+                delegation_record_context,
                 &companion_fetch_log_context,
             )
             .await

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -2163,16 +2163,17 @@ where
         let record_context = fetch_context
             .clone()
             .with_reason(AccountFetchReason::DelegationRecord);
+        let companion_fetch_log_context = CompanionFetchLogContext {
+            origin: record_context.clone(),
+            primary_pubkey: candidate.pubkey,
+            context_slot: candidate.slot,
+        };
         let Some((deleg_record, _)) = self
             .fetch_and_parse_delegation_record(
                 candidate.pubkey,
                 candidate.slot,
-                record_context.clone(),
-                CompanionFetchLogContext {
-                    origin: record_context.clone(),
-                    primary_pubkey: candidate.pubkey,
-                    context_slot: candidate.slot,
-                },
+                record_context,
+                companion_fetch_log_context,
             )
             .await
         else {
@@ -2286,17 +2287,18 @@ where
         let record_context = discovery_context
             .clone()
             .with_reason(AccountFetchReason::DelegationRecord);
+        let companion_fetch_log_context = CompanionFetchLogContext {
+            origin: record_context.clone(),
+            primary_pubkey: pubkey,
+            context_slot: account.remote_slot(),
+        };
 
         let Some((deleg_record, delegation_actions)) = self
             .fetch_and_parse_delegation_record(
                 pubkey,
                 account.remote_slot(),
-                record_context.clone(),
-                CompanionFetchLogContext {
-                    origin: record_context.clone(),
-                    primary_pubkey: pubkey,
-                    context_slot: account.remote_slot(),
-                },
+                record_context,
+                companion_fetch_log_context,
             )
             .await
         else {
@@ -3401,18 +3403,17 @@ where
                 let undelegating_refresh_context = fetch_context
                     .clone()
                     .with_reason(AccountFetchReason::UndelegatingRefresh);
+                let companion_fetch_log_context = CompanionFetchLogContext {
+                    origin: undelegating_refresh_context.clone(),
+                    primary_pubkey: eata_pubkey,
+                    context_slot: self.remote_account_provider.chain_slot(),
+                };
                 let projected_deleg_record = self
                     .fetch_and_parse_delegation_record(
                         eata_pubkey,
                         self.remote_account_provider.chain_slot(),
-                        undelegating_refresh_context.clone(),
-                        CompanionFetchLogContext {
-                            origin: undelegating_refresh_context.clone(),
-                            primary_pubkey: eata_pubkey,
-                            context_slot: self
-                                .remote_account_provider
-                                .chain_slot(),
-                        },
+                        undelegating_refresh_context,
+                        companion_fetch_log_context,
                     )
                     .await;
                 if projected_deleg_record.as_ref().is_some_and(|(record, _)| {
@@ -3431,16 +3432,17 @@ where
             let undelegating_refresh_context = fetch_context
                 .clone()
                 .with_reason(AccountFetchReason::UndelegatingRefresh);
+            let companion_fetch_log_context = CompanionFetchLogContext {
+                origin: undelegating_refresh_context.clone(),
+                primary_pubkey: *pubkey,
+                context_slot: self.remote_account_provider.chain_slot(),
+            };
             let deleg_record = self
                 .fetch_and_parse_delegation_record(
                     *pubkey,
                     self.remote_account_provider.chain_slot(),
-                    undelegating_refresh_context.clone(),
-                    CompanionFetchLogContext {
-                        origin: undelegating_refresh_context.clone(),
-                        primary_pubkey: *pubkey,
-                        context_slot: self.remote_account_provider.chain_slot(),
-                    },
+                    undelegating_refresh_context,
+                    companion_fetch_log_context,
                 )
                 .await;
 
@@ -3611,7 +3613,7 @@ where
                         this.should_refresh_undelegating_in_bank_account(
                             &pubkey,
                             &account_in_bank,
-                            fetch_context.clone(),
+                            fetch_context,
                         ),
                     )
                     .await

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -384,7 +384,7 @@ pub(crate) struct ProgramVerifyState {
     pub(crate) deferred_verify: bool,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 struct CompanionFetchLogContext {
     origin: AccountFetchContext,
     primary_pubkey: Pubkey,
@@ -754,7 +754,7 @@ where
                     &pubkeys,
                     mark_empty_ref,
                     slot,
-                    fetch_context,
+                    fetch_context.clone(),
                 ),
             )
             .await
@@ -800,7 +800,7 @@ where
                     account,
                     mark_empty_if_not_found,
                     slot,
-                    fetch_context,
+                    fetch_context.clone(),
                 );
             }
         });
@@ -1050,7 +1050,7 @@ where
 
             if self.local_account_satisfies_clone_request(request_ref) {
                 metrics::inc_chainlink_clone_accounts_total_with_context(
-                    fetch_context,
+                    fetch_context.clone(),
                     remote_result,
                     clone_intent,
                     ChainlinkCloneOutcome::Skipped,
@@ -1065,7 +1065,7 @@ where
                         pubkey,
                     );
                     metrics::inc_chainlink_clone_accounts_total_with_context(
-                        fetch_context,
+                        fetch_context.clone(),
                         remote_result,
                         clone_intent,
                         ChainlinkCloneOutcome::Submitted,
@@ -1095,7 +1095,7 @@ where
                     let request_slot = owned_request.account.remote_slot();
                     Self::record_empty_placeholder_stage(
                         is_empty_placeholder,
-                        fetch_context,
+                        fetch_context.clone(),
                         ChainlinkEmptyPlaceholderStage::CloneSubmitted,
                         Outcome::Success,
                     );
@@ -1114,14 +1114,14 @@ where
                             "Clone request satisfied by concurrently active local delegation"
                         );
                         metrics::inc_chainlink_clone_accounts_total_with_context(
-                            fetch_context,
+                            fetch_context.clone(),
                             remote_result,
                             clone_intent,
                             ChainlinkCloneOutcome::Skipped,
                         );
                     } else if result.is_ok() {
                         metrics::inc_chainlink_clone_accounts_total_with_context(
-                            fetch_context,
+                            fetch_context.clone(),
                             remote_result,
                             clone_intent,
                             ChainlinkCloneOutcome::CloneSucceeded,
@@ -1131,29 +1131,29 @@ where
                                 &pubkey,
                                 request_slot,
                                 remote_result,
-                                fetch_context,
+                                fetch_context.clone(),
                             );
                         Self::record_empty_placeholder_materialization_stage(
                             is_empty_placeholder,
-                            fetch_context,
+                            fetch_context.clone(),
                             materialization_outcome,
                         );
                     } else {
                         metrics::inc_chainlink_clone_accounts_total_with_context(
-                            fetch_context,
+                            fetch_context.clone(),
                             remote_result,
                             clone_intent,
                             ChainlinkCloneOutcome::CloneFailed,
                         );
                         metrics::inc_chainlink_clone_accounts_total_with_context(
-                            fetch_context,
+                            fetch_context.clone(),
                             remote_result,
                             clone_intent,
                             ChainlinkCloneOutcome::SubmitFailed,
                         );
                         Self::record_empty_placeholder_stage(
                             is_empty_placeholder,
-                            fetch_context,
+                            fetch_context.clone(),
                             ChainlinkEmptyPlaceholderStage::CloneSubmitFailed,
                             Outcome::Error,
                         );
@@ -1212,7 +1212,7 @@ where
                 .is_some_and(|account| account.remote_slot() >= remote_slot)
             {
                 metrics::inc_chainlink_clone_accounts_total_with_context(
-                    fetch_context,
+                    fetch_context.clone(),
                     remote_result,
                     clone_intent,
                     ChainlinkCloneOutcome::Skipped,
@@ -1234,7 +1234,7 @@ where
                             account.remote_slot() >= remote_slot
                         }) {
                         metrics::inc_chainlink_clone_accounts_total_with_context(
-                            fetch_context,
+                            fetch_context.clone(),
                             remote_result,
                             clone_intent,
                             ChainlinkCloneOutcome::Skipped,
@@ -1242,7 +1242,7 @@ where
                         Ok(Signature::default())
                     } else {
                         metrics::inc_chainlink_clone_accounts_total_with_context(
-                            fetch_context,
+                            fetch_context.clone(),
                             remote_result,
                             clone_intent,
                             ChainlinkCloneOutcome::Submitted,
@@ -1250,7 +1250,7 @@ where
                         let result = self.cloner.clone_program(program).await;
                         if result.is_ok() {
                             metrics::inc_chainlink_clone_accounts_total_with_context(
-                                fetch_context,
+                                fetch_context.clone(),
                                 remote_result,
                                 clone_intent,
                                 ChainlinkCloneOutcome::CloneSucceeded,
@@ -1262,13 +1262,13 @@ where
                             );
                         } else {
                             metrics::inc_chainlink_clone_accounts_total_with_context(
-                                fetch_context,
+                                fetch_context.clone(),
                                 remote_result,
                                 clone_intent,
                                 ChainlinkCloneOutcome::CloneFailed,
                             );
                             metrics::inc_chainlink_clone_accounts_total_with_context(
-                                fetch_context,
+                                fetch_context.clone(),
                                 remote_result,
                                 clone_intent,
                                 ChainlinkCloneOutcome::SubmitFailed,
@@ -1351,12 +1351,15 @@ where
                 request.pubkey,
                 request.account.remote_slot(),
                 &request.delegation_actions,
-                fetch_context,
+                fetch_context.clone(),
             )
             .await?;
 
             Ok(self
-                .clone_account_with_ownership(request.clone(), fetch_context)
+                .clone_account_with_ownership(
+                    request.clone(),
+                    fetch_context.clone(),
+                )
                 .await?)
         }
         .await;
@@ -1384,7 +1387,7 @@ where
                 match self
                     .clone_account_and_schedule_undelegation_with_ownership(
                         request,
-                        fetch_context,
+                        fetch_context.clone(),
                     )
                     .await
                 {
@@ -1421,7 +1424,7 @@ where
                 .is_some_and(|account| account.undelegating())
             {
                 metrics::inc_chainlink_clone_accounts_total_with_context(
-                    fetch_context,
+                    fetch_context.clone(),
                     remote_result,
                     clone_intent,
                     ChainlinkCloneOutcome::Skipped,
@@ -1453,7 +1456,7 @@ where
                         );
                     };
                     metrics::inc_chainlink_clone_accounts_total_with_context(
-                        fetch_context,
+                        fetch_context.clone(),
                         remote_result,
                         clone_intent,
                         ChainlinkCloneOutcome::Submitted,
@@ -1465,14 +1468,14 @@ where
                     let request_slot = owned_request.account.remote_slot();
                     Self::record_empty_placeholder_stage(
                         is_empty_placeholder,
-                        fetch_context,
+                        fetch_context.clone(),
                         ChainlinkEmptyPlaceholderStage::CloneSubmitted,
                         Outcome::Success,
                     );
                     let result = self.cloner.clone_account(owned_request).await;
                     if result.is_ok() {
                         metrics::inc_chainlink_clone_accounts_total_with_context(
-                            fetch_context,
+                            fetch_context.clone(),
                             remote_result,
                             clone_intent,
                             ChainlinkCloneOutcome::CloneSucceeded,
@@ -1482,29 +1485,29 @@ where
                                 &pubkey,
                                 request_slot,
                                 remote_result,
-                                fetch_context,
+                                fetch_context.clone(),
                             );
                         Self::record_empty_placeholder_materialization_stage(
                             is_empty_placeholder,
-                            fetch_context,
+                            fetch_context.clone(),
                             materialization_outcome,
                         );
                     } else {
                         metrics::inc_chainlink_clone_accounts_total_with_context(
-                            fetch_context,
+                            fetch_context.clone(),
                             remote_result,
                             clone_intent,
                             ChainlinkCloneOutcome::CloneFailed,
                         );
                         metrics::inc_chainlink_clone_accounts_total_with_context(
-                            fetch_context,
+                            fetch_context.clone(),
                             remote_result,
                             clone_intent,
                             ChainlinkCloneOutcome::SubmitFailed,
                         );
                         Self::record_empty_placeholder_stage(
                             is_empty_placeholder,
-                            fetch_context,
+                            fetch_context.clone(),
                             ChainlinkEmptyPlaceholderStage::CloneSubmitFailed,
                             Outcome::Error,
                         );
@@ -1956,7 +1959,7 @@ where
                         delegated_to_other,
                         needs_undelegation: false,
                     },
-                    subscription_clone_context,
+                    subscription_clone_context.clone(),
                 )
                 .await
             {
@@ -1971,7 +1974,7 @@ where
                 if let Err(err) = self
                     .clone_projected_ata_request(
                         projected_ata_clone_request,
-                        subscription_clone_context,
+                        subscription_clone_context.clone(),
                     )
                     .await
                 {
@@ -2157,15 +2160,16 @@ where
         );
         // Same authority gate as discovery: accounts delegated to another
         // validator must not be cloned from the firehose.
-        let record_context =
-            fetch_context.with_reason(AccountFetchReason::DelegationRecord);
+        let record_context = fetch_context
+            .clone()
+            .with_reason(AccountFetchReason::DelegationRecord);
         let Some((deleg_record, _)) = self
             .fetch_and_parse_delegation_record(
                 candidate.pubkey,
                 candidate.slot,
-                record_context,
+                record_context.clone(),
                 CompanionFetchLogContext {
-                    origin: record_context,
+                    origin: record_context.clone(),
                     primary_pubkey: candidate.pubkey,
                     context_slot: candidate.slot,
                 },
@@ -2201,7 +2205,7 @@ where
                     &[candidate.pubkey],
                     None,
                     Some(candidate.slot),
-                    fetch_context,
+                    fetch_context.clone(),
                     &HashSet::from([candidate.pubkey]),
                     Some((candidate.pubkey, deleg_record.delegation_slot)),
                 )
@@ -2279,16 +2283,17 @@ where
         let discovery_context = AccountFetchContext::subscription_update(
             AccountFetchReason::SubscriptionUpdateGreedyDiscovery,
         );
-        let record_context =
-            discovery_context.with_reason(AccountFetchReason::DelegationRecord);
+        let record_context = discovery_context
+            .clone()
+            .with_reason(AccountFetchReason::DelegationRecord);
 
         let Some((deleg_record, delegation_actions)) = self
             .fetch_and_parse_delegation_record(
                 pubkey,
                 account.remote_slot(),
-                record_context,
+                record_context.clone(),
                 CompanionFetchLogContext {
-                    origin: record_context,
+                    origin: record_context.clone(),
                     primary_pubkey: pubkey,
                     context_slot: account.remote_slot(),
                 },
@@ -2344,7 +2349,7 @@ where
                 &pubkeys_to_clone,
                 None,
                 Some(account.remote_slot()),
-                discovery_context,
+                discovery_context.clone(),
             )
             .await
         } else {
@@ -2352,7 +2357,7 @@ where
                 &pubkeys_to_clone,
                 None,
                 Some(account.remote_slot()),
-                discovery_context,
+                discovery_context.clone(),
             )
             .await
         };
@@ -2387,7 +2392,7 @@ where
                         Some(&deleg_record),
                         &delegation_actions,
                         &CompanionFetchLogContext {
-                            origin: discovery_context,
+                            origin: discovery_context.clone(),
                             primary_pubkey: pubkey,
                             context_slot: account.remote_slot(),
                         },
@@ -2399,7 +2404,7 @@ where
                     if let Err(err) = self
                         .clone_projected_ata_request(
                             projected_ata_clone_request,
-                            discovery_context,
+                            discovery_context.clone(),
                         )
                         .await
                     {
@@ -2941,7 +2946,7 @@ where
                 pubkeys,
                 mark_empty_if_not_found,
                 slot,
-                fetch_context,
+                fetch_context.clone(),
             )
             .await
         {
@@ -2949,7 +2954,7 @@ where
             Err(err) => {
                 for _ in pubkeys {
                     metrics::inc_chainlink_clone_accounts_total_with_context(
-                        fetch_context,
+                        fetch_context.clone(),
                         ChainlinkCloneRemoteResult::Failed,
                         ChainlinkCloneIntent::Unknown,
                         ChainlinkCloneOutcome::Skipped,
@@ -3102,7 +3107,7 @@ where
             owned_by_deleg,
             plain,
             min_context_slot,
-            fetch_context,
+            fetch_context.clone(),
         )
         .await
         {
@@ -3129,7 +3134,7 @@ where
             self,
             programs,
             min_context_slot,
-            fetch_context,
+            fetch_context.clone(),
         )
         .await
         {
@@ -3175,7 +3180,7 @@ where
             self,
             atas,
             min_context_slot,
-            fetch_context,
+            fetch_context.clone(),
         )
         .await;
         accounts_to_clone.extend(ata_accounts);
@@ -3212,13 +3217,14 @@ where
                 Ordering::Relaxed,
             );
             let action_dependency_context = fetch_context
+                .clone()
                 .with_reason(AccountFetchReason::ActionDependencyMissing);
             let action_dep_accs = self
                 .remote_account_provider
                 .try_get_multi(
                     &action_dependencies_to_fetch,
                     None,
-                    action_dependency_context,
+                    action_dependency_context.clone(),
                     min_context_slot,
                 )
                 .await?;
@@ -3253,7 +3259,7 @@ where
                 owned_by_deleg,
                 plain,
                 min_context_slot,
-                action_dependency_context,
+                action_dependency_context.clone(),
             )
             .await
             {
@@ -3303,7 +3309,7 @@ where
                 self,
                 programs,
                 min_context_slot,
-                action_dependency_context,
+                action_dependency_context.clone(),
             )
             .await
             {
@@ -3393,14 +3399,15 @@ where
                 )
             {
                 let undelegating_refresh_context = fetch_context
+                    .clone()
                     .with_reason(AccountFetchReason::UndelegatingRefresh);
                 let projected_deleg_record = self
                     .fetch_and_parse_delegation_record(
                         eata_pubkey,
                         self.remote_account_provider.chain_slot(),
-                        undelegating_refresh_context,
+                        undelegating_refresh_context.clone(),
                         CompanionFetchLogContext {
-                            origin: undelegating_refresh_context,
+                            origin: undelegating_refresh_context.clone(),
                             primary_pubkey: eata_pubkey,
                             context_slot: self
                                 .remote_account_provider
@@ -3422,14 +3429,15 @@ where
             }
 
             let undelegating_refresh_context = fetch_context
+                .clone()
                 .with_reason(AccountFetchReason::UndelegatingRefresh);
             let deleg_record = self
                 .fetch_and_parse_delegation_record(
                     *pubkey,
                     self.remote_account_provider.chain_slot(),
-                    undelegating_refresh_context,
+                    undelegating_refresh_context.clone(),
                     CompanionFetchLogContext {
-                        origin: undelegating_refresh_context,
+                        origin: undelegating_refresh_context.clone(),
                         primary_pubkey: *pubkey,
                         context_slot: self.remote_account_provider.chain_slot(),
                     },
@@ -3596,13 +3604,14 @@ where
             let mut join_set = JoinSet::new();
             for (pubkey, account_in_bank) in undelegating_checks {
                 let this = self.clone();
+                let fetch_context = fetch_context.clone();
                 join_set.spawn(async move {
                     let decision = match tokio::time::timeout(
                         Duration::from_secs(5),
                         this.should_refresh_undelegating_in_bank_account(
                             &pubkey,
                             &account_in_bank,
-                            fetch_context,
+                            fetch_context.clone(),
                         ),
                     )
                     .await
@@ -3656,37 +3665,39 @@ where
             }
         }
         metrics::inc_chainlink_bank_precheck_accounts_with_context(
-            fetch_context,
+            fetch_context.clone(),
             BankPrecheckOutcome::BankHitNoFetch,
             BankPrecheckReason::NonUndelegatingPresent,
             bank_hit_no_fetch_non_undelegating_count,
         );
         metrics::inc_chainlink_bank_precheck_accounts_with_context(
-            fetch_context,
+            fetch_context.clone(),
             BankPrecheckOutcome::BankHitNoFetch,
             BankPrecheckReason::UndelegatingStillValid,
             bank_hit_no_fetch_undelegating_still_valid_count,
         );
         metrics::inc_chainlink_bank_precheck_accounts_with_context(
-            fetch_context,
+            fetch_context.clone(),
             BankPrecheckOutcome::BankHitNoFetch,
             BankPrecheckReason::UndelegatingCheckTimeout,
             bank_hit_no_fetch_undelegating_timeout_count,
         );
         metrics::inc_chainlink_bank_precheck_accounts_with_context(
-            fetch_context.with_reason(AccountFetchReason::UndelegatingRefresh),
+            fetch_context
+                .clone()
+                .with_reason(AccountFetchReason::UndelegatingRefresh),
             BankPrecheckOutcome::BankHitUndelegatingRefreshRequired,
             BankPrecheckReason::UndelegatingRefresh,
             bank_hit_undelegating_refresh_required_count,
         );
         metrics::inc_chainlink_bank_precheck_accounts_with_context(
-            fetch_context,
+            fetch_context.clone(),
             BankPrecheckOutcome::BankMissRemoteRequired,
             BankPrecheckReason::Absent,
             bank_miss_remote_required_count,
         );
         metrics::inc_chainlink_bank_precheck_accounts_with_context(
-            fetch_context,
+            fetch_context.clone(),
             BankPrecheckOutcome::ForcedRefreshRemoteRequired,
             BankPrecheckReason::ForcedRefresh,
             forced_refresh_remote_required_count,
@@ -3703,7 +3714,9 @@ where
         let mut waiters: Vec<PendingWaiter> = vec![];
         let mut claimed_ops: Vec<ClaimedOperation> = vec![];
         for pubkey in pubkeys {
-            match self.claim_or_join_owned_operation(*pubkey, fetch_context) {
+            match self
+                .claim_or_join_owned_operation(*pubkey, fetch_context.clone())
+            {
                 PendingClaim::Created(handles) => {
                     let PendingHandles {
                         waiter,
@@ -3743,7 +3756,7 @@ where
                 claimed_ops,
                 &mark_empty_set,
                 slot,
-                fetch_context,
+                fetch_context.clone(),
             );
         }
 

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/pending_operation.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/pending_operation.rs
@@ -168,7 +168,7 @@ impl PendingOwner {
             return;
         }
         metrics::observe_chainlink_pending_fetch_owner_duration_seconds_with_context(
-            self.origin,
+            self.origin.clone(),
             self.layer,
             outcome,
             self.started_at.elapsed().as_secs_f64(),
@@ -231,7 +231,7 @@ pub(super) fn claim_or_join_pending(
                 cancel: Arc::clone(&cancel),
             });
             metrics::inc_chainlink_pending_fetch_accounts_with_context(
-                origin,
+                origin.clone(),
                 layer,
                 ChainlinkPendingFetchOutcome::Owned,
                 1,
@@ -263,7 +263,7 @@ pub(super) fn claim_or_join_pending(
             let cancel = Arc::clone(&entry.get().cancel);
             entry.get_mut().waiters.insert(waiter_id, tx);
             metrics::inc_chainlink_pending_fetch_accounts_with_context(
-                origin,
+                origin.clone(),
                 layer,
                 ChainlinkPendingFetchOutcome::JoinedExisting,
                 1,

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/pipeline.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/pipeline.rs
@@ -234,7 +234,7 @@ where
             this.task_to_fetch_with_delegation_record(
                 *pubkey,
                 effective_slot,
-                fetch_context,
+                fetch_context.clone(),
             ),
         );
     }
@@ -711,7 +711,7 @@ where
     for acc in loaded_programs {
         if !this.is_program_allowed(&acc.program_id) {
             metrics::inc_chainlink_clone_accounts_total_with_context(
-                fetch_context,
+                fetch_context.clone(),
                 ChainlinkCloneRemoteResult::Found,
                 ChainlinkCloneIntent::ProgramData,
                 ChainlinkCloneOutcome::Skipped,
@@ -720,6 +720,7 @@ where
             continue;
         }
         let this_clone = this.clone();
+        let fetch_context = fetch_context.clone();
         program_join_set.spawn(async move {
             this_clone
                 .clone_program_with_ownership(acc, fetch_context)
@@ -751,6 +752,7 @@ where
         };
 
         let this_clone = this.clone();
+        let fetch_context = fetch_context.clone();
         accounts_join_set.spawn(async move {
             this_clone
                 .clone_account_with_post_delegation_action_invariants(
@@ -779,6 +781,7 @@ where
         };
 
         let this_clone = this.clone();
+        let fetch_context = fetch_context.clone();
         action_accounts_join_set.spawn(async move {
             this_clone
                 .clone_account_with_post_delegation_action_invariants(

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/program_loader.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/program_loader.rs
@@ -68,7 +68,7 @@ fn schedule_deferred_verify<T, U, V, C>(
     }
     let this = this.clone();
     let account = account.clone();
-    let ctx = *companion_fetch_log_context;
+    let ctx = companion_fetch_log_context.clone();
     let delay = PROGRAM_VERIFY_THROTTLE.saturating_sub(elapsed)
         + Duration::from_millis(10);
     tokio::task::spawn(async move {
@@ -244,8 +244,9 @@ pub(crate) async fn handle_executable_sub_update_with_context<T, U, V, C>(
     let program_load_context = AccountFetchContext::subscription_update(
         AccountFetchReason::ProgramLoad,
     );
-    let program_data_context =
-        program_load_context.with_reason(AccountFetchReason::ProgramData);
+    let program_data_context = program_load_context
+        .clone()
+        .with_reason(AccountFetchReason::ProgramData);
 
     let (program_account, program_data_account) =
         if account.owner().eq(&LOADER_V3) {

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -9652,26 +9652,27 @@ async fn test_pending_fetch_metrics_count_fetch_cloner_owner_and_waiter() {
 
     let fetch_context = AccountFetchContext::rpc_get_multiple_accounts();
     let owned_baseline = pending_accounts_value(
-        fetch_context,
+        fetch_context.clone(),
         ChainlinkPendingFetchOutcome::Owned,
     );
     let joined_baseline = pending_accounts_value(
-        fetch_context,
+        fetch_context.clone(),
         ChainlinkPendingFetchOutcome::JoinedExisting,
     );
-    let waiters_baseline = pending_waiters_value(fetch_context);
+    let waiters_baseline = pending_waiters_value(fetch_context.clone());
 
     rpc_client.block_fetches();
 
     let owner_task = {
         let fetch_cloner = fetch_cloner.clone();
+        let fetch_context = fetch_context.clone();
         tokio::spawn(async move {
             fetch_cloner
                 .fetch_and_clone_accounts_with_dedup(
                     &[account_pubkey],
                     None,
                     None,
-                    fetch_context,
+                    fetch_context.clone(),
                 )
                 .await
         })
@@ -9682,13 +9683,14 @@ async fn test_pending_fetch_metrics_count_fetch_cloner_owner_and_waiter() {
 
     let waiter_task = {
         let fetch_cloner = fetch_cloner.clone();
+        let fetch_context = fetch_context.clone();
         tokio::spawn(async move {
             fetch_cloner
                 .fetch_and_clone_accounts_with_dedup(
                     &[account_pubkey],
                     None,
                     None,
-                    fetch_context,
+                    fetch_context.clone(),
                 )
                 .await
         })
@@ -9714,7 +9716,7 @@ async fn test_pending_fetch_metrics_count_fetch_cloner_owner_and_waiter() {
         .expect("waiter fetch should succeed");
 
     let owned_delta = pending_accounts_value(
-        fetch_context,
+        fetch_context.clone(),
         ChainlinkPendingFetchOutcome::Owned,
     )
     .saturating_sub(owned_baseline);
@@ -9723,7 +9725,7 @@ async fn test_pending_fetch_metrics_count_fetch_cloner_owner_and_waiter() {
         "fetch_cloner owned metric should increase by at least 1; got {owned_delta}"
     );
     let joined_delta = pending_accounts_value(
-        fetch_context,
+        fetch_context.clone(),
         ChainlinkPendingFetchOutcome::JoinedExisting,
     )
     .saturating_sub(joined_baseline);
@@ -9731,8 +9733,8 @@ async fn test_pending_fetch_metrics_count_fetch_cloner_owner_and_waiter() {
         joined_delta >= 1,
         "fetch_cloner joined-existing metric should increase by at least 1; got {joined_delta}"
     );
-    let waiters_delta =
-        pending_waiters_value(fetch_context).saturating_sub(waiters_baseline);
+    let waiters_delta = pending_waiters_value(fetch_context.clone())
+        .saturating_sub(waiters_baseline);
     assert!(
         waiters_delta >= 1,
         "fetch_cloner waiter metric should increase by at least 1; got {waiters_delta}"

--- a/magicblock-chainlink/src/chainlink/mod.rs
+++ b/magicblock-chainlink/src/chainlink/mod.rs
@@ -189,16 +189,31 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
         }
     }
 
+    pub async fn ensure_transaction_accounts_with_context(
+        &self,
+        tx: &SanitizedTransaction,
+        fetch_context: impl Into<AccountFetchContext>,
+    ) -> ChainlinkResult<FetchAndCloneResult> {
+        let fetch_context = fetch_context.into();
+        match self {
+            Self::Enabled(chainlink) => {
+                chainlink
+                    .ensure_transaction_accounts_with_context(tx, fetch_context)
+                    .await
+            }
+            Self::Disabled => Err(ChainlinkError::DisabledForNonPrimaryMode),
+        }
+    }
+
     pub async fn ensure_transaction_accounts(
         &self,
         tx: &SanitizedTransaction,
     ) -> ChainlinkResult<FetchAndCloneResult> {
-        match self {
-            Self::Enabled(chainlink) => {
-                chainlink.ensure_transaction_accounts(tx).await
-            }
-            Self::Disabled => Err(ChainlinkError::DisabledForNonPrimaryMode),
-        }
+        self.ensure_transaction_accounts_with_context(
+            tx,
+            AccountFetchContext::send_transaction(*tx.signature()),
+        )
+        .await
     }
 
     pub async fn fetch_accounts(
@@ -521,10 +536,11 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
     /// is cloned in our validator.
     /// Returns the state of each account (writable and readonly) after the checks
     /// and cloning are done.
-    #[instrument(skip(self, tx))]
-    pub async fn ensure_transaction_accounts(
+    #[instrument(skip(self, tx, fetch_context))]
+    pub async fn ensure_transaction_accounts_with_context(
         &self,
         tx: &SanitizedTransaction,
+        fetch_context: impl Into<AccountFetchContext>,
     ) -> ChainlinkResult<FetchAndCloneResult> {
         if is_noop_system_transfer(tx) {
             trace!(
@@ -533,6 +549,8 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
             );
             return Ok(Default::default());
         }
+
+        let fetch_context = fetch_context.into();
 
         let mut pubkeys = tx
             .message()
@@ -563,14 +581,21 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
 
         // Ensure accounts
         let res = self
-            .ensure_accounts(
-                &pubkeys,
-                mark_empty_if_not_found,
-                AccountFetchContext::send_transaction(*tx.signature()),
-            )
+            .ensure_accounts(&pubkeys, mark_empty_if_not_found, fetch_context)
             .await?;
 
         Ok(res)
+    }
+
+    pub async fn ensure_transaction_accounts(
+        &self,
+        tx: &SanitizedTransaction,
+    ) -> ChainlinkResult<FetchAndCloneResult> {
+        self.ensure_transaction_accounts_with_context(
+            tx,
+            AccountFetchContext::send_transaction(*tx.signature()),
+        )
+        .await
     }
 
     /// Same as fetch accounts, but does not return the accounts, just

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -2797,6 +2797,18 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
             }
         }
 
+        if fetch_context.should_count_remote_account_claims()
+            && !claimed_pubkeys.is_empty()
+        {
+            let unique_claimed_pubkey_count = claimed_pubkeys
+                .iter()
+                .copied()
+                .collect::<HashSet<_>>()
+                .len();
+            fetch_context
+                .add_remote_account_claims(unique_claimed_pubkey_count);
+        }
+
         // Setup subscriptions and trigger the fetch only for pubkeys this
         // call actually claimed. Waiter-only pubkeys already have a
         // subscription and an in-flight fetch owned by the original

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -1541,13 +1541,13 @@ fn observe_companion_fetch_if_configured(
 ) {
     if let Some(kind) = kind {
         observe_chainlink_companion_fetch_attempts(
-            context,
+            context.clone(),
             kind,
             outcome,
             attempts as f64,
         );
         observe_chainlink_companion_fetch_duration_seconds(
-            context,
+            context.clone(),
             kind,
             outcome,
             started_at.elapsed().as_secs_f64(),
@@ -2189,13 +2189,13 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                                     if slot >= state.fetch_start_slot {
                                         trace!(pubkey = %update.pubkey, slot = slot, fetch_start_slot = state.fetch_start_slot, generation, "Using subscription update instead of fetch");
                                         metrics::observe_chainlink_pending_fetch_owner_duration_seconds_with_context(
-                                            state.fetch_context,
+                                            state.fetch_context.clone(),
                                             ChainlinkPendingFetchLayer::RemoteAccountProvider,
                                             ChainlinkPendingFetchOutcome::ResolvedBySubscriptionUpdate,
                                             state.owner_started_at.elapsed().as_secs_f64(),
                                         );
                                         metrics::inc_chainlink_pending_fetch_accounts_with_context(
-                                            state.fetch_context,
+                                            state.fetch_context.clone(),
                                             ChainlinkPendingFetchLayer::RemoteAccountProvider,
                                             ChainlinkPendingFetchOutcome::ResolvedBySubscriptionUpdate,
                                             1,
@@ -2397,13 +2397,13 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
         // 1. Fetch the _normal_ way and hope the slots match and if required
         //    the min_context_slot is met
         let mut remote_accounts = match self
-            .try_get_multi(pubkeys, None, fetch_context, None)
+            .try_get_multi(pubkeys, None, fetch_context.clone(), None)
             .await
         {
             Ok(accounts) => accounts,
             Err(err) => {
                 observe_companion_fetch_if_configured(
-                    fetch_context,
+                    fetch_context.clone(),
                     companion_fetch_kind,
                     ChainlinkCompanionFetchOutcome::FailedRpc,
                     companion_fetch_attempts,
@@ -2420,7 +2420,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
             slots_match_and_meet_min_context(&remote_accounts, min_context_slot)
         {
             observe_companion_fetch_if_configured(
-                fetch_context,
+                fetch_context.clone(),
                 companion_fetch_kind,
                 ChainlinkCompanionFetchOutcome::Succeeded,
                 companion_fetch_attempts,
@@ -2470,7 +2470,11 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
             }
             companion_fetch_attempts += 1;
             remote_accounts = match self
-                .fetch_multi_rpc_only(pubkeys, fetch_start_slot, fetch_context)
+                .fetch_multi_rpc_only(
+                    pubkeys,
+                    fetch_start_slot,
+                    fetch_context.clone(),
+                )
                 .await
             {
                 Ok(remote_accounts) => remote_accounts,
@@ -2542,7 +2546,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
             );
             if let Match = slots_match_result {
                 observe_companion_fetch_if_configured(
-                    fetch_context,
+                    fetch_context.clone(),
                     companion_fetch_kind,
                     ChainlinkCompanionFetchOutcome::Succeeded,
                     companion_fetch_attempts,
@@ -2752,13 +2756,13 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                     Entry::Occupied(mut entry) => {
                         entry.get_mut().waiters.push(sender);
                         inc_chainlink_pending_fetch_accounts_with_context(
-                            fetch_context,
+                            fetch_context.clone(),
                             layer,
                             ChainlinkPendingFetchOutcome::JoinedExisting,
                             1,
                         );
                         inc_chainlink_pending_fetch_waiters_with_context(
-                            fetch_context,
+                            fetch_context.clone(),
                             layer,
                             1,
                         );
@@ -2772,12 +2776,12 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                         entry.insert(FetchingAccountState {
                             generation,
                             fetch_start_slot,
-                            fetch_context,
+                            fetch_context: fetch_context.clone(),
                             owner_started_at: std::time::Instant::now(),
                             waiters: vec![sender],
                         });
                         inc_chainlink_pending_fetch_accounts_with_context(
-                            fetch_context,
+                            fetch_context.clone(),
                             layer,
                             ChainlinkPendingFetchOutcome::Owned,
                             1,
@@ -2810,7 +2814,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                     claimed_generations.clone(),
                 );
             if let Err(err) = self
-                .setup_subscriptions(&claimed_pubkeys, fetch_context)
+                .setup_subscriptions(&claimed_pubkeys, fetch_context.clone())
                 .await
             {
                 subscription_setup_guard
@@ -2829,7 +2833,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                     claimed_generations.clone(),
                     mark_empty_if_not_found,
                     min_context_slot,
-                    fetch_context,
+                    fetch_context.clone(),
                 );
             }
         }
@@ -2977,7 +2981,10 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
             .collect();
 
         inc_account_fetches_success(pubkeys.len() as u64);
-        inc_account_fetches_found_with_context(fetch_context, found_count);
+        inc_account_fetches_found_with_context(
+            fetch_context.clone(),
+            found_count,
+        );
         inc_account_fetches_not_found_with_context(
             fetch_context,
             not_found_count,
@@ -3002,16 +3009,18 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
         // Send all subscription requests in parallel (non-fail-fast).
         // We use join_all instead of try_join_all to ensure ALL acquire
         // attempts complete, even if some fail.
-        let subscription_results =
-            join_all(pubkeys.iter().map(|pubkey| async move {
+        let subscription_results = join_all(pubkeys.iter().map(|pubkey| {
+            let fetch_context = fetch_context.clone();
+            async move {
                 self.acquire_subscription_with_origin(
                     pubkey,
                     SubscriptionReason::DirectAccount,
                     SubscriptionRegistrationOrigin::Fetch(fetch_context),
                 )
                 .await
-            }))
-            .await;
+            }
+        }))
+        .await;
 
         let mut errors = Vec::new();
         let mut acquired = Vec::new();
@@ -3361,7 +3370,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                         // Evicted by another key's admission mid-flight;
                         // register it from scratch.
                         Ok(PromotionOutcome::Evicted) => {
-                            self.register_subscription(pubkey, reason, origin)
+                            self.register_subscription(pubkey, reason, origin.clone())
                                 .await
                         }
                         Ok(PromotionOutcome::NoCapacity)
@@ -3404,7 +3413,8 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                     }
                 }
             } else {
-                self.register_subscription(pubkey, reason, origin).await
+                self.register_subscription(pubkey, reason, origin.clone())
+                    .await
             };
 
             if let Err(err) = repair_result {
@@ -3421,7 +3431,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                 return Err(err);
             }
             inc_chainlink_subscription_registration_accounts(
-                origin,
+                origin.clone(),
                 reason.into(),
                 SubscriptionRegistrationOutcome::AlreadyPresent,
             );
@@ -3429,7 +3439,8 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
         }
         drop(ownership);
 
-        self.register_subscription(pubkey, reason, origin).await?;
+        self.register_subscription(pubkey, reason, origin.clone())
+            .await?;
 
         let mut ownership = self.subscription_ownership.lock().await;
         ownership.entry(*pubkey).or_default().acquire(reason);
@@ -4057,7 +4068,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                         not_found_count += 1;
                         not_found_pubkeys.insert(*pubkey);
                         inc_chainlink_empty_placeholder_accounts_total_with_context(
-                            fetch_context,
+                            fetch_context.clone(),
                             ChainlinkEmptyPlaceholderStage::ConvertedToEmpty,
                             Outcome::Success,
                         );
@@ -4083,9 +4094,12 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
 
             // Update metrics for successful RPC fetch
             inc_account_fetches_success(pubkeys.len() as u64);
-            inc_account_fetches_found_with_context(fetch_context, found_count);
+            inc_account_fetches_found_with_context(
+                fetch_context.clone(),
+                found_count,
+            );
             inc_account_fetches_not_found_with_context(
-                fetch_context,
+                fetch_context.clone(),
                 not_found_count,
             );
 
@@ -4143,7 +4157,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                             )
                             .await;
                         observe_chainlink_pending_fetch_owner_duration_seconds_with_context(
-                            state.fetch_context,
+                            state.fetch_context.clone(),
                             ChainlinkPendingFetchLayer::RemoteAccountProvider,
                             if classification_result.is_ok() {
                                 ChainlinkPendingFetchOutcome::OwnerSucceeded
@@ -4155,7 +4169,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                         (waiters, classification_result)
                     } else {
                         inc_chainlink_pending_fetch_accounts_with_context(
-                            fetch_context,
+                            fetch_context.clone(),
                             ChainlinkPendingFetchLayer::RemoteAccountProvider,
                             ChainlinkPendingFetchOutcome::RpcFetchCompletedAfterUpdate,
                             1,

--- a/magicblock-chainlink/src/remote_account_provider/tests.rs
+++ b/magicblock-chainlink/src/remote_account_provider/tests.rs
@@ -161,7 +161,7 @@ async fn wait_for_direct_subscription(
 }
 
 async fn wait_for_pending_account_delta_at_least(
-    origin: impl Into<AccountFetchContext> + Copy,
+    origin: AccountFetchContext,
     outcome: ChainlinkPendingFetchOutcome,
     baseline: u64,
     minimum_delta: u64,
@@ -169,8 +169,8 @@ async fn wait_for_pending_account_delta_at_least(
     let start = tokio::time::Instant::now();
     let timeout = Duration::from_secs(2);
     loop {
-        let delta =
-            pending_accounts_value(origin, outcome).saturating_sub(baseline);
+        let delta = pending_accounts_value(origin.clone(), outcome)
+            .saturating_sub(baseline);
         if delta >= minimum_delta {
             break;
         }
@@ -1584,14 +1584,26 @@ async fn test_companion_fetch_metrics_record_fast_path_success() {
     );
     let kind = ChainlinkCompanionFetchKind::ProgramData;
     let outcome = ChainlinkCompanionFetchOutcome::Succeeded;
-    let attempts_count_before =
-        chainlink_companion_fetch_attempts_sample_count(context, kind, outcome);
-    let attempts_sum_before =
-        chainlink_companion_fetch_attempts_sample_sum(context, kind, outcome);
-    let duration_count_before =
-        chainlink_companion_fetch_duration_sample_count(context, kind, outcome);
-    let duration_sum_before =
-        chainlink_companion_fetch_duration_sample_sum(context, kind, outcome);
+    let attempts_count_before = chainlink_companion_fetch_attempts_sample_count(
+        context.clone(),
+        kind,
+        outcome,
+    );
+    let attempts_sum_before = chainlink_companion_fetch_attempts_sample_sum(
+        context.clone(),
+        kind,
+        outcome,
+    );
+    let duration_count_before = chainlink_companion_fetch_duration_sample_count(
+        context.clone(),
+        kind,
+        outcome,
+    );
+    let duration_sum_before = chainlink_companion_fetch_duration_sample_sum(
+        context.clone(),
+        kind,
+        outcome,
+    );
 
     let res = remote_account_provider
         .try_get_multi_until_slots_match(
@@ -1602,26 +1614,41 @@ async fn test_companion_fetch_metrics_record_fast_path_success() {
                 min_context_slot: Some(CURRENT_SLOT),
                 companion_fetch_kind: kind,
             }),
-            context,
+            context.clone(),
         )
         .await;
 
     assert!(res.is_ok());
     assert_eq!(
-        chainlink_companion_fetch_attempts_sample_count(context, kind, outcome),
+        chainlink_companion_fetch_attempts_sample_count(
+            context.clone(),
+            kind,
+            outcome
+        ),
         attempts_count_before + 1
     );
     assert_eq!(
-        chainlink_companion_fetch_attempts_sample_sum(context, kind, outcome),
+        chainlink_companion_fetch_attempts_sample_sum(
+            context.clone(),
+            kind,
+            outcome
+        ),
         attempts_sum_before + 1.0
     );
     assert_eq!(
-        chainlink_companion_fetch_duration_sample_count(context, kind, outcome),
+        chainlink_companion_fetch_duration_sample_count(
+            context.clone(),
+            kind,
+            outcome
+        ),
         duration_count_before + 1
     );
     assert!(
-        chainlink_companion_fetch_duration_sample_sum(context, kind, outcome)
-            >= duration_sum_before
+        chainlink_companion_fetch_duration_sample_sum(
+            context.clone(),
+            kind,
+            outcome
+        ) >= duration_sum_before
     );
 }
 
@@ -1652,10 +1679,16 @@ async fn test_companion_fetch_metrics_record_retry_success() {
     );
     let kind = ChainlinkCompanionFetchKind::ProgramData;
     let outcome = ChainlinkCompanionFetchOutcome::Succeeded;
-    let attempts_count_before =
-        chainlink_companion_fetch_attempts_sample_count(context, kind, outcome);
-    let attempts_sum_before =
-        chainlink_companion_fetch_attempts_sample_sum(context, kind, outcome);
+    let attempts_count_before = chainlink_companion_fetch_attempts_sample_count(
+        context.clone(),
+        kind,
+        outcome,
+    );
+    let attempts_sum_before = chainlink_companion_fetch_attempts_sample_sum(
+        context.clone(),
+        kind,
+        outcome,
+    );
 
     let res = remote_account_provider
         .try_get_multi_until_slots_match(
@@ -1666,19 +1699,26 @@ async fn test_companion_fetch_metrics_record_retry_success() {
                 min_context_slot: Some(CURRENT_SLOT + 1),
                 companion_fetch_kind: kind,
             }),
-            context,
+            context.clone(),
         )
         .await;
     advance_handle.await.unwrap();
 
     assert!(res.is_ok());
     assert_eq!(
-        chainlink_companion_fetch_attempts_sample_count(context, kind, outcome),
+        chainlink_companion_fetch_attempts_sample_count(
+            context.clone(),
+            kind,
+            outcome
+        ),
         attempts_count_before + 1
     );
     assert!(
-        chainlink_companion_fetch_attempts_sample_sum(context, kind, outcome)
-            > attempts_sum_before + 1.0
+        chainlink_companion_fetch_attempts_sample_sum(
+            context.clone(),
+            kind,
+            outcome
+        ) > attempts_sum_before + 1.0
     );
 }
 
@@ -1690,17 +1730,23 @@ async fn test_companion_fetch_metrics_record_slot_mismatch_failure() {
         .with_reason(AccountFetchReason::DelegationRecord);
     let kind = ChainlinkCompanionFetchKind::DelegationRecord;
     let outcome = ChainlinkCompanionFetchOutcome::FailedSlotMismatch;
-    let attempts_count_before =
-        chainlink_companion_fetch_attempts_sample_count(context, kind, outcome);
-    let duration_count_before =
-        chainlink_companion_fetch_duration_sample_count(context, kind, outcome);
+    let attempts_count_before = chainlink_companion_fetch_attempts_sample_count(
+        context.clone(),
+        kind,
+        outcome,
+    );
+    let duration_count_before = chainlink_companion_fetch_duration_sample_count(
+        context.clone(),
+        kind,
+        outcome,
+    );
 
     // RPC-only retries in the provider test mock use one batch context slot,
     // which normalizes slots before the terminal mismatch branch. Exercise the
     // private observation helper directly so this test covers the metric path
     // without changing production retry behavior.
     observe_companion_fetch_if_configured(
-        context,
+        context.clone(),
         Some(kind),
         outcome,
         1,
@@ -1708,11 +1754,19 @@ async fn test_companion_fetch_metrics_record_slot_mismatch_failure() {
     );
 
     assert_eq!(
-        chainlink_companion_fetch_attempts_sample_count(context, kind, outcome),
+        chainlink_companion_fetch_attempts_sample_count(
+            context.clone(),
+            kind,
+            outcome
+        ),
         attempts_count_before + 1
     );
     assert_eq!(
-        chainlink_companion_fetch_duration_sample_count(context, kind, outcome),
+        chainlink_companion_fetch_duration_sample_count(
+            context.clone(),
+            kind,
+            outcome
+        ),
         duration_count_before + 1
     );
 }
@@ -1737,22 +1791,40 @@ async fn test_companion_fetch_metrics_not_recorded_without_kind() {
     let context = AccountFetchContext::project_ata();
     let kind = ChainlinkCompanionFetchKind::AtaProjection;
     let outcome = ChainlinkCompanionFetchOutcome::Succeeded;
-    let attempts_count_before =
-        chainlink_companion_fetch_attempts_sample_count(context, kind, outcome);
-    let duration_count_before =
-        chainlink_companion_fetch_duration_sample_count(context, kind, outcome);
+    let attempts_count_before = chainlink_companion_fetch_attempts_sample_count(
+        context.clone(),
+        kind,
+        outcome,
+    );
+    let duration_count_before = chainlink_companion_fetch_duration_sample_count(
+        context.clone(),
+        kind,
+        outcome,
+    );
 
     let res = remote_account_provider
-        .try_get_multi_until_slots_match(&[pubkey1, pubkey2], None, context)
+        .try_get_multi_until_slots_match(
+            &[pubkey1, pubkey2],
+            None,
+            context.clone(),
+        )
         .await;
 
     assert!(res.is_ok());
     assert_eq!(
-        chainlink_companion_fetch_attempts_sample_count(context, kind, outcome),
+        chainlink_companion_fetch_attempts_sample_count(
+            context.clone(),
+            kind,
+            outcome
+        ),
         attempts_count_before
     );
     assert_eq!(
-        chainlink_companion_fetch_duration_sample_count(context, kind, outcome),
+        chainlink_companion_fetch_duration_sample_count(
+            context.clone(),
+            kind,
+            outcome
+        ),
         duration_count_before
     );
 }
@@ -2620,22 +2692,23 @@ async fn test_pending_fetch_metrics_count_remote_provider_owner_and_waiter() {
 
     let fetch_context = AccountFetchContext::rpc_get_multiple_accounts();
     let owned_baseline = pending_accounts_value(
-        fetch_context,
+        fetch_context.clone(),
         ChainlinkPendingFetchOutcome::Owned,
     );
     let joined_baseline = pending_accounts_value(
-        fetch_context,
+        fetch_context.clone(),
         ChainlinkPendingFetchOutcome::JoinedExisting,
     );
-    let waiters_baseline = pending_waiters_value(fetch_context);
+    let waiters_baseline = pending_waiters_value(fetch_context.clone());
 
     rpc_client.block_fetches();
 
     let owner_task = tokio::spawn({
         let provider = provider.clone();
+        let fetch_context = fetch_context.clone();
         async move {
             provider
-                .try_get_multi(&[pubkey], None, fetch_context, None)
+                .try_get_multi(&[pubkey], None, fetch_context.clone(), None)
                 .await
         }
     });
@@ -2644,9 +2717,10 @@ async fn test_pending_fetch_metrics_count_remote_provider_owner_and_waiter() {
 
     let waiter_task = tokio::spawn({
         let provider = provider.clone();
+        let fetch_context = fetch_context.clone();
         async move {
             provider
-                .try_get_multi(&[pubkey], None, fetch_context, None)
+                .try_get_multi(&[pubkey], None, fetch_context.clone(), None)
                 .await
         }
     });
@@ -2671,7 +2745,7 @@ async fn test_pending_fetch_metrics_count_remote_provider_owner_and_waiter() {
         .expect("waiter fetch should succeed");
 
     let owned_delta = pending_accounts_value(
-        fetch_context,
+        fetch_context.clone(),
         ChainlinkPendingFetchOutcome::Owned,
     )
     .saturating_sub(owned_baseline);
@@ -2680,7 +2754,7 @@ async fn test_pending_fetch_metrics_count_remote_provider_owner_and_waiter() {
         "remote provider owned metric should increase by at least 1; got {owned_delta}"
     );
     let joined_delta = pending_accounts_value(
-        fetch_context,
+        fetch_context.clone(),
         ChainlinkPendingFetchOutcome::JoinedExisting,
     )
     .saturating_sub(joined_baseline);
@@ -2688,8 +2762,8 @@ async fn test_pending_fetch_metrics_count_remote_provider_owner_and_waiter() {
         joined_delta >= 1,
         "remote provider joined-existing metric should increase by at least 1; got {joined_delta}"
     );
-    let waiters_delta =
-        pending_waiters_value(fetch_context).saturating_sub(waiters_baseline);
+    let waiters_delta = pending_waiters_value(fetch_context.clone())
+        .saturating_sub(waiters_baseline);
     assert!(
         waiters_delta >= 1,
         "remote provider waiter metric should increase by at least 1; got {waiters_delta}"
@@ -2739,11 +2813,11 @@ async fn test_pending_fetch_metrics_count_subscription_update_resolution_and_lat
 
     let fetch_context = AccountFetchContext::rpc_get_multiple_accounts();
     let resolved_baseline = pending_accounts_value(
-        fetch_context,
+        fetch_context.clone(),
         ChainlinkPendingFetchOutcome::ResolvedBySubscriptionUpdate,
     );
     let late_rpc_baseline = pending_accounts_value(
-        fetch_context,
+        fetch_context.clone(),
         ChainlinkPendingFetchOutcome::RpcFetchCompletedAfterUpdate,
     );
 
@@ -2751,6 +2825,7 @@ async fn test_pending_fetch_metrics_count_subscription_update_resolution_and_lat
 
     let task_handle = tokio::spawn({
         let provider = provider.clone();
+        let fetch_context = fetch_context.clone();
         async move {
             provider
                 .try_get_multi(&[pubkey], None, fetch_context, None)
@@ -2783,7 +2858,7 @@ async fn test_pending_fetch_metrics_count_subscription_update_resolution_and_lat
         Some(RemoteAccountUpdateSource::Subscription)
     );
     let resolved_delta = pending_accounts_value(
-        fetch_context,
+        fetch_context.clone(),
         ChainlinkPendingFetchOutcome::ResolvedBySubscriptionUpdate,
     )
     .saturating_sub(resolved_baseline);
@@ -2797,7 +2872,7 @@ async fn test_pending_fetch_metrics_count_subscription_update_resolution_and_lat
     rpc_client.set_current_slot(fetch_start_slot + 1);
     rpc_client.allow_fetches();
     wait_for_pending_account_delta_at_least(
-        fetch_context,
+        fetch_context.clone(),
         ChainlinkPendingFetchOutcome::RpcFetchCompletedAfterUpdate,
         late_rpc_baseline,
         1,

--- a/magicblock-chainlink/src/remote_account_provider/tests.rs
+++ b/magicblock-chainlink/src/remote_account_provider/tests.rs
@@ -18,7 +18,7 @@ use magicblock_metrics::metrics::{
     ChainlinkCompanionFetchKind, ChainlinkCompanionFetchOutcome,
     ChainlinkPendingFetchLayer, ChainlinkPendingFetchOutcome,
 };
-use solana_account::Account;
+use solana_account::{Account, AccountSharedData};
 use solana_system_interface::program as system_program;
 use tokio::sync::mpsc;
 
@@ -70,6 +70,47 @@ async fn setup_provider_with_lru_capacity(
     let (subscribed_accounts, config) = create_test_lru_cache(lru_capacity);
     let config = config
         .with_secondary_subscriptions_lru_capacity(lru_capacity)
+        .unwrap();
+    let chain_slot = Arc::<AtomicU64>::default();
+
+    let provider = Arc::new(
+        RemoteAccountProvider::new(
+            rpc_client.clone(),
+            pubsub_client.clone(),
+            forward_tx,
+            &config,
+            subscribed_accounts,
+            ChainSlot::new(chain_slot),
+        )
+        .await
+        .unwrap(),
+    );
+
+    ProviderTestCtx {
+        provider,
+        rpc_client,
+        pubsub_client,
+        _forward_rx: forward_rx,
+    }
+}
+
+async fn setup_provider_multi(
+    accounts: Vec<(Pubkey, Account)>,
+) -> ProviderTestCtx {
+    let rpc_client = ChainRpcClientMockBuilder::new()
+        .slot(100)
+        .clock_sysvar_for_slot(100)
+        .accounts(accounts.into_iter().collect())
+        .build();
+
+    let (updates_sender, updates_receiver) = mpsc::channel(1_000);
+    let pubsub_client =
+        ChainPubsubClientMock::new(updates_sender, updates_receiver);
+
+    let (forward_tx, forward_rx) = mpsc::channel(1_000);
+    let (subscribed_accounts, config) = create_test_lru_cache(1000);
+    let config = config
+        .with_secondary_subscriptions_lru_capacity(1000)
         .unwrap();
     let chain_slot = Arc::<AtomicU64>::default();
 
@@ -2668,6 +2709,64 @@ async fn test_try_get_multi_owner_success_cleans_up_pending_entry() {
         .expect("fetch should succeed");
     assert_eq!(result.len(), 1);
     assert!(!provider.is_pending(&pubkey));
+}
+
+#[tokio::test]
+async fn test_remote_account_claims_count_owned_unique_requested_pubkeys() {
+    let _metrics_guard =
+        crate::testing::pending_metric_test_lock().lock().await;
+    init_logger();
+
+    let pubkey1 = Pubkey::new_unique();
+    let pubkey2 = Pubkey::new_unique();
+    let account1 = AccountSharedData::new(1, 0, &Pubkey::new_unique()).into();
+    let account2 = AccountSharedData::new(2, 0, &Pubkey::new_unique()).into();
+    let ctx =
+        setup_provider_multi(vec![(pubkey1, account1), (pubkey2, account2)])
+            .await;
+    let fetch_context = AccountFetchContext::rpc_get_multiple_accounts();
+
+    let result = ctx
+        .provider
+        .try_get_multi(
+            &[pubkey1, pubkey1, pubkey2],
+            None,
+            fetch_context.clone(),
+            None,
+        )
+        .await
+        .expect("multi-account fetch should succeed");
+
+    assert_eq!(result.len(), 3);
+    assert_eq!(
+        fetch_context.remote_account_claims_value(),
+        2,
+        "duplicate requested pubkeys should count once per owned direct claim"
+    );
+}
+
+#[tokio::test]
+async fn test_remote_account_claims_ignore_companion_fetch_reason() {
+    let _metrics_guard =
+        crate::testing::pending_metric_test_lock().lock().await;
+    init_logger();
+
+    let pubkey = Pubkey::new_unique();
+    let account = AccountSharedData::new(1, 0, &Pubkey::new_unique()).into();
+    let ctx = setup_provider_multi(vec![(pubkey, account)]).await;
+    let fetch_context = AccountFetchContext::rpc_get_account()
+        .with_reason(AccountFetchReason::DelegationRecord);
+
+    ctx.provider
+        .try_get_multi(&[pubkey], None, fetch_context.clone(), None)
+        .await
+        .expect("companion-like fetch should succeed");
+
+    assert_eq!(
+        fetch_context.remote_account_claims_value(),
+        0,
+        "companion fetch reasons must not contribute to the response-header count"
+    );
 }
 
 #[tokio::test]

--- a/magicblock-metrics/src/metrics/types.rs
+++ b/magicblock-metrics/src/metrics/types.rs
@@ -254,6 +254,8 @@ impl AccountFetchContext {
     }
 
     pub fn should_count_remote_account_claims(&self) -> bool {
+        // We only count fetches due to direct user requests, not due to internal
+        // fetches, i.e. to get a companion account
         if self.reason != AccountFetchReason::RequestedAccount {
             return false;
         }

--- a/magicblock-metrics/src/metrics/types.rs
+++ b/magicblock-metrics/src/metrics/types.rs
@@ -1,4 +1,10 @@
-use std::fmt;
+use std::{
+    fmt,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+};
 
 use solana_signature::Signature;
 
@@ -168,10 +174,11 @@ impl LabelValue for AccountFetchReason {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct AccountFetchContext {
     entrypoint: AccountFetchEntrypoint,
     reason: AccountFetchReason,
+    remote_account_claims: Arc<AtomicU64>,
 }
 
 impl AccountFetchContext {
@@ -179,7 +186,23 @@ impl AccountFetchContext {
         entrypoint: AccountFetchEntrypoint,
         reason: AccountFetchReason,
     ) -> Self {
-        Self { entrypoint, reason }
+        Self::new_with_claims_counter(
+            entrypoint,
+            reason,
+            Arc::new(AtomicU64::new(0)),
+        )
+    }
+
+    pub fn new_with_claims_counter(
+        entrypoint: AccountFetchEntrypoint,
+        reason: AccountFetchReason,
+        remote_account_claims: Arc<AtomicU64>,
+    ) -> Self {
+        Self {
+            entrypoint,
+            reason,
+            remote_account_claims,
+        }
     }
 
     pub fn rpc_get_account() -> Self {
@@ -228,6 +251,15 @@ impl AccountFetchContext {
 
     pub fn with_reason(self, reason: AccountFetchReason) -> Self {
         Self { reason, ..self }
+    }
+
+    pub fn add_remote_account_claims(&self, count: usize) {
+        self.remote_account_claims
+            .fetch_add(count as u64, Ordering::Relaxed);
+    }
+
+    pub fn remote_account_claims_value(&self) -> u64 {
+        self.remote_account_claims.load(Ordering::Relaxed)
     }
 
     pub fn signature(&self) -> Option<&Signature> {
@@ -601,7 +633,7 @@ impl LabelValue for ChainlinkEmptyPlaceholderStage {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub enum SubscriptionRegistrationOrigin {
     Fetch(AccountFetchContext),
     Internal,

--- a/magicblock-metrics/src/metrics/types.rs
+++ b/magicblock-metrics/src/metrics/types.rs
@@ -253,6 +253,18 @@ impl AccountFetchContext {
         Self { reason, ..self }
     }
 
+    pub fn should_count_remote_account_claims(&self) -> bool {
+        if self.reason != AccountFetchReason::RequestedAccount {
+            return false;
+        }
+        matches!(
+            self.entrypoint,
+            AccountFetchEntrypoint::RpcGetAccount
+                | AccountFetchEntrypoint::RpcGetMultipleAccounts
+                | AccountFetchEntrypoint::SendTransaction(_)
+        )
+    }
+
     pub fn add_remote_account_claims(&self, count: usize) {
         self.remote_account_claims
             .fetch_add(count as u64, Ordering::Relaxed);


### PR DESCRIPTION
## Summary

Add `X-MB-Remote-Account-Claims` to JSON-RPC responses, reporting the number of unique remote
accounts claimed while serving a request.

## Details

- Propagate request-scoped claim accounting through account-read, transaction, and simulation
paths.
- Count only direct user-requested remote claims owned by the current fetch; exclude bank hits,
duplicates, waiters, companion fetches, and internal/background fetches.
- Emit the header on successful, error, and batch JSON-RPC responses. Requests with no remote
claims report `0`.
- Add Aperture response-header coverage and Chainlink ownership/counting tests, including
positive coverage in `test_remote_account_claims_count_owned_unique_requested_pubkeys`.
- Made `AccountFetchContext` cloneable rather than `Copy`: it owns an `Arc<AtomicU64>`, and the remaining clones are required for async ownership and shared request accounting.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `X-MB-Remote-Account-Claims` response header to account-related RPC requests, including batch responses.
  * The header reports the number of remote account claims made while processing each request.

* **Bug Fixes**
  * Improved account-fetch tracking across account reads, transaction submission, and transaction simulation.
  * Ensured claim counts are reported consistently for successful and error responses.

* **Tests**
  * Added coverage for account, balance, token, delegation, transaction, simulation, and batch RPC responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->