### PR TITLE
fix(metrics): attribute simulation fetches

### DIFF
--- a/magicblock-aperture/src/requests/http/mod.rs
+++ b/magicblock-aperture/src/requests/http/mod.rs
@@ -182,6 +182,17 @@ impl HttpDispatcher {
         )
     }
 
+    fn simulate_transaction_context(
+        signature: Signature,
+        remote_account_claims: Arc<AtomicU64>,
+    ) -> AccountFetchContext {
+        AccountFetchContext::new_with_claims_counter(
+            AccountFetchEntrypoint::SimulateTransaction(signature),
+            AccountFetchReason::RequestedAccount,
+            remote_account_claims,
+        )
+    }
+
     /// Fetches an account's data from the `AccountsDb` filling it in from chain
     /// as needed.
     #[instrument(skip_all)]

--- a/magicblock-aperture/src/requests/http/simulate_transaction.rs
+++ b/magicblock-aperture/src/requests/http/simulate_transaction.rs
@@ -52,7 +52,7 @@ impl HttpDispatcher {
             .inspect_err(|err| {
                 debug!(error = ?err, "Failed to prepare transaction to simulate")
             })?;
-        let fetch_context = Self::send_transaction_context(
+        let fetch_context = Self::simulate_transaction_context(
             *transaction.txn.signature(),
             remote_account_claims.clone(),
         );

--- a/magicblock-metrics/src/metrics/mod.rs
+++ b/magicblock-metrics/src/metrics/mod.rs
@@ -1611,6 +1611,9 @@ mod fetch_context_metric_tests {
         );
         let undelegating_context = AccountFetchContext::rpc_get_account()
             .with_reason(AccountFetchReason::UndelegatingRefresh);
+        let simulation_context = AccountFetchContext::simulate_transaction(
+            solana_signature::Signature::from([1u8; 64]),
+        );
 
         let action_labels = &[
             "rpc_get_account",
@@ -1724,6 +1727,30 @@ mod fetch_context_metric_tests {
                 undelegating_labels
             ),
             before_undelegating + 1
+        );
+
+        let simulation_labels = &[
+            "simulate_transaction",
+            "requested_account",
+            "fetch_cloner",
+            "owned",
+        ];
+        let before_simulation = counter_value(
+            &CHAINLINK_PENDING_FETCH_ACCOUNTS_TOTAL,
+            simulation_labels,
+        );
+        inc_chainlink_pending_fetch_accounts_with_context(
+            simulation_context,
+            ChainlinkPendingFetchLayer::FetchCloner,
+            ChainlinkPendingFetchOutcome::Owned,
+            1,
+        );
+        assert_eq!(
+            counter_value(
+                &CHAINLINK_PENDING_FETCH_ACCOUNTS_TOTAL,
+                simulation_labels,
+            ),
+            before_simulation + 1
         );
     }
 }

--- a/magicblock-metrics/src/metrics/types.rs
+++ b/magicblock-metrics/src/metrics/types.rs
@@ -88,6 +88,7 @@ pub enum AccountFetchEntrypoint {
     RpcGetAccount,
     RpcGetMultipleAccounts,
     SendTransaction(Signature),
+    SimulateTransaction(Signature),
     SubscriptionUpdate,
     ProjectAta,
     Internal,
@@ -99,6 +100,7 @@ impl AccountFetchEntrypoint {
             Self::RpcGetAccount => "rpc_get_account",
             Self::RpcGetMultipleAccounts => "rpc_get_multiple_accounts",
             Self::SendTransaction(_) => "send_transaction",
+            Self::SimulateTransaction(_) => "simulate_transaction",
             Self::SubscriptionUpdate => "subscription_update",
             Self::ProjectAta => "project_ata",
             Self::Internal => "internal",
@@ -107,7 +109,9 @@ impl AccountFetchEntrypoint {
 
     pub fn signature(&self) -> Option<&Signature> {
         match self {
-            Self::SendTransaction(sig) => Some(sig),
+            Self::SendTransaction(sig) | Self::SimulateTransaction(sig) => {
+                Some(sig)
+            }
             _ => None,
         }
     }
@@ -226,6 +230,13 @@ impl AccountFetchContext {
         )
     }
 
+    pub fn simulate_transaction(signature: Signature) -> Self {
+        Self::new(
+            AccountFetchEntrypoint::SimulateTransaction(signature),
+            AccountFetchReason::RequestedAccount,
+        )
+    }
+
     pub fn subscription_update(reason: AccountFetchReason) -> Self {
         Self::new(AccountFetchEntrypoint::SubscriptionUpdate, reason)
     }
@@ -264,6 +275,7 @@ impl AccountFetchContext {
             AccountFetchEntrypoint::RpcGetAccount
                 | AccountFetchEntrypoint::RpcGetMultipleAccounts
                 | AccountFetchEntrypoint::SendTransaction(_)
+                | AccountFetchEntrypoint::SimulateTransaction(_)
         )
     }
 
@@ -889,6 +901,10 @@ mod tests {
                 "send_transaction",
             ),
             (
+                AccountFetchEntrypoint::SimulateTransaction(signature),
+                "simulate_transaction",
+            ),
+            (
                 AccountFetchEntrypoint::SubscriptionUpdate,
                 "subscription_update",
             ),
@@ -942,11 +958,15 @@ mod tests {
     }
 
     #[test]
-    fn account_fetch_context_signature_is_only_for_send_transaction() {
+    fn account_fetch_context_signature_is_for_transaction_entrypoints() {
         let signature = Signature::from([1u8; 64]);
         let send_context = AccountFetchContext::send_transaction(signature);
-        assert_eq!(send_context.signature(), Some(&signature));
-        assert_eq!(send_context.entrypoint().signature(), Some(&signature));
+        let simulate_context =
+            AccountFetchContext::simulate_transaction(signature);
+        for context in [&send_context, &simulate_context] {
+            assert_eq!(context.signature(), Some(&signature));
+            assert_eq!(context.entrypoint().signature(), Some(&signature));
+        }
 
         let contexts = [
             AccountFetchContext::rpc_get_account(),
@@ -962,5 +982,16 @@ mod tests {
             assert_eq!(context.signature(), None);
             assert_eq!(context.entrypoint().signature(), None);
         }
+    }
+
+    #[test]
+    fn simulation_requested_accounts_count_remote_account_claims() {
+        let context = AccountFetchContext::simulate_transaction(
+            Signature::from([1u8; 64]),
+        );
+        assert!(context.should_count_remote_account_claims());
+        assert!(!context
+            .with_reason(AccountFetchReason::ProgramData)
+            .should_count_remote_account_claims());
     }
 }


### PR DESCRIPTION
## Summary

Attribute account fetches needed to simulate a transaction to a dedicated `simulate_transaction` metrics entrypoint rather than `send_transaction`.

## Details

Simulation account ensuring now preserves its own request origin through the existing account-fetch context. This separates simulation-driven fetch, clone, pending-work, and companion-fetch observability from submitted transactions without changing transaction preparation, account ordering, primary-mode checks, replay handling, or simulation responses.

The new entrypoint is a static, bounded Prometheus label value. Transaction signatures remain tracing-only and are not labels.

Example PromQL for simulation-owned fetch activity over five minutes:

```promql
sum by (layer, outcome) (
  increase(chainlink_pending_fetch_accounts_total{
    entrypoint="simulate_transaction",
    fetch_reason="requested_account"
  }[5m])
)
```

The change adds metrics-level coverage and Aperture simulation tests to verify the new attribution while retaining existing send-transaction behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `simulateTransaction` account and ledger fetching by using the correct request context.
  * Simulation requests now report accurate fetch metrics and remote-account claim counts.
  * Added clearer tracking of simulated transaction activity in monitoring data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->