### PR TITLE
refactor(cloner): make post-delegation clone mode exclusive

### DIFF
--- a/magicblock-account-cloner/src/lib.rs
+++ b/magicblock-account-cloner/src/lib.rs
@@ -248,18 +248,15 @@ impl ChainlinkCloner {
         blockhash: Hash,
     ) -> Transaction {
         let fields = Self::clone_fields(request);
-        let clone_actions = match &request.post_delegation_mode {
-            ClonePostDelegationMode::ExecuteActions(actions) => {
-                actions.to_vec()
-            }
-            ClonePostDelegationMode::None
-            | ClonePostDelegationMode::RescueUndelegate => Vec::new(),
-        };
         let clone_ix = Self::clone_ix(
             request.pubkey,
             request.account.data().to_vec(),
             fields,
-            clone_actions,
+            request
+                .post_delegation_mode
+                .execute_actions()
+                .map(|actions| actions.to_vec())
+                .unwrap_or_default(),
         );
 
         // TODO(#625): Re-enable frequency commits when proper limits are in place:

--- a/magicblock-account-cloner/src/lib.rs
+++ b/magicblock-account-cloner/src/lib.rs
@@ -254,7 +254,7 @@ impl ChainlinkCloner {
             fields,
             request
                 .post_delegation_mode
-                .execute_actions()
+                .actions()
                 .map(|actions| actions.to_vec())
                 .unwrap_or_default(),
         );

--- a/magicblock-account-cloner/src/lib.rs
+++ b/magicblock-account-cloner/src/lib.rs
@@ -30,7 +30,7 @@ use async_trait::async_trait;
 use magicblock_chainlink::{
     cloner::{
         errors::{ClonerError, ClonerResult},
-        AccountCloneRequest, Cloner,
+        AccountCloneRequest, ClonePostDelegationMode, Cloner,
     },
     remote_account_provider::program_account::{
         LoadedProgram, RemoteProgramLoader,
@@ -248,12 +248,12 @@ impl ChainlinkCloner {
         blockhash: Hash,
     ) -> Transaction {
         let fields = Self::clone_fields(request);
-        let actions: Vec<Instruction> =
-            request.delegation_actions.clone().into();
-        let clone_actions = if request.needs_undelegation {
-            Vec::new()
-        } else {
-            actions.clone()
+        let clone_actions = match &request.post_delegation_mode {
+            ClonePostDelegationMode::ExecuteActions(actions) => {
+                actions.to_vec()
+            }
+            ClonePostDelegationMode::None
+            | ClonePostDelegationMode::RescueUndelegate => Vec::new(),
         };
         let clone_ix = Self::clone_ix(
             request.pubkey,
@@ -270,10 +270,20 @@ impl ChainlinkCloner {
         // To re-enable, uncomment the following and use `ixs` instead of `[clone_ix]`:
         // let ixs = self.maybe_add_crank_commits_ix(request, clone_ix);
         let mut ixs = vec![clone_ix];
-        if request.needs_undelegation {
-            ixs.push(Self::schedule_undelegation_ix(request.pubkey));
-        } else if !actions.is_empty() {
-            ixs.push(Self::post_delegation_action_ix(request.pubkey, actions));
+        match &request.post_delegation_mode {
+            ClonePostDelegationMode::ExecuteActions(actions)
+                if !actions.is_empty() =>
+            {
+                ixs.push(Self::post_delegation_action_ix(
+                    request.pubkey,
+                    actions.to_vec(),
+                ));
+            }
+            ClonePostDelegationMode::RescueUndelegate => {
+                ixs.push(Self::schedule_undelegation_ix(request.pubkey));
+            }
+            ClonePostDelegationMode::None
+            | ClonePostDelegationMode::ExecuteActions(_) => {}
         }
 
         self.create_signed_tx(&ixs, blockhash)
@@ -329,17 +339,28 @@ impl ChainlinkCloner {
         );
         txs.push(self.create_signed_tx(&[init_ix], blockhash));
 
-        let actions: Vec<Instruction> =
-            request.delegation_actions.clone().into();
-        let clone_actions = if request.needs_undelegation {
-            Vec::new()
-        } else {
-            actions.clone()
+        let post_delegation = match &request.post_delegation_mode {
+            ClonePostDelegationMode::ExecuteActions(actions)
+                if !actions.is_empty() =>
+            {
+                let actions = actions.to_vec();
+                Some((
+                    actions.clone(),
+                    false,
+                    Self::post_delegation_action_ix(request.pubkey, actions),
+                ))
+            }
+            ClonePostDelegationMode::RescueUndelegate => Some((
+                Vec::new(),
+                true,
+                Self::schedule_undelegation_ix(request.pubkey),
+            )),
+            ClonePostDelegationMode::None
+            | ClonePostDelegationMode::ExecuteActions(_) => None,
         };
 
         // Continue txs for remaining chunks
-        let has_post_delegation_action =
-            !clone_actions.is_empty() || request.needs_undelegation;
+        let has_post_delegation_action = post_delegation.is_some();
         let mut offset = MAX_INLINE_DATA_SIZE;
         while offset < data.len() {
             let end = (offset + MAX_INLINE_DATA_SIZE).min(data.len());
@@ -359,20 +380,15 @@ impl ChainlinkCloner {
             offset = end;
         }
 
-        if request.needs_undelegation || !actions.is_empty() {
+        if let Some((clone_actions, needs_undelegation, ix)) = post_delegation {
             let continue_ix = Self::clone_continue_ix(
                 request.pubkey,
                 data.len() as u32,
                 Vec::new(),
                 true,
                 clone_actions,
-                request.needs_undelegation,
+                needs_undelegation,
             );
-            let ix = if request.needs_undelegation {
-                Self::schedule_undelegation_ix(request.pubkey)
-            } else {
-                Self::post_delegation_action_ix(request.pubkey, actions)
-            };
             txs.push(self.create_signed_tx(&[continue_ix, ix], blockhash));
         }
 
@@ -637,7 +653,7 @@ impl Cloner for ChainlinkCloner {
             let tx = self.build_small_account_tx(&request, blockhash);
             let tx_size = Self::transaction_size(&tx)?;
             if tx_size > MAX_INLINE_TRANSACTION_SIZE
-                && !request.delegation_actions.is_empty()
+                && request.post_delegation_mode.has_actions()
             {
                 debug!(
                     pubkey = %request.pubkey,
@@ -732,7 +748,9 @@ impl Cloner for ChainlinkCloner {
 
 #[cfg(test)]
 mod tests {
-    use magicblock_chainlink::cloner::DelegationActions;
+    use magicblock_chainlink::cloner::{
+        ClonePostDelegationMode, DelegationActions,
+    };
     use magicblock_core::link::link;
     use magicblock_magic_program_api::{
         instruction::{
@@ -767,9 +785,10 @@ mod tests {
             pubkey,
             account,
             commit_frequency_ms: None,
-            delegation_actions: DelegationActions::from(actions),
+            post_delegation_mode: ClonePostDelegationMode::from(
+                DelegationActions::from(actions),
+            ),
             delegated_to_other: None,
-            needs_undelegation: false,
         }
     }
 
@@ -878,7 +897,8 @@ mod tests {
     fn small_undelegation_clone_schedules_in_same_tx_without_actions() {
         let pubkey = Pubkey::new_unique();
         let mut request = request(pubkey, vec![1, 2, 3], vec![action()]);
-        request.needs_undelegation = true;
+        request.post_delegation_mode =
+            ClonePostDelegationMode::RescueUndelegate;
         let tx = cloner().build_small_account_tx(&request, Hash::default());
 
         assert_eq!(tx.message().instructions.len(), 2);
@@ -914,7 +934,8 @@ mod tests {
         let pubkey = Pubkey::new_unique();
         let mut request =
             request(pubkey, vec![7; MAX_INLINE_DATA_SIZE + 1], vec![action()]);
-        request.needs_undelegation = true;
+        request.post_delegation_mode =
+            ClonePostDelegationMode::RescueUndelegate;
         let txs = cloner().build_large_account_txs(&request, Hash::default());
 
         assert_eq!(txs.len(), 3);
@@ -989,7 +1010,8 @@ mod tests {
         let pubkey = Pubkey::new_unique();
         let mut request =
             request(pubkey, vec![7; MAX_INLINE_DATA_SIZE * 2], vec![]);
-        request.needs_undelegation = true;
+        request.post_delegation_mode =
+            ClonePostDelegationMode::RescueUndelegate;
         let txs = cloner().build_large_account_txs(&request, Hash::default());
 
         ChainlinkCloner::ensure_transactions_fit(pubkey, &txs).unwrap();
@@ -1000,7 +1022,8 @@ mod tests {
         let pubkey = Pubkey::new_unique();
         let data = vec![1, 2, 3];
         let mut request = request(pubkey, data.clone(), vec![action()]);
-        request.needs_undelegation = true;
+        request.post_delegation_mode =
+            ClonePostDelegationMode::RescueUndelegate;
         let txs = cloner().build_large_account_txs(&request, Hash::default());
 
         assert_eq!(txs.len(), 2);

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/ata_projection.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/ata_projection.rs
@@ -20,7 +20,9 @@ use super::{
     CompanionFetchLogContext, FetchCloner,
 };
 use crate::{
-    cloner::{AccountCloneRequest, Cloner, DelegationActions},
+    cloner::{
+        AccountCloneRequest, ClonePostDelegationMode, Cloner, DelegationActions,
+    },
     remote_account_provider::{
         pubsub_common::SubscriptionSource, ChainPubsubClient, ChainRpcClient,
         MatchSlotsConfig, RemoteAccount, ResolvedAccountSharedData,
@@ -251,9 +253,10 @@ where
         pubkey: ata_pubkey,
         account: projected_ata,
         commit_frequency_ms: None,
-        delegation_actions: delegation_actions.clone(),
+        post_delegation_mode: ClonePostDelegationMode::from(
+            delegation_actions.clone(),
+        ),
         delegated_to_other: None,
-        needs_undelegation: false,
     })
 }
 
@@ -683,9 +686,10 @@ where
             pubkey: input.ata_pubkey,
             account: account_to_clone,
             commit_frequency_ms,
-            delegation_actions: actions.unwrap_or_default(),
+            post_delegation_mode: ClonePostDelegationMode::from(
+                actions.unwrap_or_default(),
+            ),
             delegated_to_other,
-            needs_undelegation: false,
         });
     }
 

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -1426,8 +1426,7 @@ where
             return Ok(Signature::default());
         }
 
-        let Some(delegation_actions) =
-            request.post_delegation_mode.execute_actions()
+        let Some(delegation_actions) = request.post_delegation_mode.actions()
         else {
             return Ok(self
                 .clone_account_with_ownership(request, fetch_context)

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -89,7 +89,8 @@ use crate::{
     },
     cloner::{
         errors::{ClonerError, ClonerResult},
-        AccountCloneRequest, Cloner, DelegationActions,
+        AccountCloneRequest, ClonePostDelegationMode, Cloner,
+        DelegationActions,
     },
     remote_account_provider::{
         program_account::{
@@ -982,9 +983,9 @@ where
         request: &AccountCloneRequest,
     ) -> bool {
         let active_delegation_satisfies_request =
-            request.delegation_actions.is_empty()
+            !request.post_delegation_mode.has_actions()
                 && request.delegated_to_other.is_none()
-                && !request.needs_undelegation;
+                && !request.post_delegation_mode.is_rescue_undelegate();
         self.accounts_bank
             .get_account(&request.pubkey)
             .is_some_and(|account| {
@@ -1022,7 +1023,7 @@ where
             ChainlinkCloneIntent::EmptyPlaceholder
         } else if request.account.delegated() {
             ChainlinkCloneIntent::DelegationRecord
-        } else if !request.delegation_actions.is_empty() {
+        } else if request.post_delegation_mode.has_actions() {
             ChainlinkCloneIntent::ActionDependency
         } else {
             ChainlinkCloneIntent::NormalAccount
@@ -1176,9 +1177,11 @@ where
                         ));
                     };
                     let active_delegation_satisfies_request =
-                        owned_request.delegation_actions.is_empty()
+                        !owned_request.post_delegation_mode.has_actions()
                             && owned_request.delegated_to_other.is_none()
-                            && !owned_request.needs_undelegation;
+                            && !owned_request
+                                .post_delegation_mode
+                                .is_rescue_undelegate();
                     let is_empty_placeholder =
                         Self::is_empty_placeholder_account(
                             &owned_request.account,
@@ -1423,11 +1426,13 @@ where
             return Ok(Signature::default());
         }
 
-        if request.delegation_actions.is_empty() {
+        let Some(delegation_actions) =
+            request.post_delegation_mode.execute_actions()
+        else {
             return Ok(self
                 .clone_account_with_ownership(request, fetch_context)
                 .await?);
-        }
+        };
 
         if !request.account.delegated() {
             return Err(ChainlinkError::InvalidDelegationActions(
@@ -1441,7 +1446,7 @@ where
             self.ensure_delegation_action_dependencies(
                 request.pubkey,
                 request.account.remote_slot(),
-                &request.delegation_actions,
+                delegation_actions,
                 fetch_context.clone(),
             )
             .await?;
@@ -1503,7 +1508,8 @@ where
         fetch_context: AccountFetchContext,
     ) -> ClonerResult<Signature> {
         let pubkey = request.pubkey;
-        request.needs_undelegation = true;
+        request.post_delegation_mode =
+            ClonePostDelegationMode::RescueUndelegate;
         let remote_result = Self::clone_remote_result_for_request(&request);
         let clone_intent = Self::clone_intent_for_request(&request);
         let mut request = Some(request);
@@ -1668,7 +1674,7 @@ where
             return Ok(());
         }
 
-        if !request.delegation_actions.is_empty() {
+        if request.post_delegation_mode.has_actions() {
             return Err(ChainlinkError::InvalidDelegationActions(
                 request.pubkey,
                 "post-delegation actions attached to unresolved DLP-owned clone target"
@@ -2098,9 +2104,10 @@ where
                         pubkey,
                         account,
                         commit_frequency_ms,
-                        delegation_actions: raw_delegation_actions,
+                        post_delegation_mode: ClonePostDelegationMode::from(
+                            raw_delegation_actions,
+                        ),
                         delegated_to_other,
-                        needs_undelegation: false,
                     },
                     subscription_clone_context.clone(),
                 )
@@ -4225,9 +4232,8 @@ where
                 pubkey,
                 account,
                 commit_frequency_ms: None,
-                delegation_actions: DelegationActions::default(),
+                post_delegation_mode: ClonePostDelegationMode::None,
                 delegated_to_other: None,
-                needs_undelegation: false,
             })
             .await?;
         Ok(())

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/pipeline.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/pipeline.rs
@@ -43,7 +43,7 @@ pub(crate) fn collect_delegation_action_dependencies(
 ) -> HashSet<Pubkey> {
     let mut dependencies = HashSet::new();
     for request in accounts_to_clone {
-        if let Some(actions) = request.post_delegation_mode.execute_actions() {
+        if let Some(actions) = request.post_delegation_mode.actions() {
             for instruction in actions.iter() {
                 dependencies.insert(instruction.program_id);
                 for account_meta in &instruction.accounts {

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/pipeline.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/pipeline.rs
@@ -24,7 +24,8 @@ use super::{
 use crate::{
     chainlink::errors::{ChainlinkError, ChainlinkResult},
     cloner::{
-        errors::ClonerResult, AccountCloneRequest, Cloner, DelegationActions,
+        errors::ClonerResult, AccountCloneRequest, ClonePostDelegationMode,
+        Cloner, DelegationActions,
     },
     remote_account_provider::{
         program_account::{
@@ -42,10 +43,12 @@ pub(crate) fn collect_delegation_action_dependencies(
 ) -> HashSet<Pubkey> {
     let mut dependencies = HashSet::new();
     for request in accounts_to_clone {
-        for instruction in request.delegation_actions.iter() {
-            dependencies.insert(instruction.program_id);
-            for account_meta in &instruction.accounts {
-                dependencies.insert(account_meta.pubkey);
+        if let Some(actions) = request.post_delegation_mode.execute_actions() {
+            for instruction in actions.iter() {
+                dependencies.insert(instruction.program_id);
+                for account_meta in &instruction.accounts {
+                    dependencies.insert(account_meta.pubkey);
+                }
             }
         }
     }
@@ -136,9 +139,8 @@ fn classify_single_account(
                             pubkey,
                             account: account_shared_data,
                             commit_frequency_ms: None,
-                            delegation_actions: DelegationActions::default(),
+                            post_delegation_mode: ClonePostDelegationMode::None,
                             delegated_to_other: None,
-                            needs_undelegation: false,
                         });
                     }
                 }
@@ -381,9 +383,10 @@ where
                 pubkey,
                 account: account.into_account_shared_data(),
                 commit_frequency_ms,
-                delegation_actions,
+                post_delegation_mode: ClonePostDelegationMode::from(
+                    delegation_actions,
+                ),
                 delegated_to_other,
-                needs_undelegation: false,
             });
             if cleanup_delegated_subscription {
                 if cleanup_undelegation_tracking {
@@ -738,7 +741,7 @@ where
     let (accounts_with_actions, accounts_without_actions): (Vec<_>, Vec<_>) =
         accounts_to_clone
             .into_iter()
-            .partition(|request| !request.delegation_actions.is_empty());
+            .partition(|request| request.post_delegation_mode.has_actions());
 
     let mut accounts_join_set = JoinSet::new();
     for request in accounts_without_actions {

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -5697,7 +5697,7 @@ async fn test_raw_eata_greedy_projection_carries_post_delegation_actions() {
         .expect("projected ATA should be cloned");
     assert!(projected_ata_request.account.delegated());
     assert!(
-        !projected_ata_request.delegation_actions.is_empty(),
+        projected_ata_request.post_delegation_mode.has_actions(),
         "post-delegation actions must stay attached to the projected ATA"
     );
 }
@@ -6194,7 +6194,7 @@ async fn test_explicit_clone_executes_post_delegation_actions_after_prefilter_ch
         .iter()
         .find(|request| request.pubkey == account_pubkey)
         .expect("delegated account clone request should be recorded");
-    assert!(!delegated_clone_request.delegation_actions.is_empty());
+    assert!(delegated_clone_request.post_delegation_mode.has_actions());
     let cloned_account = accounts_bank
         .get_account(&account_pubkey)
         .expect("delegated account should be cloned explicitly");

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -372,9 +372,8 @@ fn account_clone_request(account: AccountSharedData) -> AccountCloneRequest {
         pubkey: random_pubkey(),
         account,
         commit_frequency_ms: None,
-        delegation_actions: DelegationActions::default(),
+        post_delegation_mode: ClonePostDelegationMode::None,
         delegated_to_other: None,
-        needs_undelegation: false,
     }
 }
 
@@ -437,12 +436,10 @@ fn clone_classification_treats_delegated_account_as_delegation_record() {
 #[test]
 fn clone_classification_treats_action_dependency_as_action_dependency() {
     let mut request = account_clone_request(non_empty_account());
-    request.delegation_actions =
-        DelegationActions::from(vec![Instruction::new_with_bytes(
-            system_program::id(),
-            &[1],
-            vec![],
-        )]);
+    request.post_delegation_mode =
+        ClonePostDelegationMode::from(DelegationActions::from(vec![
+            Instruction::new_with_bytes(system_program::id(), &[1], vec![]),
+        ]));
 
     assert!(!request.account.delegated());
     assert_eq!(
@@ -7537,7 +7534,7 @@ async fn test_subscription_update_with_delegation_actions_clones_dependencies()
         .expect("delegated account should be cloned");
     assert!(action_request.account.delegated());
     assert!(
-        !action_request.delegation_actions.is_empty(),
+        action_request.post_delegation_mode.has_actions(),
         "post-delegation actions must stay attached to the delegated target"
     );
 }
@@ -7887,7 +7884,7 @@ async fn test_delegated_eata_subscription_update_projects_remote_ata() {
         .expect("projected ATA should be cloned");
     assert!(projected_ata_request.account.delegated());
     assert!(
-        !projected_ata_request.delegation_actions.is_empty(),
+        projected_ata_request.post_delegation_mode.has_actions(),
         "post-delegation actions must stay attached to the projected ATA"
     );
 }
@@ -8107,7 +8104,7 @@ async fn test_delegated_eata_subscription_update_clones_action_dependencies() {
         .expect("raw eATA should be cloned");
     assert!(!raw_eata_request.account.delegated());
     assert!(
-        raw_eata_request.delegation_actions.is_empty(),
+        !raw_eata_request.post_delegation_mode.has_actions(),
         "raw eATA must never carry post-delegation actions"
     );
 
@@ -8117,7 +8114,7 @@ async fn test_delegated_eata_subscription_update_clones_action_dependencies() {
         .expect("projected ATA should be cloned");
     assert!(projected_ata_request.account.delegated());
     assert!(
-        !projected_ata_request.delegation_actions.is_empty(),
+        projected_ata_request.post_delegation_mode.has_actions(),
         "projected delegated ATA must be the action-bearing clone target"
     );
 
@@ -8138,7 +8135,7 @@ async fn test_delegated_eata_subscription_update_clones_action_dependencies() {
     let action_request_count = cloner
         .clone_requests()
         .iter()
-        .filter(|request| !request.delegation_actions.is_empty())
+        .filter(|request| request.post_delegation_mode.has_actions())
         .count();
     assert_eq!(
         action_request_count, 1,
@@ -8186,9 +8183,8 @@ async fn test_post_delegation_actions_reject_non_delegated_clone_target() {
                 pubkey: account_pubkey,
                 account,
                 commit_frequency_ms: None,
-                delegation_actions: actions,
+                post_delegation_mode: ClonePostDelegationMode::from(actions),
                 delegated_to_other: None,
-                needs_undelegation: false,
             },
             AccountFetchContext::rpc_get_account(),
         )
@@ -8239,9 +8235,8 @@ async fn test_dlp_owned_clone_without_actions_clears_stale_delegated_flag() {
                 pubkey: account_pubkey,
                 account,
                 commit_frequency_ms: None,
-                delegation_actions: DelegationActions::default(),
+                post_delegation_mode: ClonePostDelegationMode::None,
                 delegated_to_other: None,
-                needs_undelegation: false,
             },
             AccountFetchContext::rpc_get_account(),
         )
@@ -8292,9 +8287,8 @@ async fn test_dlp_owned_magic_fee_vault_without_actions_remains_delegated() {
                 pubkey: account_pubkey,
                 account,
                 commit_frequency_ms: None,
-                delegation_actions: DelegationActions::default(),
+                post_delegation_mode: ClonePostDelegationMode::None,
                 delegated_to_other: None,
-                needs_undelegation: false,
             },
             AccountFetchContext::rpc_get_account(),
         )
@@ -8341,9 +8335,8 @@ async fn test_delegated_native_token_clone_uses_data_only_amount() {
                 pubkey: ata_pubkey,
                 account,
                 commit_frequency_ms: None,
-                delegation_actions: DelegationActions::default(),
+                post_delegation_mode: ClonePostDelegationMode::None,
                 delegated_to_other: None,
-                needs_undelegation: false,
             },
             AccountFetchContext::rpc_get_account(),
         )
@@ -8404,9 +8397,8 @@ async fn test_delegated_malformed_ata_clone_is_rejected() {
                 pubkey: ata_pubkey,
                 account,
                 commit_frequency_ms: None,
-                delegation_actions: DelegationActions::default(),
+                post_delegation_mode: ClonePostDelegationMode::None,
                 delegated_to_other: None,
-                needs_undelegation: false,
             },
             AccountFetchContext::rpc_get_account(),
         )
@@ -8461,9 +8453,8 @@ async fn test_delegated_non_ata_native_token_clone_preserves_wrapped_sol_layout(
                 pubkey: account_pubkey,
                 account,
                 commit_frequency_ms: None,
-                delegation_actions: DelegationActions::default(),
+                post_delegation_mode: ClonePostDelegationMode::None,
                 delegated_to_other: None,
-                needs_undelegation: false,
             },
             AccountFetchContext::rpc_get_account(),
         )
@@ -8513,9 +8504,8 @@ async fn test_plain_native_token_clone_preserves_wrapped_sol_layout() {
                 pubkey: ata_pubkey,
                 account,
                 commit_frequency_ms: None,
-                delegation_actions: DelegationActions::default(),
+                post_delegation_mode: ClonePostDelegationMode::None,
                 delegated_to_other: None,
-                needs_undelegation: false,
             },
             AccountFetchContext::rpc_get_account(),
         )
@@ -8606,9 +8596,8 @@ async fn test_post_delegation_actions_refresh_writable_dependency_before_target(
                 pubkey: target_pubkey,
                 account: target_account,
                 commit_frequency_ms: None,
-                delegation_actions: actions,
+                post_delegation_mode: ClonePostDelegationMode::from(actions),
                 delegated_to_other: None,
-                needs_undelegation: false,
             },
             AccountFetchContext::rpc_get_account(),
         )
@@ -8637,7 +8626,9 @@ async fn test_post_delegation_actions_refresh_writable_dependency_before_target(
         "writable dependency must be cloned before the action target"
     );
     assert!(
-        !clone_requests[target_idx].delegation_actions.is_empty(),
+        clone_requests[target_idx]
+            .post_delegation_mode
+            .has_actions(),
         "actions must stay attached to the delegated target"
     );
 }
@@ -8726,9 +8717,8 @@ async fn test_undelegating_action_dependency_stays_locked_and_target_is_rescued(
                 pubkey: target_pubkey,
                 account: target_account,
                 commit_frequency_ms: None,
-                delegation_actions: actions,
+                post_delegation_mode: ClonePostDelegationMode::from(actions),
                 delegated_to_other: None,
-                needs_undelegation: false,
             },
             AccountFetchContext::rpc_get_account(),
         )
@@ -8757,8 +8747,14 @@ async fn test_undelegating_action_dependency_stays_locked_and_target_is_rescued(
     assert!(clone_requests
         .iter()
         .all(|request| request.pubkey == target_pubkey));
-    assert!(!clone_requests[0].needs_undelegation);
-    assert!(clone_requests[1].needs_undelegation);
+    assert!(matches!(
+        clone_requests[0].post_delegation_mode,
+        ClonePostDelegationMode::ExecuteActions(_)
+    ));
+    assert!(matches!(
+        clone_requests[1].post_delegation_mode,
+        ClonePostDelegationMode::RescueUndelegate
+    ));
 }
 
 #[tokio::test]
@@ -8802,9 +8798,10 @@ async fn test_post_delegation_actions_execute_once_across_remote_slots() {
                     pubkey: target_pubkey,
                     account: target_account,
                     commit_frequency_ms: None,
-                    delegation_actions: actions.clone(),
+                    post_delegation_mode: ClonePostDelegationMode::from(
+                        actions.clone(),
+                    ),
                     delegated_to_other: None,
-                    needs_undelegation: false,
                 },
                 AccountFetchContext::rpc_get_account(),
             )
@@ -8823,7 +8820,7 @@ async fn test_post_delegation_actions_execute_once_across_remote_slots() {
         "newer remote-slot updates must not reclone an already delegated action target"
     );
     assert!(
-        !target_requests[0].delegation_actions.is_empty(),
+        target_requests[0].post_delegation_mode.has_actions(),
         "the first clone remains the only action-bearing clone"
     );
 }
@@ -8870,9 +8867,8 @@ async fn test_post_delegation_action_clone_failure_schedules_undelegation_rescue
                 pubkey: target_pubkey,
                 account: target_account,
                 commit_frequency_ms: None,
-                delegation_actions: actions,
+                post_delegation_mode: ClonePostDelegationMode::from(actions),
                 delegated_to_other: None,
-                needs_undelegation: false,
             },
             AccountFetchContext::rpc_get_account(),
         )
@@ -8932,9 +8928,8 @@ async fn test_delegated_clone_does_not_override_active_local_target() {
                 pubkey: target_pubkey,
                 account: newer_remote_target,
                 commit_frequency_ms: None,
-                delegation_actions: DelegationActions::default(),
+                post_delegation_mode: ClonePostDelegationMode::None,
                 delegated_to_other: None,
-                needs_undelegation: false,
             },
             AccountFetchContext::rpc_get_account(),
         )
@@ -9139,7 +9134,7 @@ async fn test_projected_ata_clone_request_from_eata_update_keeps_actions() {
 
     assert_eq!(projected_ata_request.pubkey, ata_pubkey);
     assert!(
-        !projected_ata_request.delegation_actions.is_empty(),
+        projected_ata_request.post_delegation_mode.has_actions(),
         "projected ATA clone request must preserve post-delegation actions",
     );
 }

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -437,9 +437,12 @@ fn clone_classification_treats_delegated_account_as_delegation_record() {
 fn clone_classification_treats_action_dependency_as_action_dependency() {
     let mut request = account_clone_request(non_empty_account());
     request.post_delegation_mode =
-        ClonePostDelegationMode::from(DelegationActions::from(vec![
-            Instruction::new_with_bytes(system_program::id(), &[1], vec![]),
-        ]));
+        DelegationActions::from(vec![Instruction::new_with_bytes(
+            system_program::id(),
+            &[1],
+            vec![],
+        )])
+        .into();
 
     assert!(!request.account.delegated());
     assert_eq!(

--- a/magicblock-chainlink/src/cloner/mod.rs
+++ b/magicblock-chainlink/src/cloner/mod.rs
@@ -49,19 +49,59 @@ impl Deref for DelegationActions {
     }
 }
 
+/// Mutually exclusive post-delegation behavior for a clone request.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub enum ClonePostDelegationMode {
+    /// Clone without post-delegation actions or rescue undelegation.
+    #[default]
+    None,
+    /// Clone and execute post-delegation actions after activation.
+    ExecuteActions(DelegationActions),
+    /// Clone and schedule undelegation instead of executing actions.
+    ///
+    /// Used for delegated accounts whose post-delegation actions cannot be
+    /// executed safely, for example because they include risky signers.
+    RescueUndelegate,
+}
+
+impl ClonePostDelegationMode {
+    pub fn execute_actions(&self) -> Option<&DelegationActions> {
+        match self {
+            Self::ExecuteActions(actions) => Some(actions),
+            Self::None | Self::RescueUndelegate => None,
+        }
+    }
+
+    pub fn has_actions(&self) -> bool {
+        self.execute_actions()
+            .is_some_and(|actions| !actions.is_empty())
+    }
+
+    pub fn is_rescue_undelegate(&self) -> bool {
+        matches!(self, Self::RescueUndelegate)
+    }
+}
+
+impl From<DelegationActions> for ClonePostDelegationMode {
+    fn from(actions: DelegationActions) -> Self {
+        if actions.is_empty() {
+            Self::None
+        } else {
+            Self::ExecuteActions(actions)
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct AccountCloneRequest {
     pub pubkey: Pubkey,
     pub account: AccountSharedData,
     pub commit_frequency_ms: Option<u64>,
-    pub delegation_actions: DelegationActions,
+    pub post_delegation_mode: ClonePostDelegationMode,
     /// If the account is delegated to another validator,
     /// this contains that validator's pubkey. None if account is not
     /// delegated to another validator.
     pub delegated_to_other: Option<Pubkey>,
-    /// Account that need to be undelegated (e.g. due to AML risk) after cloning.
-    /// Is only true if there are actions with risky signers.
-    pub needs_undelegation: bool,
 }
 
 #[async_trait]

--- a/magicblock-chainlink/src/cloner/mod.rs
+++ b/magicblock-chainlink/src/cloner/mod.rs
@@ -65,7 +65,7 @@ pub enum ClonePostDelegationMode {
 }
 
 impl ClonePostDelegationMode {
-    pub fn execute_actions(&self) -> Option<&DelegationActions> {
+    pub fn actions(&self) -> Option<&DelegationActions> {
         match self {
             Self::ExecuteActions(actions) => Some(actions),
             Self::None | Self::RescueUndelegate => None,
@@ -73,8 +73,7 @@ impl ClonePostDelegationMode {
     }
 
     pub fn has_actions(&self) -> bool {
-        self.execute_actions()
-            .is_some_and(|actions| !actions.is_empty())
+        self.actions().is_some_and(|actions| !actions.is_empty())
     }
 
     pub fn is_rescue_undelegate(&self) -> bool {

--- a/magicblock-chainlink/src/testing/cloner_stub.rs
+++ b/magicblock-chainlink/src/testing/cloner_stub.rs
@@ -199,7 +199,7 @@ impl Cloner for ClonerStub {
         self.account_clone_count.fetch_add(1, Ordering::SeqCst);
         self.account_clone_notify.notify_waiters();
 
-        if request.needs_undelegation {
+        if request.post_delegation_mode.is_rescue_undelegate() {
             self.undelegation_requests
                 .lock()
                 .unwrap()

--- a/test-integration/test-chainlink/src/ixtest_context.rs
+++ b/test-integration/test-chainlink/src/ixtest_context.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use integration_test_tools::dlp_interface;
 use magicblock_chainlink::{
     accounts_bank::mock::AccountsBankStub,
-    cloner::{AccountCloneRequest, Cloner, DelegationActions},
+    cloner::{AccountCloneRequest, ClonePostDelegationMode, Cloner},
     config::ChainlinkConfig,
     fetch_cloner::FetchCloner,
     native_program_accounts,
@@ -101,9 +101,8 @@ impl IxtestContext {
                         pubkey,
                         account: program_stub.clone(),
                         commit_frequency_ms: None,
-                        delegation_actions: DelegationActions::default(),
+                        post_delegation_mode: ClonePostDelegationMode::None,
                         delegated_to_other: None,
-                        needs_undelegation: false,
                     })
                     .await
                     .unwrap();

--- a/test-integration/test-chainlink/tests/ix_aml_undelegation.rs
+++ b/test-integration/test-chainlink/tests/ix_aml_undelegation.rs
@@ -15,7 +15,9 @@ use dlp_api::{
     state::DelegationRecord,
 };
 use magicblock_aml::RiskService;
-use magicblock_chainlink::testing::init_logger;
+use magicblock_chainlink::{
+    cloner::ClonePostDelegationMode, testing::init_logger,
+};
 use magicblock_config::config::RiskConfig;
 use solana_account::Account;
 use solana_pubkey::Pubkey;
@@ -205,7 +207,10 @@ async fn post_delegation_aml_rejection_schedules_undelegation_with_high_risk_sig
 
     let req = ctx.cloner.clone_requests().first().cloned().unwrap();
     assert!(
-        req.needs_undelegation,
+        matches!(
+            req.post_delegation_mode,
+            ClonePostDelegationMode::RescueUndelegate
+        ),
         "AML-rejected action must schedule undelegation"
     );
 
@@ -222,7 +227,10 @@ async fn post_delegation_aml_accepts_low_risk_signer() {
 
     let req = ctx.cloner.clone_requests().first().cloned().unwrap();
     assert!(
-        !req.needs_undelegation,
+        matches!(
+            req.post_delegation_mode,
+            ClonePostDelegationMode::ExecuteActions(_)
+        ),
         "AML-accepted action must not schedule undelegation"
     );
 


### PR DESCRIPTION
This PR replaces product-state with sum-type (enum) to make the exclusivity semantic obvious. See `enum ClonePostDelegationMode` that replaces the two-fields with one field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added unified post-delegation handling for account cloning.
  * Clone requests now support executing delegation actions, scheduling undelegation recovery, or taking no post-delegation action.

* **Bug Fixes**
  * Improved clone transaction behavior and fallback handling for small and large account clones.
  * Improved delegation dependency resolution and post-delegation validation.

* **Tests**
  * Updated coverage for cloning, delegation ordering, deduplication, ATA/eATA projections, and undelegation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->