### PR TITLE
fix: avoid unnecessary program clones

### DIFF
--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -146,10 +146,9 @@ where
 
     /// Per-program state from the last successful load, so the per-slot
     /// notifications providers emit for heavily-invoked program accounts
-    /// resolve without re-pulling full program data. Bounded by the number
-    /// of programs loaded into the bank.
-    program_verify_cache:
-        Arc<PlMutex<hash_map::HashMap<Pubkey, ProgramVerifyState>>>,
+    /// resolve without re-pulling full program data. Entries for programs
+    /// evicted from the bank are pruned on their next notification.
+    program_verify_cache: Arc<PlMutex<LruCache<Pubkey, ProgramVerifyState>>>,
 
     /// Recognizes freshly delegated accounts whose app data collides with an
     /// internal DLP discriminator via delegation-record sightings.
@@ -194,6 +193,14 @@ const KNOWN_EMPTY_EATAS_CAPACITY: NonZeroUsize =
         Some(n) => n,
         None => panic!("KNOWN_EMPTY_EATAS_CAPACITY must be non-zero"),
     };
+
+/// Capacity of the program verify cache; far above the number of programs
+/// a validator realistically loads, while bounding it across eviction churn.
+const PROGRAM_VERIFY_CACHE_CAPACITY: NonZeroUsize = match NonZeroUsize::new(64)
+{
+    Some(n) => n,
+    None => panic!("PROGRAM_VERIFY_CACHE_CAPACITY must be non-zero"),
+};
 
 /// Capacity for recently sighted delegation-record update slots; sized to
 /// outlast DLP firehose churn across the SubMux debounce window.
@@ -468,9 +475,9 @@ where
             known_empty_eatas: Arc::new(PlMutex::new(LruCache::new(
                 KNOWN_EMPTY_EATAS_CAPACITY,
             ))),
-            program_verify_cache: Arc::new(PlMutex::new(
-                hash_map::HashMap::new(),
-            )),
+            program_verify_cache: Arc::new(PlMutex::new(LruCache::new(
+                PROGRAM_VERIFY_CACHE_CAPACITY,
+            ))),
             dlp_collision_tracker: Arc::new(PlMutex::new(
                 DlpCollisionTracker::new(),
             )),

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -144,6 +144,13 @@ where
     /// Negative cache for derived eATAs confirmed missing on chain.
     known_empty_eatas: Arc<PlMutex<LruCache<Pubkey, ()>>>,
 
+    /// Per-program state from the last successful load, so the per-slot
+    /// notifications providers emit for heavily-invoked program accounts
+    /// resolve without re-pulling full program data. Bounded by the number
+    /// of programs loaded into the bank.
+    program_verify_cache:
+        Arc<PlMutex<hash_map::HashMap<Pubkey, ProgramVerifyState>>>,
+
     /// Recognizes freshly delegated accounts whose app data collides with an
     /// internal DLP discriminator via delegation-record sightings.
     dlp_collision_tracker: Arc<PlMutex<DlpCollisionTracker>>,
@@ -341,6 +348,7 @@ where
             allowed_programs: self.allowed_programs.clone(),
             programs_not_to_subscribe: self.programs_not_to_subscribe.clone(),
             known_empty_eatas: self.known_empty_eatas.clone(),
+            program_verify_cache: self.program_verify_cache.clone(),
             dlp_collision_tracker: self.dlp_collision_tracker.clone(),
             pending_clones: self.pending_clones.clone(),
             pending_undelegations: self.pending_undelegations.clone(),
@@ -353,6 +361,20 @@ where
                 .clone(),
         }
     }
+}
+
+/// State from the last successful program load driving the cheap
+/// executable-update resolution in [program_loader].
+#[derive(Debug, Clone)]
+pub(crate) struct ProgramVerifyState {
+    /// Raw programdata metadata prefix (tag + deploy slot + authority)
+    /// from the last load; `None` for loaders without programdata.
+    pub(crate) programdata_header: Option<Vec<u8>>,
+    /// When the program was last loaded or verified against remote state.
+    pub(crate) verified_at: std::time::Instant,
+    /// A verification is scheduled for when the throttle window expires,
+    /// covering notifications suppressed within the window.
+    pub(crate) deferred_verify: bool,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -446,6 +468,9 @@ where
             known_empty_eatas: Arc::new(PlMutex::new(LruCache::new(
                 KNOWN_EMPTY_EATAS_CAPACITY,
             ))),
+            program_verify_cache: Arc::new(PlMutex::new(
+                hash_map::HashMap::new(),
+            )),
             dlp_collision_tracker: Arc::new(PlMutex::new(
                 DlpCollisionTracker::new(),
             )),

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/program_loader.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/program_loader.rs
@@ -113,7 +113,8 @@ where
     };
     if this.accounts_bank.get_account(&pubkey).is_none() {
         // The bank copy was evicted since the load that populated the
-        // cache; reload instead of trusting the stale entry.
+        // cache; drop the stale entry and reload.
+        this.program_verify_cache.lock().pop(&pubkey);
         return false;
     }
 
@@ -127,6 +128,8 @@ where
     }
     let elapsed = state.verified_at.elapsed();
     if elapsed < PROGRAM_VERIFY_THROTTLE {
+        // Suppressed, but never lost: a single verification covering the
+        // window's notifications runs at window expiry.
         schedule_deferred_verify(
             this,
             pubkey,
@@ -331,7 +334,7 @@ pub(crate) async fn handle_executable_sub_update_with_context<T, U, V, C>(
         // Only successful loads are remembered: a failure leaves the next
         // notification free to retry immediately, as before.
         Ok(_) => {
-            this.program_verify_cache.lock().insert(
+            this.program_verify_cache.lock().put(
                 pubkey,
                 ProgramVerifyState {
                     programdata_header: account_owner

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/program_loader.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/program_loader.rs
@@ -1,25 +1,179 @@
+use std::time::{Duration, Instant};
+
 use magicblock_accounts_db::traits::AccountsBank;
 use magicblock_metrics::metrics::{
     AccountFetchContext, AccountFetchReason, ChainlinkCompanionFetchKind,
 };
 use solana_account::{AccountSharedData, ReadableAccount};
+use solana_loader_v3_interface::state::UpgradeableLoaderState;
 use solana_pubkey::Pubkey;
 use tracing::*;
 
 use super::{
     log_companion_fetch_failure, subscription::release_program_data_subs,
-    CompanionFetchLogContext, FetchCloner,
+    CompanionFetchLogContext, FetchCloner, ProgramVerifyState,
 };
 use crate::{
     cloner::Cloner,
     remote_account_provider::{
         program_account::{
             get_loaderv3_get_program_data_address, ProgramAccountResolver,
-            LOADER_V1, LOADER_V3,
+            LOADER_V1, LOADER_V2, LOADER_V3,
         },
         ChainPubsubClient, ChainRpcClient, SubscriptionReason,
     },
 };
+
+/// Minimum spacing between remote verifications of an already-loaded
+/// LoaderV3 program. Providers emit a notification for heavily-invoked
+/// program accounts on every mainnet slot without anything changing;
+/// this bounds upgrade-detection latency for such programs to roughly
+/// the window.
+#[cfg(not(test))]
+const PROGRAM_VERIFY_THROTTLE: Duration = Duration::from_secs(60 * 60);
+#[cfg(test)]
+const PROGRAM_VERIFY_THROTTLE: Duration = Duration::from_millis(50);
+
+/// Length of the programdata metadata prefix (tag + deploy slot +
+/// authority) the header check compares.
+fn programdata_header_len() -> usize {
+    UpgradeableLoaderState::size_of_programdata_metadata()
+}
+
+/// Schedules a single verification at throttle-window expiry so
+/// notifications suppressed within the window are never lost — without
+/// this, an upgrade of a rarely-invoked program could go undetected
+/// indefinitely because no later notification would re-trigger a check.
+fn schedule_deferred_verify<T, U, V, C>(
+    this: &FetchCloner<T, U, V, C>,
+    pubkey: Pubkey,
+    account: &AccountSharedData,
+    companion_fetch_log_context: &CompanionFetchLogContext,
+    elapsed: Duration,
+) where
+    T: ChainRpcClient,
+    U: ChainPubsubClient,
+    V: AccountsBank,
+    C: Cloner,
+{
+    {
+        let mut cache = this.program_verify_cache.lock();
+        match cache.get_mut(&pubkey) {
+            Some(state) if !state.deferred_verify => {
+                state.deferred_verify = true;
+            }
+            // Already scheduled or state gone: nothing to do.
+            _ => return,
+        }
+    }
+    let this = this.clone();
+    let account = account.clone();
+    let ctx = *companion_fetch_log_context;
+    let delay = PROGRAM_VERIFY_THROTTLE.saturating_sub(elapsed)
+        + Duration::from_millis(10);
+    tokio::task::spawn(async move {
+        tokio::time::sleep(delay).await;
+        if let Some(state) = this.program_verify_cache.lock().get_mut(&pubkey) {
+            state.deferred_verify = false;
+        }
+        // Box-erased to break the async type cycle with the handler.
+        let fut: std::pin::Pin<
+            Box<dyn std::future::Future<Output = ()> + Send>,
+        > = Box::pin(handle_executable_sub_update_with_context(
+            &this, pubkey, account, &ctx,
+        ));
+        fut.await;
+    });
+}
+
+/// Resolves a subscription update for a program this validator already
+/// loaded without re-pulling the full program data. Returns `true` when
+/// the update needs no further handling: immutable programs carry no
+/// information, and LoaderV3 programs are verified against a ~45-byte
+/// programdata header fetch (throttled, with a deferred check covering
+/// suppressed notifications). Any doubt returns `false` so the caller
+/// runs the unchanged full-reload path.
+async fn resolve_update_for_loaded_program<T, U, V, C>(
+    this: &FetchCloner<T, U, V, C>,
+    pubkey: Pubkey,
+    account: &AccountSharedData,
+    program_data_pubkey: Pubkey,
+    companion_fetch_log_context: &CompanionFetchLogContext,
+) -> bool
+where
+    T: ChainRpcClient,
+    U: ChainPubsubClient,
+    V: AccountsBank,
+    C: Cloner,
+{
+    let Some(state) = this.program_verify_cache.lock().get(&pubkey).cloned()
+    else {
+        // Not loaded by this process yet: full load.
+        return false;
+    };
+
+    if account.owner().eq(&LOADER_V2) {
+        // LoaderV2 programs are immutable once deployed.
+        trace!(pubkey = %pubkey, "Ignoring update for immutable LoaderV2 program");
+        return true;
+    }
+    if !account.owner().eq(&LOADER_V3) {
+        return false;
+    }
+    let elapsed = state.verified_at.elapsed();
+    if elapsed < PROGRAM_VERIFY_THROTTLE {
+        schedule_deferred_verify(
+            this,
+            pubkey,
+            account,
+            companion_fetch_log_context,
+            elapsed,
+        );
+        return true;
+    }
+    let Some(loaded_header) = state.programdata_header else {
+        return false;
+    };
+
+    match this
+        .remote_account_provider
+        .get_account_data_slice(
+            &program_data_pubkey,
+            0,
+            programdata_header_len(),
+            account.remote_slot(),
+        )
+        .await
+    {
+        // Comparing the raw metadata prefix catches deploy-slot changes
+        // (upgrades) and authority changes alike. Responses are truncated
+        // to the prefix in case a provider ignores `dataSlice`.
+        Ok(Some(header))
+            if header.get(..programdata_header_len()).unwrap_or(&header)
+                == loaded_header =>
+        {
+            trace!(pubkey = %pubkey, "Programdata header unchanged; skipping program reload");
+            if let Some(state) =
+                this.program_verify_cache.lock().get_mut(&pubkey)
+            {
+                state.verified_at = Instant::now();
+            }
+            true
+        }
+        // Header changed, or programdata closed: reload so the bank
+        // reflects remote state.
+        Ok(_) => false,
+        Err(err) => {
+            warn!(
+                pubkey = %pubkey,
+                program_data = %program_data_pubkey,
+                error = %err,
+                "Programdata header check failed; falling back to full program reload"
+            );
+            false
+        }
+    }
+}
 
 pub(crate) async fn handle_executable_sub_update_with_context<T, U, V, C>(
     this: &FetchCloner<T, U, V, C>,
@@ -47,6 +201,20 @@ pub(crate) async fn handle_executable_sub_update_with_context<T, U, V, C>(
 
     // For LoaderV3 programs we need to fetch the program data account
     let program_data_pubkey = get_loaderv3_get_program_data_address(&pubkey);
+    let account_owner = *account.owner();
+
+    if resolve_update_for_loaded_program(
+        this,
+        pubkey,
+        &account,
+        program_data_pubkey,
+        companion_fetch_log_context,
+    )
+    .await
+    {
+        return;
+    }
+
     let acquired_program_data_reason = if account.owner().eq(&LOADER_V3) {
         this.acquire_subscription_reason(
             &program_data_pubkey,
@@ -126,6 +294,11 @@ pub(crate) async fn handle_executable_sub_update_with_context<T, U, V, C>(
             (account, None::<AccountSharedData>)
         };
 
+    let fetched_programdata_header = program_data_account
+        .as_ref()
+        .and_then(|pd| pd.data().get(..programdata_header_len()))
+        .map(|header| header.to_vec());
+
     let loaded_program = match ProgramAccountResolver::try_new(
         pubkey,
         *program_account.owner(),
@@ -146,11 +319,28 @@ pub(crate) async fn handle_executable_sub_update_with_context<T, U, V, C>(
             return;
         }
     };
-    if let Err(err) = this
+    match this
         .clone_program_with_ownership(loaded_program, program_load_context)
         .await
     {
-        warn!(pubkey = %pubkey, error = %err, "Failed to clone program into bank");
+        // Only successful loads are remembered: a failure leaves the next
+        // notification free to retry immediately, as before.
+        Ok(_) => {
+            this.program_verify_cache.lock().insert(
+                pubkey,
+                ProgramVerifyState {
+                    programdata_header: account_owner
+                        .eq(&LOADER_V3)
+                        .then_some(fetched_programdata_header)
+                        .flatten(),
+                    verified_at: Instant::now(),
+                    deferred_verify: false,
+                },
+            );
+        }
+        Err(err) => {
+            warn!(pubkey = %pubkey, error = %err, "Failed to clone program into bank");
+        }
     }
 
     if acquired_program_data_reason {

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/program_loader.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/program_loader.rs
@@ -28,11 +28,11 @@ use crate::{
 /// LoaderV3 program. Providers emit a notification for heavily-invoked
 /// program accounts on every mainnet slot without anything changing;
 /// this bounds upgrade-detection latency for such programs to roughly
-/// the window.
+/// the window, at a cost of one ~45-byte header fetch per window.
 #[cfg(not(test))]
-const PROGRAM_VERIFY_THROTTLE: Duration = Duration::from_secs(60 * 60);
+const PROGRAM_VERIFY_THROTTLE: Duration = Duration::from_secs(60);
 #[cfg(test)]
-const PROGRAM_VERIFY_THROTTLE: Duration = Duration::from_millis(50);
+const PROGRAM_VERIFY_THROTTLE: Duration = Duration::from_millis(300);
 
 /// Length of the programdata metadata prefix (tag + deploy slot +
 /// authority) the header check compares.
@@ -111,6 +111,11 @@ where
         // Not loaded by this process yet: full load.
         return false;
     };
+    if this.accounts_bank.get_account(&pubkey).is_none() {
+        // The bank copy was evicted since the load that populated the
+        // cache; reload instead of trusting the stale entry.
+        return false;
+    }
 
     if account.owner().eq(&LOADER_V2) {
         // LoaderV2 programs are immutable once deployed.

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -3629,6 +3629,375 @@ async fn test_program_loader_resolver_error_releases_program_data_refs() {
     );
 }
 
+fn loaderv3_program_accounts(
+    program_data_pubkey: &Pubkey,
+    deploy_slot: u64,
+    elf: &[u8],
+) -> (Account, Account) {
+    use solana_loader_v3_interface::state::UpgradeableLoaderState;
+
+    use crate::remote_account_provider::program_account::LOADER_V3;
+
+    let program_account = Account {
+        lamports: 1_000_000,
+        data: bincode::serialize(&UpgradeableLoaderState::Program {
+            programdata_address: *program_data_pubkey,
+        })
+        .unwrap(),
+        owner: LOADER_V3,
+        executable: true,
+        rent_epoch: 0,
+    };
+    let mut program_data =
+        bincode::serialize(&UpgradeableLoaderState::ProgramData {
+            slot: deploy_slot,
+            upgrade_authority_address: Some(random_pubkey()),
+        })
+        .unwrap();
+    program_data.extend_from_slice(elf);
+    let program_data_account = Account {
+        lamports: 1_000_000,
+        data: program_data,
+        owner: LOADER_V3,
+        executable: false,
+        rent_epoch: 0,
+    };
+    (program_account, program_data_account)
+}
+
+/// Per-slot notifications for an unchanged LoaderV3 program must resolve via
+/// a programdata header fetch (or the throttle) instead of re-pulling the
+/// full program data.
+#[tokio::test]
+async fn test_executable_update_noise_resolves_without_program_reload() {
+    use crate::remote_account_provider::program_account::get_loaderv3_get_program_data_address;
+
+    init_logger();
+    let validator_keypair = Keypair::new();
+    let program_pubkey = random_pubkey();
+    let program_data_pubkey =
+        get_loaderv3_get_program_data_address(&program_pubkey);
+    const DEPLOY_SLOT: u64 = 90;
+    const CURRENT_SLOT: u64 = 100;
+
+    let (program_account, program_data_account) =
+        loaderv3_program_accounts(&program_data_pubkey, DEPLOY_SLOT, &[7; 64]);
+
+    let FetcherTestCtx {
+        fetch_cloner,
+        rpc_client,
+        cloner,
+        ..
+    } = setup(
+        [
+            (program_pubkey, program_account.clone()),
+            (program_data_pubkey, program_data_account),
+        ],
+        CURRENT_SLOT,
+        validator_keypair.insecure_clone(),
+    )
+    .await;
+
+    let mut update = AccountSharedData::from(program_account);
+    update.set_remote_slot(CURRENT_SLOT);
+
+    // First sighting performs the full load and seeds the verify cache.
+    handle_executable_sub_update(&fetch_cloner, program_pubkey, update.clone())
+        .await;
+    assert_eq!(cloner.program_clone_count(), 1);
+    let multi_after_load = rpc_client.multi_account_fetches();
+    let single_after_load = rpc_client.single_account_fetches();
+
+    // Past the throttle, a per-slot notification resolves with a single
+    // header fetch and no program reload.
+    tokio::time::sleep(Duration::from_millis(70)).await;
+    rpc_client.set_current_slot(CURRENT_SLOT + 1);
+    rpc_client.account_override_slot(&program_pubkey, CURRENT_SLOT + 1);
+    rpc_client.account_override_slot(&program_data_pubkey, CURRENT_SLOT + 1);
+    update.set_remote_slot(CURRENT_SLOT + 1);
+    handle_executable_sub_update(&fetch_cloner, program_pubkey, update.clone())
+        .await;
+    assert_eq!(
+        rpc_client.multi_account_fetches(),
+        multi_after_load,
+        "unchanged program must not be refetched in full"
+    );
+    assert_eq!(
+        rpc_client.single_account_fetches(),
+        single_after_load + 1,
+        "verification must be a single header fetch"
+    );
+    assert_eq!(cloner.program_clone_count(), 1);
+
+    // A notification arriving within the throttle window costs nothing.
+    update.set_remote_slot(CURRENT_SLOT + 2);
+    handle_executable_sub_update(&fetch_cloner, program_pubkey, update).await;
+    assert_eq!(rpc_client.multi_account_fetches(), multi_after_load);
+    assert_eq!(rpc_client.single_account_fetches(), single_after_load + 1);
+    assert_eq!(cloner.program_clone_count(), 1);
+}
+
+/// A real upgrade (programdata deploy slot advanced) must still be detected
+/// by the header check and trigger a full reload.
+#[tokio::test]
+async fn test_executable_update_detects_program_upgrade() {
+    use crate::remote_account_provider::program_account::get_loaderv3_get_program_data_address;
+
+    init_logger();
+    let validator_keypair = Keypair::new();
+    let program_pubkey = random_pubkey();
+    let program_data_pubkey =
+        get_loaderv3_get_program_data_address(&program_pubkey);
+    const DEPLOY_SLOT: u64 = 90;
+    const CURRENT_SLOT: u64 = 100;
+    const UPGRADE_SLOT: u64 = 150;
+
+    let (program_account, program_data_account) =
+        loaderv3_program_accounts(&program_data_pubkey, DEPLOY_SLOT, &[7; 64]);
+
+    let FetcherTestCtx {
+        fetch_cloner,
+        rpc_client,
+        cloner,
+        ..
+    } = setup(
+        [
+            (program_pubkey, program_account.clone()),
+            (program_data_pubkey, program_data_account),
+        ],
+        CURRENT_SLOT,
+        validator_keypair.insecure_clone(),
+    )
+    .await;
+
+    let mut update = AccountSharedData::from(program_account.clone());
+    update.set_remote_slot(CURRENT_SLOT);
+    handle_executable_sub_update(&fetch_cloner, program_pubkey, update.clone())
+        .await;
+    assert_eq!(cloner.program_clone_count(), 1);
+
+    // Upgrade on chain: new deploy slot and new program data.
+    let upgraded_elf = [9u8; 64];
+    let (_, upgraded_program_data) = loaderv3_program_accounts(
+        &program_data_pubkey,
+        UPGRADE_SLOT,
+        &upgraded_elf,
+    );
+    rpc_client.set_current_slot(UPGRADE_SLOT);
+    rpc_client.account_override_slot(&program_pubkey, UPGRADE_SLOT);
+    rpc_client.add_account(program_data_pubkey, upgraded_program_data);
+
+    tokio::time::sleep(Duration::from_millis(70)).await;
+    update.set_remote_slot(UPGRADE_SLOT);
+    handle_executable_sub_update(&fetch_cloner, program_pubkey, update.clone())
+        .await;
+    assert_eq!(
+        cloner.program_clone_count(),
+        2,
+        "deploy slot change must trigger a full reload"
+    );
+    let reloaded = cloner
+        .get_cloned_program(&program_pubkey)
+        .expect("program must be cloned");
+    assert_eq!(
+        reloaded.program_data, upgraded_elf,
+        "reload must pick up the upgraded program data"
+    );
+
+    // Subsequent noise verifies against the new deploy slot without reload.
+    tokio::time::sleep(Duration::from_millis(70)).await;
+    rpc_client.set_current_slot(UPGRADE_SLOT + 1);
+    rpc_client.account_override_slot(&program_pubkey, UPGRADE_SLOT + 1);
+    rpc_client.account_override_slot(&program_data_pubkey, UPGRADE_SLOT + 1);
+    update.set_remote_slot(UPGRADE_SLOT + 1);
+    let multi_before = rpc_client.multi_account_fetches();
+    handle_executable_sub_update(&fetch_cloner, program_pubkey, update).await;
+    assert_eq!(rpc_client.multi_account_fetches(), multi_before);
+    assert_eq!(cloner.program_clone_count(), 2);
+}
+
+/// Updates for an already-loaded immutable LoaderV2 program carry no
+/// information and must not fetch or clone anything.
+#[tokio::test]
+async fn test_executable_update_immutable_loaderv2_skipped() {
+    use crate::remote_account_provider::program_account::LOADER_V2;
+
+    init_logger();
+    let validator_keypair = Keypair::new();
+    let program_pubkey = random_pubkey();
+    const CURRENT_SLOT: u64 = 100;
+
+    let program_account = Account {
+        lamports: 1_000_000,
+        data: vec![7; 64],
+        owner: LOADER_V2,
+        executable: true,
+        rent_epoch: 0,
+    };
+
+    let FetcherTestCtx {
+        fetch_cloner,
+        rpc_client,
+        cloner,
+        ..
+    } = setup(
+        [(program_pubkey, program_account.clone())],
+        CURRENT_SLOT,
+        validator_keypair.insecure_clone(),
+    )
+    .await;
+
+    let mut update = AccountSharedData::from(program_account);
+    update.set_remote_slot(CURRENT_SLOT);
+
+    // First sighting loads the program (from the update payload, no fetch).
+    handle_executable_sub_update(&fetch_cloner, program_pubkey, update.clone())
+        .await;
+    assert_eq!(cloner.program_clone_count(), 1);
+    let multi_after_load = rpc_client.multi_account_fetches();
+    let single_after_load = rpc_client.single_account_fetches();
+
+    // Any further update for the immutable program is a no-op.
+    update.set_remote_slot(CURRENT_SLOT + 1);
+    handle_executable_sub_update(&fetch_cloner, program_pubkey, update).await;
+    assert_eq!(rpc_client.multi_account_fetches(), multi_after_load);
+    assert_eq!(rpc_client.single_account_fetches(), single_after_load);
+    assert_eq!(cloner.program_clone_count(), 1);
+}
+
+/// An upgrade whose notification arrives inside the throttle window must
+/// still be picked up by the deferred verification at window expiry —
+/// a rarely-invoked program emits no later notification to re-trigger it.
+#[tokio::test]
+async fn test_executable_update_suppressed_upgrade_verified_deferred() {
+    use crate::remote_account_provider::program_account::get_loaderv3_get_program_data_address;
+
+    init_logger();
+    let validator_keypair = Keypair::new();
+    let program_pubkey = random_pubkey();
+    let program_data_pubkey =
+        get_loaderv3_get_program_data_address(&program_pubkey);
+    const DEPLOY_SLOT: u64 = 90;
+    const CURRENT_SLOT: u64 = 100;
+    const UPGRADE_SLOT: u64 = 150;
+
+    let (program_account, program_data_account) =
+        loaderv3_program_accounts(&program_data_pubkey, DEPLOY_SLOT, &[7; 64]);
+
+    let FetcherTestCtx {
+        fetch_cloner,
+        rpc_client,
+        cloner,
+        ..
+    } = setup(
+        [
+            (program_pubkey, program_account.clone()),
+            (program_data_pubkey, program_data_account),
+        ],
+        CURRENT_SLOT,
+        validator_keypair.insecure_clone(),
+    )
+    .await;
+
+    let mut update = AccountSharedData::from(program_account.clone());
+    update.set_remote_slot(CURRENT_SLOT);
+    handle_executable_sub_update(&fetch_cloner, program_pubkey, update.clone())
+        .await;
+    assert_eq!(cloner.program_clone_count(), 1);
+
+    // Upgrade lands on chain and its notification arrives while still
+    // inside the throttle window: suppressed, but a deferred verification
+    // is scheduled.
+    let upgraded_elf = [9u8; 64];
+    let (_, upgraded_program_data) = loaderv3_program_accounts(
+        &program_data_pubkey,
+        UPGRADE_SLOT,
+        &upgraded_elf,
+    );
+    rpc_client.set_current_slot(UPGRADE_SLOT);
+    rpc_client.account_override_slot(&program_pubkey, UPGRADE_SLOT);
+    rpc_client.add_account(program_data_pubkey, upgraded_program_data);
+    update.set_remote_slot(UPGRADE_SLOT);
+    handle_executable_sub_update(&fetch_cloner, program_pubkey, update).await;
+    assert_eq!(
+        cloner.program_clone_count(),
+        1,
+        "notification within the window must be suppressed"
+    );
+
+    // The deferred verification fires at window expiry and reloads.
+    let deadline = std::time::Instant::now() + Duration::from_secs(2);
+    while cloner.program_clone_count() < 2
+        && std::time::Instant::now() < deadline
+    {
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert_eq!(
+        cloner.program_clone_count(),
+        2,
+        "deferred verification must detect the suppressed upgrade"
+    );
+    let reloaded = cloner
+        .get_cloned_program(&program_pubkey)
+        .expect("program must be cloned");
+    assert_eq!(reloaded.program_data, upgraded_elf);
+}
+
+/// An authority-only change (deploy slot and program data unchanged) must
+/// be detected by the header fingerprint and trigger a reload.
+#[tokio::test]
+async fn test_executable_update_detects_authority_change() {
+    use crate::remote_account_provider::program_account::get_loaderv3_get_program_data_address;
+
+    init_logger();
+    let validator_keypair = Keypair::new();
+    let program_pubkey = random_pubkey();
+    let program_data_pubkey =
+        get_loaderv3_get_program_data_address(&program_pubkey);
+    const DEPLOY_SLOT: u64 = 90;
+    const CURRENT_SLOT: u64 = 100;
+
+    let (program_account, program_data_account) =
+        loaderv3_program_accounts(&program_data_pubkey, DEPLOY_SLOT, &[7; 64]);
+
+    let FetcherTestCtx {
+        fetch_cloner,
+        rpc_client,
+        cloner,
+        ..
+    } = setup(
+        [
+            (program_pubkey, program_account.clone()),
+            (program_data_pubkey, program_data_account),
+        ],
+        CURRENT_SLOT,
+        validator_keypair.insecure_clone(),
+    )
+    .await;
+
+    let mut update = AccountSharedData::from(program_account.clone());
+    update.set_remote_slot(CURRENT_SLOT);
+    handle_executable_sub_update(&fetch_cloner, program_pubkey, update.clone())
+        .await;
+    assert_eq!(cloner.program_clone_count(), 1);
+
+    // SetAuthority: same deploy slot, same program data, new authority
+    // (the helper randomizes the authority on every call).
+    let (_, program_data_new_authority) =
+        loaderv3_program_accounts(&program_data_pubkey, DEPLOY_SLOT, &[7; 64]);
+    tokio::time::sleep(Duration::from_millis(70)).await;
+    rpc_client.set_current_slot(CURRENT_SLOT + 1);
+    rpc_client.account_override_slot(&program_pubkey, CURRENT_SLOT + 1);
+    rpc_client.add_account(program_data_pubkey, program_data_new_authority);
+    update.set_remote_slot(CURRENT_SLOT + 1);
+    handle_executable_sub_update(&fetch_cloner, program_pubkey, update).await;
+    assert_eq!(
+        cloner.program_clone_count(),
+        2,
+        "authority change must trigger a reload"
+    );
+}
+
 // -----------------
 // Allowed Programs Tests
 // -----------------

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -3710,7 +3710,7 @@ async fn test_executable_update_noise_resolves_without_program_reload() {
 
     // Past the throttle, a per-slot notification resolves with a single
     // header fetch and no program reload.
-    tokio::time::sleep(Duration::from_millis(70)).await;
+    tokio::time::sleep(Duration::from_millis(350)).await;
     rpc_client.set_current_slot(CURRENT_SLOT + 1);
     rpc_client.account_override_slot(&program_pubkey, CURRENT_SLOT + 1);
     rpc_client.account_override_slot(&program_data_pubkey, CURRENT_SLOT + 1);
@@ -3787,7 +3787,7 @@ async fn test_executable_update_detects_program_upgrade() {
     rpc_client.account_override_slot(&program_pubkey, UPGRADE_SLOT);
     rpc_client.add_account(program_data_pubkey, upgraded_program_data);
 
-    tokio::time::sleep(Duration::from_millis(70)).await;
+    tokio::time::sleep(Duration::from_millis(350)).await;
     update.set_remote_slot(UPGRADE_SLOT);
     handle_executable_sub_update(&fetch_cloner, program_pubkey, update.clone())
         .await;
@@ -3805,7 +3805,7 @@ async fn test_executable_update_detects_program_upgrade() {
     );
 
     // Subsequent noise verifies against the new deploy slot without reload.
-    tokio::time::sleep(Duration::from_millis(70)).await;
+    tokio::time::sleep(Duration::from_millis(350)).await;
     rpc_client.set_current_slot(UPGRADE_SLOT + 1);
     rpc_client.account_override_slot(&program_pubkey, UPGRADE_SLOT + 1);
     rpc_client.account_override_slot(&program_data_pubkey, UPGRADE_SLOT + 1);
@@ -3985,7 +3985,7 @@ async fn test_executable_update_detects_authority_change() {
     // (the helper randomizes the authority on every call).
     let (_, program_data_new_authority) =
         loaderv3_program_accounts(&program_data_pubkey, DEPLOY_SLOT, &[7; 64]);
-    tokio::time::sleep(Duration::from_millis(70)).await;
+    tokio::time::sleep(Duration::from_millis(350)).await;
     rpc_client.set_current_slot(CURRENT_SLOT + 1);
     rpc_client.account_override_slot(&program_pubkey, CURRENT_SLOT + 1);
     rpc_client.add_account(program_data_pubkey, program_data_new_authority);

--- a/magicblock-chainlink/src/remote_account_provider/errors.rs
+++ b/magicblock-chainlink/src/remote_account_provider/errors.rs
@@ -125,6 +125,9 @@ pub enum RemoteAccountProviderError {
         "Failed to update gRPC subscription to {0} after {1} retries: {2}"
     )]
     GrpcSubscriptionUpdateFailed(String, usize, String),
+
+    #[error("Failed to fetch data slice for {0} at min context slot {1}: {2}")]
+    AccountDataSliceFetchFailed(Pubkey, u64, String),
 }
 impl From<solana_pubsub_client::pubsub_client::PubsubClientError>
     for RemoteAccountProviderError

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -3640,7 +3640,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
         min_context_slot: u64,
     ) -> RemoteAccountProviderResult<Option<Vec<u8>>> {
         let mut last_err = String::new();
-        for _ in 0..DATA_SLICE_FETCH_MAX_ATTEMPTS {
+        for attempt in 1..=DATA_SLICE_FETCH_MAX_ATTEMPTS {
             let config = RpcAccountInfoConfig {
                 commitment: Some(self.rpc_client.commitment()),
                 // The context slot is verified locally below; passing
@@ -3673,7 +3673,9 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                     )
                 }
             }
-            tokio::time::sleep(RPC_FETCH_RETRY_DELAY).await;
+            if attempt < DATA_SLICE_FETCH_MAX_ATTEMPTS {
+                tokio::time::sleep(RPC_FETCH_RETRY_DELAY).await;
+            }
         }
         Err(RemoteAccountProviderError::AccountDataSliceFetchFailed(
             *pubkey,

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -24,7 +24,9 @@ use magicblock_config::config::GrpcConfig;
 pub(crate) use remote_account::RemoteAccount;
 pub use remote_account::RemoteAccountUpdateSource;
 use solana_account::Account;
-use solana_account_decoder_client_types::UiAccountEncoding;
+use solana_account_decoder_client_types::{
+    UiAccountEncoding, UiDataSliceConfig,
+};
 use solana_commitment_config::CommitmentConfig;
 use solana_pubkey::Pubkey;
 use solana_rpc_client_api::{
@@ -1336,6 +1338,9 @@ const HELIUS_CONTEXT_SLOT_NOT_REACHED: i64 = -32603;
 // otherwise one-shot subscription updates (e.g. program upgrades) could be dropped
 const RPC_FETCH_MAX_RETRIES: u64 = 15;
 const RPC_FETCH_RETRY_DELAY: Duration = Duration::from_millis(400);
+/// Attempts for a `dataSlice` fetch to reach the required context slot
+/// before giving up; callers fall back to a full fetch.
+const DATA_SLICE_FETCH_MAX_ATTEMPTS: usize = 5;
 const RPC_FETCH_TIMEOUT: Duration = Duration::from_secs(5);
 const MATCH_SLOTS_MAX_TOTAL_TIME: Duration = Duration::from_secs(10);
 
@@ -3622,6 +3627,59 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
         }
 
         Ok(())
+    }
+
+    /// Fetches a byte range of an account via `dataSlice`, retrying until the
+    /// response context reaches `min_context_slot` so the caller never acts on
+    /// pre-notification state. Returns `None` if the account does not exist.
+    pub(crate) async fn get_account_data_slice(
+        &self,
+        pubkey: &Pubkey,
+        offset: usize,
+        length: usize,
+        min_context_slot: u64,
+    ) -> RemoteAccountProviderResult<Option<Vec<u8>>> {
+        let mut last_err = String::new();
+        for _ in 0..DATA_SLICE_FETCH_MAX_ATTEMPTS {
+            let config = RpcAccountInfoConfig {
+                commitment: Some(self.rpc_client.commitment()),
+                // The context slot is verified locally below; passing
+                // min_context_slot would surface provider-specific errors
+                // instead of a plain lagging context.
+                min_context_slot: None,
+                encoding: Some(UiAccountEncoding::Base64),
+                data_slice: Some(UiDataSliceConfig { offset, length }),
+            };
+            match tokio::time::timeout(
+                RPC_FETCH_TIMEOUT,
+                self.rpc_client.get_account_with_config(pubkey, config),
+            )
+            .await
+            {
+                Ok(Ok(response)) => {
+                    if response.context.slot >= min_context_slot {
+                        return Ok(response.value.map(|account| account.data));
+                    }
+                    last_err = format!(
+                        "context slot {} below min {}",
+                        response.context.slot, min_context_slot
+                    );
+                }
+                Ok(Err(err)) => last_err = format!("{err:?}"),
+                Err(_) => {
+                    last_err = format!(
+                        "timeout after {}ms",
+                        RPC_FETCH_TIMEOUT.as_millis()
+                    )
+                }
+            }
+            tokio::time::sleep(RPC_FETCH_RETRY_DELAY).await;
+        }
+        Err(RemoteAccountProviderError::AccountDataSliceFetchFailed(
+            *pubkey,
+            min_context_slot,
+            last_err,
+        ))
     }
 
     /// Tries to fetch the given accounts from RPC.

--- a/magicblock-chainlink/src/remote_account_provider/program_account.rs
+++ b/magicblock-chainlink/src/remote_account_provider/program_account.rs
@@ -69,7 +69,7 @@ pub enum RemoteProgramLoader {
 
 pub const LOADER_V1: Pubkey =
     pubkey!("BPFLoader1111111111111111111111111111111111");
-const LOADER_V2: Pubkey =
+pub const LOADER_V2: Pubkey =
     pubkey!("BPFLoader2111111111111111111111111111111111");
 pub const LOADER_V3: Pubkey =
     pubkey!("BPFLoaderUpgradeab1e11111111111111111111111");


### PR DESCRIPTION
## Problem

  Providers emit an `accountNotification` for heavily-invoked program accounts on
  **every mainnet slot**, even though the account never changes: geyser notifies on
  account *stores*, not content changes, and Agave re-commits executable accounts
  loaded by transaction processing each slot. `handle_executable_sub_update` treated
  every such notification as a potential upgrade and unconditionally re-fetched the
  program **plus its full programdata** from the RPC remote.

  Measured on prod nodes: Token-2022 (1.38 MB programdata) was re-fetched
  ~1×/s around the clock — ~110k fetches/day, **~120–170 GB/day of upstream RPC
  egress** — plus continuous re-clones of the immutable Tokenkeg program. The
  programs were never actually upgraded (Token-2022's last upgrade: June 17).

  ## Fix

  All new behavior is gated on "this process already successfully loaded the
  program" (a small per-program map, populated only on successful clone). Every
  other path — first load, restart recovery, failure retry — is unchanged.

  For an executable notification on an already-loaded program:

  - **Immutable loaders skip entirely.** LoaderV2 programs (Tokenkeg) cannot change
    by definition; the update carries no information (LoaderV1 was already handled).
  - **LoaderV3 verifies via a ~45-byte header fetch instead of a full reload.**
    Upgrades and authority changes only ever modify the programdata account, so the
    check fetches its metadata prefix (tag + deploy slot + authority) with
    `dataSlice` and byte-compares it against the prefix cached at the last load.
    Unchanged → skip; changed, closed, unparsable, or fetch failure → fall through
    to the existing full-reload path.
  - **Checks are throttled to one per program per minute**, with two guarantees that
    keep upgrade detection lossless:
    - a notification suppressed inside the window schedules a **single deferred
      verification at window expiry**, so an upgrade of a rarely-invoked program
      (which emits no later notification) is still detected within the window;
    - the header fetch retries until the RPC response context reaches the
      notification slot, so a lagging remote can never serve pre-upgrade state and
      masquerade an upgrade as "unchanged".
  - **Only successful loads are remembered.** A failed reload leaves the state
    untouched, so the next notification retries immediately — identical to the
    current recovery behavior.

  Net effect: Token-2022 goes from ~110k × 1.38 MB/day to ~1.4k × 45 B/day; the
  Tokenkeg re-clone churn stops. Worst-case upgrade-detection latency is bounded by
  the 60s window (`PROGRAM_VERIFY_THROTTLE`) for all programs, hot or cold.
