### PR TITLE
fix(aperture): add a catch all method-not-found handler

### DIFF
--- a/magicblock-aperture/src/error.rs
+++ b/magicblock-aperture/src/error.rs
@@ -8,6 +8,7 @@ pub(crate) const TRANSACTION_SIMULATION: i16 = -32002;
 pub(crate) const TRANSACTION_VERIFICATION: i16 = -32003;
 pub(crate) const BLOCK_NOT_FOUND: i16 = -32009;
 pub(crate) const INVALID_REQUEST: i16 = -32600;
+pub(crate) const METHOD_NOT_FOUND: i16 = -32601;
 pub(crate) const INVALID_PARAMS: i16 = -32602;
 pub(crate) const INTERNAL_ERROR: i16 = -32603;
 pub(crate) const PARSE_ERROR: i16 = -32700;
@@ -149,6 +150,14 @@ impl RpcError {
         Self {
             code: INVALID_REQUEST,
             message: format!("invalid request: {error}"),
+            http_status: 200,
+        }
+    }
+
+    pub(crate) fn method_not_found() -> Self {
+        Self {
+            code: METHOD_NOT_FOUND,
+            message: "Method not found".to_owned(),
             http_status: 200,
         }
     }

--- a/magicblock-aperture/src/requests/mod.rs
+++ b/magicblock-aperture/src/requests/mod.rs
@@ -83,6 +83,8 @@ pub(crate) enum JsonRpcHttpMethod {
     GetBlockhashForAccounts,
     /// Custom Magic Router-compatible method: exposes simple delegation flag.
     GetDelegationStatus,
+    #[serde(other)]
+    MethodNotFound,
 }
 
 /// All supported JSON-RPC Websocket method names.
@@ -100,6 +102,8 @@ pub(crate) enum JsonRpcWsMethod {
     SignatureUnsubscribe,
     SlotSubscribe,
     SlotUnsubscribe,
+    #[serde(other)]
+    MethodNotFound,
 }
 
 impl JsonRpcHttpMethod {
@@ -150,6 +154,7 @@ impl JsonRpcHttpMethod {
             Self::GetRoutes => "getRoutes",
             Self::GetBlockhashForAccounts => "getBlockhashForAccounts",
             Self::GetDelegationStatus => "getDelegationStatus",
+            Self::MethodNotFound => "methodNotFound",
         }
     }
 }
@@ -168,6 +173,7 @@ impl JsonRpcWsMethod {
             Self::SignatureUnsubscribe => "signatureUnsubscribe",
             Self::SlotSubscribe => "slotSubscribe",
             Self::SlotUnsubscribe => "slotUnsubscribe",
+            Self::MethodNotFound => "methodNotFound",
         }
     }
 }

--- a/magicblock-aperture/src/server/http/dispatch.rs
+++ b/magicblock-aperture/src/server/http/dispatch.rs
@@ -23,6 +23,7 @@ use magicblock_metrics::metrics::{
 use tokio::sync::Semaphore;
 
 use crate::{
+    error::RpcError,
     requests::{
         http::{extract_bytes, parse_body, HandlerResult},
         payload::ResponseErrorPayload,
@@ -243,6 +244,7 @@ impl HttpDispatcher {
             // Alias for getLatestBlockhash; exists for Magic Router SDK compatibility.
             GetBlockhashForAccounts => self.get_latest_blockhash(request),
             GetDelegationStatus => self.get_delegation_status(request).await,
+            MethodNotFound => Err(RpcError::method_not_found()),
         }
     }
 

--- a/magicblock-aperture/src/server/websocket/dispatch.rs
+++ b/magicblock-aperture/src/server/websocket/dispatch.rs
@@ -87,6 +87,7 @@ impl WsDispatcher {
                 self.unsubscribe(request)
             }
             Ping => Ok(SubResult::Pong("pong")),
+            MethodNotFound => Err(RpcError::method_not_found()),
         }?;
 
         Ok(WsDispatchResult {

--- a/magicblock-aperture/tests/websocket.rs
+++ b/magicblock-aperture/tests/websocket.rs
@@ -1,15 +1,71 @@
 use std::time::Duration;
 
 use futures::StreamExt;
+use json::{JsonValueTrait, Value};
 use setup::RpcTestEnv;
+use solana_pubsub_client::nonblocking::pubsub_client::PubsubClientError;
 use solana_rpc_client_api::{
-    config::{RpcTransactionLogsConfig, RpcTransactionLogsFilter},
+    config::{
+        RpcBlockSubscribeFilter, RpcTransactionLogsConfig,
+        RpcTransactionLogsFilter,
+    },
     response::{ProcessedSignatureResult, RpcSignatureResult},
 };
 use test_kit::guinea;
 use tokio::time::timeout;
 
 mod setup;
+
+#[tokio::test]
+async fn test_unknown_http_and_websocket_methods() {
+    let env = RpcTestEnv::new().await;
+
+    let response = reqwest::Client::new()
+        .post(env.rpc.url())
+        .json(&json::json!({
+            "jsonrpc": "2.0",
+            "method": "unknownHttpMethod",
+            "id": 1,
+        }))
+        .send()
+        .await
+        .expect("failed to send unknown HTTP method");
+    let body: Value = json::from_str(
+        &response
+            .text()
+            .await
+            .expect("failed to read HTTP response"),
+    )
+    .expect("failed to parse HTTP response");
+    assert_eq!(body["id"].as_i64(), Some(1));
+    assert_eq!(body["error"]["code"].as_i64(), Some(-32601));
+    assert_eq!(
+        body["error"]["message"].as_str(),
+        Some("Method not found")
+    );
+
+    let error = match env
+        .pubsub
+        .block_subscribe(RpcBlockSubscribeFilter::All, None)
+        .await
+    {
+        Ok(_) => panic!("unknown WebSocket method unexpectedly succeeded"),
+        Err(error) => error,
+    };
+    let PubsubClientError::SubscribeFailed { reason, message } = error else {
+        panic!("unexpected WebSocket error: {error}");
+    };
+    assert_eq!(reason, "Method not found (-32601)");
+
+    let body: Value =
+        json::from_str(&message).expect("failed to parse WebSocket response");
+    assert_eq!(body["id"].as_i64(), Some(1));
+    assert_eq!(body["error"]["code"].as_i64(), Some(-32601));
+    assert_eq!(
+        body["error"]["message"].as_str(),
+        Some("Method not found")
+    );
+}
 
 /// Verifies `accountSubscribe` and `accountUnsubscribe` work correctly.
 #[tokio::test]

--- a/magicblock-aperture/tests/websocket.rs
+++ b/magicblock-aperture/tests/websocket.rs
@@ -31,18 +31,12 @@ async fn test_unknown_http_and_websocket_methods() {
         .await
         .expect("failed to send unknown HTTP method");
     let body: Value = json::from_str(
-        &response
-            .text()
-            .await
-            .expect("failed to read HTTP response"),
+        &response.text().await.expect("failed to read HTTP response"),
     )
     .expect("failed to parse HTTP response");
     assert_eq!(body["id"].as_i64(), Some(1));
     assert_eq!(body["error"]["code"].as_i64(), Some(-32601));
-    assert_eq!(
-        body["error"]["message"].as_str(),
-        Some("Method not found")
-    );
+    assert_eq!(body["error"]["message"].as_str(), Some("Method not found"));
 
     let error = match env
         .pubsub
@@ -61,10 +55,7 @@ async fn test_unknown_http_and_websocket_methods() {
         json::from_str(&message).expect("failed to parse WebSocket response");
     assert_eq!(body["id"].as_i64(), Some(1));
     assert_eq!(body["error"]["code"].as_i64(), Some(-32601));
-    assert_eq!(
-        body["error"]["message"].as_str(),
-        Some("Method not found")
-    );
+    assert_eq!(body["error"]["message"].as_str(), Some("Method not found"));
 }
 
 /// Verifies `accountSubscribe` and `accountUnsubscribe` work correctly.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unknown JSON-RPC methods now return a standardized “Method not found” error with code `-32601`.
  * HTTP and WebSocket requests consistently preserve the original request ID in error responses.
  * Unsupported WebSocket subscription methods now fail with a clear, descriptive error instead of being left unhandled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->