### PR TITLE
fix: never resolve a fetch to state older than an observed found result

### DIFF
--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -10466,3 +10466,53 @@ async fn test_repro_redelegation_update_forwarded_when_no_fetch_inflight() {
     assert_eq!(forwarded.pubkey, repro.account_pubkey);
     assert_eq!(forwarded.account.slot(), WEDGE_SLOT_REDELEGATED);
 }
+
+/// Replay-sourced updates bypass the unwatched-account drop: unlike an
+/// Account-sourced update (see
+/// test_subscription_update_for_unwatched_present_account_enqueues_removal),
+/// a replayed recovery update must be processed even when the account is in
+/// no watch tier.
+#[tokio::test]
+async fn test_replay_subscription_update_for_unwatched_account_is_processed() {
+    init_logger();
+    let pubkey = Pubkey::new_unique();
+    let validator_keypair = Keypair::new();
+    let owner = Pubkey::new_unique();
+    let chain_account = Account {
+        lamports: 2_000_000,
+        data: vec![5; 8],
+        owner,
+        executable: false,
+        rent_epoch: 0,
+    };
+
+    let ctx =
+        setup([(pubkey, chain_account.clone())], 50, validator_keypair).await;
+    let mut stale = AccountSharedData::new(1_000_000, 0, &owner);
+    stale.set_remote_slot(42);
+    ctx.accounts_bank.insert(pubkey, stale);
+
+    assert!(!ctx.remote_account_provider.is_watching(&pubkey));
+
+    ctx.fetch_cloner
+        .process_subscription_update(
+            pubkey,
+            ForwardedSubscriptionUpdate {
+                pubkey,
+                account: RemoteAccount::from_fresh_account(
+                    chain_account.clone(),
+                    50,
+                    RemoteAccountUpdateSource::Subscription,
+                ),
+                source: SubscriptionSource::Replay,
+            },
+        )
+        .await;
+
+    let in_bank = ctx
+        .accounts_bank
+        .get_account(&pubkey)
+        .expect("account should be in bank");
+    assert_eq!(in_bank.remote_slot(), 50);
+    assert_eq!(in_bank.lamports(), 2_000_000);
+}

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -10456,11 +10456,13 @@ async fn test_repro_redelegation_update_forwarded_when_no_fetch_inflight() {
         )
         .await;
 
-    let forwarded =
-        tokio::time::timeout(Duration::from_secs(2), repro.ctx.forward_rx.recv())
-            .await
-            .expect("provider should forward the update when nothing consumes it")
-            .expect("forward channel should be open");
+    let forwarded = tokio::time::timeout(
+        Duration::from_secs(2),
+        repro.ctx.forward_rx.recv(),
+    )
+    .await
+    .expect("provider should forward the update when nothing consumes it")
+    .expect("forward channel should be open");
     assert_eq!(forwarded.pubkey, repro.account_pubkey);
     assert_eq!(forwarded.account.slot(), WEDGE_SLOT_REDELEGATED);
 }

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -10044,3 +10044,423 @@ async fn test_delegated_account_owned_by_token_program_does_not_subscribe_progra
         subscribed_programs
     );
 }
+
+// -----------------
+// Repro: delegated account permanently stuck after a missed re-delegation
+// update (flash-trade wedge, Jul 29-30 2026).
+//
+// Lifecycle of a PDA that is rapidly re-delegated (create -> undelegate ->
+// settle -> re-create on the same address):
+//
+// 1. account is delegated on chain and cloned into the bank
+// 2. undelegation completes: the account and its delegation record are
+//    closed on chain while the bank copy is flagged undelegating
+// 3. a client read during the closed window refreshes the undelegating
+//    account, finds nothing on chain and replaces the bank copy with an
+//    empty placeholder
+// 4. the PDA is re-delegated on chain a few slots later, but the validator
+//    misses the subscription update (see the silent drop gates in the
+//    provider loop / submux dedup)
+//
+// The stuck condition: with the placeholder in the bank every ensure path
+// (getAccountInfo, sendTransaction) hits the bank precheck ("found in bank
+// in valid state, no fetch needed") and never refetches, even though the
+// chain holds the account delegated to this validator. Only a processed
+// subscription update at a newer slot recovers it.
+// -----------------
+
+struct WedgeReproCtx {
+    ctx: FetcherTestCtx,
+    account_pubkey: Pubkey,
+    chain_account: Account,
+    account_owner: Pubkey,
+}
+
+const WEDGE_SLOT_DELEGATED: u64 = 100;
+const WEDGE_SLOT_CLOSED: u64 = 110;
+const WEDGE_SLOT_REDELEGATED: u64 = 115;
+
+/// Drives phases 1-3 above: the account was delegated and cloned, then
+/// closed on chain, and a closed-window read left an empty placeholder in
+/// the bank. The chain (RPC view) still shows the closed state.
+async fn setup_closed_window_placeholder(
+    validator_keypair: Keypair,
+) -> WedgeReproCtx {
+    init_logger();
+    let validator_pubkey = validator_keypair.pubkey();
+    let account_pubkey = random_pubkey();
+    let account_owner = random_pubkey();
+
+    let chain_account = Account {
+        lamports: 1_670_400,
+        data: vec![9; 112],
+        owner: dlp_api::id(),
+        executable: false,
+        rent_epoch: 0,
+    };
+
+    let ctx = setup(
+        [(account_pubkey, chain_account.clone())],
+        WEDGE_SLOT_DELEGATED,
+        validator_keypair,
+    )
+    .await;
+    let deleg_record_pubkey = add_delegation_record_for(
+        &ctx.rpc_client,
+        account_pubkey,
+        validator_pubkey,
+        account_owner,
+    );
+
+    // 1. initial ensure clones the delegated account
+    ctx.fetch_cloner
+        .fetch_and_clone_accounts_with_dedup(
+            &[account_pubkey],
+            Some(&[account_pubkey]),
+            None,
+            AccountFetchContext::rpc_get_account(),
+        )
+        .await
+        .expect("initial ensure should succeed");
+    let in_bank = ctx
+        .accounts_bank
+        .get_account(&account_pubkey)
+        .expect("account should be cloned");
+    assert!(in_bank.delegated(), "account should be cloned as delegated");
+
+    // 2. undelegation completes on chain: account + record closed
+    ctx.rpc_client.set_slot(WEDGE_SLOT_CLOSED);
+    ctx.rpc_client.set_clock_sysvar_for_slot(WEDGE_SLOT_CLOSED);
+    ctx.rpc_client.remove_account(&account_pubkey);
+    ctx.rpc_client.remove_account(&deleg_record_pubkey);
+    ctx.accounts_bank.undelegate(&account_pubkey);
+
+    // 3. a client read during the closed window replaces the bank copy with
+    //    an empty placeholder
+    ctx.fetch_cloner
+        .fetch_and_clone_accounts_with_dedup(
+            &[account_pubkey],
+            Some(&[account_pubkey]),
+            None,
+            AccountFetchContext::rpc_get_account(),
+        )
+        .await
+        .expect("closed-window ensure should succeed");
+    let placeholder = ctx
+        .accounts_bank
+        .get_account(&account_pubkey)
+        .expect("placeholder should be in bank");
+    assert_eq!(placeholder.lamports(), 0);
+    assert!(placeholder.data().is_empty());
+    assert_eq!(*placeholder.owner(), system_program::id());
+    assert!(!placeholder.delegated());
+    assert!(!placeholder.undelegating());
+
+    WedgeReproCtx {
+        ctx,
+        account_pubkey,
+        chain_account,
+        account_owner,
+    }
+}
+
+/// Phase 4: the PDA is re-delegated on chain (RPC view catches up).
+fn redelegate_on_chain(repro: &WedgeReproCtx, validator_pubkey: Pubkey) {
+    repro.ctx.rpc_client.set_slot(WEDGE_SLOT_REDELEGATED);
+    repro
+        .ctx
+        .rpc_client
+        .set_clock_sysvar_for_slot(WEDGE_SLOT_REDELEGATED);
+    repro
+        .ctx
+        .rpc_client
+        .add_account(repro.account_pubkey, repro.chain_account.clone());
+    add_delegation_record_for(
+        &repro.ctx.rpc_client,
+        repro.account_pubkey,
+        validator_pubkey,
+        repro.account_owner,
+    );
+}
+
+/// Drives phases 1-4 above and returns with the account re-delegated on
+/// chain, the bank holding the stale placeholder and no update delivered.
+async fn setup_wedged_account(validator_keypair: Keypair) -> WedgeReproCtx {
+    let validator_pubkey = validator_keypair.pubkey();
+    let repro = setup_closed_window_placeholder(validator_keypair).await;
+    redelegate_on_chain(&repro, validator_pubkey);
+    repro
+}
+
+#[tokio::test]
+async fn test_repro_account_stuck_after_missed_redelegation_update() {
+    let WedgeReproCtx {
+        ctx,
+        account_pubkey,
+        ..
+    } = setup_wedged_account(Keypair::new()).await;
+
+    // The chain now holds the account delegated to us, but every ensure
+    // (getAccountInfo / sendTransaction) hits the placeholder in the bank
+    // and never even attempts a remote fetch: the account is stuck.
+    let single_before = ctx.rpc_client.single_account_fetches();
+    let multi_before = ctx.rpc_client.multi_account_fetches();
+    for _ in 0..3 {
+        ctx.fetch_cloner
+            .fetch_and_clone_accounts_with_dedup(
+                &[account_pubkey],
+                Some(&[account_pubkey]),
+                None,
+                AccountFetchContext::rpc_get_account(),
+            )
+            .await
+            .expect("ensure should succeed");
+    }
+
+    let single_fetches =
+        ctx.rpc_client.single_account_fetches() - single_before;
+    let multi_fetches = ctx.rpc_client.multi_account_fetches() - multi_before;
+    assert_eq!(
+        (multi_fetches, single_fetches),
+        (0, 0),
+        "STUCK CONDITION: the bank placeholder suppresses every remote fetch"
+    );
+
+    let in_bank = ctx
+        .accounts_bank
+        .get_account(&account_pubkey)
+        .expect("placeholder should still be in bank");
+    assert!(
+        !in_bank.delegated(),
+        "STUCK CONDITION: the re-delegated account is never cloned"
+    );
+    assert_eq!(
+        in_bank.lamports(),
+        0,
+        "STUCK CONDITION: bank still holds the empty placeholder"
+    );
+}
+
+#[tokio::test]
+async fn test_repro_stuck_account_recovers_when_update_is_delivered() {
+    let WedgeReproCtx {
+        ctx,
+        account_pubkey,
+        chain_account,
+        account_owner,
+        ..
+    } = setup_wedged_account(Keypair::new()).await;
+
+    // Control: delivering the re-delegation update (what the dropped
+    // notification would have done) recovers the account.
+    ctx.fetch_cloner
+        .process_subscription_update(
+            account_pubkey,
+            ForwardedSubscriptionUpdate {
+                pubkey: account_pubkey,
+                account: RemoteAccount::from_fresh_account(
+                    chain_account.clone(),
+                    WEDGE_SLOT_REDELEGATED,
+                    RemoteAccountUpdateSource::Subscription,
+                ),
+                source: SubscriptionSource::Program,
+            },
+        )
+        .await;
+
+    let in_bank = ctx
+        .accounts_bank
+        .get_account(&account_pubkey)
+        .expect("account should be in bank");
+    assert!(
+        in_bank.delegated(),
+        "a processed update at a newer slot heals the account"
+    );
+    assert_eq!(*in_bank.owner(), account_owner);
+    assert_eq!(in_bank.remote_slot(), WEDGE_SLOT_REDELEGATED);
+}
+
+#[tokio::test]
+async fn test_repro_stuck_account_recovers_when_placeholder_absent() {
+    let WedgeReproCtx {
+        ctx,
+        account_pubkey,
+        account_owner,
+        ..
+    } = setup_wedged_account(Keypair::new()).await;
+
+    // Control: the placeholder is the load-bearing part of the stuck
+    // condition. With the bank entry gone (e.g. evicted by a removal
+    // notification), the very same ensure fetches and clones the
+    // re-delegated account.
+    ctx.accounts_bank.remove_account(&account_pubkey);
+
+    ctx.fetch_cloner
+        .fetch_and_clone_accounts_with_dedup(
+            &[account_pubkey],
+            Some(&[account_pubkey]),
+            None,
+            AccountFetchContext::rpc_get_account(),
+        )
+        .await
+        .expect("ensure should succeed");
+
+    let in_bank = ctx
+        .accounts_bank
+        .get_account(&account_pubkey)
+        .expect("account should be re-cloned");
+    assert!(
+        in_bank.delegated(),
+        "without the placeholder the pull path recovers on its own"
+    );
+    assert_eq!(*in_bank.owner(), account_owner);
+}
+
+// Slot of a stale (pre-re-delegation) update whose in-flight resolution
+// races the re-delegation notification.
+const WEDGE_SLOT_STALE_UPDATE: u64 = 112;
+
+/// Repro of the actual update loss with ALL transports delivering: the
+/// re-delegation notification is received by the provider while a fetch
+/// for an older update of the same account is still in flight. The
+/// provider consumes the notification to resolve that pending fetch
+/// (mod.rs "Using subscription update instead of fetch") instead of
+/// forwarding it to the fetch cloner.
+///
+/// Enforced behavior: the consumed state must not be discarded. The
+/// resolving fetch's companion (the delegation record) resolved at an
+/// older slot, so the slot-matching retry refetches RPC-only; the floor
+/// for an acceptable response is the consumed update's slot, so a lagging
+/// RPC view (still in the closed window) cannot finalize NotFound below
+/// it. Once the RPC view catches up the account is cloned as delegated.
+/// Without the min-context floor the fetch concludes NotFound, the
+/// freshest state is silently swallowed, and the account is permanently
+/// stuck behind the bank placeholder.
+#[tokio::test]
+async fn test_repro_redelegation_update_delivered_but_consumed_by_inflight_fetch(
+) {
+    let validator_keypair = Keypair::new();
+    let validator_pubkey = validator_keypair.pubkey();
+    let mut repro = setup_closed_window_placeholder(validator_keypair).await;
+
+    // A stale delegate-shaped update (from the previous incarnation of the
+    // burst) starts resolving while the RPC is slow to respond.
+    repro.ctx.rpc_client.set_slot(WEDGE_SLOT_STALE_UPDATE);
+    repro
+        .ctx
+        .rpc_client
+        .set_clock_sysvar_for_slot(WEDGE_SLOT_STALE_UPDATE);
+    repro.ctx.rpc_client.block_fetches();
+
+    let fetch_count_before = repro.ctx.fetch_cloner.fetch_count();
+    let stale_update = ForwardedSubscriptionUpdate {
+        pubkey: repro.account_pubkey,
+        account: RemoteAccount::from_fresh_account(
+            repro.chain_account.clone(),
+            WEDGE_SLOT_STALE_UPDATE,
+            RemoteAccountUpdateSource::Subscription,
+        ),
+        source: SubscriptionSource::Program,
+    };
+    let resolve_task = {
+        let fetch_cloner = repro.ctx.fetch_cloner.clone();
+        let pubkey = repro.account_pubkey;
+        tokio::spawn(async move {
+            fetch_cloner
+                .process_subscription_update(pubkey, stale_update)
+                .await;
+        })
+    };
+
+    // Wait until the stale resolve registered its (blocked) fetch.
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while repro.ctx.fetch_cloner.fetch_count() < fetch_count_before + 2 {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("stale resolve should start its fetch");
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    // The re-delegation notification IS delivered by the transport while
+    // the stale fetch is still in flight.
+    let pubsub_client = repro.ctx.remote_account_provider.pubsub_client();
+    pubsub_client.insert_subscription(repro.account_pubkey);
+    pubsub_client
+        .send_account_update(
+            repro.account_pubkey,
+            WEDGE_SLOT_REDELEGATED,
+            &repro.chain_account,
+        )
+        .await;
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    // The provider consumed the notification to resolve the pending fetch
+    // instead of forwarding it to the fetch cloner.
+    assert!(
+        repro.ctx.forward_rx.try_recv().is_err(),
+        "UPDATE LOST: the delivered notification was consumed by the \
+         in-flight fetch and never forwarded to the fetch cloner"
+    );
+
+    // The stale fetch resumes: its companion record resolved during the
+    // closed window, so the slot-matching retry refetches RPC-only. The
+    // RPC view catches up shortly after (as it did in production).
+    repro.ctx.rpc_client.allow_fetches();
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    redelegate_on_chain(&repro, validator_pubkey);
+    tokio::time::timeout(Duration::from_secs(5), resolve_task)
+        .await
+        .expect("stale resolve should complete")
+        .expect("stale resolve task should not panic");
+
+    // The notification was consumed, never forwarded.
+    assert!(
+        repro.ctx.forward_rx.try_recv().is_err(),
+        "no update was forwarded to the fetch cloner"
+    );
+
+    // ENFORCED: the consumed re-delegation state must be honored, not
+    // discarded — the account ends up cloned as delegated.
+    let in_bank = repro
+        .ctx
+        .accounts_bank
+        .get_account(&repro.account_pubkey)
+        .expect("account should be in bank");
+    assert!(
+        in_bank.delegated(),
+        "the delivered re-delegation update must not be lost: the in-flight \
+         fetch that consumed it has to resolve the account as delegated"
+    );
+    assert_eq!(in_bank.remote_slot(), WEDGE_SLOT_REDELEGATED);
+}
+
+/// Positive control for the consumed-update repro: with no fetch in
+/// flight, the very same delivery is forwarded by the provider. This
+/// proves the empty forward channel in the repro above means "consumed by
+/// the pending fetch", not "never delivered".
+#[tokio::test]
+async fn test_repro_redelegation_update_forwarded_when_no_fetch_inflight() {
+    let validator_keypair = Keypair::new();
+    let validator_pubkey = validator_keypair.pubkey();
+    let mut repro = setup_closed_window_placeholder(validator_keypair).await;
+    redelegate_on_chain(&repro, validator_pubkey);
+
+    let pubsub_client = repro.ctx.remote_account_provider.pubsub_client();
+    pubsub_client.insert_subscription(repro.account_pubkey);
+    pubsub_client
+        .send_account_update(
+            repro.account_pubkey,
+            WEDGE_SLOT_REDELEGATED,
+            &repro.chain_account,
+        )
+        .await;
+
+    let forwarded =
+        tokio::time::timeout(Duration::from_secs(2), repro.ctx.forward_rx.recv())
+            .await
+            .expect("provider should forward the update when nothing consumes it")
+            .expect("forward channel should be open");
+    assert_eq!(forwarded.pubkey, repro.account_pubkey);
+    assert_eq!(forwarded.account.slot(), WEDGE_SLOT_REDELEGATED);
+}

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -10046,27 +10046,11 @@ async fn test_delegated_account_owned_by_token_program_does_not_subscribe_progra
 }
 
 // -----------------
-// Repro: delegated account permanently stuck after a missed re-delegation
-// update (flash-trade wedge, Jul 29-30 2026).
-//
-// Lifecycle of a PDA that is rapidly re-delegated (create -> undelegate ->
-// settle -> re-create on the same address):
-//
-// 1. account is delegated on chain and cloned into the bank
-// 2. undelegation completes: the account and its delegation record are
-//    closed on chain while the bank copy is flagged undelegating
-// 3. a client read during the closed window refreshes the undelegating
-//    account, finds nothing on chain and replaces the bank copy with an
-//    empty placeholder
-// 4. the PDA is re-delegated on chain a few slots later, but the validator
-//    misses the subscription update (see the silent drop gates in the
-//    provider loop / submux dedup)
-//
-// The stuck condition: with the placeholder in the bank every ensure path
-// (getAccountInfo, sendTransaction) hits the bank precheck ("found in bank
-// in valid state, no fetch needed") and never refetches, even though the
-// chain holds the account delegated to this validator. Only a processed
-// subscription update at a newer slot recovers it.
+// Repro: rapid re-delegation of the same PDA (create -> undelegate ->
+// settle -> re-create). A closed-window read leaves an empty placeholder in
+// the bank; if the re-delegation update is then lost, every ensure path
+// skips the remote fetch and only a processed update at a newer slot
+// recovers the account.
 // -----------------
 
 struct WedgeReproCtx {
@@ -10320,22 +10304,11 @@ async fn test_repro_stuck_account_recovers_when_placeholder_absent() {
 // races the re-delegation notification.
 const WEDGE_SLOT_STALE_UPDATE: u64 = 112;
 
-/// Repro of the actual update loss with ALL transports delivering: the
-/// re-delegation notification is received by the provider while a fetch
-/// for an older update of the same account is still in flight. The
-/// provider consumes the notification to resolve that pending fetch
-/// (mod.rs "Using subscription update instead of fetch") instead of
-/// forwarding it to the fetch cloner.
-///
-/// Enforced behavior: the consumed state must not be discarded. The
-/// resolving fetch's companion (the delegation record) resolved at an
-/// older slot, so the slot-matching retry refetches RPC-only; the floor
-/// for an acceptable response is the consumed update's slot, so a lagging
-/// RPC view (still in the closed window) cannot finalize NotFound below
-/// it. Once the RPC view catches up the account is cloned as delegated.
-/// Without the min-context floor the fetch concludes NotFound, the
-/// freshest state is silently swallowed, and the account is permanently
-/// stuck behind the bank placeholder.
+/// The re-delegation notification arrives while a fetch for an older
+/// update of the same account is in flight and is consumed to resolve it,
+/// never forwarded. Enforced: the consumed state must not be discarded —
+/// the slot-matching retry may not finalize a view older than the consumed
+/// slot, and once the RPC catches up the account is cloned as delegated.
 #[tokio::test]
 async fn test_repro_redelegation_update_delivered_but_consumed_by_inflight_fetch(
 ) {
@@ -10398,9 +10371,12 @@ async fn test_repro_redelegation_update_delivered_but_consumed_by_inflight_fetch
     // The provider consumed the notification to resolve the pending fetch
     // instead of forwarding it to the fetch cloner.
     assert!(
-        repro.ctx.forward_rx.try_recv().is_err(),
-        "UPDATE LOST: the delivered notification was consumed by the \
-         in-flight fetch and never forwarded to the fetch cloner"
+        matches!(
+            repro.ctx.forward_rx.try_recv(),
+            Err(mpsc::error::TryRecvError::Empty)
+        ),
+        "the delivered notification must be consumed by the in-flight fetch, \
+         not forwarded"
     );
 
     // The stale fetch resumes: its companion record resolved during the
@@ -10416,7 +10392,10 @@ async fn test_repro_redelegation_update_delivered_but_consumed_by_inflight_fetch
 
     // The notification was consumed, never forwarded.
     assert!(
-        repro.ctx.forward_rx.try_recv().is_err(),
+        matches!(
+            repro.ctx.forward_rx.try_recv(),
+            Err(mpsc::error::TryRecvError::Empty)
+        ),
         "no update was forwarded to the fetch cloner"
     );
 

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -2400,11 +2400,8 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                 return Err(err);
             }
         };
-        // A found result observed at slot S must never be discarded in favor
-        // of an older view: a pending fetch resolved by a subscription update
-        // (e.g. a rapid re-delegation racing the previous incarnation's
-        // fetch) would otherwise be finalized as NotFound by a lagging
-        // RPC-only refetch, silently losing the freshest state.
+        // State observed at slot S must never be superseded by an older
+        // view: raise the floor to any found result already consumed.
         let mut min_context_slot =
             raised_min_context_slot(config.min_context_slot, &remote_accounts);
         if let Match =
@@ -2420,11 +2417,8 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
             return Ok(remote_accounts);
         }
 
-        // Found results injected by subscription updates were consumed from
-        // the update pipeline to resolve this fetch. If the fetch fails
-        // (e.g. the RPC lags the consumed slot beyond the retry budget)
-        // they must re-enter the pipeline, otherwise the freshest observed
-        // state is silently lost.
+        // Subscription results consumed to resolve this fetch must re-enter
+        // the update pipeline if the fetch fails, or they are lost.
         let consumed_subscription_results: Vec<(Pubkey, RemoteAccount)> =
             pubkeys
                 .iter()
@@ -2609,10 +2603,8 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
         }
     }
 
-    /// Re-forwards found results that were consumed from the subscription
-    /// update pipeline to resolve a fetch that is now failing. Without this
-    /// the consumed update is lost: it was never forwarded downstream and no
-    /// further notification arrives until the account changes on chain again.
+    /// Re-forwards found results consumed from the update pipeline by a
+    /// fetch that is now failing; otherwise the consumed update is lost.
     async fn reforward_consumed_subscription_results(
         &self,
         consumed: &[(Pubkey, RemoteAccount)],

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -2400,10 +2400,16 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                 return Err(err);
             }
         };
-        if let Match = slots_match_and_meet_min_context(
-            &remote_accounts,
-            config.min_context_slot,
-        ) {
+        // A found result observed at slot S must never be discarded in favor
+        // of an older view: a pending fetch resolved by a subscription update
+        // (e.g. a rapid re-delegation racing the previous incarnation's
+        // fetch) would otherwise be finalized as NotFound by a lagging
+        // RPC-only refetch, silently losing the freshest state.
+        let mut min_context_slot =
+            raised_min_context_slot(config.min_context_slot, &remote_accounts);
+        if let Match =
+            slots_match_and_meet_min_context(&remote_accounts, min_context_slot)
+        {
             observe_companion_fetch_if_configured(
                 fetch_context,
                 companion_fetch_kind,
@@ -2414,14 +2420,12 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
             return Ok(remote_accounts);
         }
 
-        // Capture the fetch start slot once and reuse it across retries. When a
-        // caller provides a stricter min_context_slot, the forced refetch must
-        // start from that slot rather than the provider's possibly lagging
-        // chain slot.
-        let fetch_start_slot = self
+        // The fetch start slot honors the strictest floor observed so far:
+        // the caller's min_context_slot or any found result consumed above.
+        let mut fetch_start_slot = self
             .chain_slot
             .load()
-            .max(config.min_context_slot.unwrap_or_default());
+            .max(min_context_slot.unwrap_or_default());
         // 2. Wait for the slots to match. Once the fast path mixed slots,
         // retry with an RPC-only batch so all accounts share one response slot.
         let start = std::time::Instant::now();
@@ -2455,7 +2459,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                     );
                     debug!(
                         pubkeys = %pubkeys_str(pubkeys),
-                        min_context_slot = ?config.min_context_slot,
+                        min_context_slot = ?min_context_slot,
                         retries = retries,
                         elapsed_ms = start.elapsed().as_millis() as u64,
                         error = %err,
@@ -2495,9 +2499,13 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                     )
                     .await?;
             }
+            min_context_slot =
+                raised_min_context_slot(min_context_slot, &remote_accounts);
+            fetch_start_slot =
+                fetch_start_slot.max(min_context_slot.unwrap_or_default());
             let slots_match_result = slots_match_and_meet_min_context(
                 &remote_accounts,
-                config.min_context_slot,
+                min_context_slot,
             );
             if let Match = slots_match_result {
                 observe_companion_fetch_if_configured(
@@ -2526,7 +2534,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                         pubkeys = %pubkeys_str(pubkeys),
                         slots = ?remote_account_slots,
                         sources = ?remote_account_sources,
-                        min_context_slot = ?config.min_context_slot,
+                        min_context_slot = ?min_context_slot,
                         retries = retries,
                         elapsed_ms = start.elapsed().as_millis() as u64,
                         limit = %limit,
@@ -4040,6 +4048,24 @@ enum SlotsMatchResult {
     Match,
     Mismatch,
     MatchButBelowMinContextSlot(u64),
+}
+
+/// Raises the min-context floor to the highest slot of any found account:
+/// state observed at slot S must never be superseded by an older view.
+fn raised_min_context_slot(
+    min_context_slot: Option<u64>,
+    accs: &[RemoteAccount],
+) -> Option<u64> {
+    let max_found_slot = accs
+        .iter()
+        .filter(|acc| acc.is_found())
+        .map(|acc| acc.slot())
+        .max();
+    match (min_context_slot, max_found_slot) {
+        (Some(min), Some(found)) => Some(min.max(found)),
+        (None, Some(found)) => Some(found),
+        (min, None) => min,
+    }
 }
 
 fn slots_match_and_meet_min_context(

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -2420,6 +2420,23 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
             return Ok(remote_accounts);
         }
 
+        // Found results injected by subscription updates were consumed from
+        // the update pipeline to resolve this fetch. If the fetch fails
+        // (e.g. the RPC lags the consumed slot beyond the retry budget)
+        // they must re-enter the pipeline, otherwise the freshest observed
+        // state is silently lost.
+        let consumed_subscription_results: Vec<(Pubkey, RemoteAccount)> =
+            pubkeys
+                .iter()
+                .zip(&remote_accounts)
+                .filter(|(_, account)| {
+                    account.is_found()
+                        && account.source()
+                            == Some(RemoteAccountUpdateSource::Subscription)
+                })
+                .map(|(pubkey, account)| (*pubkey, account.clone()))
+                .collect();
+
         // The fetch start slot honors the strictest floor observed so far:
         // the caller's min_context_slot or any found result consumed above.
         let mut fetch_start_slot = self
@@ -2478,6 +2495,10 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                                 companion_fetch_attempts,
                                 companion_fetch_started_at,
                             );
+                            self.reforward_consumed_subscription_results(
+                                &consumed_subscription_results,
+                            )
+                            .await;
                             return Err(err);
                         }
                     }
@@ -2551,6 +2572,10 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                                 companion_fetch_attempts,
                                 companion_fetch_started_at,
                             );
+                            self.reforward_consumed_subscription_results(
+                                &consumed_subscription_results,
+                            )
+                            .await;
                             return Err(
                                 RemoteAccountProviderError::SlotsDidNotMatch(
                                     pubkeys_str(pubkeys),
@@ -2567,6 +2592,10 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                                 companion_fetch_attempts,
                                 companion_fetch_started_at,
                             );
+                            self.reforward_consumed_subscription_results(
+                                &consumed_subscription_results,
+                            )
+                            .await;
                             return Err(RemoteAccountProviderError::MatchingSlotsNotSatisfyingMinContextSlot(
                                 pubkeys_str(pubkeys),
                                 remote_account_slots,
@@ -2576,6 +2605,30 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                         }
                     }
                 }
+            }
+        }
+    }
+
+    /// Re-forwards found results that were consumed from the subscription
+    /// update pipeline to resolve a fetch that is now failing. Without this
+    /// the consumed update is lost: it was never forwarded downstream and no
+    /// further notification arrives until the account changes on chain again.
+    async fn reforward_consumed_subscription_results(
+        &self,
+        consumed: &[(Pubkey, RemoteAccount)],
+    ) {
+        for (pubkey, account) in consumed {
+            let update = ForwardedSubscriptionUpdate {
+                pubkey: *pubkey,
+                account: account.clone(),
+                source: SubscriptionSource::Account,
+            };
+            if let Err(err) = self.subscription_forwarder.send(update).await {
+                warn!(
+                    pubkey = %pubkey,
+                    error = ?err,
+                    "Failed to re-forward consumed subscription update"
+                );
             }
         }
     }

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -2491,8 +2491,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                             );
                             self.reforward_consumed_subscription_results(
                                 &consumed_subscription_results,
-                            )
-                            .await;
+                            );
                             return Err(err);
                         }
                     }
@@ -2506,13 +2505,20 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                         *pubkey,
                     )
                     .await;
-                self.subscription_tier_ctx()
+                if let Err(err) = self
+                    .subscription_tier_ctx()
                     .apply_fetch_classification(
                         pubkey,
                         remote_account.slot(),
                         !remote_account.is_found(),
                     )
-                    .await?;
+                    .await
+                {
+                    self.reforward_consumed_subscription_results(
+                        &consumed_subscription_results,
+                    );
+                    return Err(err);
+                }
             }
             min_context_slot =
                 raised_min_context_slot(min_context_slot, &remote_accounts);
@@ -2568,8 +2574,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                             );
                             self.reforward_consumed_subscription_results(
                                 &consumed_subscription_results,
-                            )
-                            .await;
+                            );
                             return Err(
                                 RemoteAccountProviderError::SlotsDidNotMatch(
                                     pubkeys_str(pubkeys),
@@ -2588,8 +2593,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                             );
                             self.reforward_consumed_subscription_results(
                                 &consumed_subscription_results,
-                            )
-                            .await;
+                            );
                             return Err(RemoteAccountProviderError::MatchingSlotsNotSatisfyingMinContextSlot(
                                 pubkeys_str(pubkeys),
                                 remote_account_slots,
@@ -2605,24 +2609,33 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
 
     /// Re-forwards found results consumed from the update pipeline by a
     /// fetch that is now failing; otherwise the consumed update is lost.
-    async fn reforward_consumed_subscription_results(
+    /// Detached so a failing resolution never blocks on the update
+    /// pipeline's own input capacity.
+    fn reforward_consumed_subscription_results(
         &self,
         consumed: &[(Pubkey, RemoteAccount)],
     ) {
-        for (pubkey, account) in consumed {
-            let update = ForwardedSubscriptionUpdate {
-                pubkey: *pubkey,
-                account: account.clone(),
-                source: SubscriptionSource::Replay,
-            };
-            if let Err(err) = self.subscription_forwarder.send(update).await {
-                warn!(
-                    pubkey = %pubkey,
-                    error = ?err,
-                    "Failed to re-forward consumed subscription update"
-                );
-            }
+        if consumed.is_empty() {
+            return;
         }
+        let forwarder = Arc::clone(&self.subscription_forwarder);
+        let consumed = consumed.to_vec();
+        task::spawn(async move {
+            for (pubkey, account) in consumed {
+                let update = ForwardedSubscriptionUpdate {
+                    pubkey,
+                    account,
+                    source: SubscriptionSource::Replay,
+                };
+                if let Err(err) = forwarder.send(update).await {
+                    warn!(
+                        pubkey = %pubkey,
+                        error = ?err,
+                        "Failed to re-forward consumed subscription update"
+                    );
+                }
+            }
+        });
     }
 
     /// Gets the accounts for the given pubkeys by fetching from RPC.

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -35,7 +35,7 @@ use solana_rpc_client_api::{
 };
 use solana_sdk_ids::sysvar::clock;
 use tokio::{
-    sync::{mpsc, oneshot, Mutex as AsyncMutex, Semaphore},
+    sync::{mpsc, oneshot, Mutex as AsyncMutex, Notify},
     task, time,
 };
 use tracing::*;
@@ -1424,9 +1424,10 @@ pub struct RemoteAccountProvider<T: ChainRpcClient, U: ChainPubsubClient> {
     removed_account_rx: Mutex<Option<mpsc::Receiver<Pubkey>>>,
 
     subscription_forwarder: Arc<mpsc::Sender<ForwardedSubscriptionUpdate>>,
-    /// Caps detached replay senders spawned when the forwarding channel is
-    /// full; replays beyond the cap are dropped with a warning.
-    pending_replay_sends: Arc<Semaphore>,
+    /// Per-account latest replay of consumed subscription results, drained
+    /// losslessly by a dedicated worker (newest slot wins).
+    replay_outbox: Arc<Mutex<HashMap<Pubkey, ForwardedSubscriptionUpdate>>>,
+    replay_notify: Arc<Notify>,
 
     /// Task that periodically reconciles subscriptions and updates the
     /// active subscriptions gauge
@@ -1449,9 +1450,6 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> Drop
 // Configs
 // -----------------
 const DEFAULT_MATCH_SLOTS_MAX_RETRIES: u64 = 10;
-/// Maximum concurrently detached replay senders (see
-/// [RemoteAccountProvider::reforward_consumed_subscription_results]).
-const MAX_PENDING_REPLAY_SENDS: usize = 256;
 const DEFAULT_MATCH_SLOTS_RETRY_INTERVAL_MS: u64 = 50;
 
 pub struct MatchSlotsConfig {
@@ -1752,9 +1750,8 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
             confirmed_missing_subscriptions,
             capacity_eviction_protection,
             subscription_forwarder: Arc::new(subscription_forwarder),
-            pending_replay_sends: Arc::new(Semaphore::new(
-                MAX_PENDING_REPLAY_SENDS,
-            )),
+            replay_outbox: Arc::default(),
+            replay_notify: Arc::new(Notify::new()),
             removed_account_tx,
             removed_account_rx: Mutex::new(Some(removed_account_rx)),
             _active_subscriptions_task_handle: active_subscriptions_updater,
@@ -1762,6 +1759,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
 
         let updates = me.pubsub_client.take_updates();
         me.listen_for_account_updates(updates)?;
+        me.start_replay_outbox_worker();
         let clock_remote_account = me
             .try_get(
                 clock::ID,
@@ -2618,44 +2616,76 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
 
     /// Re-forwards found results consumed from the update pipeline by a
     /// fetch that is now failing; otherwise the consumed update is lost.
-    /// Never blocks on the pipeline's own input capacity: a full channel
-    /// falls back to a bounded detached sender, beyond which replays are
-    /// dropped with a warning.
+    /// Coalesced per account (newest slot wins) into an outbox drained by
+    /// [Self::start_replay_outbox_worker], so callers never block and the
+    /// backlog is bounded by the number of affected accounts.
     fn reforward_consumed_subscription_results(
         &self,
         consumed: &[(Pubkey, RemoteAccount)],
     ) {
-        for (pubkey, account) in consumed {
-            let update = ForwardedSubscriptionUpdate {
-                pubkey: *pubkey,
-                account: account.clone(),
-                source: SubscriptionSource::Replay,
-            };
-            let update = match self.subscription_forwarder.try_send(update) {
-                Ok(()) => continue,
-                Err(mpsc::error::TrySendError::Closed(_)) => continue,
-                Err(mpsc::error::TrySendError::Full(update)) => update,
-            };
-            let Ok(permit) =
-                Arc::clone(&self.pending_replay_sends).try_acquire_owned()
-            else {
-                warn!(
-                    pubkey = %pubkey,
-                    "Dropping consumed subscription replay: pipeline full and replay cap reached"
-                );
-                continue;
-            };
-            let forwarder = Arc::clone(&self.subscription_forwarder);
-            task::spawn(async move {
-                let _permit = permit;
-                if let Err(err) = forwarder.send(update).await {
-                    warn!(
-                        error = ?err,
-                        "Failed to re-forward consumed subscription update"
-                    );
-                }
-            });
+        if consumed.is_empty() {
+            return;
         }
+        {
+            let mut outbox = self
+                .replay_outbox
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner());
+            for (pubkey, account) in consumed {
+                let entry = outbox.entry(*pubkey);
+                match entry {
+                    Entry::Occupied(mut existing)
+                        if existing.get().account.slot() < account.slot() =>
+                    {
+                        existing.insert(ForwardedSubscriptionUpdate {
+                            pubkey: *pubkey,
+                            account: account.clone(),
+                            source: SubscriptionSource::Replay,
+                        });
+                    }
+                    Entry::Occupied(_) => {}
+                    Entry::Vacant(vacant) => {
+                        vacant.insert(ForwardedSubscriptionUpdate {
+                            pubkey: *pubkey,
+                            account: account.clone(),
+                            source: SubscriptionSource::Replay,
+                        });
+                    }
+                }
+            }
+        }
+        self.replay_notify.notify_one();
+    }
+
+    /// Drains the replay outbox into the update pipeline. Runs detached so
+    /// replays never block a failing resolution; exits when the pipeline
+    /// closes.
+    fn start_replay_outbox_worker(&self) {
+        let outbox = Arc::clone(&self.replay_outbox);
+        let notify = Arc::clone(&self.replay_notify);
+        let forwarder = Arc::clone(&self.subscription_forwarder);
+        task::spawn(async move {
+            loop {
+                notify.notified().await;
+                loop {
+                    let update = {
+                        let mut outbox = outbox
+                            .lock()
+                            .unwrap_or_else(|poison| poison.into_inner());
+                        let Some(pubkey) = outbox.keys().next().copied() else {
+                            break;
+                        };
+                        outbox.remove(&pubkey)
+                    };
+                    let Some(update) = update else {
+                        break;
+                    };
+                    if forwarder.send(update).await.is_err() {
+                        return;
+                    }
+                }
+            }
+        });
     }
 
     /// Gets the accounts for the given pubkeys by fetching from RPC.

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -2621,7 +2621,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
             let update = ForwardedSubscriptionUpdate {
                 pubkey: *pubkey,
                 account: account.clone(),
-                source: SubscriptionSource::Account,
+                source: SubscriptionSource::Replay,
             };
             if let Err(err) = self.subscription_forwarder.send(update).await {
                 warn!(

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -35,7 +35,7 @@ use solana_rpc_client_api::{
 };
 use solana_sdk_ids::sysvar::clock;
 use tokio::{
-    sync::{mpsc, oneshot, Mutex as AsyncMutex},
+    sync::{mpsc, oneshot, Mutex as AsyncMutex, Semaphore},
     task, time,
 };
 use tracing::*;
@@ -1424,6 +1424,9 @@ pub struct RemoteAccountProvider<T: ChainRpcClient, U: ChainPubsubClient> {
     removed_account_rx: Mutex<Option<mpsc::Receiver<Pubkey>>>,
 
     subscription_forwarder: Arc<mpsc::Sender<ForwardedSubscriptionUpdate>>,
+    /// Caps detached replay senders spawned when the forwarding channel is
+    /// full; replays beyond the cap are dropped with a warning.
+    pending_replay_sends: Arc<Semaphore>,
 
     /// Task that periodically reconciles subscriptions and updates the
     /// active subscriptions gauge
@@ -1446,6 +1449,9 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> Drop
 // Configs
 // -----------------
 const DEFAULT_MATCH_SLOTS_MAX_RETRIES: u64 = 10;
+/// Maximum concurrently detached replay senders (see
+/// [RemoteAccountProvider::reforward_consumed_subscription_results]).
+const MAX_PENDING_REPLAY_SENDS: usize = 256;
 const DEFAULT_MATCH_SLOTS_RETRY_INTERVAL_MS: u64 = 50;
 
 pub struct MatchSlotsConfig {
@@ -1746,6 +1752,9 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
             confirmed_missing_subscriptions,
             capacity_eviction_protection,
             subscription_forwarder: Arc::new(subscription_forwarder),
+            pending_replay_sends: Arc::new(Semaphore::new(
+                MAX_PENDING_REPLAY_SENDS,
+            )),
             removed_account_tx,
             removed_account_rx: Mutex::new(Some(removed_account_rx)),
             _active_subscriptions_task_handle: active_subscriptions_updater,
@@ -2609,33 +2618,44 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
 
     /// Re-forwards found results consumed from the update pipeline by a
     /// fetch that is now failing; otherwise the consumed update is lost.
-    /// Detached so a failing resolution never blocks on the update
-    /// pipeline's own input capacity.
+    /// Never blocks on the pipeline's own input capacity: a full channel
+    /// falls back to a bounded detached sender, beyond which replays are
+    /// dropped with a warning.
     fn reforward_consumed_subscription_results(
         &self,
         consumed: &[(Pubkey, RemoteAccount)],
     ) {
-        if consumed.is_empty() {
-            return;
-        }
-        let forwarder = Arc::clone(&self.subscription_forwarder);
-        let consumed = consumed.to_vec();
-        task::spawn(async move {
-            for (pubkey, account) in consumed {
-                let update = ForwardedSubscriptionUpdate {
-                    pubkey,
-                    account,
-                    source: SubscriptionSource::Replay,
-                };
+        for (pubkey, account) in consumed {
+            let update = ForwardedSubscriptionUpdate {
+                pubkey: *pubkey,
+                account: account.clone(),
+                source: SubscriptionSource::Replay,
+            };
+            let update = match self.subscription_forwarder.try_send(update) {
+                Ok(()) => continue,
+                Err(mpsc::error::TrySendError::Closed(_)) => continue,
+                Err(mpsc::error::TrySendError::Full(update)) => update,
+            };
+            let Ok(permit) =
+                Arc::clone(&self.pending_replay_sends).try_acquire_owned()
+            else {
+                warn!(
+                    pubkey = %pubkey,
+                    "Dropping consumed subscription replay: pipeline full and replay cap reached"
+                );
+                continue;
+            };
+            let forwarder = Arc::clone(&self.subscription_forwarder);
+            task::spawn(async move {
+                let _permit = permit;
                 if let Err(err) = forwarder.send(update).await {
                     warn!(
-                        pubkey = %pubkey,
                         error = ?err,
                         "Failed to re-forward consumed subscription update"
                     );
                 }
-            }
-        });
+            });
+        }
     }
 
     /// Gets the accounts for the given pubkeys by fetching from RPC.

--- a/magicblock-chainlink/src/remote_account_provider/pubsub_common.rs
+++ b/magicblock-chainlink/src/remote_account_provider/pubsub_common.rs
@@ -53,6 +53,10 @@ impl PubsubClientConfig {
 pub enum SubscriptionSource {
     Account,
     Program,
+    /// Provider-initiated replay of a subscription result that was consumed
+    /// to resolve a fetch which subsequently failed. Must be processed
+    /// regardless of the account's watch state.
+    Replay,
 }
 
 #[derive(Debug, Clone)]

--- a/magicblock-chainlink/src/remote_account_provider/tests.rs
+++ b/magicblock-chainlink/src/remote_account_provider/tests.rs
@@ -4298,4 +4298,5 @@ async fn test_get_accounts_until_slots_match_reforwards_consumed_update_on_failu
     assert_eq!(reforwarded.account.slot(), CURRENT_SLOT + 1);
     assert!(reforwarded.account.is_found());
     assert_eq!(reforwarded.account.fresh_lamports(), Some(777));
+    assert_eq!(reforwarded.source, SubscriptionSource::Replay);
 }

--- a/magicblock-chainlink/src/remote_account_provider/tests.rs
+++ b/magicblock-chainlink/src/remote_account_provider/tests.rs
@@ -4181,3 +4181,121 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
         .await
     }
 }
+
+/// A found result consumed from the subscription pipeline to resolve a
+/// pending fetch must not be lost when the fetch fails: if the RPC view
+/// cannot catch up to the consumed slot within the retry budget, the
+/// result is re-forwarded into the update pipeline so downstream
+/// processing retries with the freshest state.
+#[tokio::test]
+async fn test_get_accounts_until_slots_match_reforwards_consumed_update_on_failure(
+) {
+    const CURRENT_SLOT: u64 = 42;
+    let pubkey1 = random_pubkey();
+    let pubkey2 = random_pubkey();
+    let account1 = Account {
+        lamports: 555,
+        data: vec![],
+        owner: system_program::id(),
+        executable: false,
+        rent_epoch: 0,
+    };
+    let account2 = Account {
+        lamports: 666,
+        ..account1.clone()
+    };
+    let subscription_account = Account {
+        lamports: 777,
+        ..account1.clone()
+    };
+    // The RPC view stays at CURRENT_SLOT and never reaches the slot of the
+    // consumed subscription update.
+    let rpc_client = ChainRpcClientMockBuilder::new()
+        .slot(CURRENT_SLOT)
+        .account(pubkey1, account1)
+        .account(pubkey2, account2)
+        .build();
+    let (updates_tx, updates_rx) = mpsc::channel(100);
+    let pubsub_client = ChainPubsubClientMock::new(updates_tx, updates_rx);
+    let (forward_tx, mut forward_rx) = mpsc::channel(100);
+    let (subscribed_accounts, config) = create_test_lru_cache(1000);
+    let provider = Arc::new(
+        RemoteAccountProvider::new(
+            rpc_client.clone(),
+            pubsub_client.clone(),
+            forward_tx,
+            &config,
+            subscribed_accounts,
+            ChainSlot::new(Arc::<AtomicU64>::default()),
+        )
+        .await
+        .unwrap(),
+    );
+
+    rpc_client.block_fetches();
+    let task_handle = tokio::spawn({
+        let provider = provider.clone();
+        async move {
+            provider
+                .try_get_multi_until_slots_match(
+                    &[pubkey1, pubkey2],
+                    Some(MatchSlotsConfig {
+                        max_retries: 3,
+                        retry_interval_ms: 10,
+                        min_context_slot: None,
+                        companion_fetch_kind:
+                            ChainlinkCompanionFetchKind::ProgramData,
+                    }),
+                    AccountFetchContext::rpc_get_account(),
+                )
+                .await
+        }
+    });
+
+    let start = tokio::time::Instant::now();
+    loop {
+        let subscriptions = pubsub_client.subscriptions_union();
+        if subscriptions.contains(&pubkey1) && subscriptions.contains(&pubkey2)
+        {
+            break;
+        }
+        assert!(start.elapsed() < Duration::from_secs(2));
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
+    // The subscription update resolves pubkey1 ahead of the RPC view and is
+    // consumed by the pending fetch.
+    pubsub_client
+        .send_account_update(pubkey1, CURRENT_SLOT + 1, &subscription_account)
+        .await;
+    let start = tokio::time::Instant::now();
+    loop {
+        if !provider.is_pending(&pubkey1) && provider.is_pending(&pubkey2) {
+            break;
+        }
+        assert!(start.elapsed() < Duration::from_secs(2));
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    rpc_client.allow_fetches();
+
+    // The retry budget exhausts below the consumed slot and the call fails.
+    let result = tokio::time::timeout(Duration::from_secs(5), task_handle)
+        .await
+        .expect("slot-match task should complete")
+        .expect("slot-match task should not panic");
+    assert!(
+        result.is_err(),
+        "fetch should fail while the RPC lags the consumed slot"
+    );
+
+    // The consumed update re-enters the pipeline instead of being lost.
+    let reforwarded =
+        tokio::time::timeout(Duration::from_secs(2), forward_rx.recv())
+            .await
+            .expect("consumed update should be re-forwarded")
+            .expect("forward channel should be open");
+    assert_eq!(reforwarded.pubkey, pubkey1);
+    assert_eq!(reforwarded.account.slot(), CURRENT_SLOT + 1);
+    assert!(reforwarded.account.is_found());
+    assert_eq!(reforwarded.account.fresh_lamports(), Some(777));
+}

--- a/magicblock-chainlink/src/remote_account_provider/tests.rs
+++ b/magicblock-chainlink/src/remote_account_provider/tests.rs
@@ -3036,6 +3036,20 @@ async fn test_get_accounts_until_slots_match_refetches_mixed_sources_as_rpc_batc
     }
     rpc_client.allow_fetches();
 
+    // The subscription resolved pubkey1 at CURRENT_SLOT + 1, which raises
+    // the min-context floor: the RPC-only batch must not regress to the
+    // older CURRENT_SLOT view. The first retry fails on min-context until
+    // the RPC catches up to the observed slot.
+    let start = tokio::time::Instant::now();
+    loop {
+        if rpc_client.multi_account_fetches() >= 2 {
+            break;
+        }
+        assert!(start.elapsed() < Duration::from_secs(2));
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    rpc_client.set_slot(CURRENT_SLOT + 1);
+
     let remote_accounts =
         tokio::time::timeout(Duration::from_secs(2), task_handle)
             .await
@@ -3052,11 +3066,11 @@ async fn test_get_accounts_until_slots_match_refetches_mixed_sources_as_rpc_batc
         remote_accounts[1].source(),
         Some(RemoteAccountUpdateSource::Fetch)
     );
-    assert_eq!(remote_accounts[0].slot(), CURRENT_SLOT);
-    assert_eq!(remote_accounts[1].slot(), CURRENT_SLOT);
+    assert_eq!(remote_accounts[0].slot(), CURRENT_SLOT + 1);
+    assert_eq!(remote_accounts[1].slot(), CURRENT_SLOT + 1);
     assert_eq!(remote_accounts[0].fresh_lamports(), Some(555));
     assert_eq!(remote_accounts[1].fresh_lamports(), Some(666));
-    assert_eq!(rpc_client.multi_account_fetches(), 2);
+    assert_eq!(rpc_client.multi_account_fetches(), 3);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Problem

When a subscription update arrives for an account with a fetch already in flight, the provider consumes the update to resolve that pending fetch instead of forwarding it to the fetch cloner. If the fetch then enters the slot-matching retry (e.g. its companion account resolved at an older slot), the RPC-only refetch could return a view older than the consumed update — a lagging RPC still showing the account as closed — and finalize `NotFound`.

The freshest state is silently dropped: nothing is forwarded, nothing is cloned, and since the bank now holds a non-delegated entry, every later `ensure` skips the remote fetch. An account that is delegated on chain can stay absent from the ER indefinitely, with no error past the initial `ResolvedAccountCouldNoLongerBeFound`.

This can be triggered by rapid re-delegation of the same PDA: the re-delegation notification races the fetch resolving the previous incarnation's update.

## Solution

`try_get_multi_until_slots_match` now raises its effective `min_context_slot` floor to the highest slot of any **found** result it has observed — including results injected by subscription updates. A lagging RPC response can no longer satisfy the slot match below that floor, so the retry loop waits for the RPC view to catch up (within the existing retry budget) and resolves with the fresh state instead of regressing to an older one.

## Tests

- `test_repro_redelegation_update_delivered_but_consumed_by_inflight_fetch` reproduces the loss deterministically (blocked RPC + update injected through the provider loop) and enforces that the consumed state is honored — red before the fix, green after.
- Additional repro/control tests pin the surrounding behavior: the same delivery is forwarded when no fetch is in flight, and a stale non-delegated bank entry suppresses refetches until an update is processed.
- `test_get_accounts_until_slots_match_refetches_mixed_sources_as_rpc_batch` updated: it previously asserted the regression (accepting an older RPC batch for an account already observed at a newer slot).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed edge cases where accounts could stay stuck in an undelegated/placeholder state after undelegation followed by re-delegation.
  - Ensured redelegation updates are preserved and honored correctly, including during concurrent fetch activity and retry failures.
  - Improved slot-matching behavior using a dynamically raised context floor based on observed results.
  - Added replay-based forwarding so consumed subscription results aren’t lost when RPC reconciliation fails.
- **Tests**
  - Expanded coverage with new re-delegation wedge, replay, and race-condition scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->