### PR TITLE
fix: forward subscription updates that resolve pending fetches

### DIFF
--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -10739,16 +10739,16 @@ async fn test_repro_redelegation_update_delivered_but_consumed_by_inflight_fetch
         .await;
     tokio::time::sleep(Duration::from_millis(300)).await;
 
-    // The provider consumed the notification to resolve the pending fetch
-    // instead of forwarding it to the fetch cloner.
-    assert!(
-        matches!(
-            repro.ctx.forward_rx.try_recv(),
-            Err(mpsc::error::TryRecvError::Empty)
-        ),
-        "the delivered notification must be consumed by the in-flight fetch, \
-         not forwarded"
-    );
+    // The notification resolves the pending fetch AND is forwarded.
+    let forwarded = tokio::time::timeout(
+        Duration::from_secs(2),
+        repro.ctx.forward_rx.recv(),
+    )
+    .await
+    .expect("consumed update must also be forwarded")
+    .expect("forward channel should be open");
+    assert_eq!(forwarded.pubkey, repro.account_pubkey);
+    assert_eq!(forwarded.account.slot(), WEDGE_SLOT_REDELEGATED);
 
     // The stale fetch resumes: its companion record resolved during the
     // closed window, so the slot-matching retry refetches RPC-only. The
@@ -10760,15 +10760,6 @@ async fn test_repro_redelegation_update_delivered_but_consumed_by_inflight_fetch
         .await
         .expect("stale resolve should complete")
         .expect("stale resolve task should not panic");
-
-    // The notification was consumed, never forwarded.
-    assert!(
-        matches!(
-            repro.ctx.forward_rx.try_recv(),
-            Err(mpsc::error::TryRecvError::Empty)
-        ),
-        "no update was forwarded to the fetch cloner"
-    );
 
     // ENFORCED: the consumed re-delegation state must be honored, not
     // discarded — the account ends up cloned as delegated.

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -2201,7 +2201,19 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                                             1,
                                         );
 
-                                        (None, true, Some((generation, state.waiters)))
+                                        // Also forward: the fetch waiters may
+                                        // not clone the result (e.g. status
+                                        // reads) and dedup already dropped
+                                        // every other copy of this update.
+                                        (
+                                            Some(ForwardedSubscriptionUpdate {
+                                                pubkey: update.pubkey,
+                                                account: remote_account.clone(),
+                                                source: update.source,
+                                            }),
+                                            true,
+                                            Some((generation, state.waiters)),
+                                        )
                                     } else {
                                         // Subscription is stale, put the fetch tracking back
                                         debug!(pubkey = %update.pubkey, slot = slot, fetch_start_slot = state.fetch_start_slot, generation, "Received stale subscription update");

--- a/magicblock-chainlink/src/remote_account_provider/tests.rs
+++ b/magicblock-chainlink/src/remote_account_provider/tests.rs
@@ -1668,21 +1668,19 @@ async fn test_companion_fetch_metrics_record_fast_path_success() {
             outcome
         ) > attempts_count_before
     );
-    assert_eq!(
+    assert!(
         chainlink_companion_fetch_attempts_sample_sum(
             context.clone(),
             kind,
             outcome
-        ),
-        attempts_sum_before + 1.0
+        ) >= attempts_sum_before + 1.0
     );
-    assert_eq!(
+    assert!(
         chainlink_companion_fetch_duration_sample_count(
             context.clone(),
             kind,
             outcome
-        ),
-        duration_count_before + 1
+        ) > duration_count_before
     );
     assert!(
         chainlink_companion_fetch_duration_sample_sum(
@@ -1802,13 +1800,12 @@ async fn test_companion_fetch_metrics_record_slot_mismatch_failure() {
         ),
         attempts_count_before + 1
     );
-    assert_eq!(
+    assert!(
         chainlink_companion_fetch_duration_sample_count(
             context.clone(),
             kind,
             outcome
-        ),
-        duration_count_before + 1
+        ) > duration_count_before
     );
 }
 

--- a/magicblock-chainlink/src/remote_account_provider/tests.rs
+++ b/magicblock-chainlink/src/remote_account_provider/tests.rs
@@ -1660,13 +1660,13 @@ async fn test_companion_fetch_metrics_record_fast_path_success() {
         .await;
 
     assert!(res.is_ok());
-    assert_eq!(
+    // Lower bound: concurrent tests can emit the same label set.
+    assert!(
         chainlink_companion_fetch_attempts_sample_count(
             context.clone(),
             kind,
             outcome
-        ),
-        attempts_count_before + 1
+        ) > attempts_count_before
     );
     assert_eq!(
         chainlink_companion_fetch_attempts_sample_sum(
@@ -1746,13 +1746,13 @@ async fn test_companion_fetch_metrics_record_retry_success() {
     advance_handle.await.unwrap();
 
     assert!(res.is_ok());
-    assert_eq!(
+    // Lower bound: concurrent tests can emit the same label set.
+    assert!(
         chainlink_companion_fetch_attempts_sample_count(
             context.clone(),
             kind,
             outcome
-        ),
-        attempts_count_before + 1
+        ) > attempts_count_before
     );
     assert!(
         chainlink_companion_fetch_attempts_sample_sum(
@@ -4462,15 +4462,116 @@ async fn test_get_accounts_until_slots_match_reforwards_consumed_update_on_failu
         "fetch should fail while the RPC lags the consumed slot"
     );
 
-    // The consumed update re-enters the pipeline instead of being lost.
-    let reforwarded =
+    // The consumed update was forwarded at consumption time and replayed
+    // again when the fetch failed; both copies carry the consumed state.
+    let mut sources = Vec::new();
+    for _ in 0..2 {
+        let forwarded =
+            tokio::time::timeout(Duration::from_secs(2), forward_rx.recv())
+                .await
+                .expect("consumed update should be forwarded")
+                .expect("forward channel should be open");
+        assert_eq!(forwarded.pubkey, pubkey1);
+        assert_eq!(forwarded.account.slot(), CURRENT_SLOT + 1);
+        assert_eq!(forwarded.account.fresh_lamports(), Some(777));
+        sources.push(forwarded.source);
+    }
+    assert!(sources.contains(&SubscriptionSource::Replay));
+}
+
+/// A subscription update that resolves a pending fetch must ALSO be
+/// forwarded to the update pipeline: the fetch caller may not clone the
+/// result (e.g. delegation-status reads), and dedup has already dropped
+/// every other copy of the notification, so exclusive consumption loses
+/// chain state permanently.
+#[tokio::test]
+async fn test_update_resolving_pending_fetch_is_also_forwarded() {
+    const CURRENT_SLOT: u64 = 100;
+    let pubkey = random_pubkey();
+    let account = Account {
+        lamports: 1_000_000,
+        data: vec![1, 2, 3, 4],
+        owner: solana_pubkey::Pubkey::new_unique(),
+        executable: false,
+        rent_epoch: 0,
+    };
+    let subscription_account = Account {
+        lamports: 2_000_000,
+        ..account.clone()
+    };
+
+    let rpc_client = ChainRpcClientMockBuilder::new()
+        .slot(CURRENT_SLOT)
+        .clock_sysvar_for_slot(CURRENT_SLOT)
+        .account(pubkey, account)
+        .build();
+    let (updates_sender, updates_receiver) = mpsc::channel(1_000);
+    let pubsub_client =
+        ChainPubsubClientMock::new(updates_sender, updates_receiver);
+    let (forward_tx, mut forward_rx) = mpsc::channel(1_000);
+    let (subscribed_accounts, config) = create_test_lru_cache(1000);
+    let provider = Arc::new(
+        RemoteAccountProvider::new(
+            rpc_client.clone(),
+            pubsub_client.clone(),
+            forward_tx,
+            &config,
+            subscribed_accounts,
+            ChainSlot::new(Arc::<AtomicU64>::default()),
+        )
+        .await
+        .unwrap(),
+    );
+
+    // A non-cloning fetch (like a delegation-status read) is in flight.
+    rpc_client.block_fetches();
+    let task_handle = tokio::spawn({
+        let provider = provider.clone();
+        async move {
+            provider
+                .try_get_multi(
+                    &[pubkey],
+                    None,
+                    AccountFetchContext::rpc_get_account(),
+                    None,
+                )
+                .await
+        }
+    });
+    wait_for_direct_subscription(&pubsub_client, pubkey).await;
+    let fetch_start_slot = {
+        let fetching = provider.fetching_accounts.lock().unwrap();
+        fetching
+            .get(&pubkey)
+            .map(|state| state.fetch_start_slot)
+            .expect("fetching account state should exist")
+    };
+
+    pubsub_client
+        .send_account_update(
+            pubkey,
+            fetch_start_slot + 1,
+            &subscription_account,
+        )
+        .await;
+
+    // The fetch resolves with the subscription state.
+    let remote_accounts =
+        tokio::time::timeout(Duration::from_secs(2), task_handle)
+            .await
+            .expect("fetch task should complete")
+            .expect("fetch task should not panic")
+            .expect("fetch should succeed");
+    assert_eq!(remote_accounts[0].fresh_lamports(), Some(2_000_000));
+    rpc_client.allow_fetches();
+
+    // The update is forwarded as well, not exclusively consumed.
+    let forwarded =
         tokio::time::timeout(Duration::from_secs(2), forward_rx.recv())
             .await
-            .expect("consumed update should be re-forwarded")
+            .expect("consumed update must also be forwarded")
             .expect("forward channel should be open");
-    assert_eq!(reforwarded.pubkey, pubkey1);
-    assert_eq!(reforwarded.account.slot(), CURRENT_SLOT + 1);
-    assert!(reforwarded.account.is_found());
-    assert_eq!(reforwarded.account.fresh_lamports(), Some(777));
-    assert_eq!(reforwarded.source, SubscriptionSource::Replay);
+    assert_eq!(forwarded.pubkey, pubkey);
+    assert_eq!(forwarded.account.slot(), fetch_start_slot + 1);
+    assert_eq!(forwarded.account.fresh_lamports(), Some(2_000_000));
 }


### PR DESCRIPTION
## Problem

A subscription update arriving for an account with a fetch in flight is consumed to resolve that fetch and never forwarded to the update pipeline — while submux dedup has already dropped every other copy. Correctness silently depends on the fetch caller cloning the result. Non-cloning callers (delegation-status reads via `fetch_remote_accounts`) and multi-stage resolutions that fail mid-churn discard it, permanently losing the freshest chain state. With a stale copy in the bank suppressing refetches, the account stays wedged until the next on-chain write — reproducible by delegating/undelegating in quick succession while anything polls the account.

#1507 fixed one consumer of this class (the slot-matching companion path); this fixes the class at its source.

## Solution

Consumption is non-exclusive: the update resolves the fetch waiters **and** is forwarded like any other notification (one `None` → `Some(update)` at the arbitration site). Double-processing is benign via the existing non-advancing-slot gate.

## Tests

- `test_update_resolving_pending_fetch_is_also_forwarded` — non-cloning fetch in flight, update consumed; red before, green after.
- Two existing tests updated from the old exclusive-consumption contract; exact global-metric asserts relaxed to lower bounds (concurrent tests share label sets).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Subscription updates that resolve in-flight account fetches are now also forwarded to downstream consumers.
  * Redelegation updates are preserved and correctly applied when finalizing account state.
  * Consumed subscription updates are reliably replayed through the update pipeline.

* **Tests**
  * Expanded coverage for forwarded subscription updates and replay behavior.
  * Improved metric assertions to remain reliable during concurrent test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->