### PR TITLE
feat: delegation-record mirror fed from the magicblock-sync firehose

### DIFF
--- a/.agents/context/crates/magicblock-chainlink.md
+++ b/.agents/context/crates/magicblock-chainlink.md
@@ -209,16 +209,15 @@ DLP-owned accounts must be resolved with their delegation record before cloning:
 
 1. Derive `delegation_record_pda_from_delegated_account(account_pubkey)`.
 2. Acquire a `DelegationRecord` subscription reason for the record PDA.
-3. Consult the optional `DelegationRecordMirror` (`chainlink/record_mirror.rs`), an in-memory mirror of all on-chain delegation records streamed via the magicblock-sync firehose. A hit proven at the requested slot (entry slot or live watermark past it) supplies the record bytes without RPC; the account is then fetched alone and the record companion is synthesized from mirror bytes. Every other outcome — miss, undelegation tombstone, stale entry, non-record bytes — falls through unchanged to the RPC path below. Absence in the mirror is never treated as "not delegated"; the mirror clears itself on stream interruption.
-4. Otherwise fetch account and delegation record with slot matching via `try_get_multi_until_slots_match`.
-5. Parse `DelegationRecord` and optional post-delegation actions.
-6. Apply local metadata:
+3. Fetch account and delegation record with slot matching via `try_get_multi_until_slots_match`.
+4. Parse `DelegationRecord` and optional post-delegation actions.
+5. Apply local metadata:
    - owner is set to `delegation_record.owner`,
    - `confined` is set when `authority == Pubkey::default()`,
    - `delegated` is set when authority is this validator or confined, except raw eATA PDAs are not marked delegated directly,
    - `commit_frequency_ms` is included only for accounts delegated/confined to this validator.
-7. If authority belongs to another validator, `delegated_to_other` is set on the clone request.
-8. Missing non-internal delegation records are reported in `FetchAndCloneResult::missing_delegation_record`.
+6. If authority belongs to another validator, `delegated_to_other` is set on the clone request.
+7. Missing non-internal delegation records are reported in `FetchAndCloneResult::missing_delegation_record`.
 
 Important caveats:
 

--- a/.agents/context/crates/magicblock-chainlink.md
+++ b/.agents/context/crates/magicblock-chainlink.md
@@ -209,15 +209,16 @@ DLP-owned accounts must be resolved with their delegation record before cloning:
 
 1. Derive `delegation_record_pda_from_delegated_account(account_pubkey)`.
 2. Acquire a `DelegationRecord` subscription reason for the record PDA.
-3. Fetch account and delegation record with slot matching via `try_get_multi_until_slots_match`.
-4. Parse `DelegationRecord` and optional post-delegation actions.
-5. Apply local metadata:
+3. Consult the optional `DelegationRecordMirror` (`chainlink/record_mirror.rs`), an in-memory mirror of all on-chain delegation records streamed via the magicblock-sync firehose. A hit proven at the requested slot (entry slot or live watermark past it) supplies the record bytes without RPC; the account is then fetched alone and the record companion is synthesized from mirror bytes. Every other outcome — miss, undelegation tombstone, stale entry, non-record bytes — falls through unchanged to the RPC path below. Absence in the mirror is never treated as "not delegated"; the mirror clears itself on stream interruption.
+4. Otherwise fetch account and delegation record with slot matching via `try_get_multi_until_slots_match`.
+5. Parse `DelegationRecord` and optional post-delegation actions.
+6. Apply local metadata:
    - owner is set to `delegation_record.owner`,
    - `confined` is set when `authority == Pubkey::default()`,
    - `delegated` is set when authority is this validator or confined, except raw eATA PDAs are not marked delegated directly,
    - `commit_frequency_ms` is included only for accounts delegated/confined to this validator.
-6. If authority belongs to another validator, `delegated_to_other` is set on the clone request.
-7. Missing non-internal delegation records are reported in `FetchAndCloneResult::missing_delegation_record`.
+7. If authority belongs to another validator, `delegated_to_other` is set on the clone request.
+8. Missing non-internal delegation records are reported in `FetchAndCloneResult::missing_delegation_record`.
 
 Important caveats:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,7 +280,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -291,7 +291,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -777,7 +777,7 @@ dependencies = [
  "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "regex",
@@ -1950,7 +1950,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4094,7 +4094,7 @@ dependencies = [
 [[package]]
 name = "magicblock-sync"
 version = "0.2.0"
-source = "git+https://github.com/magicblock-labs/magicblock-sync.git?rev=d1f13ee#d1f13ee9500a335584a6f6dbcd108471134493b4"
+source = "git+https://github.com/magicblock-labs/magicblock-sync.git?rev=3c71985#3c719851767544d1ae003bbf53d74c82c14acb01"
 dependencies = [
  "futures",
  "helius-laserstream",
@@ -4444,7 +4444,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5021,7 +5021,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph",
@@ -5042,7 +5042,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -5744,7 +5744,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6298,7 +6298,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9647,7 +9647,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10605,7 +10605,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3661,6 +3661,7 @@ dependencies = [
  "magicblock-delegation-program-api",
  "magicblock-magic-program-api",
  "magicblock-metrics",
+ "magicblock-sync",
  "parking_lot",
  "scc",
  "solana-account 3.4.0",
@@ -4087,6 +4088,17 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "magicblock-sync"
+version = "0.1.0"
+source = "git+https://github.com/magicblock-labs/magicblock-sync.git?rev=f8932e36fb86e8121fef557ddb4cf5210db6482d#f8932e36fb86e8121fef557ddb4cf5210db6482d"
+dependencies = [
+ "futures",
+ "helius-laserstream",
+ "tokio",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,7 +280,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -291,7 +291,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -777,7 +777,7 @@ dependencies = [
  "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "regex",
@@ -1950,7 +1950,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3840,7 +3840,7 @@ dependencies = [
  "solana-system-interface 2.0.0",
  "static_assertions",
  "strum 0.28.0",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4093,8 +4093,8 @@ dependencies = [
 
 [[package]]
 name = "magicblock-sync"
-version = "0.1.0"
-source = "git+https://github.com/magicblock-labs/magicblock-sync.git?rev=f8932e36fb86e8121fef557ddb4cf5210db6482d#f8932e36fb86e8121fef557ddb4cf5210db6482d"
+version = "0.2.0"
+source = "git+https://github.com/magicblock-labs/magicblock-sync.git?rev=c979bb0#c979bb0ab403423cacab49f67c6437e0d389d902"
 dependencies = [
  "futures",
  "helius-laserstream",
@@ -4444,7 +4444,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5021,7 +5021,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph",
@@ -5042,7 +5042,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -5268,7 +5268,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5744,7 +5744,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6298,7 +6298,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9647,7 +9647,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10605,7 +10605,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,7 +280,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -291,7 +291,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -777,7 +777,7 @@ dependencies = [
  "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -1950,7 +1950,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4094,7 +4094,7 @@ dependencies = [
 [[package]]
 name = "magicblock-sync"
 version = "0.2.0"
-source = "git+https://github.com/magicblock-labs/magicblock-sync.git?rev=c979bb0#c979bb0ab403423cacab49f67c6437e0d389d902"
+source = "git+https://github.com/magicblock-labs/magicblock-sync.git?rev=d1f13ee#d1f13ee9500a335584a6f6dbcd108471134493b4"
 dependencies = [
  "futures",
  "helius-laserstream",
@@ -4444,7 +4444,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5021,7 +5021,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "petgraph",
@@ -5042,7 +5042,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -5744,7 +5744,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6298,7 +6298,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9647,7 +9647,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10605,7 +10605,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ magicblock-program = { path = "./programs/magicblock" }
 magicblock-replicator = { path = "./magicblock-replicator" }
 magicblock-rpc-client = { path = "./magicblock-rpc-client" }
 magicblock-services = { path = "./magicblock-services" }
-magicblock-sync = { git = "https://github.com/magicblock-labs/magicblock-sync.git", rev = "f8932e36fb86e8121fef557ddb4cf5210db6482d" }
+magicblock-sync = { git = "https://github.com/magicblock-labs/magicblock-sync.git", rev = "c979bb0" }
 magicblock-table-mania = { path = "./magicblock-table-mania" }
 magicblock-task-scheduler = { path = "./magicblock-task-scheduler" }
 magicblock-tui-client = { path = "./tools/magicblock-tui-client" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ magicblock-program = { path = "./programs/magicblock" }
 magicblock-replicator = { path = "./magicblock-replicator" }
 magicblock-rpc-client = { path = "./magicblock-rpc-client" }
 magicblock-services = { path = "./magicblock-services" }
-magicblock-sync = { git = "https://github.com/magicblock-labs/magicblock-sync.git", rev = "d1f13ee" }
+magicblock-sync = { git = "https://github.com/magicblock-labs/magicblock-sync.git", rev = "3c71985" }
 magicblock-table-mania = { path = "./magicblock-table-mania" }
 magicblock-task-scheduler = { path = "./magicblock-task-scheduler" }
 magicblock-tui-client = { path = "./tools/magicblock-tui-client" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ magicblock-program = { path = "./programs/magicblock" }
 magicblock-replicator = { path = "./magicblock-replicator" }
 magicblock-rpc-client = { path = "./magicblock-rpc-client" }
 magicblock-services = { path = "./magicblock-services" }
-magicblock-sync = { git = "https://github.com/magicblock-labs/magicblock-sync.git", rev = "c979bb0" }
+magicblock-sync = { git = "https://github.com/magicblock-labs/magicblock-sync.git", rev = "d1f13ee" }
 magicblock-table-mania = { path = "./magicblock-table-mania" }
 magicblock-task-scheduler = { path = "./magicblock-task-scheduler" }
 magicblock-tui-client = { path = "./tools/magicblock-tui-client" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,6 +123,7 @@ magicblock-program = { path = "./programs/magicblock" }
 magicblock-replicator = { path = "./magicblock-replicator" }
 magicblock-rpc-client = { path = "./magicblock-rpc-client" }
 magicblock-services = { path = "./magicblock-services" }
+magicblock-sync = { git = "https://github.com/magicblock-labs/magicblock-sync.git", rev = "f8932e36fb86e8121fef557ddb4cf5210db6482d" }
 magicblock-table-mania = { path = "./magicblock-table-mania" }
 magicblock-task-scheduler = { path = "./magicblock-task-scheduler" }
 magicblock-tui-client = { path = "./tools/magicblock-tui-client" }

--- a/config.example.toml
+++ b/config.example.toml
@@ -310,6 +310,28 @@ request-timeout = "5s"
 # Env: MBV_CHAINLINK__RISK__RISK_SCORE_THRESHOLD
 # risk-score-threshold = 5
 
+[chainlink.record-sync]
+# In-memory delegation-record mirror streamed from the record firehose.
+# Any mirror miss falls back to an RPC record fetch, so disabling this only
+# costs upstream RPC traffic, never correctness.
+# Default: true
+# Env: MBV_CHAINLINK__RECORD_SYNC__ENABLED
+enabled = true
+
+# Laserstream gRPC endpoint for the record firehose.
+# Default: the first gRPC remote (with its api key)
+# Env: MBV_CHAINLINK__RECORD_SYNC__ENDPOINT
+# endpoint = "https://laserstream-mainnet-ewr.helius-rpc.com"
+
+# API key for the endpoint above.
+# Env: MBV_CHAINLINK__RECORD_SYNC__API_KEY
+# api-key = "YOUR_API_KEY"
+
+# Maximum number of record entries retained in the mirror.
+# Default: 262144
+# Env: MBV_CHAINLINK__RECORD_SYNC__CAPACITY
+# capacity = 262144
+
 # ==============================================================================
 # On-Chain Registration (Optional)
 # ==============================================================================

--- a/magicblock-chainlink/Cargo.toml
+++ b/magicblock-chainlink/Cargo.toml
@@ -18,6 +18,7 @@ magicblock-core = { workspace = true }
 magicblock-delegation-program-api = { workspace = true }
 magicblock-magic-program-api = { workspace = true }
 magicblock-metrics = { workspace = true }
+magicblock-sync = { workspace = true }
 parking_lot = { workspace = true }
 scc = { workspace = true }
 solana-account = { workspace = true }

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/delegation.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/delegation.rs
@@ -20,7 +20,10 @@ use super::{
     CompanionFetchLogContext, FetchCloner,
 };
 use crate::{
-    chainlink::errors::{ChainlinkError, ChainlinkResult},
+    chainlink::{
+        errors::{ChainlinkError, ChainlinkResult},
+        record_mirror::MirrorLookup,
+    },
     cloner::{Cloner, DelegationActions},
     remote_account_provider::{
         ChainPubsubClient, ChainRpcClient, MatchSlotsConfig,
@@ -200,44 +203,61 @@ where
             false
         });
 
-    let res = match this
-        .remote_account_provider
-        .try_get_multi_until_slots_match(
-            &[delegation_record_pubkey],
-            Some(MatchSlotsConfig {
-                min_context_slot: Some(min_context_slot),
-                ..MatchSlotsConfig::new(
-                    ChainlinkCompanionFetchKind::DelegationRecord,
-                )
-            }),
-            fetch_context
-                .with_reason(metrics::AccountFetchReason::DelegationRecord),
-        )
-        .await
+    // A mirror hit is the record's state proven at min_context_slot — no
+    // RPC needed. Every other outcome (miss, tombstone, unparsable bytes)
+    // falls through to the RPC fetch below, byte-for-byte the prior path.
+    let mirrored = this.record_mirror.as_ref().and_then(|mirror| match mirror
+        .get(&delegation_record_pubkey, min_context_slot)
     {
-        Ok(mut delegation_records) => {
-            if let Some(delegation_record_remote) = delegation_records.pop() {
-                match delegation_record_remote.fresh_account() {
-                    Some(delegation_record_account) => this
-                        .parse_delegation_record(
-                            delegation_record_account.data(),
-                            delegation_record_pubkey,
-                        )
-                        .ok(),
-                    None => None,
+        MirrorLookup::Hit { data, .. } => this
+            .parse_delegation_record(&data, delegation_record_pubkey)
+            .ok(),
+        MirrorLookup::Tombstone { .. } | MirrorLookup::Miss => None,
+    });
+
+    let res = if mirrored.is_some() {
+        mirrored
+    } else {
+        match this
+            .remote_account_provider
+            .try_get_multi_until_slots_match(
+                &[delegation_record_pubkey],
+                Some(MatchSlotsConfig {
+                    min_context_slot: Some(min_context_slot),
+                    ..MatchSlotsConfig::new(
+                        ChainlinkCompanionFetchKind::DelegationRecord,
+                    )
+                }),
+                fetch_context
+                    .with_reason(metrics::AccountFetchReason::DelegationRecord),
+            )
+            .await
+        {
+            Ok(mut delegation_records) => {
+                if let Some(delegation_record_remote) = delegation_records.pop()
+                {
+                    match delegation_record_remote.fresh_account() {
+                        Some(delegation_record_account) => this
+                            .parse_delegation_record(
+                                delegation_record_account.data(),
+                                delegation_record_pubkey,
+                            )
+                            .ok(),
+                        None => None,
+                    }
+                } else {
+                    None
                 }
-            } else {
+            }
+            Err(err) => {
+                log_companion_fetch_failure(
+                    companion_fetch_log_context,
+                    delegation_record_pubkey,
+                    ChainlinkCompanionFetchKind::DelegationRecord,
+                    &err,
+                );
                 None
             }
-        }
-        Err(err) => {
-            log_companion_fetch_failure(
-                companion_fetch_log_context,
-                delegation_record_pubkey,
-                ChainlinkCompanionFetchKind::DelegationRecord,
-                &err,
-            );
-            None
         }
     };
 

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/delegation.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/delegation.rs
@@ -209,9 +209,18 @@ where
     let mirrored = this.record_mirror.as_ref().and_then(|mirror| match mirror
         .get(&delegation_record_pubkey, min_context_slot)
     {
-        MirrorLookup::Hit { data, .. } => this
-            .parse_delegation_record(&data, delegation_record_pubkey)
-            .ok(),
+        MirrorLookup::Hit { data, .. } => {
+            use metrics::RecordMirrorLookupOutcome as Outcome;
+            let parsed = this
+                .parse_delegation_record(&data, delegation_record_pubkey)
+                .ok();
+            metrics::inc_record_mirror_lookup(if parsed.is_some() {
+                Outcome::Hit
+            } else {
+                Outcome::ParseFallback
+            });
+            parsed
+        }
         MirrorLookup::Tombstone { .. } | MirrorLookup::Miss => None,
     });
 

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -2778,6 +2778,8 @@ where
                 match self
                     .task_to_fetch_with_delegation_record(
                         pubkey,
+                        ResolvedAccountSharedData::Fresh(account.clone()),
+                        account.remote_slot(),
                         account.remote_slot(),
                         AccountFetchContext::subscription_update(
                             AccountFetchReason::DelegationRecord,
@@ -3981,33 +3983,64 @@ where
         Ok(final_result)
     }
 
+    /// Resolves an account with its delegation record, pairing the account
+    /// copy the caller already holds (at `account_slot`) with a mirrored
+    /// record when the pair is snapshot-consistent: the record must be
+    /// proven through `slot` AND unchanged since at or before
+    /// `account_slot`, so both sides describe the same chain state. That
+    /// path performs no RPC at all. Every other outcome runs the batched
+    /// two-account fetch, byte-for-byte the prior path.
     fn task_to_fetch_with_delegation_record(
         &self,
         pubkey: Pubkey,
+        account: ResolvedAccountSharedData,
+        account_slot: u64,
         slot: u64,
         fetch_context: AccountFetchContext,
     ) -> task::JoinHandle<ChainlinkResult<AccountWithCompanion>> {
         let delegation_record_pubkey =
             delegation_record_pda_from_delegated_account(&pubkey);
 
-        // A mirror hit is the record's state proven at `slot`, so only the
-        // account itself needs fetching. Any other outcome — including bytes
-        // that do not look like a record — keeps the batched two-account
-        // fetch, byte-for-byte the prior path.
-        if let Some(MirrorLookup::Hit { data, .. }) = self
+        if let Some(MirrorLookup::Hit {
+            data,
+            slot: record_slot,
+        }) = self
             .record_mirror
             .as_ref()
             .map(|mirror| mirror.get(&delegation_record_pubkey, slot))
         {
-            if is_delegation_record_data(&data) {
-                return self.task_to_fetch_with_mirrored_delegation_record(
-                    pubkey,
-                    delegation_record_pubkey,
-                    data,
+            use metrics::RecordMirrorLookupOutcome as Outcome;
+            if record_slot > account_slot {
+                // The record changed after the held account copy was taken;
+                // only the batched fetch can produce a consistent pair.
+                metrics::inc_record_mirror_lookup(Outcome::Stale);
+            } else if !is_delegation_record_data(&data) {
+                metrics::inc_record_mirror_lookup(Outcome::ParseFallback);
+            } else {
+                metrics::inc_record_mirror_lookup(Outcome::Hit);
+                trace!(
+                    pubkey = %pubkey,
+                    companion = %delegation_record_pubkey,
                     slot,
-                    fetch_context
-                        .with_reason(AccountFetchReason::DelegationRecord),
+                    "Pairing held account with mirrored delegation record"
                 );
+                let companion_account = ResolvedAccountSharedData::Fresh(
+                    AccountSharedData::from(Account {
+                        lamports: MIRRORED_RECORD_LAMPORTS,
+                        data,
+                        owner: dlp_api::id(),
+                        executable: false,
+                        rent_epoch: 0,
+                    }),
+                );
+                return task::spawn(async move {
+                    Ok(AccountWithCompanion {
+                        pubkey,
+                        account,
+                        companion_pubkey: delegation_record_pubkey,
+                        companion_account: Some(companion_account),
+                    })
+                });
             }
         }
 
@@ -4018,76 +4051,6 @@ where
             fetch_context.with_reason(AccountFetchReason::DelegationRecord),
             ChainlinkCompanionFetchKind::DelegationRecord,
         )
-    }
-
-    /// Companion-fetch variant for a delegation record already served by the
-    /// mirror: fetches only the primary account and synthesizes the record
-    /// companion from the mirrored bytes (downstream consumers only read the
-    /// companion's data).
-    fn task_to_fetch_with_mirrored_delegation_record(
-        &self,
-        pubkey: Pubkey,
-        delegation_record_pubkey: Pubkey,
-        record_data: Vec<u8>,
-        slot: u64,
-        fetch_context: AccountFetchContext,
-    ) -> task::JoinHandle<ChainlinkResult<AccountWithCompanion>> {
-        let provider = self.remote_account_provider.clone();
-        let bank = self.accounts_bank.clone();
-        let fetch_count = self.fetch_count.clone();
-        task::spawn(async move {
-            trace!(
-                pubkey = %pubkey,
-                companion = %delegation_record_pubkey,
-                slot,
-                "Fetching account with mirrored delegation record"
-            );
-
-            fetch_count.fetch_add(1, Ordering::Relaxed);
-
-            let mut accs = provider
-                .try_get_multi_until_slots_match(
-                    &[pubkey],
-                    Some(MatchSlotsConfig {
-                        min_context_slot: Some(slot),
-                        ..MatchSlotsConfig::new(
-                            ChainlinkCompanionFetchKind::DelegationRecord,
-                        )
-                    }),
-                    fetch_context,
-                )
-                .await
-                .map_err(ChainlinkError::from)?;
-
-            let account = accs
-                .pop()
-                .and_then(|acc| match acc {
-                    RemoteAccount::Found(acc) => {
-                        acc.account.resolved_account_shared_data(bank.as_ref())
-                    }
-                    RemoteAccount::NotFound(_) => None,
-                })
-                .ok_or(ChainlinkError::ResolvedAccountCouldNoLongerBeFound(
-                    pubkey,
-                ))?;
-
-            let companion_account = ResolvedAccountSharedData::Fresh(
-                AccountSharedData::from(Account {
-                    lamports: MIRRORED_RECORD_LAMPORTS,
-                    data: record_data,
-                    owner: dlp_api::id(),
-                    executable: false,
-                    rent_epoch: 0,
-                }),
-            );
-
-            Ok(AccountWithCompanion {
-                pubkey,
-                account,
-                companion_pubkey: delegation_record_pubkey,
-                companion_account: Some(companion_account),
-            })
-        })
     }
 
     fn task_to_fetch_with_program_data(

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -32,7 +32,7 @@ use magicblock_metrics::metrics::{
 };
 use parking_lot::Mutex as PlMutex;
 use scc::HashMap;
-use solana_account::{AccountSharedData, ReadableAccount};
+use solana_account::{Account, AccountSharedData, ReadableAccount};
 use solana_account_decoder_client_types::UiAccountEncoding;
 use solana_keypair::Keypair;
 use solana_pubkey::Pubkey;
@@ -85,6 +85,7 @@ use crate::{
         blacklisted_accounts::{
             blacklisted_accounts, programs_not_to_subscribe,
         },
+        record_mirror::{DelegationRecordMirror, MirrorLookup},
         ObservedUndelegationRequest,
     },
     cloner::{
@@ -169,6 +170,10 @@ where
     /// Risk checker for post-delegation action addresses.
     risk_service: Option<Arc<RiskService>>,
 
+    /// In-memory delegation-record mirror consulted before RPC record
+    /// fetches; any miss falls back to the RPC path.
+    record_mirror: Option<Arc<DelegationRecordMirror>>,
+
     undelegation_request_sender: broadcast::Sender<ObservedUndelegationRequest>,
 }
 
@@ -185,6 +190,10 @@ impl Drop for PendingUndelegationGuard {
         }
     }
 }
+
+/// Lamports for a record companion synthesized from mirrored bytes.
+/// Downstream consumers only read the companion's data, never its lamports.
+const MIRRORED_RECORD_LAMPORTS: u64 = 1_000_000;
 
 /// Negative-cache capacity for known-empty eATAs.
 const KNOWN_EMPTY_EATAS_CAPACITY: NonZeroUsize =
@@ -371,6 +380,7 @@ where
                 .pending_operation_timeout_ms
                 .clone(),
             risk_service: self.risk_service.clone(),
+            record_mirror: self.record_mirror.clone(),
             undelegation_request_sender: self
                 .undelegation_request_sender
                 .clone(),
@@ -444,6 +454,7 @@ where
             subscription_updates_rx,
             allowed_programs,
             risk_service,
+            None,
             undelegation_request_sender,
         )
     }
@@ -458,6 +469,7 @@ where
         subscription_updates_rx: mpsc::Receiver<ForwardedSubscriptionUpdate>,
         allowed_programs: Option<Vec<AllowedProgram>>,
         risk_service: Option<Arc<RiskService>>,
+        record_mirror: Option<Arc<DelegationRecordMirror>>,
         undelegation_request_sender: broadcast::Sender<
             ObservedUndelegationRequest,
         >,
@@ -495,6 +507,7 @@ where
                 FETCH_CLONE_OPERATION_TIMEOUT.as_millis() as u64,
             )),
             risk_service,
+            record_mirror,
             undelegation_request_sender,
         });
 
@@ -522,6 +535,17 @@ where
     /// Get the current fetch count
     pub fn fetch_count(&self) -> u64 {
         self.fetch_count.load(Ordering::Relaxed)
+    }
+
+    /// Drops the mirror entry for an account's delegation record when local
+    /// state observed its undelegation completing — insurance against a
+    /// missed tombstone leaving a stale delegated entry behind.
+    fn invalidate_mirrored_record(&self, pubkey: &Pubkey) {
+        if let Some(mirror) = &self.record_mirror {
+            mirror.invalidate(&delegation_record_pda_from_delegated_account(
+                pubkey,
+            ));
+        }
     }
 
     async fn classify_dlp_program_update_interest(
@@ -2752,14 +2776,12 @@ where
                     });
 
                 match self
-                    .task_to_fetch_with_companion(
+                    .task_to_fetch_with_delegation_record(
                         pubkey,
-                        delegation_record_pubkey,
                         account.remote_slot(),
                         AccountFetchContext::subscription_update(
                             AccountFetchReason::DelegationRecord,
                         ),
-                        ChainlinkCompanionFetchKind::DelegationRecord,
                     )
                     .await
                 {
@@ -3617,6 +3639,7 @@ where
                 // If there is no delegation record then it is possible that the account itself
                 // does not exist either.
                 // In that case we need to refresh it as empty to clear the undelegation state.
+                self.invalidate_mirrored_record(pubkey);
                 return RefreshDecision::YesAndMarkEmptyIfNotFound;
             }
 
@@ -3636,6 +3659,7 @@ where
                 debug!(
                     "Account {pubkey} marked as undelegating will be overridden since undelegation completed"
                 );
+                self.invalidate_mirrored_record(pubkey);
                 return RefreshDecision::Yes;
             }
         } else if in_bank.owner().eq(&dlp_api::id()) {
@@ -3965,6 +3989,28 @@ where
     ) -> task::JoinHandle<ChainlinkResult<AccountWithCompanion>> {
         let delegation_record_pubkey =
             delegation_record_pda_from_delegated_account(&pubkey);
+
+        // A mirror hit is the record's state proven at `slot`, so only the
+        // account itself needs fetching. Any other outcome — including bytes
+        // that do not look like a record — keeps the batched two-account
+        // fetch, byte-for-byte the prior path.
+        if let Some(MirrorLookup::Hit { data, .. }) = self
+            .record_mirror
+            .as_ref()
+            .map(|mirror| mirror.get(&delegation_record_pubkey, slot))
+        {
+            if is_delegation_record_data(&data) {
+                return self.task_to_fetch_with_mirrored_delegation_record(
+                    pubkey,
+                    delegation_record_pubkey,
+                    data,
+                    slot,
+                    fetch_context
+                        .with_reason(AccountFetchReason::DelegationRecord),
+                );
+            }
+        }
+
         self.task_to_fetch_with_companion(
             pubkey,
             delegation_record_pubkey,
@@ -3972,6 +4018,76 @@ where
             fetch_context.with_reason(AccountFetchReason::DelegationRecord),
             ChainlinkCompanionFetchKind::DelegationRecord,
         )
+    }
+
+    /// Companion-fetch variant for a delegation record already served by the
+    /// mirror: fetches only the primary account and synthesizes the record
+    /// companion from the mirrored bytes (downstream consumers only read the
+    /// companion's data).
+    fn task_to_fetch_with_mirrored_delegation_record(
+        &self,
+        pubkey: Pubkey,
+        delegation_record_pubkey: Pubkey,
+        record_data: Vec<u8>,
+        slot: u64,
+        fetch_context: AccountFetchContext,
+    ) -> task::JoinHandle<ChainlinkResult<AccountWithCompanion>> {
+        let provider = self.remote_account_provider.clone();
+        let bank = self.accounts_bank.clone();
+        let fetch_count = self.fetch_count.clone();
+        task::spawn(async move {
+            trace!(
+                pubkey = %pubkey,
+                companion = %delegation_record_pubkey,
+                slot,
+                "Fetching account with mirrored delegation record"
+            );
+
+            fetch_count.fetch_add(1, Ordering::Relaxed);
+
+            let mut accs = provider
+                .try_get_multi_until_slots_match(
+                    &[pubkey],
+                    Some(MatchSlotsConfig {
+                        min_context_slot: Some(slot),
+                        ..MatchSlotsConfig::new(
+                            ChainlinkCompanionFetchKind::DelegationRecord,
+                        )
+                    }),
+                    fetch_context,
+                )
+                .await
+                .map_err(ChainlinkError::from)?;
+
+            let account = accs
+                .pop()
+                .and_then(|acc| match acc {
+                    RemoteAccount::Found(acc) => {
+                        acc.account.resolved_account_shared_data(bank.as_ref())
+                    }
+                    RemoteAccount::NotFound(_) => None,
+                })
+                .ok_or(ChainlinkError::ResolvedAccountCouldNoLongerBeFound(
+                    pubkey,
+                ))?;
+
+            let companion_account = ResolvedAccountSharedData::Fresh(
+                AccountSharedData::from(Account {
+                    lamports: MIRRORED_RECORD_LAMPORTS,
+                    data: record_data,
+                    owner: dlp_api::id(),
+                    executable: false,
+                    rent_epoch: 0,
+                }),
+            );
+
+            Ok(AccountWithCompanion {
+                pubkey,
+                account,
+                companion_pubkey: delegation_record_pubkey,
+                companion_account: Some(companion_account),
+            })
+        })
     }
 
     fn task_to_fetch_with_program_data(

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/pipeline.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/pipeline.rs
@@ -33,7 +33,7 @@ use crate::{
         },
         pubsub_common::is_internal_dlp_account_data,
         ChainPubsubClient, ChainRpcClient, MatchSlotsConfig, RemoteAccount,
-        ResolvedAccount, SubscriptionReason,
+        ResolvedAccount, ResolvedAccountSharedData, SubscriptionReason,
     },
 };
 
@@ -224,7 +224,7 @@ where
 
     // For potentially delegated accounts we update the owner and delegation state first
     let mut fetch_with_delegation_record_join_set = JoinSet::new();
-    for (pubkey, _, account_slot) in &owned_by_deleg {
+    for (pubkey, account, account_slot) in &owned_by_deleg {
         let effective_slot = if let Some(min_slot) = min_context_slot {
             min_slot.max(*account_slot)
         } else {
@@ -233,6 +233,8 @@ where
         fetch_with_delegation_record_join_set.spawn(
             this.task_to_fetch_with_delegation_record(
                 *pubkey,
+                ResolvedAccountSharedData::Fresh(account.clone()),
+                *account_slot,
                 effective_slot,
                 fetch_context.clone(),
             ),

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -52,7 +52,8 @@ use crate::{
         },
         cloner_stub::ClonerStub,
         deleg::{
-            add_delegation_record_for, add_delegation_record_with_actions_for,
+            add_delegation_record_for, add_delegation_record_to_mirror,
+            add_delegation_record_with_actions_for,
             add_invalid_delegation_record_for, delegation_record_to_vec,
         },
         eatas::{
@@ -12111,4 +12112,367 @@ async fn test_replay_subscription_update_for_unwatched_account_is_processed() {
         .expect("account should be in bank");
     assert_eq!(in_bank.remote_slot(), 50);
     assert_eq!(in_bank.lamports(), 2_000_000);
+}
+
+// -----------------
+// Delegation-record mirror
+// -----------------
+
+/// Like [`setup`], but with a record mirror wired into the FetchCloner.
+async fn setup_with_mirror<I>(
+    accounts: I,
+    current_slot: u64,
+    validator_keypair: Keypair,
+) -> (
+    FetcherTestCtx,
+    Arc<crate::chainlink::record_mirror::DelegationRecordMirror>,
+)
+where
+    I: IntoIterator<Item = (Pubkey, Account)>,
+{
+    init_logger();
+
+    let accounts_map: HashMap<Pubkey, Account> = accounts.into_iter().collect();
+    let rpc_client = ChainRpcClientMockBuilder::new()
+        .slot(current_slot)
+        .clock_sysvar_for_slot(current_slot)
+        .accounts(accounts_map)
+        .build();
+
+    let (updates_sender, updates_receiver) = mpsc::channel(1_000);
+    let pubsub_client =
+        ChainPubsubClientMock::new(updates_sender, updates_receiver);
+    let accounts_bank = Arc::new(AccountsBankStub::default());
+    let rpc_client_clone = rpc_client.clone();
+
+    let (forward_tx, forward_rx) = mpsc::channel(1_000);
+    let (subscribed_accounts, config) = create_test_lru_cache(1000);
+    let chain_slot = Arc::<AtomicU64>::default();
+
+    let remote_account_provider = Arc::new(
+        RemoteAccountProvider::new(
+            rpc_client,
+            pubsub_client,
+            forward_tx,
+            &config,
+            subscribed_accounts,
+            ChainSlot::new(chain_slot),
+        )
+        .await
+        .unwrap(),
+    );
+
+    let mirror =
+        crate::chainlink::record_mirror::DelegationRecordMirror::new_for_tests(
+        );
+    let (subscription_tx, subscription_rx) = mpsc::channel(100);
+    let cloner = Arc::new(ClonerStub::new(accounts_bank.clone()));
+    let (undelegation_request_sender, _) =
+        tokio::sync::broadcast::channel(1024);
+    let fetch_cloner = FetchCloner::new_with_undelegation_request_sender(
+        &remote_account_provider,
+        &accounts_bank,
+        &cloner,
+        validator_keypair,
+        subscription_rx,
+        None,
+        None,
+        Some(mirror.clone()),
+        undelegation_request_sender,
+    );
+
+    (
+        FetcherTestCtx {
+            remote_account_provider,
+            accounts_bank,
+            rpc_client: rpc_client_clone,
+            forward_rx,
+            fetch_cloner,
+            subscription_tx,
+            cloner,
+        },
+        mirror,
+    )
+}
+
+fn delegated_dlp_account(data: Vec<u8>) -> Account {
+    Account {
+        lamports: 1_234,
+        data,
+        owner: dlp_api::id(),
+        executable: false,
+        rent_epoch: 0,
+    }
+}
+
+/// The record lives ONLY in the mirror: resolving the account as delegated
+/// proves the record was served from memory, since an RPC fetch would have
+/// found nothing and cloned the account as-is.
+#[tokio::test]
+async fn test_delegated_account_resolves_from_mirror_without_record_rpc() {
+    let validator_keypair = Keypair::new();
+    let validator_pubkey = validator_keypair.pubkey();
+    let account_pubkey = random_pubkey();
+    let account_owner = random_pubkey();
+    const CURRENT_SLOT: u64 = 100;
+
+    let account = delegated_dlp_account(vec![1, 2, 3, 4]);
+    let (ctx, mirror) = setup_with_mirror(
+        [(account_pubkey, account.clone())],
+        CURRENT_SLOT,
+        validator_keypair.insecure_clone(),
+    )
+    .await;
+
+    let deleg_record_pubkey = add_delegation_record_to_mirror(
+        &mirror,
+        account_pubkey,
+        validator_pubkey,
+        account_owner,
+        50,
+    );
+    mirror.test_set_watermark(CURRENT_SLOT);
+
+    let calls_before = ctx.rpc_client.single_account_fetches()
+        + ctx.rpc_client.multi_account_fetches();
+
+    ctx.fetch_cloner
+        .fetch_and_clone_accounts(
+            &[account_pubkey],
+            None,
+            None,
+            AccountFetchContext::rpc_get_account(),
+        )
+        .await
+        .expect("fetch and clone should succeed");
+
+    let cloned = ctx
+        .accounts_bank
+        .get_account(&account_pubkey)
+        .expect("account should be cloned");
+    let mut expected =
+        delegated_account_shared_with_owner(&account, account_owner);
+    expected.set_remote_slot(CURRENT_SLOT);
+    assert_eq!(
+        cloned, expected,
+        "record authority/owner must come from the mirror"
+    );
+
+    // Same call count as the RPC-record path (initial fetch + resolution
+    // fetch), but the resolution fetch carries only the account: the record
+    // is not in the RPC mock at all, so any record fetch would have changed
+    // the delegated outcome asserted above.
+    let calls = ctx.rpc_client.single_account_fetches()
+        + ctx.rpc_client.multi_account_fetches()
+        - calls_before;
+    assert_eq!(calls, 2, "no extra RPC calls beyond the account fetches");
+    assert!(ctx
+        .accounts_bank
+        .get_account(&deleg_record_pubkey)
+        .is_none());
+}
+
+/// An entry the mirror cannot prove fresh (entry slot and watermark both
+/// behind the requested slot) must fall back to the RPC record.
+#[tokio::test]
+async fn test_stale_mirror_entry_falls_back_to_rpc_record() {
+    let validator_keypair = Keypair::new();
+    let validator_pubkey = validator_keypair.pubkey();
+    let account_pubkey = random_pubkey();
+    let account_owner = random_pubkey();
+    const CURRENT_SLOT: u64 = 100;
+
+    let account = delegated_dlp_account(vec![5, 6]);
+    let (ctx, mirror) = setup_with_mirror(
+        [(account_pubkey, account.clone())],
+        CURRENT_SLOT,
+        validator_keypair.insecure_clone(),
+    )
+    .await;
+
+    // Mirror entry provable only up to slot 90 -- lookups at CURRENT_SLOT
+    // must not use it. The RPC mock carries the authoritative record.
+    add_delegation_record_to_mirror(
+        &mirror,
+        account_pubkey,
+        validator_pubkey,
+        account_owner,
+        50,
+    );
+    mirror.test_set_watermark(90);
+    add_delegation_record_for(
+        &ctx.rpc_client,
+        account_pubkey,
+        validator_pubkey,
+        account_owner,
+    );
+
+    ctx.fetch_cloner
+        .fetch_and_clone_accounts(
+            &[account_pubkey],
+            None,
+            None,
+            AccountFetchContext::rpc_get_account(),
+        )
+        .await
+        .expect("fetch and clone should succeed");
+
+    let cloned = ctx
+        .accounts_bank
+        .get_account(&account_pubkey)
+        .expect("account should be cloned");
+    assert!(
+        cloned.delegated(),
+        "RPC fallback must still resolve the record"
+    );
+}
+
+/// Unparsable mirror bytes must fall back to the RPC record.
+#[tokio::test]
+async fn test_invalid_mirror_record_falls_back_to_rpc_record() {
+    let validator_keypair = Keypair::new();
+    let validator_pubkey = validator_keypair.pubkey();
+    let account_pubkey = random_pubkey();
+    let account_owner = random_pubkey();
+    const CURRENT_SLOT: u64 = 100;
+
+    let account = delegated_dlp_account(vec![7]);
+    let (ctx, mirror) = setup_with_mirror(
+        [(account_pubkey, account.clone())],
+        CURRENT_SLOT,
+        validator_keypair.insecure_clone(),
+    )
+    .await;
+
+    let deleg_record_pubkey =
+        dlp_api::pda::delegation_record_pda_from_delegated_account(
+            &account_pubkey,
+        );
+    mirror.test_insert_record(deleg_record_pubkey, vec![255; 4], CURRENT_SLOT);
+    mirror.test_set_watermark(CURRENT_SLOT);
+    add_delegation_record_for(
+        &ctx.rpc_client,
+        account_pubkey,
+        validator_pubkey,
+        account_owner,
+    );
+
+    ctx.fetch_cloner
+        .fetch_and_clone_accounts(
+            &[account_pubkey],
+            None,
+            None,
+            AccountFetchContext::rpc_get_account(),
+        )
+        .await
+        .expect("fetch and clone should succeed");
+
+    let cloned = ctx
+        .accounts_bank
+        .get_account(&account_pubkey)
+        .expect("account should be cloned");
+    assert!(
+        cloned.delegated(),
+        "parse fallback must still resolve via RPC"
+    );
+}
+
+/// A tombstone never skips RPC: with no RPC record either, the account is
+/// cloned as-is (not delegated), exactly like today's no-record path.
+#[tokio::test]
+async fn test_mirror_tombstone_still_confirms_via_rpc() {
+    let validator_keypair = Keypair::new();
+    let account_pubkey = random_pubkey();
+    const CURRENT_SLOT: u64 = 100;
+
+    let account = delegated_dlp_account(vec![8, 9]);
+    let (ctx, mirror) = setup_with_mirror(
+        [(account_pubkey, account.clone())],
+        CURRENT_SLOT,
+        validator_keypair.insecure_clone(),
+    )
+    .await;
+
+    let deleg_record_pubkey =
+        dlp_api::pda::delegation_record_pda_from_delegated_account(
+            &account_pubkey,
+        );
+    mirror.test_insert_tombstone(deleg_record_pubkey, CURRENT_SLOT);
+    mirror.test_set_watermark(CURRENT_SLOT);
+
+    ctx.fetch_cloner
+        .fetch_and_clone_accounts(
+            &[account_pubkey],
+            None,
+            None,
+            AccountFetchContext::rpc_get_account(),
+        )
+        .await
+        .expect("fetch and clone should succeed");
+
+    let cloned = ctx
+        .accounts_bank
+        .get_account(&account_pubkey)
+        .expect("account should be cloned");
+    assert!(
+        !cloned.delegated(),
+        "tombstone must behave exactly like the no-record RPC result"
+    );
+}
+
+/// The dominant prod path: a program-source update for an unknown DLP-owned
+/// account is greedily cloned with the record served from the mirror -- the
+/// record is absent from the RPC mock, so delegation state proves the source.
+#[tokio::test]
+async fn test_greedy_discovery_resolves_record_from_mirror() {
+    let validator_keypair = Keypair::new();
+    let validator_pubkey = validator_keypair.pubkey();
+    let account_pubkey = random_pubkey();
+    let account_owner = random_pubkey();
+    const CURRENT_SLOT: u64 = 100;
+
+    let delegated_account = delegated_dlp_account(vec![1, 2, 3, 4]);
+    let (ctx, mirror) = setup_with_mirror(
+        [(account_pubkey, delegated_account.clone())],
+        CURRENT_SLOT,
+        validator_keypair.insecure_clone(),
+    )
+    .await;
+
+    add_delegation_record_to_mirror(
+        &mirror,
+        account_pubkey,
+        validator_pubkey,
+        account_owner,
+        CURRENT_SLOT,
+    );
+    mirror.test_set_watermark(CURRENT_SLOT);
+
+    ctx.subscription_tx
+        .send(ForwardedSubscriptionUpdate {
+            pubkey: account_pubkey,
+            account: RemoteAccount::from_fresh_account(
+                delegated_account,
+                CURRENT_SLOT,
+                RemoteAccountUpdateSource::Subscription,
+            ),
+            source: SubscriptionSource::Program,
+        })
+        .await
+        .unwrap();
+
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while ctx.accounts_bank.get_account(&account_pubkey).is_none() {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("timed out waiting for greedy DLP discovery clone");
+
+    let cloned = ctx
+        .accounts_bank
+        .get_account(&account_pubkey)
+        .expect("account should be cloned");
+    assert!(cloned.delegated());
+    assert_eq!(cloned.owner(), &account_owner);
 }

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -12258,14 +12258,14 @@ async fn test_delegated_account_resolves_from_mirror_without_record_rpc() {
         "record authority/owner must come from the mirror"
     );
 
-    // Same call count as the RPC-record path (initial fetch + resolution
-    // fetch), but the resolution fetch carries only the account: the record
-    // is not in the RPC mock at all, so any record fetch would have changed
-    // the delegated outcome asserted above.
+    // Only the initial classification fetch touches RPC: the mirrored
+    // record is paired with the already-held account copy, so resolution
+    // itself performs no fetch at all (the record is not in the RPC mock,
+    // so any record fetch would also have changed the outcome above).
     let calls = ctx.rpc_client.single_account_fetches()
         + ctx.rpc_client.multi_account_fetches()
         - calls_before;
-    assert_eq!(calls, 2, "no extra RPC calls beyond the account fetches");
+    assert_eq!(calls, 1, "resolution must not fetch when the mirror pairs");
     assert!(ctx
         .accounts_bank
         .get_account(&deleg_record_pubkey)

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -12476,3 +12476,68 @@ async fn test_greedy_discovery_resolves_record_from_mirror() {
     assert!(cloned.delegated());
     assert_eq!(cloned.owner(), &account_owner);
 }
+
+/// Choke-point-1 fallback (`fetch_and_parse_delegation_record` via greedy
+/// discovery): an unprovable mirror entry must fall back to the RPC record
+/// and still greedily clone the account as delegated.
+#[tokio::test]
+async fn test_greedy_discovery_falls_back_to_rpc_on_stale_mirror() {
+    let validator_keypair = Keypair::new();
+    let validator_pubkey = validator_keypair.pubkey();
+    let account_pubkey = random_pubkey();
+    let account_owner = random_pubkey();
+    const CURRENT_SLOT: u64 = 100;
+
+    let delegated_account = delegated_dlp_account(vec![4, 5, 6]);
+    let (ctx, mirror) = setup_with_mirror(
+        [(account_pubkey, delegated_account.clone())],
+        CURRENT_SLOT,
+        validator_keypair.insecure_clone(),
+    )
+    .await;
+
+    // Mirror entry provable only up to slot 90; the authoritative record
+    // lives in the RPC mock.
+    add_delegation_record_to_mirror(
+        &mirror,
+        account_pubkey,
+        validator_pubkey,
+        account_owner,
+        50,
+    );
+    mirror.test_set_watermark(90);
+    add_delegation_record_for(
+        &ctx.rpc_client,
+        account_pubkey,
+        validator_pubkey,
+        account_owner,
+    );
+
+    ctx.subscription_tx
+        .send(ForwardedSubscriptionUpdate {
+            pubkey: account_pubkey,
+            account: RemoteAccount::from_fresh_account(
+                delegated_account,
+                CURRENT_SLOT,
+                RemoteAccountUpdateSource::Subscription,
+            ),
+            source: SubscriptionSource::Program,
+        })
+        .await
+        .unwrap();
+
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while ctx.accounts_bank.get_account(&account_pubkey).is_none() {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("timed out waiting for greedy DLP discovery clone");
+
+    let cloned = ctx
+        .accounts_bank
+        .get_account(&account_pubkey)
+        .expect("account should be cloned");
+    assert!(cloned.delegated());
+    assert_eq!(cloned.owner(), &account_owner);
+}

--- a/magicblock-chainlink/src/chainlink/mod.rs
+++ b/magicblock-chainlink/src/chainlink/mod.rs
@@ -22,6 +22,7 @@ use tokio::{
 use tracing::*;
 
 use crate::{
+    chainlink::record_mirror::DelegationRecordMirror,
     cloner::Cloner,
     config::ChainlinkConfig,
     fetch_cloner::FetchAndCloneResult,
@@ -38,6 +39,7 @@ mod blacklisted_accounts;
 pub mod config;
 pub mod errors;
 pub mod fetch_cloner;
+pub mod record_mirror;
 
 pub use blacklisted_accounts::*;
 
@@ -413,6 +415,11 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
                 ledger_path,
             )?
             .map(Arc::new);
+            let record_mirror = DelegationRecordMirror::try_from_config(
+                &chainlink_config.record_sync,
+                endpoints,
+            )
+            .await;
             let fetch_cloner =
                 FetchCloner::new_with_undelegation_request_sender(
                     &provider,
@@ -422,6 +429,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
                     rx,
                     chainlink_config.allowed_programs.clone(),
                     risk_service,
+                    record_mirror,
                     undelegation_request_sender.clone(),
                 );
             Some(fetch_cloner)

--- a/magicblock-chainlink/src/chainlink/record_mirror.rs
+++ b/magicblock-chainlink/src/chainlink/record_mirror.rs
@@ -1,0 +1,331 @@
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+
+use lru::LruCache;
+use magicblock_config::config::RecordSyncConfig;
+use magicblock_metrics::metrics::{self, RecordMirrorLookupOutcome};
+use magicblock_sync::{AccountUpdate, DlpSyncer};
+use parking_lot::Mutex as PlMutex;
+use solana_pubkey::Pubkey;
+use tokio::sync::mpsc::Receiver;
+use tracing::{info, warn};
+
+use crate::remote_account_provider::{Endpoint, Endpoints};
+
+/// In-memory mirror of on-chain delegation records, fed by the
+/// magicblock-sync record firehose.
+///
+/// The firehose carries every delegation-record update on chain plus in-band
+/// `SlotAdvanced` watermarks, delivered losslessly. That gives the mirror a
+/// freshness proof: an entry that has seen no update while the watermark
+/// advanced to slot `w` IS the record's state at every slot up to `w`. On any
+/// continuity break (`SyncInterrupted`) the mirror clears itself, so a lookup
+/// can only degrade to [`MirrorLookup::Miss`] — and every non-hit outcome
+/// falls back to an RPC fetch. Absence here is never "not delegated".
+pub struct DelegationRecordMirror {
+    inner: PlMutex<MirrorState>,
+}
+
+struct MirrorState {
+    /// Record PDA -> last observed state.
+    entries: LruCache<Pubkey, RecordEntry>,
+    /// Latest `SlotAdvanced` watermark; 0 until the first one.
+    watermark: u64,
+    /// True while the stream is live and the watermark trustworthy.
+    live: bool,
+}
+
+struct RecordEntry {
+    slot: u64,
+    /// Record bytes, or `None` for an undelegation tombstone.
+    data: Option<Vec<u8>>,
+}
+
+/// Result of a mirror lookup.
+pub enum MirrorLookup {
+    /// The record's state at or after the requested slot.
+    Hit { data: Vec<u8>, slot: u64 },
+    /// The record was observed undelegated. Callers must still confirm via
+    /// RPC: undelegation events are heuristic (tx-parsed) in the stream.
+    Tombstone { slot: u64 },
+    /// Nothing provable for the requested slot.
+    Miss,
+}
+
+impl DelegationRecordMirror {
+    /// Starts the mirror from config, connecting the record firehose.
+    ///
+    /// Returns `None` (with a warning) when disabled, when no gRPC
+    /// endpoint/api-key can be resolved, or when the initial connection
+    /// fails: the mirror is an optimization and must never block startup.
+    pub async fn try_from_config(
+        config: &RecordSyncConfig,
+        endpoints: &Endpoints,
+    ) -> Option<Arc<Self>> {
+        if !config.enabled {
+            return None;
+        }
+
+        let (endpoint, api_key) = match resolve_endpoint(config, endpoints) {
+            Some(resolved) => resolved,
+            None => {
+                warn!(
+                    "record mirror enabled but no gRPC endpoint with api key \
+                     available; running without it"
+                );
+                return None;
+            }
+        };
+
+        let updates =
+            match DlpSyncer::start_firehose(endpoint.clone(), api_key).await {
+                Ok(updates) => updates,
+                Err(error) => {
+                    warn!(
+                        ?error,
+                        endpoint,
+                        "record mirror failed to connect; running without it"
+                    );
+                    return None;
+                }
+            };
+
+        info!(endpoint, "record mirror connected");
+        Some(Self::start_consumer(updates, config.capacity))
+    }
+
+    fn start_consumer(
+        mut updates: Receiver<AccountUpdate>,
+        capacity: usize,
+    ) -> Arc<Self> {
+        let mirror = Arc::new(Self::with_capacity(capacity));
+        let consumer = Arc::clone(&mirror);
+        tokio::spawn(async move {
+            while let Some(update) = updates.recv().await {
+                consumer.apply(update);
+            }
+            // Stream task gone for good; leave the mirror cold.
+            consumer.clear();
+            metrics::set_record_mirror_live(false);
+            warn!("record mirror stream ended; running without it");
+        });
+        mirror
+    }
+
+    fn with_capacity(capacity: usize) -> Self {
+        let capacity = NonZeroUsize::new(capacity)
+            .unwrap_or(NonZeroUsize::new(1).expect("1 is non-zero"));
+        Self {
+            inner: PlMutex::new(MirrorState {
+                entries: LruCache::new(capacity),
+                watermark: 0,
+                live: false,
+            }),
+        }
+    }
+
+    fn apply(&self, update: AccountUpdate) {
+        match update {
+            AccountUpdate::Delegated { record, data, slot } => {
+                self.insert(Pubkey::new_from_array(record), slot, Some(data));
+            }
+            AccountUpdate::Undelegated { record, slot } => {
+                self.insert(Pubkey::new_from_array(record), slot, None);
+            }
+            AccountUpdate::SlotAdvanced(slot) => {
+                let mut inner = self.inner.lock();
+                inner.watermark = inner.watermark.max(slot);
+                inner.live = true;
+                drop(inner);
+                metrics::set_record_mirror_live(true);
+                metrics::set_record_mirror_watermark(slot);
+            }
+            AccountUpdate::SyncInterrupted | AccountUpdate::SyncTerminated => {
+                self.clear();
+                metrics::set_record_mirror_live(false);
+            }
+        }
+    }
+
+    /// Inserts monotonically: an update older than the stored slot is a
+    /// resume re-delivery and must not roll state back.
+    fn insert(&self, record: Pubkey, slot: u64, data: Option<Vec<u8>>) {
+        let mut inner = self.inner.lock();
+        if let Some(existing) = inner.entries.peek(&record) {
+            if existing.slot > slot {
+                return;
+            }
+        }
+        inner.entries.put(record, RecordEntry { slot, data });
+    }
+
+    fn clear(&self) {
+        let mut inner = self.inner.lock();
+        inner.entries.clear();
+        inner.watermark = 0;
+        inner.live = false;
+    }
+
+    /// Looks up a record's state provable at or after `min_context_slot`.
+    ///
+    /// An entry qualifies when its own slot reaches `min_context_slot`, or
+    /// when the live watermark does: the firehose carries every record
+    /// update, so an entry unchanged while the watermark advanced past the
+    /// requested slot is that record's current state.
+    pub fn get(&self, record: &Pubkey, min_context_slot: u64) -> MirrorLookup {
+        let mut inner = self.inner.lock();
+        let fresh_watermark = inner.live && inner.watermark >= min_context_slot;
+        let Some(entry) = inner.entries.get(record) else {
+            metrics::inc_record_mirror_lookup(RecordMirrorLookupOutcome::Miss);
+            return MirrorLookup::Miss;
+        };
+
+        if entry.slot < min_context_slot && !fresh_watermark {
+            metrics::inc_record_mirror_lookup(RecordMirrorLookupOutcome::Stale);
+            return MirrorLookup::Miss;
+        }
+
+        match &entry.data {
+            Some(data) => {
+                metrics::inc_record_mirror_lookup(
+                    RecordMirrorLookupOutcome::Hit,
+                );
+                MirrorLookup::Hit {
+                    data: data.clone(),
+                    slot: entry.slot,
+                }
+            }
+            None => {
+                metrics::inc_record_mirror_lookup(
+                    RecordMirrorLookupOutcome::Tombstone,
+                );
+                MirrorLookup::Tombstone { slot: entry.slot }
+            }
+        }
+    }
+
+    /// Drops a single entry, forcing the next lookup to fall back to RPC.
+    pub fn invalidate(&self, record: &Pubkey) {
+        self.inner.lock().entries.pop(record);
+    }
+}
+
+/// Resolves the firehose endpoint: explicit config wins, otherwise the
+/// first gRPC remote (which always carries an api key).
+fn resolve_endpoint(
+    config: &RecordSyncConfig,
+    endpoints: &Endpoints,
+) -> Option<(String, String)> {
+    if let (Some(endpoint), Some(api_key)) = (&config.endpoint, &config.api_key)
+    {
+        return Some((endpoint.to_string(), api_key.clone()));
+    }
+
+    endpoints.iter().find_map(|ep| match ep {
+        Endpoint::Grpc { url, api_key, .. } => {
+            Some((url.clone(), api_key.clone()))
+        }
+        _ => None,
+    })
+}
+
+#[cfg(any(test, feature = "dev-context"))]
+impl DelegationRecordMirror {
+    pub fn new_for_tests() -> Arc<Self> {
+        Arc::new(Self::with_capacity(1024))
+    }
+
+    pub fn test_insert_record(&self, record: Pubkey, data: Vec<u8>, slot: u64) {
+        self.insert(record, slot, Some(data));
+    }
+
+    pub fn test_insert_tombstone(&self, record: Pubkey, slot: u64) {
+        self.insert(record, slot, None);
+    }
+
+    pub fn test_set_watermark(&self, slot: u64) {
+        self.apply(AccountUpdate::SlotAdvanced(slot));
+    }
+
+    pub fn test_clear(&self) {
+        self.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn record() -> Pubkey {
+        Pubkey::new_unique()
+    }
+
+    #[test]
+    fn hit_requires_entry_slot_or_live_watermark() {
+        let mirror = DelegationRecordMirror::with_capacity(16);
+        let pda = record();
+        mirror.insert(pda, 50, Some(vec![1]));
+
+        // Entry slot below the requested slot, no watermark -> miss.
+        assert!(matches!(mirror.get(&pda, 100), MirrorLookup::Miss));
+        // Entry slot satisfies the request directly.
+        assert!(matches!(mirror.get(&pda, 40), MirrorLookup::Hit { .. }));
+
+        // Watermark past the requested slot proves the entry unchanged.
+        mirror.apply(AccountUpdate::SlotAdvanced(120));
+        assert!(matches!(
+            mirror.get(&pda, 100),
+            MirrorLookup::Hit { slot: 50, .. }
+        ));
+        // But not beyond the watermark.
+        assert!(matches!(mirror.get(&pda, 121), MirrorLookup::Miss));
+    }
+
+    #[test]
+    fn inserts_are_monotonic_per_record() {
+        let mirror = DelegationRecordMirror::with_capacity(16);
+        let pda = record();
+        mirror.insert(pda, 50, Some(vec![1]));
+        mirror.insert(pda, 40, Some(vec![9]));
+
+        let MirrorLookup::Hit { data, slot } = mirror.get(&pda, 40) else {
+            panic!("expected hit");
+        };
+        assert_eq!((data.as_slice(), slot), (&[1][..], 50));
+
+        // A newer tombstone replaces the record.
+        mirror.insert(pda, 60, None);
+        assert!(matches!(
+            mirror.get(&pda, 40),
+            MirrorLookup::Tombstone { slot: 60 }
+        ));
+    }
+
+    #[test]
+    fn interruption_clears_entries_and_watermark() {
+        let mirror = DelegationRecordMirror::with_capacity(16);
+        let pda = record();
+        mirror.insert(pda, 50, Some(vec![1]));
+        mirror.apply(AccountUpdate::SlotAdvanced(120));
+
+        mirror.apply(AccountUpdate::SyncInterrupted);
+        assert!(matches!(mirror.get(&pda, 1), MirrorLookup::Miss));
+
+        // A stale watermark from before the gap must not count.
+        mirror.insert(pda, 130, Some(vec![2]));
+        assert!(matches!(mirror.get(&pda, 140), MirrorLookup::Miss));
+    }
+
+    #[test]
+    fn lru_eviction_degrades_to_miss() {
+        let mirror = DelegationRecordMirror::with_capacity(2);
+        let (a, b, c) = (record(), record(), record());
+        mirror.insert(a, 10, Some(vec![1]));
+        mirror.insert(b, 11, Some(vec![2]));
+        mirror.insert(c, 12, Some(vec![3]));
+
+        assert!(matches!(mirror.get(&a, 5), MirrorLookup::Miss));
+        assert!(matches!(mirror.get(&b, 5), MirrorLookup::Hit { .. }));
+        assert!(matches!(mirror.get(&c, 5), MirrorLookup::Hit { .. }));
+    }
+}

--- a/magicblock-chainlink/src/chainlink/record_mirror.rs
+++ b/magicblock-chainlink/src/chainlink/record_mirror.rs
@@ -1,5 +1,4 @@
-use std::num::NonZeroUsize;
-use std::sync::Arc;
+use std::{num::NonZeroUsize, sync::Arc};
 
 use lru::LruCache;
 use magicblock_config::config::RecordSyncConfig;

--- a/magicblock-chainlink/src/chainlink/record_mirror.rs
+++ b/magicblock-chainlink/src/chainlink/record_mirror.rs
@@ -135,9 +135,10 @@ impl DelegationRecordMirror {
                 let mut inner = self.inner.lock();
                 inner.watermark = inner.watermark.max(slot);
                 inner.live = true;
+                let watermark = inner.watermark;
                 drop(inner);
                 metrics::set_record_mirror_live(true);
-                metrics::set_record_mirror_watermark(slot);
+                metrics::set_record_mirror_watermark(watermark);
             }
             AccountUpdate::SyncInterrupted | AccountUpdate::SyncTerminated => {
                 self.clear();

--- a/magicblock-chainlink/src/chainlink/record_mirror.rs
+++ b/magicblock-chainlink/src/chainlink/record_mirror.rs
@@ -185,15 +185,13 @@ impl DelegationRecordMirror {
         }
 
         match &entry.data {
-            Some(data) => {
-                metrics::inc_record_mirror_lookup(
-                    RecordMirrorLookupOutcome::Hit,
-                );
-                MirrorLookup::Hit {
-                    data: data.clone(),
-                    slot: entry.slot,
-                }
-            }
+            // Not counted as a hit here: callers validate the bytes (and the
+            // pairing slot) first and count Hit/ParseFallback/Stale so the
+            // hit metric only reports lookups that actually skipped an RPC.
+            Some(data) => MirrorLookup::Hit {
+                data: data.clone(),
+                slot: entry.slot,
+            },
             None => {
                 metrics::inc_record_mirror_lookup(
                     RecordMirrorLookupOutcome::Tombstone,
@@ -209,23 +207,31 @@ impl DelegationRecordMirror {
     }
 }
 
-/// Resolves the firehose endpoint: explicit config wins, otherwise the
-/// first gRPC remote (which always carries an api key).
+/// Resolves the firehose endpoint. Each field independently prefers the
+/// explicit config value and falls back to the first gRPC remote (which
+/// always carries an api key), so partial overrides take effect.
 fn resolve_endpoint(
     config: &RecordSyncConfig,
     endpoints: &Endpoints,
 ) -> Option<(String, String)> {
-    if let (Some(endpoint), Some(api_key)) = (&config.endpoint, &config.api_key)
-    {
-        return Some((endpoint.to_string(), api_key.clone()));
-    }
-
-    endpoints.iter().find_map(|ep| match ep {
+    let grpc_remote = endpoints.iter().find_map(|ep| match ep {
         Endpoint::Grpc { url, api_key, .. } => {
             Some((url.clone(), api_key.clone()))
         }
         _ => None,
-    })
+    });
+
+    let endpoint = config
+        .endpoint
+        .as_ref()
+        .map(ToString::to_string)
+        .or_else(|| grpc_remote.as_ref().map(|(url, _)| url.clone()))?;
+    let api_key = config
+        .api_key
+        .clone()
+        .or_else(|| grpc_remote.map(|(_, key)| key))?;
+
+    Some((endpoint, api_key))
 }
 
 #[cfg(any(test, feature = "dev-context"))]

--- a/magicblock-chainlink/src/testing/deleg.rs
+++ b/magicblock-chainlink/src/testing/deleg.rs
@@ -94,6 +94,33 @@ pub fn add_delegation_record_with_actions_for(
     deleg_record_pubkey
 }
 
+/// Registers a delegation record in the record mirror (instead of the RPC
+/// mock), proving it at `slot`. Returns the record PDA.
+#[cfg(any(test, feature = "dev-context"))]
+pub fn add_delegation_record_to_mirror(
+    mirror: &crate::chainlink::record_mirror::DelegationRecordMirror,
+    pubkey: Pubkey,
+    authority: Pubkey,
+    owner: Pubkey,
+    slot: u64,
+) -> Pubkey {
+    let deleg_record_pubkey =
+        delegation_record_pda_from_delegated_account(&pubkey);
+    let deleg_record = DelegationRecord {
+        authority,
+        owner,
+        delegation_slot: 1,
+        lamports: 1_000,
+        commit_frequency_ms: 2_000,
+    };
+    mirror.test_insert_record(
+        deleg_record_pubkey,
+        delegation_record_to_vec(&deleg_record),
+        slot,
+    );
+    deleg_record_pubkey
+}
+
 #[cfg(any(test, feature = "dev-context"))]
 pub fn add_invalid_delegation_record_for(
     rpc_client: &ChainRpcClientMock,

--- a/magicblock-config/src/config/chain.rs
+++ b/magicblock-config/src/config/chain.rs
@@ -77,6 +77,9 @@ pub struct ChainLinkConfig {
 
     /// AML/Risk checks for post-delegation actions via Range API.
     pub risk: RiskConfig,
+
+    /// Delegation-record mirror fed from the magicblock-sync record firehose.
+    pub record_sync: RecordSyncConfig,
 }
 
 impl Default for ChainLinkConfig {
@@ -94,6 +97,35 @@ impl Default for ChainLinkConfig {
                 consts::DEFAULT_UNDELEGATION_REQUEST_POLL_INTERVAL_SECS,
             ),
             risk: RiskConfig::default(),
+            record_sync: RecordSyncConfig::default(),
+        }
+    }
+}
+
+/// Configuration for the in-memory delegation-record mirror streamed from
+/// the magicblock-sync record firehose. On any mirror miss the validator
+/// falls back to fetching the record via RPC, so disabling this only costs
+/// upstream RPC traffic, never correctness.
+#[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
+pub struct RecordSyncConfig {
+    /// Enables the delegation-record mirror.
+    pub enabled: bool,
+    /// Laserstream gRPC endpoint. Defaults to the first gRPC remote.
+    pub endpoint: Option<Url>,
+    /// API key for the endpoint. Defaults to the first gRPC remote's key.
+    pub api_key: Option<String>,
+    /// Maximum number of record entries retained in the mirror.
+    pub capacity: usize,
+}
+
+impl Default for RecordSyncConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            endpoint: None,
+            api_key: None,
+            capacity: consts::DEFAULT_RECORD_SYNC_CAPACITY,
         }
     }
 }

--- a/magicblock-config/src/config/mod.rs
+++ b/magicblock-config/src/config/mod.rs
@@ -15,7 +15,7 @@ pub use accounts::{AccountsDbConfig, BlockSize};
 pub use aperture::ApertureConfig;
 pub use chain::{
     AllowedProgram, ChainLinkConfig, ChainOperationConfig, CommittorConfig,
-    RiskConfig,
+    RecordSyncConfig, RiskConfig,
 };
 pub use grpc::GrpcConfig;
 pub use ledger::LedgerConfig;

--- a/magicblock-config/src/consts.rs
+++ b/magicblock-config/src/consts.rs
@@ -99,3 +99,6 @@ pub const DEFAULT_RISK_REQUEST_TIMEOUT_SEC: u64 = 5;
 
 /// Default risk score threshold for Range risk service
 pub const DEFAULT_RISK_SCORE_THRESHOLD: u64 = 5;
+
+/// Default capacity of the delegation-record mirror (~40 MB of records)
+pub const DEFAULT_RECORD_SYNC_CAPACITY: usize = 262_144;

--- a/magicblock-metrics/src/metrics/mod.rs
+++ b/magicblock-metrics/src/metrics/mod.rs
@@ -241,17 +241,17 @@ lazy_static::lazy_static! {
             ),
             &["outcome"],
         )
-        .unwrap();
+        .expect("static name and label set are valid metric identifiers");
 
     static ref CHAINLINK_RECORD_MIRROR_LIVE_GAUGE: IntGauge = IntGauge::new(
         "chainlink_record_mirror_live",
         "1 while the delegation-record mirror stream is live (watermark advancing), 0 otherwise",
-    ).unwrap();
+    ).expect("static name is a valid metric identifier");
 
     static ref CHAINLINK_RECORD_MIRROR_WATERMARK_GAUGE: IntGauge = IntGauge::new(
         "chainlink_record_mirror_watermark",
         "Latest confirmed slot the delegation-record mirror is caught up to",
-    ).unwrap();
+    ).expect("static name is a valid metric identifier");
 
     static ref PROGRAM_SUBSCRIPTION_ACCOUNT_UPDATES_COUNT: IntCounterVec =
         IntCounterVec::new(

--- a/magicblock-metrics/src/metrics/mod.rs
+++ b/magicblock-metrics/src/metrics/mod.rs
@@ -233,6 +233,26 @@ lazy_static::lazy_static! {
         "program_subscription_discovered_dlp_update_delegated_elsewhere_count", "DLP-owned subscription updates that, after fetching the delegation record, were found delegated to another validator and dropped",
     ).unwrap();
 
+    static ref CHAINLINK_RECORD_MIRROR_LOOKUPS_TOTAL: IntCounterVec =
+        IntCounterVec::new(
+            Opts::new(
+                "chainlink_record_mirror_lookups_total",
+                "Delegation-record mirror lookups by outcome; every non-hit outcome falls back to an RPC fetch",
+            ),
+            &["outcome"],
+        )
+        .unwrap();
+
+    static ref CHAINLINK_RECORD_MIRROR_LIVE_GAUGE: IntGauge = IntGauge::new(
+        "chainlink_record_mirror_live",
+        "1 while the delegation-record mirror stream is live (watermark advancing), 0 otherwise",
+    ).unwrap();
+
+    static ref CHAINLINK_RECORD_MIRROR_WATERMARK_GAUGE: IntGauge = IntGauge::new(
+        "chainlink_record_mirror_watermark",
+        "Latest confirmed slot the delegation-record mirror is caught up to",
+    ).unwrap();
+
     static ref PROGRAM_SUBSCRIPTION_ACCOUNT_UPDATES_COUNT: IntCounterVec =
         IntCounterVec::new(
             Opts::new(
@@ -789,6 +809,9 @@ pub(crate) fn register() {
         register!(CHAINLINK_SUBSCRIPTION_RELEASE_ACCOUNTS_TOTAL);
         register!(CHAINLINK_SUBSCRIPTION_CLEANUP_ACCOUNTS_TOTAL);
         register!(PROGRAM_SUBSCRIPTION_DISCOVERED_DLP_UPDATE_DELEGATED_ELSEWHERE_COUNT);
+        register!(CHAINLINK_RECORD_MIRROR_LOOKUPS_TOTAL);
+        register!(CHAINLINK_RECORD_MIRROR_LIVE_GAUGE);
+        register!(CHAINLINK_RECORD_MIRROR_WATERMARK_GAUGE);
         register!(PROGRAM_SUBSCRIPTION_ACCOUNT_UPDATES_COUNT);
         register!(ACCOUNT_SUBSCRIPTION_ACCOUNT_UPDATES_COUNT);
         register!(ACCOUNT_SUBSCRIPTION_ACTIVATIONS_COUNT);
@@ -1068,6 +1091,49 @@ pub fn chainlink_subscription_cleanup_accounts_value(
 
 pub fn inc_discovered_dlp_update_delegated_elsewhere() {
     PROGRAM_SUBSCRIPTION_DISCOVERED_DLP_UPDATE_DELEGATED_ELSEWHERE_COUNT.inc();
+}
+
+/// Outcome of a delegation-record mirror lookup. Every non-`Hit` outcome
+/// falls back to an RPC fetch.
+#[derive(Debug, Clone, Copy)]
+pub enum RecordMirrorLookupOutcome {
+    /// Record served from the mirror; RPC fetch skipped.
+    Hit,
+    /// Record not in the mirror.
+    Miss,
+    /// Entry present but freshness could not be proven for the requested slot.
+    Stale,
+    /// Entry present as an undelegation tombstone.
+    Tombstone,
+    /// Mirror bytes failed to parse as a delegation record.
+    ParseFallback,
+}
+
+impl RecordMirrorLookupOutcome {
+    fn as_str(&self) -> &'static str {
+        use RecordMirrorLookupOutcome::*;
+        match self {
+            Hit => "hit",
+            Miss => "miss",
+            Stale => "stale",
+            Tombstone => "tombstone",
+            ParseFallback => "parse_fallback",
+        }
+    }
+}
+
+pub fn inc_record_mirror_lookup(outcome: RecordMirrorLookupOutcome) {
+    CHAINLINK_RECORD_MIRROR_LOOKUPS_TOTAL
+        .with_label_values(&[outcome.as_str()])
+        .inc();
+}
+
+pub fn set_record_mirror_live(live: bool) {
+    CHAINLINK_RECORD_MIRROR_LIVE_GAUGE.set(live as i64);
+}
+
+pub fn set_record_mirror_watermark(slot: u64) {
+    CHAINLINK_RECORD_MIRROR_WATERMARK_GAUGE.set(slot as i64);
 }
 
 pub fn inc_committor_intents_count() {

--- a/test-integration/Cargo.lock
+++ b/test-integration/Cargo.lock
@@ -289,7 +289,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -300,7 +300,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -795,7 +795,7 @@ dependencies = [
  "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -2021,7 +2021,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3833,7 +3833,7 @@ dependencies = [
  "solana-system-interface 2.0.0",
  "static_assertions",
  "strum",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3865,7 +3865,7 @@ dependencies = [
  "solana-system-interface 2.0.0",
  "static_assertions",
  "strum",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4112,7 +4112,7 @@ dependencies = [
 [[package]]
 name = "magicblock-sync"
 version = "0.2.0"
-source = "git+https://github.com/magicblock-labs/magicblock-sync.git?rev=c979bb0#c979bb0ab403423cacab49f67c6437e0d389d902"
+source = "git+https://github.com/magicblock-labs/magicblock-sync.git?rev=d1f13ee#d1f13ee9500a335584a6f6dbcd108471134493b4"
 dependencies = [
  "futures",
  "helius-laserstream",
@@ -4435,7 +4435,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5076,7 +5076,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "petgraph",
@@ -5097,7 +5097,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -5785,7 +5785,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6407,7 +6407,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9743,7 +9743,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10928,7 +10928,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/test-integration/Cargo.lock
+++ b/test-integration/Cargo.lock
@@ -289,7 +289,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -300,7 +300,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -795,7 +795,7 @@ dependencies = [
  "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "regex",
@@ -2021,7 +2021,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3659,6 +3659,7 @@ dependencies = [
  "magicblock-delegation-program-api 3.1.0",
  "magicblock-magic-program-api 0.13.18",
  "magicblock-metrics",
+ "magicblock-sync",
  "parking_lot",
  "scc",
  "solana-account 3.4.0",
@@ -4109,6 +4110,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "magicblock-sync"
+version = "0.2.0"
+source = "git+https://github.com/magicblock-labs/magicblock-sync.git?rev=c979bb0#c979bb0ab403423cacab49f67c6437e0d389d902"
+dependencies = [
+ "futures",
+ "helius-laserstream",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "magicblock-table-mania"
 version = "0.13.18"
 dependencies = [
@@ -4423,7 +4435,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5064,7 +5076,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph",
@@ -5085,7 +5097,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -5311,7 +5323,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5773,7 +5785,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6395,7 +6407,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9731,7 +9743,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10916,7 +10928,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/test-integration/Cargo.lock
+++ b/test-integration/Cargo.lock
@@ -289,7 +289,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -300,7 +300,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -795,7 +795,7 @@ dependencies = [
  "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "regex",
@@ -2021,7 +2021,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4112,7 +4112,7 @@ dependencies = [
 [[package]]
 name = "magicblock-sync"
 version = "0.2.0"
-source = "git+https://github.com/magicblock-labs/magicblock-sync.git?rev=d1f13ee#d1f13ee9500a335584a6f6dbcd108471134493b4"
+source = "git+https://github.com/magicblock-labs/magicblock-sync.git?rev=3c71985#3c719851767544d1ae003bbf53d74c82c14acb01"
 dependencies = [
  "futures",
  "helius-laserstream",
@@ -4435,7 +4435,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5076,7 +5076,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph",
@@ -5097,7 +5097,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -5785,7 +5785,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6407,7 +6407,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9743,7 +9743,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10928,7 +10928,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

~70% of upstream RPC traffic on mainnet-usa/europe is `subscription_update → delegation_record` fetches (~1.9k per node per 2.2h, 55% not-found): every DLP-owned account update RPC-fetches the companion delegation record just to learn its authority.

This is the **minimal first step** against that: keep chainlink's behavior exactly as it is, add an in-memory mirror of all on-chain delegation records (streamed over one Laserstream gRPC subscription by [magicblock-sync](https://github.com/magicblock-labs/magicblock-sync)), and consult it before the two functions through which **every** record RPC read flows. A mirror hit skips the RPC; every other outcome falls back to the existing RPC path, byte-for-byte unchanged. No classifier/collision-machinery changes — that cleanup is follow-up work, gated on this proving itself in prod metrics.

## How it works

**`chainlink/record_mirror.rs`** — a bounded LRU (`record PDA → latest state`, default 262,144 entries ≈ 40 MB) fed by the magicblock-sync firehose (magicblock-labs/magicblock-sync#6), which delivers every record update on chain plus in-band `SlotAdvanced` watermarks with lossless backpressure.

The freshness proof for a lookup at `min_context_slot = S`:
- entry slot ≥ S — the entry directly satisfies "state at or after S"; or
- live watermark ≥ S — the stream carries **all** record updates and the mirror clears itself on any continuity break, so an entry unchanged while the watermark passed S *is* the record's state at S.

**Consistency rule** (learned from the placeholder-wedge incident): absence in the mirror is never "not delegated". Misses, stale entries, undelegation tombstones (tx-parse heuristic — counted separately to earn trust, but never skipping RPC), and non-record bytes all fall through to the RPC fetch. LRU eviction just degrades to a miss. `SyncInterrupted`/`SyncTerminated` clear the mirror entirely.

**Choke points** (cover all record RPC reads):
1. `fetch_and_parse_delegation_record` — mirror consult before `try_get_multi_until_slots_match`; covers all seven standalone callers (greedy discovery, collision release, undelegating refresh, ATA projection).
2. `task_to_fetch_with_delegation_record` — on a hit, fetches only the account and synthesizes the record companion from mirror bytes (downstream only reads the companion's data). The subscription-update path now routes through this wrapper instead of duplicating its body — behavior-neutral, and the dominant traffic source goes through the mirror.

Undelegation-completion refresh additionally invalidates the mirrored record — cheap insurance against a missed tombstone.

## Config & rollout

`[chainlink.record-sync]` — **enabled by default**, endpoint/api-key auto-derived from the first gRPC remote, so rollout needs zero config changes. Startup never fails on mirror errors; it degrades to running without one (status quo). Disabling only costs RPC traffic, never correctness.

Verification is metric-driven: `chainlink_record_mirror_lookups_total{outcome}` + live/watermark gauges; success = `AccountFetchReason::DelegationRecord` RPC counters collapse while `outcome=hit` rises.

## Tests

- Mirror-only record resolution through the ensure pipeline and greedy discovery (the record exists **only** in the mirror, so the delegated outcome itself proves no RPC fetch happened).
- Stale-entry, unparsable-bytes, and tombstone fallbacks to RPC.
- Mirror unit tests: hit criterion, monotonic inserts, interruption clearing, LRU eviction.
- All 387 pre-existing chainlink tests run unchanged (no mirror configured → `FetchCloner::new` keeps its signature); 396 total green. Config crate: 34 green (new section round-trips).

## Notes

- Depends on magicblock-labs/magicblock-sync#6; the Cargo pin currently points at that branch head and will be bumped to the merged rev once it lands.
- magicblock-sync now pins the same helius-laserstream rev as this workspace, so a single laserstream copy is built.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional delegation-record synchronization using an in-memory mirror.
  * Delegated account lookups can avoid extra RPC requests when fresh records are available.
  * Added configuration for synchronization, endpoint, API key, and mirror capacity.
  * Added monitoring metrics for lookup outcomes, synchronization status, and record freshness.

* **Bug Fixes**
  * Stale, invalid, interrupted, or missing mirror data safely falls back to existing RPC behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->