### PR TITLE
refactor: replace the DLP collision tracker with mirror rechecks

### DIFF
--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -2471,11 +2471,17 @@ where
                 break;
             }
         }
+        // The RPC kept serving pre-delegation (or still-undelegating) state.
+        // Requeue for strictly newer evidence — a fresh record update or the
+        // mirror watermark passing the failed generation — so a later record
+        // state re-triggers discovery instead of waiting for on-demand
+        // access, as the replaced re-parking did.
         warn!(
             pubkey = %pubkey,
             slot,
-            "Colliding delegated account did not settle at the update slot; on-demand cloning remains the backstop"
+            "Colliding delegated account did not settle at the update slot; requeueing for newer record evidence"
         );
+        self.schedule_collision_recheck(pubkey, slot + 1);
     }
 
     async fn maybe_greedily_clone_discovered_delegated_account(

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -2215,10 +2215,13 @@ where
         }
     }
 
-    /// Parks a collision candidate for one delayed mirror recheck. Dedup is
-    /// keyed by the derived record PDA with a monotonic slot; capacity
-    /// eviction silently drops the oldest candidate, matching the bounded
-    /// parking behavior this replaces.
+    /// Parks a collision candidate for delayed mirror rechecks. Dedup is
+    /// keyed by the derived record PDA with a monotonic slot. Admitted
+    /// candidates are never displaced: at capacity, newcomers are dropped
+    /// instead — parity with the parking this replaces, so genuine internal
+    /// firehose churn cannot evict a real collision candidate. Exactly one
+    /// worker owns each admitted entry, and only that worker removes it, so
+    /// entries and worker tasks stay 1:1 bounded by the map capacity.
     fn schedule_collision_recheck(&self, pubkey: Pubkey, slot: u64) {
         let record_pda = delegation_record_pda_from_delegated_account(&pubkey);
         {
@@ -2228,15 +2231,31 @@ where
                 pending.1 = pending.1.max(slot);
                 return;
             }
+            if rechecks.len() >= PENDING_COLLISION_RECHECKS_CAPACITY.get() {
+                trace!(
+                    pubkey = %pubkey,
+                    slot,
+                    "Dropping collision candidate; recheck queue is full"
+                );
+                return;
+            }
             rechecks.put(record_pda, (pubkey, slot));
         }
 
         let this = self.clone();
         task::spawn(async move {
-            for delay in COLLISION_RECHECK_DELAYS {
-                tokio::time::sleep(delay).await;
-                // Peek so replayed updates keep bumping the slot between
-                // attempts; evicted by capacity pressure -> dropped.
+            // Probes for the current generation, i.e. consecutive attempts
+            // that observed the same slot. A newer update bumps the slot in
+            // place and restarts the budget; every bump is driven by a real
+            // firehose update, which rate-limits the loop externally.
+            let mut generation_probes = 0usize;
+            let mut probed_slot = None;
+            loop {
+                let delay_idx =
+                    generation_probes.min(COLLISION_RECHECK_DELAYS.len() - 1);
+                tokio::time::sleep(COLLISION_RECHECK_DELAYS[delay_idx]).await;
+
+                // Read fresh each attempt: later updates bump the slot.
                 let candidate = this
                     .pending_collision_rechecks
                     .lock()
@@ -2245,6 +2264,7 @@ where
                 let Some((pubkey, slot)) = candidate else {
                     return;
                 };
+
                 let hit = this.record_mirror.as_ref().is_some_and(|mirror| {
                     matches!(
                         mirror.probe(&record_pda, slot),
@@ -2252,19 +2272,60 @@ where
                     )
                 });
                 if hit {
-                    this.pending_collision_rechecks.lock().pop(&record_pda);
-                    this.clone_colliding_delegated_account(pubkey, slot).await;
-                    return;
+                    // Remove only the generation that was probed: a newer
+                    // update racing in keeps the entry for the next attempt.
+                    let owned = {
+                        let mut rechecks =
+                            this.pending_collision_rechecks.lock();
+                        let matches_probed = rechecks
+                            .peek(&record_pda)
+                            .is_some_and(|&(_, s)| s == slot);
+                        if matches_probed {
+                            rechecks.pop(&record_pda);
+                        }
+                        matches_probed
+                    };
+                    if owned {
+                        this.clone_colliding_delegated_account(pubkey, slot)
+                            .await;
+                        return;
+                    }
+                    generation_probes = 0;
+                    probed_slot = None;
+                    continue;
                 }
-            }
-            if let Some((pubkey, slot)) =
-                this.pending_collision_rechecks.lock().pop(&record_pda)
-            {
-                trace!(
-                    pubkey = %pubkey,
-                    slot,
-                    "Dropping internal DLP program subscription update (no record after rechecks)"
-                );
+
+                if probed_slot == Some(slot) {
+                    generation_probes += 1;
+                } else {
+                    generation_probes = 1;
+                    probed_slot = Some(slot);
+                }
+                if generation_probes >= COLLISION_RECHECK_DELAYS.len() {
+                    // Give up only on the generation that exhausted its
+                    // probes; a newer one racing in keeps the worker going.
+                    let dropped = {
+                        let mut rechecks =
+                            this.pending_collision_rechecks.lock();
+                        let matches_probed = rechecks
+                            .peek(&record_pda)
+                            .is_some_and(|&(_, s)| s == slot);
+                        if matches_probed {
+                            rechecks.pop(&record_pda);
+                        }
+                        matches_probed
+                    };
+                    if dropped {
+                        trace!(
+                            pubkey = %pubkey,
+                            slot,
+                            "Dropping internal DLP program subscription update (no record after rechecks)"
+                        );
+                        return;
+                    }
+                    generation_probes = 0;
+                    probed_slot = None;
+                }
             }
         });
     }

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -152,7 +152,9 @@ where
 
     /// Recognizes freshly delegated accounts whose app data collides with an
     /// internal DLP discriminator via delegation-record sightings.
-    dlp_collision_tracker: Arc<PlMutex<DlpCollisionTracker>>,
+    /// Internal-looking DLP updates awaiting one delayed mirror recheck,
+    /// keyed by derived delegation-record PDA -> (pubkey, max update slot).
+    pending_collision_rechecks: Arc<PlMutex<LruCache<Pubkey, (Pubkey, u64)>>>,
 
     /// Tracks in-flight clone operations.
     /// The first caller to claim a key becomes the owner and performs
@@ -210,28 +212,20 @@ const PROGRAM_VERIFY_CACHE_CAPACITY: NonZeroUsize = match NonZeroUsize::new(64)
     None => panic!("PROGRAM_VERIFY_CACHE_CAPACITY must be non-zero"),
 };
 
-/// Capacity for recently sighted delegation-record update slots; sized to
-/// outlast DLP firehose churn across the SubMux debounce window.
-const SEEN_DELEGATION_RECORD_SLOTS_CAPACITY: NonZeroUsize =
-    match NonZeroUsize::new(65_536) {
-        Some(n) => n,
-        None => {
-            panic!("SEEN_DELEGATION_RECORD_SLOTS_CAPACITY must be non-zero")
-        }
-    };
-
-/// Capacity for internal-looking account updates parked until their
-/// delegation record is sighted. Once full, new unsighted candidates are
-/// dropped instead of evicting already parked candidates; this preserves
-/// account-first collision candidates across record-heavy firehose bursts
-/// while keeping memory bounded.
-const PARKED_COLLISION_UPDATES_CAPACITY: NonZeroUsize =
+/// Capacity for internal-looking account updates awaiting one delayed
+/// mirror recheck; bounds memory across record-heavy firehose bursts.
+const PENDING_COLLISION_RECHECKS_CAPACITY: NonZeroUsize =
     match NonZeroUsize::new(16_384) {
         Some(n) => n,
         None => {
-            panic!("PARKED_COLLISION_UPDATES_CAPACITY must be non-zero")
+            panic!("PENDING_COLLISION_RECHECKS_CAPACITY must be non-zero")
         }
     };
+
+/// Delay before re-consulting the record mirror for a collision candidate:
+/// the account update and its delegation record arrive on different
+/// streams, so the record may lag the account by a moment.
+const COLLISION_RECHECK_DELAY: Duration = Duration::from_secs(2);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum DlpProgramUpdateInterest {
@@ -240,101 +234,6 @@ enum DlpProgramUpdateInterest {
     ProcessAtaProjection,
     ProcessDirectlyWatched,
     DiscoverDelegatedAccount,
-}
-
-/// A parked internal-looking account update, reduced to pubkey + slot so
-/// the firehose cannot pin account payloads in memory.
-#[derive(Debug, Clone, Copy)]
-struct ParkedCollisionCandidate {
-    pubkey: Pubkey,
-    slot: u64,
-}
-
-/// Tracks delegation-record sightings from the DLP program subscription and
-/// internal-looking account updates parked until their record is sighted.
-/// A single lock keeps check-then-park atomic against sight-then-release, so
-/// an update can never be parked after its record sighting already passed.
-struct DlpCollisionTracker {
-    record_slots: LruCache<Pubkey, u64>,
-    /// Keyed by the derived delegation-record PDA of the parked account.
-    parked: LruCache<Pubkey, ParkedCollisionCandidate>,
-}
-
-impl DlpCollisionTracker {
-    fn new() -> Self {
-        Self {
-            record_slots: LruCache::new(SEEN_DELEGATION_RECORD_SLOTS_CAPACITY),
-            parked: LruCache::new(PARKED_COLLISION_UPDATES_CAPACITY),
-        }
-    }
-
-    /// Records a delegation-record sighting and releases a parked candidate
-    /// it covers. Monotonic: a stale replayed record can neither lower the
-    /// sighted slot nor consume a candidate parked at a newer slot.
-    fn sight_record(
-        &mut self,
-        record_pubkey: Pubkey,
-        slot: u64,
-    ) -> Option<ParkedCollisionCandidate> {
-        let sighted_slot =
-            self.record_slots.get_or_insert_mut(record_pubkey, || slot);
-        *sighted_slot = (*sighted_slot).max(slot);
-        let sighted_slot = *sighted_slot;
-        self.parked
-            .peek(&record_pubkey)
-            .is_some_and(|candidate| sighted_slot >= candidate.slot)
-            .then(|| self.parked.pop(&record_pubkey))
-            .flatten()
-    }
-
-    fn preserve_released_candidate(
-        &mut self,
-        candidate: ParkedCollisionCandidate,
-    ) -> bool {
-        let record_pubkey =
-            delegation_record_pda_from_delegated_account(&candidate.pubkey);
-        if !self.parked.contains(&record_pubkey)
-            && self.parked.len() >= PARKED_COLLISION_UPDATES_CAPACITY.get()
-        {
-            return false;
-        }
-
-        let parked = self.parked.get_or_insert_mut(record_pubkey, || candidate);
-        parked.slot = parked.slot.max(candidate.slot);
-        true
-    }
-
-    /// True when the pubkey's delegation record was sighted at or after the
-    /// update slot: a fresh delegation writes both accounts in one slot, so
-    /// the sighting marks a delegated account whose app data collides with an
-    /// internal DLP discriminator. Otherwise the update is parked so a late
-    /// (e.g. debounced) record sighting can release it.
-    fn check_or_park(&mut self, update: &ForwardedSubscriptionUpdate) -> bool {
-        let record_pubkey =
-            delegation_record_pda_from_delegated_account(&update.pubkey);
-        let sighted = self
-            .record_slots
-            .get(&record_pubkey)
-            .is_some_and(|&record_slot| record_slot >= update.account.slot());
-        if !sighted {
-            if !self.parked.contains(&record_pubkey)
-                && self.parked.len() >= PARKED_COLLISION_UPDATES_CAPACITY.get()
-            {
-                return false;
-            }
-
-            // Monotonic like sightings: a replayed older update must not
-            // downgrade the parked slot.
-            let parked = self.parked.get_or_insert_mut(record_pubkey, || {
-                ParkedCollisionCandidate {
-                    pubkey: update.pubkey,
-                    slot: update.account.slot(),
-                }
-            });
-            parked.slot = parked.slot.max(update.account.slot());
-        }
-        sighted
-    }
 }
 
 /// A pending fetch+clone operation claimed by one dedup call, resolved by
@@ -373,7 +272,7 @@ where
             programs_not_to_subscribe: self.programs_not_to_subscribe.clone(),
             known_empty_eatas: self.known_empty_eatas.clone(),
             program_verify_cache: self.program_verify_cache.clone(),
-            dlp_collision_tracker: self.dlp_collision_tracker.clone(),
+            pending_collision_rechecks: self.pending_collision_rechecks.clone(),
             pending_clones: self.pending_clones.clone(),
             pending_undelegations: self.pending_undelegations.clone(),
             pending_operation_timeout_ms: self
@@ -498,9 +397,9 @@ where
             program_verify_cache: Arc::new(PlMutex::new(LruCache::new(
                 PROGRAM_VERIFY_CACHE_CAPACITY,
             ))),
-            dlp_collision_tracker: Arc::new(PlMutex::new(
-                DlpCollisionTracker::new(),
-            )),
+            pending_collision_rechecks: Arc::new(PlMutex::new(LruCache::new(
+                PENDING_COLLISION_RECHECKS_CAPACITY,
+            ))),
             pending_clones: Arc::new(Mutex::new(hash_map::HashMap::new())),
             pending_undelegations: Arc::new(Mutex::new(HashSet::new())),
             pending_operation_timeout_ms: Arc::new(AtomicU64::new(
@@ -1823,44 +1722,26 @@ where
         // greedily cloned, so drop them before discovery issues remote
         // fetches. The exception is an account whose app data collides with
         // an internal discriminator: its delegation also writes the
-        // delegation record, whose sighting routes the account update to
-        // discovery — immediately when the record arrived first, or by
-        // releasing the parked update once the record arrives later.
+        // delegation record, which the mirror observes on its own stream —
+        // resolve via the mirror now, or after one short recheck covering
+        // the skew between the account and record streams. Only the program
+        // firehose is handled here; account-sourced internal payloads (e.g.
+        // directly watched records) proceed to normal processing.
         if !matches!(
             dlp_program_interest,
             Some(DlpProgramUpdateInterest::ProcessUndelegating)
                 | Some(DlpProgramUpdateInterest::ProcessAtaProjection)
         ) && is_dlp_owned_update
+            && is_internal_dlp_update
+            && matches!(update.source, SubscriptionSource::Program)
         {
-            if let Some(account) = fresh_update_account.as_ref() {
-                if is_internal_dlp_update {
-                    // Sight records from either source: SubMux dedup can
-                    // deliver a directly watched record account-sourced.
-                    let released = is_delegation_record_data(account.data())
-                        .then(|| {
-                            self.dlp_collision_tracker
-                                .lock()
-                                .sight_record(pubkey, update.account.slot())
-                        })
-                        .flatten();
-                    if let Some(released) = released {
-                        self.clone_released_collision_candidate(released).await;
-                    }
-                    // Only the program firehose is dropped/parked.
-                    if matches!(update.source, SubscriptionSource::Program)
-                        && !self
-                            .dlp_collision_tracker
-                            .lock()
-                            .check_or_park(&update)
-                    {
-                        trace!(
-                            pubkey = %pubkey,
-                            "Dropping internal DLP program subscription update"
-                        );
-                        return;
-                    }
-                }
-            }
+            // Internal-shaped bytes cannot be told apart from a colliding
+            // user account (record-shaped app data included), so every
+            // payload is probed; genuine internal accounts have no record
+            // at their derived PDA and drop after the recheck.
+            self.resolve_internal_dlp_collision(pubkey, update.account.slot())
+                .await;
+            return;
         }
 
         if self
@@ -2304,20 +2185,90 @@ where
         .await
     }
 
-    /// Deferred discovery for a parked candidate whose record was just
-    /// sighted: authority-gated like discovery, then cloned through the
-    /// deduped on-demand path. Only genuine collisions release.
-    async fn clone_released_collision_candidate(
+    /// A program-source internal-looking update is either genuine internal
+    /// DLP state or a delegated account whose app data collides with an
+    /// internal discriminator. Its delegation writes the record in the same
+    /// slot, so the mirror proves the collision: resolve immediately on a
+    /// mirror hit, or once more after a short delay covering record-stream
+    /// skew. A final miss drops the update — the on-demand ensure path
+    /// remains the backstop, exactly as unsighted parked candidates were
+    /// dropped before. Without a live mirror there is no proactive
+    /// collision discovery.
+    async fn resolve_internal_dlp_collision(&self, pubkey: Pubkey, slot: u64) {
+        let Some(mirror) = &self.record_mirror else {
+            trace!(
+                pubkey = %pubkey,
+                "Dropping internal DLP program subscription update (no record mirror)"
+            );
+            return;
+        };
+        let record_pda = delegation_record_pda_from_delegated_account(&pubkey);
+        if matches!(mirror.probe(&record_pda, slot), MirrorLookup::Hit { .. }) {
+            self.clone_colliding_delegated_account(pubkey, slot).await;
+        } else {
+            self.schedule_collision_recheck(pubkey, slot);
+        }
+    }
+
+    /// Parks a collision candidate for one delayed mirror recheck. Dedup is
+    /// keyed by the derived record PDA with a monotonic slot; capacity
+    /// eviction silently drops the oldest candidate, matching the bounded
+    /// parking behavior this replaces.
+    fn schedule_collision_recheck(&self, pubkey: Pubkey, slot: u64) {
+        let record_pda = delegation_record_pda_from_delegated_account(&pubkey);
+        {
+            let mut rechecks = self.pending_collision_rechecks.lock();
+            if let Some(pending) = rechecks.get_mut(&record_pda) {
+                // A replayed older update must not downgrade the slot.
+                pending.1 = pending.1.max(slot);
+                return;
+            }
+            rechecks.put(record_pda, (pubkey, slot));
+        }
+
+        let this = self.clone();
+        task::spawn(async move {
+            tokio::time::sleep(COLLISION_RECHECK_DELAY).await;
+            let candidate =
+                this.pending_collision_rechecks.lock().pop(&record_pda);
+            // Evicted by capacity pressure in the meantime -> dropped.
+            let Some((pubkey, slot)) = candidate else {
+                return;
+            };
+            let hit = this.record_mirror.as_ref().is_some_and(|mirror| {
+                matches!(
+                    mirror.probe(&record_pda, slot),
+                    MirrorLookup::Hit { .. }
+                )
+            });
+            if hit {
+                this.clone_colliding_delegated_account(pubkey, slot).await;
+            } else {
+                trace!(
+                    pubkey = %pubkey,
+                    slot,
+                    "Dropping internal DLP program subscription update (no record after recheck)"
+                );
+            }
+        });
+    }
+
+    /// Discovery for an account whose app data collides with an internal
+    /// DLP discriminator, proven delegated by its mirrored record:
+    /// authority-gated like discovery, then cloned through the deduped
+    /// on-demand path with a forced refresh.
+    async fn clone_colliding_delegated_account(
         &self,
-        candidate: ParkedCollisionCandidate,
+        pubkey: Pubkey,
+        slot: u64,
     ) {
         // A pre-delegation bank copy must be force-refreshed; only a
-        // delegated copy at the sighted slot or newer settles the candidate.
+        // delegated copy at the update slot or newer settles the candidate.
         let fresh_delegated_in_bank = self
             .accounts_bank
-            .get_account(&candidate.pubkey)
+            .get_account(&pubkey)
             .is_some_and(|in_bank| {
-                in_bank.delegated() && in_bank.remote_slot() >= candidate.slot
+                in_bank.delegated() && in_bank.remote_slot() >= slot
             });
         if fresh_delegated_in_bank {
             return;
@@ -2332,22 +2283,22 @@ where
             .with_reason(AccountFetchReason::DelegationRecord);
         let companion_fetch_log_context = CompanionFetchLogContext {
             origin: record_context.clone(),
-            primary_pubkey: candidate.pubkey,
-            context_slot: candidate.slot,
+            primary_pubkey: pubkey,
+            context_slot: slot,
         };
         let Some((deleg_record, _)) = self
             .fetch_and_parse_delegation_record(
-                candidate.pubkey,
-                candidate.slot,
+                pubkey,
+                slot,
                 record_context,
                 companion_fetch_log_context,
             )
             .await
         else {
             trace!(
-                pubkey = %candidate.pubkey,
-                slot = candidate.slot,
-                "Released collision candidate has no resolvable delegation record; falling back to on-demand cloning"
+                pubkey = %pubkey,
+                slot = slot,
+                "Colliding delegated account has no resolvable delegation record; falling back to on-demand cloning"
             );
             return;
         };
@@ -2357,27 +2308,27 @@ where
         if !is_delegated_to_us {
             metrics::inc_discovered_dlp_update_delegated_elsewhere();
             trace!(
-                pubkey = %candidate.pubkey,
+                pubkey = %pubkey,
                 authority = %deleg_record.authority,
-                "Ignoring released collision candidate delegated elsewhere"
+                "Ignoring colliding delegated account delegated elsewhere"
             );
             return;
         }
         // The deduped fetch can join an in-flight pre-delegation owner and
-        // settle stale; retry until the bank reflects the sighted delegation
-        // (at the sighted slot itself only a delegated copy settles).
+        // settle stale; retry until the bank reflects the mirrored delegation
+        // (at the update slot itself only a delegated copy settles).
         const MAX_RELEASE_CLONE_ATTEMPTS: usize = 3;
         for _ in 0..MAX_RELEASE_CLONE_ATTEMPTS {
-            // The candidate may have been parked before local undelegation
-            // started. Do not let its later record sighting bypass the normal
+            // The update may predate a local undelegation that started in
+            // the meantime. Do not let the mirrored record bypass the normal
             // confirmation check and overwrite protected local state.
             if self
                 .accounts_bank
-                .get_account(&candidate.pubkey)
+                .get_account(&pubkey)
                 .is_some_and(|in_bank| {
                     in_bank.undelegating()
                         && account_still_undelegating_on_chain(
-                            &candidate.pubkey,
+                            &pubkey,
                             true,
                             in_bank.remote_slot(),
                             Some(deleg_record),
@@ -2386,30 +2337,30 @@ where
                 })
             {
                 trace!(
-                    pubkey = %candidate.pubkey,
-                    slot = candidate.slot,
-                    "Ignoring released collision candidate while local undelegation remains pending"
+                    pubkey = %pubkey,
+                    slot = slot,
+                    "Ignoring colliding delegated account while local undelegation remains pending"
                 );
                 return;
             }
 
             let result = match self
                 .fetch_and_clone_accounts_with_dedup_forced_refresh(
-                    &[candidate.pubkey],
+                    &[pubkey],
                     None,
-                    Some(candidate.slot),
+                    Some(slot),
                     fetch_context.clone(),
-                    &HashSet::from([candidate.pubkey]),
-                    Some((candidate.pubkey, deleg_record.delegation_slot)),
+                    &HashSet::from([pubkey]),
+                    Some((pubkey, deleg_record.delegation_slot)),
                 )
                 .await
             {
                 Ok(result) => result,
                 Err(err) => {
                     warn!(
-                        pubkey = %candidate.pubkey,
+                        pubkey = %pubkey,
                         error = %err,
-                        "Failed to clone released colliding delegated account"
+                        "Failed to clone colliding delegated account"
                     );
                     return;
                 }
@@ -2418,21 +2369,20 @@ where
                 .not_found_on_chain
                 .iter()
                 .chain(result.missing_delegation_record.iter())
-                .any(|(missing_pubkey, _)| missing_pubkey == &candidate.pubkey);
+                .any(|(missing_pubkey, _)| missing_pubkey == &pubkey);
             if unresolvable {
                 trace!(
-                    pubkey = %candidate.pubkey,
-                    slot = candidate.slot,
+                    pubkey = %pubkey,
+                    slot = slot,
                     ?result,
-                    "Released collision candidate no longer resolvable on chain"
+                    "Colliding delegated account no longer resolvable on chain"
                 );
                 return;
             }
-            let in_bank = self.accounts_bank.get_account(&candidate.pubkey);
+            let in_bank = self.accounts_bank.get_account(&pubkey);
             let settled = in_bank.as_ref().is_some_and(|in_bank| {
-                in_bank.remote_slot() > candidate.slot
-                    || (in_bank.remote_slot() == candidate.slot
-                        && in_bank.delegated())
+                in_bank.remote_slot() > slot
+                    || (in_bank.remote_slot() == slot && in_bank.delegated())
             });
             if settled {
                 return;
@@ -2444,15 +2394,10 @@ where
                 break;
             }
         }
-        let preserved = self
-            .dlp_collision_tracker
-            .lock()
-            .preserve_released_candidate(candidate);
         warn!(
-            pubkey = %candidate.pubkey,
-            slot = candidate.slot,
-            preserved,
-            "Released collision candidate did not settle at the sighted slot; preserving it for a later delegation-record sighting"
+            pubkey = %pubkey,
+            slot,
+            "Colliding delegated account did not settle at the update slot; on-demand cloning remains the backstop"
         );
     }
 

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -222,10 +222,15 @@ const PENDING_COLLISION_RECHECKS_CAPACITY: NonZeroUsize =
         }
     };
 
-/// Delay before re-consulting the record mirror for a collision candidate:
-/// the account update and its delegation record arrive on different
-/// streams, so the record may lag the account by a moment.
-const COLLISION_RECHECK_DELAY: Duration = Duration::from_secs(2);
+/// Backoff schedule for re-consulting the record mirror on a collision
+/// candidate: the account update and its delegation record arrive on
+/// different streams, so the record may lag the account — briefly in
+/// steady state, longer across a mirror reconnect that replays the stream.
+const COLLISION_RECHECK_DELAYS: [Duration; 3] = [
+    Duration::from_secs(2),
+    Duration::from_secs(8),
+    Duration::from_secs(30),
+];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum DlpProgramUpdateInterest {
@@ -2228,26 +2233,37 @@ where
 
         let this = self.clone();
         task::spawn(async move {
-            tokio::time::sleep(COLLISION_RECHECK_DELAY).await;
-            let candidate =
-                this.pending_collision_rechecks.lock().pop(&record_pda);
-            // Evicted by capacity pressure in the meantime -> dropped.
-            let Some((pubkey, slot)) = candidate else {
-                return;
-            };
-            let hit = this.record_mirror.as_ref().is_some_and(|mirror| {
-                matches!(
-                    mirror.probe(&record_pda, slot),
-                    MirrorLookup::Hit { .. }
-                )
-            });
-            if hit {
-                this.clone_colliding_delegated_account(pubkey, slot).await;
-            } else {
+            for delay in COLLISION_RECHECK_DELAYS {
+                tokio::time::sleep(delay).await;
+                // Peek so replayed updates keep bumping the slot between
+                // attempts; evicted by capacity pressure -> dropped.
+                let candidate = this
+                    .pending_collision_rechecks
+                    .lock()
+                    .peek(&record_pda)
+                    .copied();
+                let Some((pubkey, slot)) = candidate else {
+                    return;
+                };
+                let hit = this.record_mirror.as_ref().is_some_and(|mirror| {
+                    matches!(
+                        mirror.probe(&record_pda, slot),
+                        MirrorLookup::Hit { .. }
+                    )
+                });
+                if hit {
+                    this.pending_collision_rechecks.lock().pop(&record_pda);
+                    this.clone_colliding_delegated_account(pubkey, slot).await;
+                    return;
+                }
+            }
+            if let Some((pubkey, slot)) =
+                this.pending_collision_rechecks.lock().pop(&record_pda)
+            {
                 trace!(
                     pubkey = %pubkey,
                     slot,
-                    "Dropping internal DLP program subscription update (no record after recheck)"
+                    "Dropping internal DLP program subscription update (no record after rechecks)"
                 );
             }
         });

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -6207,20 +6207,20 @@ async fn test_explicit_clone_executes_post_delegation_actions_after_prefilter_ch
 // the same delegation routes it to discovery, in either delivery order.
 #[tokio::test]
 async fn test_discovered_colliding_delegated_account_record_first_is_cloned() {
-    colliding_delegated_account_is_cloned(false, false, false).await;
+    colliding_delegated_account_is_cloned(false, false).await;
 }
 
 #[tokio::test]
 async fn test_discovered_colliding_delegated_account_record_late_is_cloned() {
-    colliding_delegated_account_is_cloned(true, false, false).await;
+    colliding_delegated_account_is_cloned(true, false).await;
 }
 
-// A stale pre-delegation clone in the bank must not settle a released
-// candidate: the release force-refreshes it into the delegated state.
+// A stale pre-delegation clone in the bank must not settle a collision
+// candidate: the mirror hit force-refreshes it into the delegated state.
 #[tokio::test]
 async fn test_discovered_colliding_delegated_account_record_late_refreshes_stale_bank_copy(
 ) {
-    colliding_delegated_account_is_cloned(true, true, false).await;
+    colliding_delegated_account_is_cloned(true, true).await;
 }
 
 #[tokio::test]
@@ -6280,10 +6280,7 @@ async fn test_released_collision_candidate_checks_undelegation_generation() {
             + rpc_client.multi_account_fetches();
 
         fetch_cloner
-            .clone_released_collision_candidate(ParkedCollisionCandidate {
-                pubkey: account_pubkey,
-                slot: CURRENT_SLOT,
-            })
+            .clone_colliding_delegated_account(account_pubkey, CURRENT_SLOT)
             .await;
 
         let in_bank = accounts_bank
@@ -6316,20 +6313,11 @@ async fn test_released_collision_candidate_checks_undelegation_generation() {
     }
 }
 
-// SubMux dedupes forwards on (pubkey, slot), so a directly watched record
-// PDA can surface only as an account-subscription update; the sighting must
-// still release the parked candidate.
+// A collision candidate can await its recheck while local undelegation
+// starts. The later mirror hit must not bypass undelegation confirmation or
+// release the tracking subscription.
 #[tokio::test]
-async fn test_discovered_colliding_delegated_account_account_sourced_record_releases(
-) {
-    colliding_delegated_account_is_cloned(true, false, true).await;
-}
-
-// A candidate can be parked before local undelegation starts. Its later
-// record sighting must not bypass undelegation confirmation or release the
-// tracking subscription.
-#[tokio::test]
-async fn test_released_collision_candidate_keeps_pending_undelegation_locked() {
+async fn test_colliding_clone_keeps_pending_undelegation_locked() {
     init_logger();
     let validator_keypair = Keypair::new();
     let validator_pubkey = validator_keypair.pubkey();
@@ -6348,45 +6336,20 @@ async fn test_released_collision_candidate_keeps_pending_undelegation_locked() {
         rent_epoch: 0,
     };
 
-    let FetcherTestCtx {
-        fetch_cloner,
-        remote_account_provider,
-        accounts_bank,
-        rpc_client,
-        subscription_tx,
-        cloner,
-        ..
-    } = setup(
+    let (ctx, mirror) = setup_with_mirror(
         [(account_pubkey, delegated_account.clone())],
         CURRENT_SLOT,
         validator_keypair.insecure_clone(),
     )
     .await;
-
-    add_delegation_record_for(
-        &rpc_client,
-        account_pubkey,
-        validator_pubkey,
-        account_owner,
-    );
-    let delegation_record_pubkey =
-        dlp_api::pda::delegation_record_pda_from_delegated_account(
-            &account_pubkey,
-        );
-    let delegation_record = DelegationRecord {
-        authority: validator_pubkey,
-        owner: account_owner,
-        delegation_slot: 1,
-        lamports: 1_000,
-        commit_frequency_ms: 2_000,
-    };
-    let delegation_record_account = Account {
-        lamports: 1_000_000,
-        data: delegation_record_to_vec(&delegation_record),
-        owner: dlp_api::id(),
-        executable: false,
-        rent_epoch: 0,
-    };
+    let FetcherTestCtx {
+        fetch_cloner,
+        remote_account_provider,
+        accounts_bank,
+        subscription_tx,
+        cloner,
+        ..
+    } = ctx;
 
     subscription_tx
         .send(ForwardedSubscriptionUpdate {
@@ -6415,21 +6378,20 @@ async fn test_released_collision_candidate_keeps_pending_undelegation_locked() {
         .await
         .expect("failed to acquire undelegation tracking");
 
-    subscription_tx
-        .send(ForwardedSubscriptionUpdate {
-            pubkey: delegation_record_pubkey,
-            account: RemoteAccount::from_fresh_account(
-                delegation_record_account,
-                CURRENT_SLOT,
-                RemoteAccountUpdateSource::Subscription,
-            ),
-            source: SubscriptionSource::Program,
-        })
-        .await
-        .unwrap();
+    // The record lands in the mirror while the recheck is pending.
+    add_delegation_record_to_mirror(
+        &mirror,
+        account_pubkey,
+        validator_pubkey,
+        account_owner,
+        CURRENT_SLOT,
+    );
     drop(subscription_tx);
 
     drain_subscription_update_tasks(&fetch_cloner, Duration::from_secs(1))
+        .await;
+    // Let the delayed mirror recheck fire and run the undelegation guard.
+    tokio::time::sleep(COLLISION_RECHECK_DELAY + Duration::from_millis(500))
         .await;
 
     let account_after = accounts_bank
@@ -6448,11 +6410,11 @@ async fn test_released_collision_candidate_keeps_pending_undelegation_locked() {
     );
 }
 
-// A release pass that settles on pre-delegation state (e.g. joining an
+// A collision clone that settles on pre-delegation state (e.g. joining an
 // in-flight pre-delegation fetch) must retry, not silently accept an
 // undelegated same-slot copy.
 #[tokio::test]
-async fn test_released_collision_candidate_retries_when_clone_settles_stale() {
+async fn test_colliding_clone_retries_when_clone_settles_stale() {
     init_logger();
     let validator_keypair = Keypair::new();
     let validator_pubkey = validator_keypair.pubkey();
@@ -6479,89 +6441,59 @@ async fn test_released_collision_candidate_retries_when_clone_settles_stale() {
         rent_epoch: 0,
     };
 
-    let FetcherTestCtx {
-        accounts_bank,
-        rpc_client,
-        subscription_tx,
-        ..
-    } = setup(
+    let (ctx, mirror) = setup_with_mirror(
         [(account_pubkey, pre_delegation_account)],
         CURRENT_SLOT,
         validator_keypair.insecure_clone(),
     )
     .await;
 
-    add_delegation_record_for(
-        &rpc_client,
+    // The mirror proves the delegation while the RPC still serves the
+    // pre-delegation state, so every clone attempt settles stale.
+    add_delegation_record_to_mirror(
+        &mirror,
         account_pubkey,
         validator_pubkey,
         account_owner,
+        CURRENT_SLOT,
     );
 
-    let delegation_record_pubkey =
-        dlp_api::pda::delegation_record_pda_from_delegated_account(
-            &account_pubkey,
-        );
-    let delegation_record = DelegationRecord {
-        authority: validator_pubkey,
-        owner: account_owner,
-        delegation_slot: 1,
-        lamports: 1_000,
-        commit_frequency_ms: 2_000,
-    };
-    let delegation_record_account = Account {
-        lamports: 1_000_000,
-        data: delegation_record_to_vec(&delegation_record),
-        owner: dlp_api::id(),
-        executable: false,
-        rent_epoch: 0,
-    };
+    let fetches_before = ctx.rpc_client.single_account_fetches()
+        + ctx.rpc_client.multi_account_fetches();
 
-    use crate::remote_account_provider::{
-        RemoteAccount, RemoteAccountUpdateSource,
-    };
-
-    let fetches_before = rpc_client.single_account_fetches()
-        + rpc_client.multi_account_fetches();
-
-    for (pubkey, account) in [
-        (account_pubkey, delegated_account),
-        (delegation_record_pubkey, delegation_record_account),
-    ] {
-        subscription_tx
-            .send(ForwardedSubscriptionUpdate {
-                pubkey,
-                account: RemoteAccount::from_fresh_account(
-                    account,
-                    CURRENT_SLOT,
-                    RemoteAccountUpdateSource::Subscription,
-                ),
-                source: SubscriptionSource::Program,
-            })
-            .await
-            .unwrap();
-        tokio::time::sleep(Duration::from_millis(50)).await;
-    }
+    ctx.subscription_tx
+        .send(ForwardedSubscriptionUpdate {
+            pubkey: account_pubkey,
+            account: RemoteAccount::from_fresh_account(
+                delegated_account,
+                CURRENT_SLOT,
+                RemoteAccountUpdateSource::Subscription,
+            ),
+            source: SubscriptionSource::Program,
+        })
+        .await
+        .unwrap();
     tokio::time::sleep(Duration::from_millis(300)).await;
 
     // The undelegated same-slot clone must never be accepted as settled.
-    let in_bank = accounts_bank
+    let in_bank = ctx
+        .accounts_bank
         .get_account(&account_pubkey)
-        .expect("release attempts clone the fetched state");
+        .expect("clone attempts clone the fetched state");
     assert!(!in_bank.delegated());
 
-    // A single-pass release (no retries) stays below this.
-    let release_fetches = rpc_client.single_account_fetches()
-        + rpc_client.multi_account_fetches()
+    // A single-pass clone (no retries) stays below this.
+    let clone_fetches = ctx.rpc_client.single_account_fetches()
+        + ctx.rpc_client.multi_account_fetches()
         - fetches_before;
     assert!(
-        release_fetches >= 4,
-        "expected retried clone attempts, saw only {release_fetches} fetches"
+        clone_fetches >= 3,
+        "expected retried clone attempts, saw only {clone_fetches} fetches"
     );
 }
 
-// A released collision candidate delegated to another validator must be
-// ignored like record-first discovery, not force-cloned from the firehose.
+// A collision candidate delegated to another validator must be ignored
+// like record-first discovery, not force-cloned from the firehose.
 #[tokio::test]
 async fn test_discovered_colliding_delegated_account_elsewhere_is_not_cloned() {
     init_logger();
@@ -6581,79 +6513,44 @@ async fn test_discovered_colliding_delegated_account_elsewhere_is_not_cloned() {
         rent_epoch: 0,
     };
 
-    let FetcherTestCtx {
-        accounts_bank,
-        rpc_client,
-        subscription_tx,
-        cloner,
-        ..
-    } = setup(
+    let (ctx, mirror) = setup_with_mirror(
         [(account_pubkey, delegated_account.clone())],
         CURRENT_SLOT,
         validator_keypair.insecure_clone(),
     )
     .await;
 
-    add_delegation_record_for(
-        &rpc_client,
+    // The mirrored record names another validator: the authority gate must
+    // drop the update without cloning.
+    add_delegation_record_to_mirror(
+        &mirror,
         account_pubkey,
         other_validator,
         account_owner,
+        CURRENT_SLOT,
     );
 
-    let delegation_record_pubkey =
-        dlp_api::pda::delegation_record_pda_from_delegated_account(
-            &account_pubkey,
-        );
-    let delegation_record = DelegationRecord {
-        authority: other_validator,
-        owner: account_owner,
-        delegation_slot: 1,
-        lamports: 1_000,
-        commit_frequency_ms: 2_000,
-    };
-    let delegation_record_account = Account {
-        lamports: 1_000_000,
-        data: delegation_record_to_vec(&delegation_record),
-        owner: dlp_api::id(),
-        executable: false,
-        rent_epoch: 0,
-    };
-
-    use crate::remote_account_provider::{
-        RemoteAccount, RemoteAccountUpdateSource,
-    };
-
-    // Account first so it parks; the late record sighting releases it into
-    // the authority gate, which must drop it.
-    for (pubkey, account) in [
-        (account_pubkey, delegated_account),
-        (delegation_record_pubkey, delegation_record_account),
-    ] {
-        subscription_tx
-            .send(ForwardedSubscriptionUpdate {
-                pubkey,
-                account: RemoteAccount::from_fresh_account(
-                    account,
-                    CURRENT_SLOT,
-                    RemoteAccountUpdateSource::Subscription,
-                ),
-                source: SubscriptionSource::Program,
-            })
-            .await
-            .unwrap();
-        tokio::time::sleep(Duration::from_millis(50)).await;
-    }
+    ctx.subscription_tx
+        .send(ForwardedSubscriptionUpdate {
+            pubkey: account_pubkey,
+            account: RemoteAccount::from_fresh_account(
+                delegated_account,
+                CURRENT_SLOT,
+                RemoteAccountUpdateSource::Subscription,
+            ),
+            source: SubscriptionSource::Program,
+        })
+        .await
+        .unwrap();
 
     tokio::time::sleep(Duration::from_millis(300)).await;
-    assert!(accounts_bank.get_account(&account_pubkey).is_none());
-    assert_eq!(cloner.clone_request_count(), 0);
+    assert!(ctx.accounts_bank.get_account(&account_pubkey).is_none());
+    assert_eq!(ctx.cloner.clone_request_count(), 0);
 }
 
 async fn colliding_delegated_account_is_cloned(
     record_late: bool,
     stale_in_bank: bool,
-    record_account_sourced: bool,
 ) {
     init_logger();
     let validator_keypair = Keypair::new();
@@ -6673,24 +6570,12 @@ async fn colliding_delegated_account_is_cloned(
         rent_epoch: 0,
     };
 
-    let FetcherTestCtx {
-        accounts_bank,
-        rpc_client,
-        subscription_tx,
-        ..
-    } = setup(
+    let (ctx, mirror) = setup_with_mirror(
         [(account_pubkey, delegated_account.clone())],
         CURRENT_SLOT,
         validator_keypair.insecure_clone(),
     )
     .await;
-
-    add_delegation_record_for(
-        &rpc_client,
-        account_pubkey,
-        validator_pubkey,
-        account_owner,
-    );
 
     if stale_in_bank {
         let mut stale_copy = AccountSharedData::from(Account {
@@ -6701,72 +6586,48 @@ async fn colliding_delegated_account_is_cloned(
             rent_epoch: 0,
         });
         stale_copy.set_remote_slot(CURRENT_SLOT - 10);
-        accounts_bank.insert(account_pubkey, stale_copy);
+        ctx.accounts_bank.insert(account_pubkey, stale_copy);
     }
 
-    let delegation_record_pubkey =
-        dlp_api::pda::delegation_record_pda_from_delegated_account(
-            &account_pubkey,
-        );
-    let delegation_record = DelegationRecord {
-        authority: validator_pubkey,
-        owner: account_owner,
-        delegation_slot: 1,
-        lamports: 1_000,
-        commit_frequency_ms: 2_000,
-    };
-    let delegation_record_account = Account {
-        lamports: 1_000_000,
-        data: delegation_record_to_vec(&delegation_record),
-        owner: dlp_api::id(),
-        executable: false,
-        rent_epoch: 0,
-    };
-
-    use crate::remote_account_provider::{
-        RemoteAccount, RemoteAccountUpdateSource,
-    };
-
-    // With the record late, the account update parks and the record
-    // sighting — from either subscription source — must release it.
-    let record_source = if record_account_sourced {
-        SubscriptionSource::Account
-    } else {
-        SubscriptionSource::Program
-    };
-    let mut updates = vec![
-        (
-            delegation_record_pubkey,
-            delegation_record_account,
-            record_source,
-        ),
-        (
+    // The record exists ONLY in the mirror: resolving the collision proves
+    // it was served from memory. With the record late, the update schedules
+    // a delayed recheck which must find the record installed by then.
+    if !record_late {
+        add_delegation_record_to_mirror(
+            &mirror,
             account_pubkey,
-            delegated_account,
-            SubscriptionSource::Program,
-        ),
-    ];
-    if record_late {
-        updates.reverse();
-    }
-    for (pubkey, account, source) in updates {
-        subscription_tx
-            .send(ForwardedSubscriptionUpdate {
-                pubkey,
-                account: RemoteAccount::from_fresh_account(
-                    account,
-                    CURRENT_SLOT,
-                    RemoteAccountUpdateSource::Subscription,
-                ),
-                source,
-            })
-            .await
-            .unwrap();
-        tokio::time::sleep(Duration::from_millis(50)).await;
+            validator_pubkey,
+            account_owner,
+            CURRENT_SLOT,
+        );
     }
 
-    tokio::time::timeout(Duration::from_secs(2), async {
-        while !accounts_bank.get_account(&account_pubkey).is_some_and(
+    ctx.subscription_tx
+        .send(ForwardedSubscriptionUpdate {
+            pubkey: account_pubkey,
+            account: RemoteAccount::from_fresh_account(
+                delegated_account,
+                CURRENT_SLOT,
+                RemoteAccountUpdateSource::Subscription,
+            ),
+            source: SubscriptionSource::Program,
+        })
+        .await
+        .unwrap();
+
+    if record_late {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        add_delegation_record_to_mirror(
+            &mirror,
+            account_pubkey,
+            validator_pubkey,
+            account_owner,
+            CURRENT_SLOT,
+        );
+    }
+
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while !ctx.accounts_bank.get_account(&account_pubkey).is_some_and(
             |account| {
                 account.delegated()
                     && account.owner() == &account_owner
@@ -6779,156 +6640,66 @@ async fn colliding_delegated_account_is_cloned(
     .await
     .expect("timed out waiting for colliding delegated account clone");
 
-    let cloned_account = accounts_bank
+    let cloned_account = ctx
+        .accounts_bank
         .get_account(&account_pubkey)
         .expect("account should be greedily cloned from program update");
     assert_eq!(cloned_account.data(), app_data.as_slice());
 }
 
-// Unrelated record-shaped internal updates parking after a candidate must not
-// evict it before its record sighting releases it.
-#[test]
-fn test_dlp_collision_tracker_parked_candidate_survives_record_shaped_firehose_churn(
-) {
-    use crate::remote_account_provider::{
-        RemoteAccount, RemoteAccountUpdateSource,
+// A replayed older update must not downgrade a pending recheck's slot:
+// the recheck must resolve at the newest observed slot.
+#[tokio::test]
+async fn test_collision_recheck_dedups_and_keeps_newest_slot() {
+    init_logger();
+    let validator_keypair = Keypair::new();
+    let validator_pubkey = validator_keypair.pubkey();
+    let account_pubkey = random_pubkey();
+    let account_owner = random_pubkey();
+    const CURRENT_SLOT: u64 = 100;
+
+    let mut app_data = vec![0; DelegationRecord::size_with_discriminator()];
+    app_data[..8].copy_from_slice(&100u64.to_le_bytes());
+    let delegated_account = Account {
+        lamports: 1_000_000,
+        data: app_data.clone(),
+        owner: dlp_api::id(),
+        executable: false,
+        rent_epoch: 0,
     };
 
-    const SLOT: u64 = 100;
-    let mut tracker = DlpCollisionTracker::new();
-    let candidate_pubkey = random_pubkey();
-    let record_pubkey =
-        dlp_api::pda::delegation_record_pda_from_delegated_account(
-            &candidate_pubkey,
-        );
+    let (ctx, mirror) = setup_with_mirror(
+        [(account_pubkey, delegated_account)],
+        CURRENT_SLOT,
+        validator_keypair.insecure_clone(),
+    )
+    .await;
 
-    let record_shaped_update = |pubkey: Pubkey| {
-        let delegation_record = DelegationRecord {
-            authority: random_pubkey(),
-            owner: random_pubkey(),
-            delegation_slot: 1,
-            lamports: 1_000,
-            commit_frequency_ms: 2_000,
-        };
-        ForwardedSubscriptionUpdate {
-            pubkey,
-            account: RemoteAccount::from_fresh_account(
-                Account {
-                    lamports: 1_000,
-                    data: delegation_record_to_vec(&delegation_record),
-                    owner: dlp_api::id(),
-                    executable: false,
-                    rent_epoch: 0,
-                },
-                SLOT,
-                RemoteAccountUpdateSource::Subscription,
-            ),
-            source: SubscriptionSource::Program,
-        }
-    };
+    ctx.fetch_cloner
+        .schedule_collision_recheck(account_pubkey, CURRENT_SLOT);
+    // A replayed older update joins the pending recheck without downgrading.
+    ctx.fetch_cloner
+        .schedule_collision_recheck(account_pubkey, CURRENT_SLOT - 10);
 
-    assert!(!tracker.check_or_park(&record_shaped_update(candidate_pubkey,)));
-    for _ in 0..PARKED_COLLISION_UPDATES_CAPACITY.get() {
-        let unrelated_record_account = random_pubkey();
-        assert!(tracker
-            .sight_record(unrelated_record_account, SLOT)
-            .is_none());
-        assert!(!tracker
-            .check_or_park(&record_shaped_update(unrelated_record_account,)));
-    }
-
-    let released = tracker.sight_record(record_pubkey, SLOT).expect(
-        "candidate must survive record-shaped firehose churn until sighting",
+    add_delegation_record_to_mirror(
+        &mirror,
+        account_pubkey,
+        validator_pubkey,
+        account_owner,
+        CURRENT_SLOT,
     );
-    assert_eq!(released.pubkey, candidate_pubkey);
-    assert_eq!(released.slot, SLOT);
-}
 
-// Stale delegation-record updates replayed out of order (reconnect,
-// multi-client races) must neither lower the sighted slot nor consume a
-// parked candidate their slot does not cover.
-#[test]
-fn test_dlp_collision_tracker_ignores_stale_record_sightings() {
-    use crate::remote_account_provider::{
-        RemoteAccount, RemoteAccountUpdateSource,
-    };
-
-    let update_at = |pubkey: Pubkey, slot: u64| ForwardedSubscriptionUpdate {
-        pubkey,
-        account: RemoteAccount::from_fresh_account(
-            Account {
-                lamports: 1_000,
-                data: vec![],
-                owner: dlp_api::id(),
-                executable: false,
-                rent_epoch: 0,
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while !ctx.accounts_bank.get_account(&account_pubkey).is_some_and(
+            |account| {
+                account.delegated() && account.remote_slot() == CURRENT_SLOT
             },
-            slot,
-            RemoteAccountUpdateSource::Subscription,
-        ),
-        source: SubscriptionSource::Program,
-    };
-
-    let account_pubkey = random_pubkey();
-    let record_pubkey =
-        dlp_api::pda::delegation_record_pda_from_delegated_account(
-            &account_pubkey,
-        );
-
-    // A stale sighting must not lower the recorded slot: the colliding
-    // account update still routes straight to discovery.
-    let mut tracker = DlpCollisionTracker::new();
-    assert!(tracker.sight_record(record_pubkey, 100).is_none());
-    assert!(tracker.sight_record(record_pubkey, 50).is_none());
-    assert!(tracker.check_or_park(&update_at(account_pubkey, 100)));
-
-    // A stale sighting must not consume a parked candidate it does not
-    // cover; the candidate is released by its own record sighting.
-    let mut tracker = DlpCollisionTracker::new();
-    assert!(!tracker.check_or_park(&update_at(account_pubkey, 100)));
-    assert!(tracker.sight_record(record_pubkey, 50).is_none());
-    let released = tracker
-        .sight_record(record_pubkey, 100)
-        .expect("covering record sighting must release the candidate");
-    assert_eq!(released.pubkey, account_pubkey);
-    assert_eq!(released.slot, 100);
-
-    // A replayed older account update must not downgrade a newer parked
-    // candidate: a record sighting covering only the old slot cannot
-    // release it, and the candidate's own record still does.
-    let mut tracker = DlpCollisionTracker::new();
-    assert!(!tracker.check_or_park(&update_at(account_pubkey, 100)));
-    assert!(!tracker.check_or_park(&update_at(account_pubkey, 90)));
-    assert!(tracker.sight_record(record_pubkey, 90).is_none());
-    let released = tracker
-        .sight_record(record_pubkey, 100)
-        .expect("covering record sighting must release the candidate");
-    assert_eq!(released.pubkey, account_pubkey);
-    assert_eq!(released.slot, 100);
-}
-
-#[test]
-fn test_dlp_collision_tracker_preserves_unsettled_released_candidate() {
-    let account_pubkey = random_pubkey();
-    let record_pubkey =
-        dlp_api::pda::delegation_record_pda_from_delegated_account(
-            &account_pubkey,
-        );
-    let mut tracker = DlpCollisionTracker::new();
-
-    assert!(
-        tracker.preserve_released_candidate(ParkedCollisionCandidate {
-            pubkey: account_pubkey,
-            slot: 100,
-        })
-    );
-    assert!(tracker.sight_record(record_pubkey, 99).is_none());
-
-    let released = tracker.sight_record(record_pubkey, 100).expect(
-        "preserved candidate must be released by a later covering sighting",
-    );
-    assert_eq!(released.pubkey, account_pubkey);
-    assert_eq!(released.slot, 100);
+        ) {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("timed out waiting for recheck-driven clone at the newest slot");
 }
 
 #[tokio::test]

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -6390,9 +6390,11 @@ async fn test_colliding_clone_keeps_pending_undelegation_locked() {
 
     drain_subscription_update_tasks(&fetch_cloner, Duration::from_secs(1))
         .await;
-    // Let the delayed mirror recheck fire and run the undelegation guard.
-    tokio::time::sleep(COLLISION_RECHECK_DELAY + Duration::from_millis(500))
-        .await;
+    // Let the first delayed mirror recheck fire and run the guard.
+    tokio::time::sleep(
+        COLLISION_RECHECK_DELAYS[0] + Duration::from_millis(500),
+    )
+    .await;
 
     let account_after = accounts_bank
         .get_account(&account_pubkey)

--- a/magicblock-chainlink/src/chainlink/record_mirror.rs
+++ b/magicblock-chainlink/src/chainlink/record_mirror.rs
@@ -173,32 +173,57 @@ impl DelegationRecordMirror {
     /// update, so an entry unchanged while the watermark advanced past the
     /// requested slot is that record's current state.
     pub fn get(&self, record: &Pubkey, min_context_slot: u64) -> MirrorLookup {
+        let (lookup, non_hit_outcome) = self.lookup(record, min_context_slot);
+        // A hit is not counted here: callers validate the bytes (and the
+        // pairing slot) first and count Hit/ParseFallback/Stale so the hit
+        // metric only reports lookups that actually skipped an RPC.
+        if let Some(outcome) = non_hit_outcome {
+            metrics::inc_record_mirror_lookup(outcome);
+        }
+        lookup
+    }
+
+    /// Like [`Self::get`] but without lookup metrics: for discovery probes
+    /// where a miss is the expected common case and would drown the
+    /// RPC-fallback-rate signal the metrics exist to expose.
+    pub fn probe(
+        &self,
+        record: &Pubkey,
+        min_context_slot: u64,
+    ) -> MirrorLookup {
+        self.lookup(record, min_context_slot).0
+    }
+
+    fn lookup(
+        &self,
+        record: &Pubkey,
+        min_context_slot: u64,
+    ) -> (MirrorLookup, Option<RecordMirrorLookupOutcome>) {
         let mut inner = self.inner.lock();
         let fresh_watermark = inner.live && inner.watermark >= min_context_slot;
         let Some(entry) = inner.entries.get(record) else {
-            metrics::inc_record_mirror_lookup(RecordMirrorLookupOutcome::Miss);
-            return MirrorLookup::Miss;
+            return (MirrorLookup::Miss, Some(RecordMirrorLookupOutcome::Miss));
         };
 
         if entry.slot < min_context_slot && !fresh_watermark {
-            metrics::inc_record_mirror_lookup(RecordMirrorLookupOutcome::Stale);
-            return MirrorLookup::Miss;
+            return (
+                MirrorLookup::Miss,
+                Some(RecordMirrorLookupOutcome::Stale),
+            );
         }
 
         match &entry.data {
-            // Not counted as a hit here: callers validate the bytes (and the
-            // pairing slot) first and count Hit/ParseFallback/Stale so the
-            // hit metric only reports lookups that actually skipped an RPC.
-            Some(data) => MirrorLookup::Hit {
-                data: data.clone(),
-                slot: entry.slot,
-            },
-            None => {
-                metrics::inc_record_mirror_lookup(
-                    RecordMirrorLookupOutcome::Tombstone,
-                );
-                MirrorLookup::Tombstone { slot: entry.slot }
-            }
+            Some(data) => (
+                MirrorLookup::Hit {
+                    data: data.clone(),
+                    slot: entry.slot,
+                },
+                None,
+            ),
+            None => (
+                MirrorLookup::Tombstone { slot: entry.slot },
+                Some(RecordMirrorLookupOutcome::Tombstone),
+            ),
         }
     }
 


### PR DESCRIPTION
## Summary

**Stacked on #1512** (base = `feat/delegation-record-mirror`; merge that first).

Phase B of the delegation-record mirror work: delete the collision sighting/parking machinery, which existed to answer a question the mirror now answers directly. 

## What the tracker did, and what replaces it

An internal-looking DLP account update is either genuine internal state (record/metadata/commit — drop it) or a delegated user account whose app data collides with an internal discriminator (clone it). Telling them apart requires the delegation record. The tracker solved this by parking updates keyed by derived record PDA and waiting for the record to appear **on the same firehose** (sighting → release), with monotonic-slot bookkeeping, capacity-preserving parking, and an unsettled-release preserve path.

The mirror observes every record on its own gRPC stream, so the pairing collapses to a lookup:

- **Probe** the mirror at the derived record PDA (a metric-free `probe()` — misses are the expected common case for genuine internal payloads and would drown the RPC-fallback-rate signal `get()`'s metrics exist to expose).
- **Hit** → run the surviving discovery body (`clone_colliding_delegated_account`, the former release handler verbatim: bank-freshness gate, authority gate + delegated-elsewhere metric, pending-undelegation guard, up to 3 forced-refresh clone attempts). The record resolves through `fetch_and_parse_delegation_record`, i.e. from the mirror.
- **Miss** → exactly one delayed recheck (2s, covering the skew between the account stream and the record stream) behind a bounded dedup LRU (16,384 entries, monotonic slots). Still a miss afterwards → drop with **no RPC** — the same terminal outcome unsighted parked candidates had; the on-demand ensure path remains the correctness backstop.

Record-shaped payloads are probed like everything else: a colliding account's data is record-shaped *by definition*, so they cannot be skipped (a test guards this).

## Behavior decisions (explicit)

- **No mirror ⇒ no proactive collision discovery**: with `record-sync` disabled or the stream dead, internal-DLP program updates are dropped outright instead of parked. Keeping the parking machinery as a fallback would defeat the deletion; genuine discriminator collisions are rare and on-demand cloning preserves correctness.
- The `preserve_released_candidate` path (re-park after unsettled release, for a later covering sighting) has no equivalent: after the 3 forced-refresh attempts the update is dropped with a warning. Subsequent record updates for the same account arrive via the mirror and re-trigger discovery.