### PR TITLE
fix: SIGABRT teardown flake in deferred-startup test envs

### DIFF
--- a/test-kit/src/lib.rs
+++ b/test-kit/src/lib.rs
@@ -506,6 +506,10 @@ impl ExecutionTestEnv {
 impl Drop for ExecutionTestEnv {
     fn drop(&mut self) {
         self.shutdown.cancel();
+        // A deferred scheduler still owns detached executor threads holding
+        // ledger references; run its (already cancelled) shutdown path so
+        // RocksDB closes before the temp dir is removed and the process exits.
+        self.run_scheduler();
         if let Some(handle) = self.scheduler_thread.take() {
             let _ = handle.join();
         }


### PR DESCRIPTION
## Problem

CI run [30607219707](https://github.com/magicblock-labs/magicblock-validator/actions/runs/30607219707/job/91081921223) failed with:

```
test tests::event_processor::block_updates_before_event_start_are_not_cached ... ok
pthread lock: Invalid argument
SIGABRT [0.378s] magicblock-aperture tests::event_processor::block_updates_before_event_start_are_not_cached
```

The test itself **passed** — the process aborted afterwards, during teardown.

## Root cause

`TransactionScheduler::new` spawns detached executor OS threads immediately (`TransactionExecutor::spawn` discards the `JoinHandle`), even when `ExecutionTestEnv` is created with `defer_startup = true`. If the env is dropped without ever spawning the scheduler (as in this test), nothing runs the scheduler's shutdown path that waits for executors (`drop(self.executors)` + draining `ready_rx`).

At teardown, dropping the deferred `TransactionScheduler` closes the executor channels, and the detached executor thread — holding the **last `Arc<Ledger>`** — closes RocksDB concurrently with the process exiting (and after the `TempDir` was already removed, since `dir` is declared before `scheduler`). When exit-time static destruction wins the race, a RocksDB thread locks an already-destroyed mutex → `pthread lock: Invalid argument` → SIGABRT.

## Fix

In `ExecutionTestEnv::drop`, spawn a still-deferred scheduler after cancelling the shutdown token: its run loop goes straight to the regular shutdown path, which drains executor teardown, and the existing `join()` synchronizes everything before the temp dir is removed and the process exits. For envs that already spawned the scheduler this is a no-op (`scheduler` is `None`).

## Verification

- `cargo nextest run -p magicblock-aperture` passes
- 30 consecutive runs of the affected test: no SIGABRT