### PR TITLE
feat: record-stream-driven delegation discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4094,7 +4094,7 @@ dependencies = [
 [[package]]
 name = "magicblock-sync"
 version = "0.3.0"
-source = "git+https://github.com/magicblock-labs/magicblock-sync.git?rev=7f6d109#7f6d109172e74e1e26ea71b4307523752c6db9e5"
+source = "git+https://github.com/magicblock-labs/magicblock-sync.git?rev=24814f6#24814f6a389e53d0c7d2c04367de93e025d02b93"
 dependencies = [
  "futures",
  "helius-laserstream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,7 +280,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -291,7 +291,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -777,7 +777,7 @@ dependencies = [
  "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -1950,7 +1950,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4093,8 +4093,8 @@ dependencies = [
 
 [[package]]
 name = "magicblock-sync"
-version = "0.2.0"
-source = "git+https://github.com/magicblock-labs/magicblock-sync.git?rev=3c71985#3c719851767544d1ae003bbf53d74c82c14acb01"
+version = "0.3.0"
+source = "git+https://github.com/magicblock-labs/magicblock-sync.git?rev=7f6d109#7f6d109172e74e1e26ea71b4307523752c6db9e5"
 dependencies = [
  "futures",
  "helius-laserstream",
@@ -4444,7 +4444,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5021,7 +5021,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "petgraph",
@@ -5042,7 +5042,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -5744,7 +5744,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6298,7 +6298,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9647,7 +9647,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10605,7 +10605,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ magicblock-program = { path = "./programs/magicblock" }
 magicblock-replicator = { path = "./magicblock-replicator" }
 magicblock-rpc-client = { path = "./magicblock-rpc-client" }
 magicblock-services = { path = "./magicblock-services" }
-magicblock-sync = { git = "https://github.com/magicblock-labs/magicblock-sync.git", rev = "7f6d109" }
+magicblock-sync = { git = "https://github.com/magicblock-labs/magicblock-sync.git", rev = "24814f6" }
 magicblock-table-mania = { path = "./magicblock-table-mania" }
 magicblock-task-scheduler = { path = "./magicblock-task-scheduler" }
 magicblock-tui-client = { path = "./tools/magicblock-tui-client" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ magicblock-program = { path = "./programs/magicblock" }
 magicblock-replicator = { path = "./magicblock-replicator" }
 magicblock-rpc-client = { path = "./magicblock-rpc-client" }
 magicblock-services = { path = "./magicblock-services" }
-magicblock-sync = { git = "https://github.com/magicblock-labs/magicblock-sync.git", rev = "3c71985" }
+magicblock-sync = { git = "https://github.com/magicblock-labs/magicblock-sync.git", rev = "7f6d109" }
 magicblock-table-mania = { path = "./magicblock-table-mania" }
 magicblock-task-scheduler = { path = "./magicblock-task-scheduler" }
 magicblock-tui-client = { path = "./tools/magicblock-tui-client" }

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -33,7 +33,9 @@ use magicblock_metrics::metrics::{
 use parking_lot::Mutex as PlMutex;
 use scc::HashMap;
 use solana_account::{Account, AccountSharedData, ReadableAccount};
-use solana_account_decoder_client_types::UiAccountEncoding;
+use solana_account_decoder_client_types::{
+    UiAccountEncoding, UiDataSliceConfig,
+};
 use solana_keypair::Keypair;
 use solana_pubkey::Pubkey;
 use solana_rpc_client_api::{
@@ -85,7 +87,9 @@ use crate::{
         blacklisted_accounts::{
             blacklisted_accounts, programs_not_to_subscribe,
         },
-        record_mirror::{DelegationRecordMirror, MirrorLookup},
+        record_mirror::{
+            DelegationRecordMirror, DiscoveredDelegation, MirrorLookup,
+        },
         ObservedUndelegationRequest,
     },
     cloner::{
@@ -221,6 +225,11 @@ const PENDING_COLLISION_RECHECKS_CAPACITY: NonZeroUsize =
             panic!("PENDING_COLLISION_RECHECKS_CAPACITY must be non-zero")
         }
     };
+
+/// Interval between authority-record sweeps: an observational gPA counting
+/// on-chain records delegated to this validator, used to detect drift
+/// against locally delegated state once the DLP firehose is gone.
+const AUTHORITY_RECORD_SWEEP_INTERVAL: Duration = Duration::from_secs(300);
 
 /// Backoff schedule for re-consulting the record mirror on a collision
 /// candidate: the account update and its delegation record arrive on
@@ -433,7 +442,96 @@ where
         me.clone()
             .start_subscription_listener(subscription_updates_rx);
 
+        // Discovery from the record stream: delegations observed on chain
+        // (naming the delegated account) resolve through the same probe/
+        // recheck path as colliding firehose updates — mirror-proven
+        // authority, forced-refresh clone, no per-event RPC.
+        if let Some(discoveries) = me
+            .record_mirror
+            .as_ref()
+            .and_then(|mirror| mirror.take_discoveries())
+        {
+            me.clone().start_discovery_listener(discoveries);
+            me.clone().start_authority_record_sweep();
+        }
+
         me
+    }
+
+    /// Periodically counts on-chain delegation records naming this
+    /// validator as authority. Purely observational: with the DLP account
+    /// firehose gone, this gauge (compared against locally delegated
+    /// accounts) is the drift detector for missed record-stream events.
+    ///
+    /// Holds only a weak reference so the task ends with the FetchCloner.
+    fn start_authority_record_sweep(self: Arc<Self>) {
+        let weak = Arc::downgrade(&self);
+        drop(self);
+        task::spawn(async move {
+            loop {
+                tokio::time::sleep(AUTHORITY_RECORD_SWEEP_INTERVAL).await;
+                let Some(this) = weak.upgrade() else { return };
+                let config = RpcProgramAccountsConfig {
+                    filters: Some(vec![
+                        RpcFilterType::Memcmp(Memcmp::new_raw_bytes(
+                            0,
+                            AccountDiscriminator::DelegationRecord
+                                .to_bytes()
+                                .to_vec(),
+                        )),
+                        // DelegationRecord.authority sits right after the
+                        // 8-byte discriminator.
+                        RpcFilterType::Memcmp(Memcmp::new_raw_bytes(
+                            8,
+                            this.validator_pubkey.to_bytes().to_vec(),
+                        )),
+                    ]),
+                    account_config: RpcAccountInfoConfig {
+                        encoding: Some(UiAccountEncoding::Base64Zstd),
+                        data_slice: Some(UiDataSliceConfig {
+                            offset: 0,
+                            length: 0,
+                        }),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                };
+                match this
+                    .remote_account_provider
+                    .get_program_accounts_with_config(&dlp_api::id(), config)
+                    .await
+                {
+                    Ok(records) => {
+                        metrics::set_authority_records_on_chain(
+                            records.len() as i64
+                        );
+                    }
+                    Err(error) => warn!(
+                        ?error,
+                        "authority record sweep failed; retrying next interval"
+                    ),
+                }
+            }
+        });
+    }
+
+    /// Holds only a weak reference so the task ends with the FetchCloner.
+    fn start_discovery_listener(
+        self: Arc<Self>,
+        mut discoveries: mpsc::Receiver<DiscoveredDelegation>,
+    ) {
+        let weak = Arc::downgrade(&self);
+        drop(self);
+        task::spawn(async move {
+            while let Some(discovered) = discoveries.recv().await {
+                let Some(this) = weak.upgrade() else { return };
+                this.resolve_internal_dlp_collision(
+                    discovered.delegated_account,
+                    discovered.slot,
+                )
+                .await;
+            }
+        });
     }
 
     /// Get the current fetch count

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -502,9 +502,17 @@ where
                     .await
                 {
                     Ok(records) => {
-                        metrics::set_authority_records_on_chain(
-                            records.len() as i64
-                        );
+                        // A delegated application account can mimic the
+                        // record layout (discriminator + authority bytes);
+                        // genuine records are never bank-resident, so
+                        // in-bank matches are collisions, not records.
+                        let count = records
+                            .iter()
+                            .filter(|(pubkey, _)| {
+                                this.accounts_bank.get_account(pubkey).is_none()
+                            })
+                            .count();
+                        metrics::set_authority_records_on_chain(count as i64);
                     }
                     Err(error) => warn!(
                         ?error,

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -12314,3 +12314,118 @@ async fn test_greedy_discovery_falls_back_to_rpc_on_stale_mirror() {
     assert!(cloned.delegated());
     assert_eq!(cloned.owner(), &account_owner);
 }
+
+// -----------------
+// Record-stream-driven discovery
+// -----------------
+
+/// A delegation observed on the record stream clones the named account with
+/// zero record RPC: the record exists only in the mirror, so the delegated
+/// outcome proves the whole path (event -> probe -> forced-refresh clone).
+#[tokio::test]
+async fn test_record_stream_discovery_clones_new_delegation() {
+    let validator_keypair = Keypair::new();
+    let validator_pubkey = validator_keypair.pubkey();
+    let account_pubkey = random_pubkey();
+    let account_owner = random_pubkey();
+    const CURRENT_SLOT: u64 = 100;
+
+    let delegated_account = delegated_dlp_account(vec![1, 2, 3]);
+    let (ctx, mirror) = setup_with_mirror(
+        [(account_pubkey, delegated_account)],
+        CURRENT_SLOT,
+        validator_keypair.insecure_clone(),
+    )
+    .await;
+
+    let record_pda = add_delegation_record_to_mirror(
+        &mirror,
+        account_pubkey,
+        validator_pubkey,
+        account_owner,
+        CURRENT_SLOT,
+    );
+
+    mirror.test_apply(magicblock_sync::AccountUpdate::DelegationObserved {
+        delegated_account: account_pubkey.to_bytes(),
+        record: record_pda.to_bytes(),
+        slot: CURRENT_SLOT,
+    });
+
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while !ctx.accounts_bank.get_account(&account_pubkey).is_some_and(
+            |account| account.delegated() && account.owner() == &account_owner,
+        ) {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("timed out waiting for record-stream discovery clone");
+}
+
+/// A delegation observed for another validator is dropped by the authority
+/// gate without cloning.
+#[tokio::test]
+async fn test_record_stream_discovery_ignores_foreign_delegation() {
+    let validator_keypair = Keypair::new();
+    let other_validator = random_pubkey();
+    let account_pubkey = random_pubkey();
+    let account_owner = random_pubkey();
+    const CURRENT_SLOT: u64 = 100;
+
+    let delegated_account = delegated_dlp_account(vec![4, 5]);
+    let (ctx, mirror) = setup_with_mirror(
+        [(account_pubkey, delegated_account)],
+        CURRENT_SLOT,
+        validator_keypair.insecure_clone(),
+    )
+    .await;
+
+    let record_pda = add_delegation_record_to_mirror(
+        &mirror,
+        account_pubkey,
+        other_validator,
+        account_owner,
+        CURRENT_SLOT,
+    );
+
+    mirror.test_apply(magicblock_sync::AccountUpdate::DelegationObserved {
+        delegated_account: account_pubkey.to_bytes(),
+        record: record_pda.to_bytes(),
+        slot: CURRENT_SLOT,
+    });
+
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    assert!(ctx.accounts_bank.get_account(&account_pubkey).is_none());
+    assert_eq!(ctx.cloner.clone_request_count(), 0);
+}
+
+/// An undelegation request observed on the record stream reaches the
+/// broadcast consumed by the undelegation-request service.
+#[tokio::test]
+async fn test_record_stream_forwards_undelegation_requests() {
+    use crate::chainlink::ObservedUndelegationRequest;
+
+    let mirror =
+        crate::chainlink::record_mirror::DelegationRecordMirror::new_for_tests(
+        );
+    let mut requests = mirror
+        .take_undelegation_requests()
+        .expect("first take yields the stream");
+
+    let delegated_account = random_pubkey();
+    let request_pda = random_pubkey();
+    mirror.test_apply(magicblock_sync::AccountUpdate::UndelegationRequested {
+        request_pda: request_pda.to_bytes(),
+        delegated_account: delegated_account.to_bytes(),
+        expires_at_slot: 250,
+        slot: 99,
+    });
+
+    let observed: ObservedUndelegationRequest =
+        requests.try_recv().expect("request must be forwarded");
+    assert_eq!(observed.request_pda, request_pda);
+    assert_eq!(observed.delegated_account, delegated_account);
+    assert_eq!(observed.expires_at_slot, 250);
+    assert_eq!(observed.observed_slot, 99);
+}

--- a/magicblock-chainlink/src/chainlink/mod.rs
+++ b/magicblock-chainlink/src/chainlink/mod.rs
@@ -396,6 +396,25 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
             C,
         >,
     > {
+        // The mirror is constructed first: with its record stream live,
+        // delegation discovery is record-driven and the DLP account
+        // firehose (program subscription) is not established at all.
+        // Without a mirror (dev/test, or record-sync disabled) the program
+        // subscription and firehose-driven discovery remain the fallback.
+        let record_mirror = DelegationRecordMirror::try_from_config(
+            &chainlink_config.record_sync,
+            endpoints,
+        )
+        .await;
+        let rap_config = if record_mirror.is_some() {
+            config
+                .remote_account_provider
+                .clone()
+                .with_program_subs(Default::default())
+        } else {
+            config.remote_account_provider.clone()
+        };
+
         // Extract accounts provider and create fetch cloner while connecting
         // the subscription channel
         let (tx, rx) = tokio::sync::mpsc::channel(SUBSCRIPTION_UPDATE_LIMIT);
@@ -403,7 +422,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
             endpoints,
             commitment,
             tx,
-            &config.remote_account_provider,
+            &rap_config,
             Some(chain_slot),
         )
         .await?;
@@ -415,11 +434,18 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
                 ledger_path,
             )?
             .map(Arc::new);
-            let record_mirror = DelegationRecordMirror::try_from_config(
-                &chainlink_config.record_sync,
-                endpoints,
-            )
-            .await;
+            // Undelegation requests observed on the record stream feed the
+            // same broadcast the firehose path used; the gPA poll remains
+            // the backstop either way.
+            if let Some(requests) = record_mirror
+                .as_ref()
+                .and_then(|mirror| mirror.take_undelegation_requests())
+            {
+                Self::forward_undelegation_requests(
+                    requests,
+                    undelegation_request_sender.clone(),
+                );
+            }
             let fetch_cloner =
                 FetchCloner::new_with_undelegation_request_sender(
                     &provider,
@@ -442,6 +468,21 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
             fetch_cloner,
             undelegation_request_sender,
         )
+    }
+
+    /// Forwards undelegation requests observed on the record stream to the
+    /// broadcast consumed by the undelegation-request service.
+    fn forward_undelegation_requests(
+        mut requests: mpsc::Receiver<ObservedUndelegationRequest>,
+        sender: broadcast::Sender<ObservedUndelegationRequest>,
+    ) {
+        task::spawn(async move {
+            while let Some(request) = requests.recv().await {
+                // Send fails only when no service is listening; the gPA
+                // poll backstop covers that configuration.
+                let _ = sender.send(request);
+            }
+        });
     }
 
     fn subscribe_account_removals(

--- a/magicblock-chainlink/src/chainlink/record_mirror.rs
+++ b/magicblock-chainlink/src/chainlink/record_mirror.rs
@@ -6,10 +6,26 @@ use magicblock_metrics::metrics::{self, RecordMirrorLookupOutcome};
 use magicblock_sync::{AccountUpdate, DlpSyncer};
 use parking_lot::Mutex as PlMutex;
 use solana_pubkey::Pubkey;
-use tokio::sync::mpsc::Receiver;
+use tokio::sync::mpsc::{self, Receiver, Sender};
 use tracing::{info, warn};
 
-use crate::remote_account_provider::{Endpoint, Endpoints};
+use crate::{
+    chainlink::ObservedUndelegationRequest,
+    remote_account_provider::{Endpoint, Endpoints},
+};
+
+/// Capacity for pending discovery / undelegation-request events awaiting
+/// their chainlink consumers.
+const MIRROR_EVENT_CHANNEL_CAPACITY: usize = 4096;
+
+/// A delegation observed on chain, naming the delegated account (which the
+/// record PDA alone cannot reveal).
+#[derive(Debug, Clone, Copy)]
+pub struct DiscoveredDelegation {
+    pub delegated_account: Pubkey,
+    pub record: Pubkey,
+    pub slot: u64,
+}
 
 /// In-memory mirror of on-chain delegation records, fed by the
 /// magicblock-sync record firehose.
@@ -23,6 +39,13 @@ use crate::remote_account_provider::{Endpoint, Endpoints};
 /// falls back to an RPC fetch. Absence here is never "not delegated".
 pub struct DelegationRecordMirror {
     inner: PlMutex<MirrorState>,
+    /// Delegations observed in the tx stream, consumed by discovery.
+    discoveries_tx: Sender<DiscoveredDelegation>,
+    discoveries_rx: PlMutex<Option<Receiver<DiscoveredDelegation>>>,
+    /// Undelegation requests observed on chain.
+    undelegation_requests_tx: Sender<ObservedUndelegationRequest>,
+    undelegation_requests_rx:
+        PlMutex<Option<Receiver<ObservedUndelegationRequest>>>,
 }
 
 struct MirrorState {
@@ -114,13 +137,36 @@ impl DelegationRecordMirror {
     fn with_capacity(capacity: usize) -> Self {
         let capacity = NonZeroUsize::new(capacity)
             .unwrap_or(NonZeroUsize::new(1).expect("1 is non-zero"));
+        let (discoveries_tx, discoveries_rx) =
+            mpsc::channel(MIRROR_EVENT_CHANNEL_CAPACITY);
+        let (undelegation_requests_tx, undelegation_requests_rx) =
+            mpsc::channel(MIRROR_EVENT_CHANNEL_CAPACITY);
         Self {
             inner: PlMutex::new(MirrorState {
                 entries: LruCache::new(capacity),
                 watermark: 0,
                 live: false,
             }),
+            discoveries_tx,
+            discoveries_rx: PlMutex::new(Some(discoveries_rx)),
+            undelegation_requests_tx,
+            undelegation_requests_rx: PlMutex::new(Some(
+                undelegation_requests_rx,
+            )),
         }
+    }
+
+    /// Takes the discovery event stream; `None` after the first call.
+    pub fn take_discoveries(&self) -> Option<Receiver<DiscoveredDelegation>> {
+        self.discoveries_rx.lock().take()
+    }
+
+    /// Takes the undelegation-request event stream; `None` after the first
+    /// call.
+    pub fn take_undelegation_requests(
+        &self,
+    ) -> Option<Receiver<ObservedUndelegationRequest>> {
+        self.undelegation_requests_rx.lock().take()
     }
 
     fn apply(&self, update: AccountUpdate) {
@@ -130,6 +176,49 @@ impl DelegationRecordMirror {
             }
             AccountUpdate::Undelegated { record, slot } => {
                 self.insert(Pubkey::new_from_array(record), slot, None);
+            }
+            AccountUpdate::DelegationObserved {
+                delegated_account,
+                record,
+                slot,
+            } => {
+                let discovered = DiscoveredDelegation {
+                    delegated_account: Pubkey::new_from_array(
+                        delegated_account,
+                    ),
+                    record: Pubkey::new_from_array(record),
+                    slot,
+                };
+                // Lossy under extreme backpressure by design: a dropped
+                // discovery is healed by the on-demand ensure path.
+                if self.discoveries_tx.try_send(discovered).is_err() {
+                    warn!(
+                        delegated_account = %discovered.delegated_account,
+                        "discovery channel full; dropping observed delegation"
+                    );
+                }
+            }
+            AccountUpdate::UndelegationRequested {
+                request_pda,
+                delegated_account,
+                expires_at_slot,
+                slot,
+            } => {
+                let request = ObservedUndelegationRequest {
+                    request_pda: Pubkey::new_from_array(request_pda),
+                    delegated_account: Pubkey::new_from_array(
+                        delegated_account,
+                    ),
+                    expires_at_slot,
+                    observed_slot: slot,
+                };
+                let delegated = request.delegated_account;
+                if self.undelegation_requests_tx.try_send(request).is_err() {
+                    warn!(
+                        delegated_account = %delegated,
+                        "undelegation-request channel full; dropping (poll backstop covers it)"
+                    );
+                }
             }
             AccountUpdate::SlotAdvanced(slot) => {
                 let mut inner = self.inner.lock();
@@ -280,6 +369,11 @@ impl DelegationRecordMirror {
 
     pub fn test_clear(&self) {
         self.clear();
+    }
+
+    /// Drives a raw sync event through the consumer path.
+    pub fn test_apply(&self, update: AccountUpdate) {
+        self.apply(update);
     }
 }
 

--- a/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/stream_manager.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/stream_manager.rs
@@ -269,6 +269,7 @@ impl<S: StreamHandle, SF: StreamFactory<S>> StreamManager<S, SF> {
             self.current_new_subs.insert(*pk);
         }
 
+        metrics::inc_grpc_account_filter_updates();
         let result = if let Some(handle) = &self.current_new_handle {
             let request = Self::build_account_request(
                 &self.current_new_subs.iter().collect::<Vec<_>>(),

--- a/magicblock-chainlink/src/remote_account_provider/config.rs
+++ b/magicblock-chainlink/src/remote_account_provider/config.rs
@@ -122,6 +122,12 @@ impl RemoteAccountProviderConfig {
         &self.program_subs
     }
 
+    /// Replaces the startup program subscriptions.
+    pub fn with_program_subs(mut self, program_subs: HashSet<Pubkey>) -> Self {
+        self.program_subs = program_subs;
+        self
+    }
+
     pub fn resubscription_delay(&self) -> Duration {
         self.resubscription_delay
     }

--- a/magicblock-metrics/src/metrics/mod.rs
+++ b/magicblock-metrics/src/metrics/mod.rs
@@ -253,6 +253,16 @@ lazy_static::lazy_static! {
         "Latest confirmed slot the delegation-record mirror is caught up to",
     ).expect("static name is a valid metric identifier");
 
+    static ref CHAINLINK_AUTHORITY_RECORDS_ON_CHAIN_GAUGE: IntGauge = IntGauge::new(
+        "chainlink_authority_records_on_chain",
+        "On-chain delegation records naming this validator as authority, from the periodic sweep",
+    ).expect("static name is a valid metric identifier");
+
+    static ref GRPC_ACCOUNT_FILTER_UPDATES_COUNT: IntCounter = IntCounter::new(
+        "grpc_account_filter_updates_count",
+        "Subscription filter updates written to gRPC account streams (churn indicator)",
+    ).expect("static name is a valid metric identifier");
+
     static ref PROGRAM_SUBSCRIPTION_ACCOUNT_UPDATES_COUNT: IntCounterVec =
         IntCounterVec::new(
             Opts::new(
@@ -810,6 +820,8 @@ pub(crate) fn register() {
         register!(CHAINLINK_SUBSCRIPTION_CLEANUP_ACCOUNTS_TOTAL);
         register!(PROGRAM_SUBSCRIPTION_DISCOVERED_DLP_UPDATE_DELEGATED_ELSEWHERE_COUNT);
         register!(CHAINLINK_RECORD_MIRROR_LOOKUPS_TOTAL);
+        register!(CHAINLINK_AUTHORITY_RECORDS_ON_CHAIN_GAUGE);
+        register!(GRPC_ACCOUNT_FILTER_UPDATES_COUNT);
         register!(CHAINLINK_RECORD_MIRROR_LIVE_GAUGE);
         register!(CHAINLINK_RECORD_MIRROR_WATERMARK_GAUGE);
         register!(PROGRAM_SUBSCRIPTION_ACCOUNT_UPDATES_COUNT);
@@ -1126,6 +1138,14 @@ pub fn inc_record_mirror_lookup(outcome: RecordMirrorLookupOutcome) {
     CHAINLINK_RECORD_MIRROR_LOOKUPS_TOTAL
         .with_label_values(&[outcome.as_str()])
         .inc();
+}
+
+pub fn set_authority_records_on_chain(count: i64) {
+    CHAINLINK_AUTHORITY_RECORDS_ON_CHAIN_GAUGE.set(count);
+}
+
+pub fn inc_grpc_account_filter_updates() {
+    GRPC_ACCOUNT_FILTER_UPDATES_COUNT.inc();
 }
 
 pub fn set_record_mirror_live(live: bool) {

--- a/test-integration/Cargo.lock
+++ b/test-integration/Cargo.lock
@@ -289,7 +289,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -300,7 +300,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -795,7 +795,7 @@ dependencies = [
  "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -2021,7 +2021,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4111,8 +4111,8 @@ dependencies = [
 
 [[package]]
 name = "magicblock-sync"
-version = "0.2.0"
-source = "git+https://github.com/magicblock-labs/magicblock-sync.git?rev=3c71985#3c719851767544d1ae003bbf53d74c82c14acb01"
+version = "0.3.0"
+source = "git+https://github.com/magicblock-labs/magicblock-sync.git?rev=7f6d109#7f6d109172e74e1e26ea71b4307523752c6db9e5"
 dependencies = [
  "futures",
  "helius-laserstream",
@@ -4435,7 +4435,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5076,7 +5076,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "petgraph",
@@ -5097,7 +5097,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -5785,7 +5785,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6407,7 +6407,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9743,7 +9743,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10928,7 +10928,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/test-integration/Cargo.lock
+++ b/test-integration/Cargo.lock
@@ -289,7 +289,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -300,7 +300,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -795,7 +795,7 @@ dependencies = [
  "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "regex",
@@ -2021,7 +2021,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4112,7 +4112,7 @@ dependencies = [
 [[package]]
 name = "magicblock-sync"
 version = "0.3.0"
-source = "git+https://github.com/magicblock-labs/magicblock-sync.git?rev=7f6d109#7f6d109172e74e1e26ea71b4307523752c6db9e5"
+source = "git+https://github.com/magicblock-labs/magicblock-sync.git?rev=24814f6#24814f6a389e53d0c7d2c04367de93e025d02b93"
 dependencies = [
  "futures",
  "helius-laserstream",
@@ -4435,7 +4435,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5076,7 +5076,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph",
@@ -5097,7 +5097,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -5785,7 +5785,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6407,7 +6407,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9743,7 +9743,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10928,7 +10928,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

**Stacked on #1514** (chain: master ← #1512 ← #1514 ← this). Depends on magicblock-labs/magicblock-sync#7 (pinned at its branch rev `7f6d109`; bump to the merged rev before landing).

With the record mirror live, delegation discovery no longer needs the DLP account firehose. The record stream's new `DelegationObserved` events — parsed from `Delegate`/`DelegateWithAnyValidator` instructions (including CPI-invoked), naming the delegated account that a record PDA alone cannot reveal — drive discovery through the exact probe → recheck → forced-refresh path #1514 built for colliding updates. Foreign delegations cost zero RPC (mirror-resolved authority gate); delegations to this validator cost one account fetch.

## Behavior

- **Mirror connected (production default)**: the DLP program subscription is **not established at all** — no firehose bandwidth, no per-update classification work, no SubMux dedup load for DLP traffic. Discovery, collision resolution, and undelegation-request detection all ride the record stream.
- **No mirror** (dev/test with `solana-test-validator`, `record-sync` disabled, or connect failure): the program subscription and the existing firehose-driven discovery remain, byte-for-byte — integration tests and localnet behavior are unchanged. The mirror's presence *is* the feature flag.
- `UndelegationRequest` account writes stream through the mirror into the existing `undelegation_request_sender` broadcast, preserving real-time request detection without the program sub (the 300s gPA poll remains the backstop either way).
- A periodic observational sweep (gPA on records with `authority == validator`, 5 min, zero-length data slice) exports `chainlink_authority_records_on_chain` — the drift detector for missed record-stream events.
- `grpc_account_filter_updates_count` counts subscription filter writes on the generational gRPC streams — the churn indicator that verifies in production that filter updates are rare once the record ceremony and firehose are gone.
- The discovery listener and sweep hold weak references, so background tasks end with the `FetchCloner` (also keeps test drain semantics intact).

## Follow-up (after prod burn-in, explicitly not here)

Once the mirror path has burn-in evidence (hit rates, churn <1/s, sweep drift ≈ 0), the now-fallback-only machinery (`classify_dlp_program_update_interest`, greedy discovery trigger, DLP forward-gates) becomes deletable for mirror-less-capable code paths — tracked as the next stacked PR after metrics review.

## Tests

397 green: end-to-end record-stream discovery (event → mirror probe → clone, record absent from RPC mock so the outcome proves the source), foreign-authority drop, undelegation-request forwarding, plus the full existing suite (wedge repro, collision, mirror) unchanged. Clippy/fmt clean; workspace check clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved delegated-account discovery and cloning through mirrored record streams.
  - Added support for forwarding undelegation requests from the delegation record mirror.
  - Added Zstandard/Base64 account encoding and zero-length data slicing for account queries.

- **Monitoring**
  - Added metrics for on-chain authority records and account-filter updates.
  - Added periodic authority-record tracking and improved subscription update visibility.

- **Bug Fixes**
  - Improved handling of delegation ownership and record collisions during discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->