### PR TITLE
feat: single-transport subscription policy

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -245,6 +245,14 @@ reset = false
 # Chainlink (cloning pipeline)
 # ==============================================================================
 [chainlink]
+# Transport for base-chain account subscriptions. "grpc" is the only
+# supported production transport; "ws" exists for local/dev validators
+# without a geyser gRPC endpoint. With "grpc" configured but no gRPC remote
+# available, the validator logs an error and runs degraded on websockets.
+# Default: "grpc"
+# Env: MBV_CHAINLINK__SUBSCRIPTION_TRANSPORT
+subscription-transport = "grpc"
+
 # Maximum number of accounts to monitor for price updates.
 # Default: 5000
 # Env: MBV_CHAINLINK__MAX_MONITORED_ACCOUNTS

--- a/magicblock-chainlink/src/chainlink/mod.rs
+++ b/magicblock-chainlink/src/chainlink/mod.rs
@@ -406,13 +406,16 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
             endpoints,
         )
         .await;
+        let rap_config = config
+            .remote_account_provider
+            .clone()
+            .with_subscription_transport(
+                chainlink_config.subscription_transport,
+            );
         let rap_config = if record_mirror.is_some() {
-            config
-                .remote_account_provider
-                .clone()
-                .with_program_subs(Default::default())
+            rap_config.with_program_subs(Default::default())
         } else {
-            config.remote_account_provider.clone()
+            rap_config
         };
 
         // Extract accounts provider and create fetch cloner while connecting

--- a/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/actor.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_laser_actor/actor.rs
@@ -55,6 +55,10 @@ pub struct Slots {
     /// Updated via `update()` when slot updates are received from GRPC.
     /// Metrics are automatically captured on updates.
     pub chain_slot: ChainSlot,
+    /// Slot notifications observed on THIS client's stream. Unlike
+    /// `chain_slot`, which is shared across all clients, this is
+    /// endpoint-local so liveness can be attributed to one endpoint.
+    pub slot_updates_seen: Arc<AtomicU64>,
 }
 
 // -----------------
@@ -729,6 +733,7 @@ impl<H: StreamHandle, S: StreamFactory<H>> ChainLaserActor<H, S> {
         // Handle slot updates - update chain_slot to max of current and received
         if let UpdateOneof::Slot(slot_update) = &update_oneof {
             self.slots.chain_slot.update(slot_update.slot);
+            self.slots.slot_updates_seen.fetch_add(1, Ordering::Relaxed);
             return;
         }
 

--- a/magicblock-chainlink/src/remote_account_provider/chain_pubsub_client.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_pubsub_client.rs
@@ -16,7 +16,7 @@ use tracing::*;
 
 use super::{
     chain_pubsub_actor::ChainPubsubActor,
-    errors::{RemoteAccountProviderError, RemoteAccountProviderResult},
+    errors::RemoteAccountProviderResult,
     pubsub_common::{ChainPubsubActorMessage, SubscriptionUpdate},
 };
 
@@ -109,28 +109,6 @@ pub trait ChainPubsubClient: Send + Sync + Clone + 'static {
 
     fn transport(&self) -> PubsubTransport {
         PubsubTransport::WebSocket
-    }
-
-    /// Prefers gRPC-only coverage for `pubkey`.
-    /// Multiplexing implementors drop websocket legs only after gRPC
-    /// coverage is confirmed and err otherwise, leaving coverage untouched.
-    async fn prefer_grpc_subscription(
-        &self,
-        pubkey: Pubkey,
-    ) -> RemoteAccountProviderResult<()> {
-        match self.transport() {
-            PubsubTransport::Grpc => self.subscribe(pubkey, None).await,
-            // Dropping a ws subscription is only safe behind a multiplexer
-            // that confirmed gRPC coverage.
-            PubsubTransport::WebSocket => {
-                Err(RemoteAccountProviderError::AccountSubscriptionsTaskFailed(
-                    format!(
-                        "cannot prefer gRPC-only coverage for {pubkey} on a \
-                         websocket-only client"
-                    ),
-                ))
-            }
-        }
     }
 }
 
@@ -453,7 +431,6 @@ pub mod mock {
         subscribe_notify: Arc<Notify>,
         client_id: String,
         transport: Arc<Mutex<PubsubTransport>>,
-        prefer_grpc_calls: Arc<Mutex<Vec<Pubkey>>>,
     }
 
     impl ChainPubsubClientMock {
@@ -488,17 +465,11 @@ pub mod mock {
                     CLIENT_ID.fetch_add(1, AtomicOrdering::SeqCst)
                 ),
                 transport: Arc::new(Mutex::new(PubsubTransport::WebSocket)),
-                prefer_grpc_calls: Arc::new(Mutex::new(Vec::new())),
             }
         }
 
         pub fn set_transport(&self, transport: PubsubTransport) {
             *self.transport.lock() = transport;
-        }
-
-        /// Pubkeys for which `prefer_grpc_subscription` was invoked.
-        pub fn prefer_grpc_calls(&self) -> Vec<Pubkey> {
-            self.prefer_grpc_calls.lock().clone()
         }
 
         /// Simulate a disconnect: clear all subscriptions and mark client as disconnected.
@@ -665,26 +636,6 @@ pub mod mock {
 
     #[async_trait]
     impl ChainPubsubClient for ChainPubsubClientMock {
-        /// Records the call, then mirrors the trait default: subscribe on a
-        /// gRPC client, error on a websocket-only client.
-        async fn prefer_grpc_subscription(
-            &self,
-            pubkey: Pubkey,
-        ) -> RemoteAccountProviderResult<()> {
-            self.prefer_grpc_calls.lock().push(pubkey);
-            match self.transport() {
-                PubsubTransport::Grpc => self.subscribe(pubkey, None).await,
-                PubsubTransport::WebSocket => Err(
-                    RemoteAccountProviderError::AccountSubscriptionsTaskFailed(
-                        format!(
-                            "cannot prefer gRPC-only coverage for {pubkey} on \
-                             a websocket-only client"
-                        ),
-                    ),
-                ),
-            }
-        }
-
         fn take_updates(&self) -> mpsc::Receiver<SubscriptionUpdate> {
             // SAFETY: This can only be None if `take_updates` is called more
             // than once (double take). That would indicate a logic bug in the

--- a/magicblock-chainlink/src/remote_account_provider/chain_updates_client.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_updates_client.rs
@@ -29,19 +29,20 @@ const GRPC_LIVENESS_PROBE_TIMEOUT: std::time::Duration =
 const GRPC_LIVENESS_PROBE_INTERVAL: std::time::Duration =
     std::time::Duration::from_millis(250);
 
-/// Subscribes to slot notifications and waits for the shared chain slot to
-/// advance, proving the endpoint actually delivers data.
+/// Subscribes to slot notifications and waits for one to arrive on THIS
+/// client's stream, proving the endpoint itself delivers data. The counter
+/// is endpoint-local, so a healthy sibling remote cannot satisfy the probe
+/// for a dead one.
 async fn probe_grpc_liveness(
     client: &ChainLaserClientImpl,
-    chain_slot: &Arc<AtomicU64>,
+    slot_updates_seen: &Arc<AtomicU64>,
 ) -> RemoteAccountProviderResult<()> {
-    let before = chain_slot.load(Ordering::Relaxed);
     client
         .subscribe(solana_sdk_ids::sysvar::clock::ID, None)
         .await?;
     let deadline = tokio::time::Instant::now() + GRPC_LIVENESS_PROBE_TIMEOUT;
     while tokio::time::Instant::now() < deadline {
-        if chain_slot.load(Ordering::Relaxed) > before {
+        if slot_updates_seen.load(Ordering::Relaxed) > 0 {
             return Ok(());
         }
         tokio::time::sleep(GRPC_LIVENESS_PROBE_INTERVAL).await;
@@ -102,8 +103,10 @@ impl ChainUpdatesClient {
                     CLIENT_ID.fetch_add(1, Ordering::SeqCst)
                 );
 
+                let slot_updates_seen = Arc::new(AtomicU64::new(0));
                 let slots = Slots {
-                    chain_slot: ChainSlot::new(chain_slot.clone()),
+                    chain_slot: ChainSlot::new(chain_slot),
+                    slot_updates_seen: slot_updates_seen.clone(),
                 };
                 let client = ChainLaserClientImpl::new_from_url(
                     url,
@@ -121,7 +124,7 @@ impl ChainUpdatesClient {
                 // delivery before accepting the client; a failure here
                 // surfaces as a connect error, which the endpoint selection
                 // handles by degrading to websockets.
-                probe_grpc_liveness(&client, &chain_slot).await?;
+                probe_grpc_liveness(&client, &slot_updates_seen).await?;
                 Ok(ChainUpdatesClient::Laser(client))
             }
             Rpc { .. } => {

--- a/magicblock-chainlink/src/remote_account_provider/chain_updates_client.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_updates_client.rs
@@ -21,6 +21,39 @@ use crate::remote_account_provider::{
     RemoteAccountProviderError, RemoteAccountProviderResult,
 };
 
+/// A live laserstream delivers a slot notification every chain slot
+/// (~400ms); silence past this deadline means the endpoint is not
+/// delivering data.
+const GRPC_LIVENESS_PROBE_TIMEOUT: std::time::Duration =
+    std::time::Duration::from_secs(10);
+const GRPC_LIVENESS_PROBE_INTERVAL: std::time::Duration =
+    std::time::Duration::from_millis(250);
+
+/// Subscribes to slot notifications and waits for the shared chain slot to
+/// advance, proving the endpoint actually delivers data.
+async fn probe_grpc_liveness(
+    client: &ChainLaserClientImpl,
+    chain_slot: &Arc<AtomicU64>,
+) -> RemoteAccountProviderResult<()> {
+    let before = chain_slot.load(Ordering::Relaxed);
+    client
+        .subscribe(solana_sdk_ids::sysvar::clock::ID, None)
+        .await?;
+    let deadline = tokio::time::Instant::now() + GRPC_LIVENESS_PROBE_TIMEOUT;
+    while tokio::time::Instant::now() < deadline {
+        if chain_slot.load(Ordering::Relaxed) > before {
+            return Ok(());
+        }
+        tokio::time::sleep(GRPC_LIVENESS_PROBE_INTERVAL).await;
+    }
+    Err(RemoteAccountProviderError::AccountSubscriptionsTaskFailed(
+        format!(
+            "gRPC endpoint delivered no slot updates within \
+             {GRPC_LIVENESS_PROBE_TIMEOUT:?}"
+        ),
+    ))
+}
+
 #[derive(Clone)]
 pub enum ChainUpdatesClient {
     WebSocket(ChainPubsubClientImpl),
@@ -70,20 +103,26 @@ impl ChainUpdatesClient {
                 );
 
                 let slots = Slots {
-                    chain_slot: ChainSlot::new(chain_slot),
+                    chain_slot: ChainSlot::new(chain_slot.clone()),
                 };
-                Ok(ChainUpdatesClient::Laser(
-                    ChainLaserClientImpl::new_from_url(
-                        url,
-                        client_id.to_string(),
-                        api_key,
-                        commitment.commitment,
-                        abort_sender,
-                        slots,
-                        rpc_client,
-                        grpc_config,
-                    ),
-                ))
+                let client = ChainLaserClientImpl::new_from_url(
+                    url,
+                    client_id.to_string(),
+                    api_key,
+                    commitment.commitment,
+                    abort_sender,
+                    slots,
+                    rpc_client,
+                    grpc_config,
+                );
+                // The laserstream subscribe API reports endpoint failures
+                // asynchronously through the stream, so construction alone
+                // cannot detect a dead gRPC remote. Require live slot
+                // delivery before accepting the client; a failure here
+                // surfaces as a connect error, which the endpoint selection
+                // handles by degrading to websockets.
+                probe_grpc_liveness(&client, &chain_slot).await?;
+                Ok(ChainUpdatesClient::Laser(client))
             }
             Rpc { .. } => {
                 Err(RemoteAccountProviderError::InvalidPubsubEndpoint(format!(

--- a/magicblock-chainlink/src/remote_account_provider/config.rs
+++ b/magicblock-chainlink/src/remote_account_provider/config.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashSet, time::Duration};
 
 use magicblock_config::{
-    config::{GrpcConfig, LifecycleMode},
+    config::{GrpcConfig, LifecycleMode, SubscriptionTransport},
     consts::{
         DEFAULT_MAX_MONITORED_ACCOUNTS, DEFAULT_RESUBSCRIPTION_DELAY_MS,
         DEFAULT_SECONDARY_MAX_MONITORED_ACCOUNTS,
@@ -24,6 +24,8 @@ pub struct RemoteAccountProviderConfig {
     /// Set of program accounts to always subscribe to as backup
     /// for direct account subs
     program_subs: HashSet<Pubkey>,
+    /// Transport used for base-chain account subscriptions.
+    subscription_transport: SubscriptionTransport,
     /// Delay between resubscribing to accounts after a pubsub
     /// reconnection
     resubscription_delay: Duration,
@@ -122,6 +124,18 @@ impl RemoteAccountProviderConfig {
         &self.program_subs
     }
 
+    pub fn subscription_transport(&self) -> SubscriptionTransport {
+        self.subscription_transport
+    }
+
+    pub fn with_subscription_transport(
+        mut self,
+        transport: SubscriptionTransport,
+    ) -> Self {
+        self.subscription_transport = transport;
+        self
+    }
+
     /// Replaces the startup program subscriptions.
     pub fn with_program_subs(mut self, program_subs: HashSet<Pubkey>) -> Self {
         self.program_subs = program_subs;
@@ -151,6 +165,7 @@ impl Default for RemoteAccountProviderConfig {
             lifecycle_mode: LifecycleMode::default(),
             enable_subscription_metrics: true,
             program_subs: vec![dlp_api::id()].into_iter().collect(),
+            subscription_transport: SubscriptionTransport::default(),
             resubscription_delay: std::time::Duration::from_millis(
                 DEFAULT_RESUBSCRIPTION_DELAY_MS,
             ),

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -20,7 +20,7 @@ pub(crate) use errors::{
 use futures_util::future::{join_all, try_join_all};
 use lru_cache::TieredSubscribedAccountsTracker;
 pub use lru_cache::{AccountsLruCache, AddAccountOutcome};
-use magicblock_config::config::GrpcConfig;
+use magicblock_config::config::{GrpcConfig, SubscriptionTransport};
 pub(crate) use remote_account::RemoteAccount;
 pub use remote_account::RemoteAccountUpdateSource;
 use solana_account::Account;
@@ -181,111 +181,6 @@ fn collect_connected_pubsubs(
             }
         })
         .collect()
-}
-
-#[allow(clippy::too_many_arguments)]
-fn spawn_deferred_pubsub_clients(
-    endpoints: Vec<Endpoint>,
-    commitment: CommitmentConfig,
-    rpc_client: ChainRpcClientImpl,
-    chain_slot: Arc<AtomicU64>,
-    resubscription_delay: Duration,
-    grpc_cfg: GrpcConfig,
-    submux: SubMuxClient<ChainUpdatesClient>,
-    subscribed_accounts: Arc<TieredSubscribedAccountsTracker>,
-) {
-    // Deferred clients are the fallback update sources; retry connect/attach
-    // with capped backoff instead of dropping them permanently on failure.
-    const INITIAL_ATTACH_RETRY_DELAY: Duration = Duration::from_secs(1);
-    const MAX_ATTACH_RETRY_DELAY: Duration = Duration::from_secs(300);
-    for ep in endpoints {
-        let rpc_client = rpc_client.clone();
-        let chain_slot = chain_slot.clone();
-        let grpc_cfg = grpc_cfg.clone();
-        let submux = submux.clone();
-        let subscribed_accounts = subscribed_accounts.clone();
-        // Stop retrying when the owning mux shuts down so an unavailable
-        // endpoint doesn't leak this task past the provider's lifetime
-        let shutdown = submux.shutdown_token();
-        tokio::spawn(async move {
-            let mut retry_delay = INITIAL_ATTACH_RETRY_DELAY;
-            loop {
-                let connect = connect_pubsub_client(
-                    ep.clone(),
-                    commitment,
-                    rpc_client.clone(),
-                    chain_slot.clone(),
-                    resubscription_delay,
-                    grpc_cfg.clone(),
-                );
-                let (label, result) = tokio::select! {
-                    _ = shutdown.cancelled() => return,
-                    connected = connect => connected,
-                };
-                match result {
-                    Ok((client, abort_rx)) => {
-                        // Attach without the subscription transition lock:
-                        // a paced resub of a large set can take minutes and
-                        // would starve foreground transitions. The reconnect
-                        // path already resubscribes lock-free.
-                        let attach = submux.add_client(
-                            client.clone(),
-                            abort_rx,
-                            subscribed_accounts.clone(),
-                        );
-                        let add_result = tokio::select! {
-                            _ = shutdown.cancelled() => {
-                                // Stop the partial client's subscription
-                                // work; the mux is gone anyway
-                                let _ = client.shutdown().await;
-                                return;
-                            }
-                            res = attach => res,
-                        };
-                        match add_result {
-                            Ok(()) => {
-                                debug!(
-                                    endpoint = %label,
-                                    "Attached deferred pubsub client"
-                                );
-                                return;
-                            }
-                            Err(err) => {
-                                warn!(
-                                    endpoint = %label,
-                                    error = %err,
-                                    retry_in = ?retry_delay,
-                                    "Deferred pubsub client failed to attach"
-                                );
-                                // Shut down so partially established
-                                // subscriptions don't leak listener tasks
-                                // before retrying with a fresh client
-                                if let Err(err) = client.shutdown().await {
-                                    debug!(
-                                        endpoint = %label,
-                                        error = %err,
-                                        "Failed to shut down partially \
-                                         attached pubsub client"
-                                    );
-                                }
-                            }
-                        }
-                    }
-                    Err(err) => warn!(
-                        endpoint = %label,
-                        error = %err,
-                        retry_in = ?retry_delay,
-                        "Deferred pubsub client failed to connect"
-                    ),
-                }
-                tokio::select! {
-                    _ = shutdown.cancelled() => return,
-                    _ = tokio::time::sleep(retry_delay) => {}
-                }
-                retry_delay = (retry_delay * 2).min(MAX_ATTACH_RETRY_DELAY);
-            }
-        });
-    }
 }
 
 // Maps pubkey -> (fetch_start_slot, requests_waiting)
@@ -1066,8 +961,7 @@ impl<U: ChainPubsubClient> SubscriptionTierCtx<U> {
 
     /// Moves a confirmed-missing account from the primary to the secondary
     /// tier. The tier move runs under one transition-lock scope; eviction
-    /// cleanup is deferred to a detached task and the gRPC-only transport
-    /// switch runs after the lock scope.
+    /// cleanup is deferred to a detached task.
     /// Precondition: the caller holds the key's subscription guard.
     async fn move_not_found_to_secondary(&self, pubkey: Pubkey) {
         if self
@@ -1090,7 +984,7 @@ impl<U: ChainPubsubClient> SubscriptionTierCtx<U> {
             return;
         }
 
-        let (confirmed_missing, evicted) = {
+        let (_confirmed_missing, evicted) = {
             let _transition_guard =
                 self.subscription_transition_lock.lock().await;
 
@@ -1121,21 +1015,6 @@ impl<U: ChainPubsubClient> SubscriptionTierCtx<U> {
 
         if let Some(evicted) = evicted {
             self.spawn_evicted_cleanup(evicted);
-        }
-        if confirmed_missing {
-            // Drop the websocket leg promptly; the multiplexer only does so
-            // after confirming gRPC coverage and errs otherwise, in which
-            // case full coverage stays and the reconciler applies the
-            // gRPC-only policy on a later pass.
-            if let Err(err) =
-                self.pubsub_client.prefer_grpc_subscription(pubkey).await
-            {
-                debug!(
-                    pubkey = %pubkey,
-                    error = ?err,
-                    "Keeping full coverage for confirmed miss; reconciler applies gRPC-only policy later"
-                );
-            }
         }
     }
 
@@ -1813,24 +1692,41 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
         let rpc_client =
             ChainRpcClientImpl::new_from_url(rpc_url.as_str(), commitment);
 
-        // Build startup pubsub clients and wrap them into a SubMuxClient.
-        // gRPC clients are cheap to create and backfill subscriptions, so
-        // when present we let slower WebSocket clients attach after startup.
-        // If gRPC cannot subscribe during startup, retry once with WebSocket
-        // endpoints so mixed configs still have a live fallback.
-        let pubsubs = endpoints.pubsubs();
-        let has_grpc =
-            pubsubs.iter().any(|ep| matches!(ep, Endpoint::Grpc { .. }));
-        let (startup_pubsubs, deferred_pubsubs): (Vec<_>, Vec<_>) = pubsubs
+        // Single-transport subscriptions: every client speaks the configured
+        // transport. gRPC is the only supported production transport; with
+        // it configured but unavailable, the validator logs an error and
+        // runs degraded on websockets rather than refusing to start.
+        let (grpc, ws): (Vec<_>, Vec<_>) = endpoints
+            .pubsubs()
             .into_iter()
             .cloned()
-            .partition(|ep| !has_grpc || matches!(ep, Endpoint::Grpc { .. }));
-        let fallback_pubsubs = (has_grpc && !deferred_pubsubs.is_empty())
-            .then(|| deferred_pubsubs.clone());
+            .partition(|ep| matches!(ep, Endpoint::Grpc { .. }));
+        let selected = match config.subscription_transport() {
+            SubscriptionTransport::Grpc if !grpc.is_empty() => {
+                metrics::set_subscription_transport_grpc(true);
+                grpc
+            }
+            SubscriptionTransport::Grpc => {
+                error!(
+                    "subscription-transport is grpc but no gRPC remote is \
+                     configured; running DEGRADED on websockets — this is \
+                     unsupported in production"
+                );
+                metrics::set_subscription_transport_grpc(false);
+                ws.clone()
+            }
+            SubscriptionTransport::Ws => {
+                warn!(
+                    "subscription-transport is ws: dev/test only, \
+                     unsupported in production"
+                );
+                metrics::set_subscription_transport_grpc(false);
+                ws.clone()
+            }
+        };
 
         match Self::try_new_from_pubsubs(
-            startup_pubsubs,
-            deferred_pubsubs,
+            selected,
             commitment,
             rpc_client.clone(),
             chain_slot.clone(),
@@ -1839,64 +1735,48 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
         )
         .await
         {
-            Ok((provider, deferred_pubsubs)) => {
-                if !deferred_pubsubs.is_empty() {
-                    spawn_deferred_pubsub_clients(
-                        deferred_pubsubs,
-                        commitment,
-                        rpc_client,
-                        chain_slot,
-                        config.resubscription_delay(),
-                        config.grpc().clone(),
-                        provider.pubsub_client.clone(),
-                        Arc::new(TieredSubscribedAccountsTracker::new(
-                            provider.lrucache_subscribed_accounts.clone(),
-                            provider.secondary_subscriptions.clone(),
-                        )),
-                    );
-                }
-                Ok(provider)
-            }
-            Err(err) => {
-                let Some(fallback_pubsubs) = fallback_pubsubs else {
-                    return Err(err);
-                };
-                warn!(
+            Ok(provider) => Ok(provider),
+            Err(err)
+                if matches!(
+                    config.subscription_transport(),
+                    SubscriptionTransport::Grpc
+                ) && !ws.is_empty() =>
+            {
+                error!(
                     error = %err,
-                    "gRPC startup pubsub failed; retrying with WebSocket fallback"
+                    "gRPC subscriptions failed at startup; running DEGRADED \
+                     on websockets — this is unsupported in production"
                 );
-                let (provider, _) = Self::try_new_from_pubsubs(
-                    fallback_pubsubs,
-                    Vec::new(),
+                metrics::set_subscription_transport_grpc(false);
+                Self::try_new_from_pubsubs(
+                    ws,
                     commitment,
                     rpc_client,
                     chain_slot,
                     subscription_forwarder,
                     config,
                 )
-                .await?;
-                Ok(provider)
+                .await
             }
+            Err(err) => Err(err),
         }
     }
 
     async fn try_new_from_pubsubs(
-        startup_pubsubs: Vec<Endpoint>,
-        mut deferred_pubsubs: Vec<Endpoint>,
+        pubsub_endpoints: Vec<Endpoint>,
         commitment: CommitmentConfig,
         rpc_client: ChainRpcClientImpl,
         chain_slot: Arc<AtomicU64>,
         subscription_forwarder: mpsc::Sender<ForwardedSubscriptionUpdate>,
         config: &RemoteAccountProviderConfig,
-    ) -> RemoteAccountProviderResult<(
+    ) -> RemoteAccountProviderResult<
         RemoteAccountProvider<
             ChainRpcClientImpl,
             SubMuxClient<ChainUpdatesClient>,
         >,
-        Vec<Endpoint>,
-    )> {
+    > {
         let resubscription_delay = config.resubscription_delay();
-        let pubsub_futs = startup_pubsubs.into_iter().map(|ep| {
+        let pubsub_futs = pubsub_endpoints.into_iter().map(|ep| {
             connect_pubsub_client(
                 ep,
                 commitment,
@@ -1907,27 +1787,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
             )
         });
         let results = join_all(pubsub_futs).await;
-        let mut pubsubs = collect_connected_pubsubs(results);
-
-        if pubsubs.is_empty() && !deferred_pubsubs.is_empty() {
-            warn!(
-                "No startup pubsub clients connected; falling back to deferred pubsub endpoints"
-            );
-            let fallback_pubsub_futs =
-                deferred_pubsubs.iter().cloned().map(|ep| {
-                    connect_pubsub_client(
-                        ep,
-                        commitment,
-                        rpc_client.clone(),
-                        chain_slot.clone(),
-                        resubscription_delay,
-                        config.grpc().clone(),
-                    )
-                });
-            let results = join_all(fallback_pubsub_futs).await;
-            pubsubs = collect_connected_pubsubs(results);
-            deferred_pubsubs.clear();
-        }
+        let pubsubs = collect_connected_pubsubs(results);
 
         if pubsubs.is_empty() {
             return Err(RemoteAccountProviderError::AllPubsubClientsFailed);
@@ -1975,7 +1835,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
             ChainSlot::new(chain_slot),
         )
         .await?;
-        Ok((provider, deferred_pubsubs))
+        Ok(provider)
     }
 
     pub(crate) fn promote_accounts(&self, pubkeys: &[&Pubkey]) {

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -1701,6 +1701,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
             .into_iter()
             .cloned()
             .partition(|ep| matches!(ep, Endpoint::Grpc { .. }));
+        let grpc_selected = !grpc.is_empty();
         let selected = match config.subscription_transport() {
             SubscriptionTransport::Grpc if !grpc.is_empty() => {
                 metrics::set_subscription_transport_grpc(true);
@@ -1740,7 +1741,8 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                 if matches!(
                     config.subscription_transport(),
                     SubscriptionTransport::Grpc
-                ) && !ws.is_empty() =>
+                ) && grpc_selected
+                    && !ws.is_empty() =>
             {
                 error!(
                     error = %err,

--- a/magicblock-chainlink/src/remote_account_provider/subscription_reconciler.rs
+++ b/magicblock-chainlink/src/remote_account_provider/subscription_reconciler.rs
@@ -395,16 +395,7 @@ pub(crate) async fn reconcile_subscriptions<PubsubClient: ChainPubsubClient>(
             continue;
         }
 
-        let grpc_preferred = confirmed_missing_subscriptions
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner())
-            .contains(&pubkey);
-        let has_grpc = grpc_snapshot.is_some();
-        let preferred_result = if grpc_preferred && has_grpc {
-            pubsub_client.prefer_grpc_subscription(pubkey).await
-        } else {
-            pubsub_client.subscribe(pubkey, None).await
-        };
+        let preferred_result = pubsub_client.subscribe(pubkey, None).await;
         if let Err(err) = &preferred_result {
             debug!(pubkey = %pubkey, error = ?err, "Secondary repair failed; restoring full coverage");
         }

--- a/magicblock-chainlink/src/remote_account_provider/tests.rs
+++ b/magicblock-chainlink/src/remote_account_provider/tests.rs
@@ -796,52 +796,6 @@ async fn test_failed_coverage_restore_rolls_back_acquired_reason() {
 }
 
 #[tokio::test]
-async fn test_confirmed_miss_switches_to_grpc_only_promptly() {
-    init_logger();
-
-    let existing = random_pubkey();
-    let missing = random_pubkey();
-    let ctx = setup_provider(
-        existing,
-        Account {
-            lamports: 1,
-            ..Default::default()
-        },
-    )
-    .await;
-    ctx.pubsub_client.set_transport(PubsubTransport::Grpc);
-
-    // A found account never triggers the gRPC-only switch.
-    assert!(ctx
-        .provider
-        .try_get(existing, AccountFetchContext::rpc_get_account())
-        .await
-        .unwrap()
-        .is_found());
-    assert!(ctx.pubsub_client.prefer_grpc_calls().is_empty());
-
-    // The confirming not-found classification switches the key to
-    // gRPC-only coverage immediately instead of waiting for the
-    // periodic reconciler pass.
-    assert!(!ctx
-        .provider
-        .try_get(missing, AccountFetchContext::rpc_get_account())
-        .await
-        .unwrap()
-        .is_found());
-    assert_eq!(ctx.pubsub_client.prefer_grpc_calls(), vec![missing]);
-    assert!(ctx.provider.secondary_subscriptions.contains(&missing));
-    assert!(ctx
-        .provider
-        .confirmed_missing_subscriptions
-        .lock()
-        .unwrap()
-        .contains(&missing));
-    // The mock is a gRPC client, so coverage stays after the switch.
-    assert!(ctx.pubsub_client.subscriptions_union().contains(&missing));
-}
-
-#[tokio::test]
 async fn test_setup_cancellation_preserves_pump_admitted_primary_membership() {
     init_logger();
 

--- a/magicblock-chainlink/src/submux/mod.rs
+++ b/magicblock-chainlink/src/submux/mod.rs
@@ -22,7 +22,7 @@ use crate::remote_account_provider::{
         ChainPubsubClient, PubsubTransport, ReconnectableClient,
         SubscriptionReconciliationSnapshot,
     },
-    errors::{RemoteAccountProviderError, RemoteAccountProviderResult},
+    errors::RemoteAccountProviderResult,
     pubsub_common::SubscriptionUpdate,
 };
 
@@ -35,7 +35,6 @@ pub use self::debounce_state::DebounceState;
 
 mod subscription_task;
 pub use self::subscription_task::AccountSubscriptionTask;
-use self::subscription_task::{SUBSCRIBE_TIMEOUT, UNSUBSCRIBE_TIMEOUT};
 
 mod subscribed_accounts_tracker;
 pub use self::subscribed_accounts_tracker::SubscribedAccountsTracker;
@@ -149,7 +148,6 @@ where
     program_subs: Arc<Mutex<HashSet<Pubkey>>>,
     /// Accounts whose desired coverage excludes websocket clients while at
     /// least one gRPC client is available.
-    grpc_only_subscriptions: Arc<Mutex<HashSet<Pubkey>>>,
     /// Client handles currently considered connected by the mux.
     connected_client_ids: Arc<Mutex<HashSet<usize>>>,
     /// Number of currently connected pubsub clients.
@@ -229,8 +227,6 @@ where
             vec![clock::ID].into_iter().collect();
 
         let program_subs: Arc<Mutex<HashSet<Pubkey>>> = Default::default();
-        let grpc_only_subscriptions: Arc<Mutex<HashSet<Pubkey>>> =
-            Default::default();
         let connected_client_ids: Arc<Mutex<HashSet<usize>>> =
             Arc::new(Mutex::new(
                 clients
@@ -274,10 +270,8 @@ where
 
         Self::spawn_reconnectors(
             clients,
-            clients_only.clone(),
             subscribed_accounts_tracker,
             program_subs.clone(),
-            grpc_only_subscriptions.clone(),
             connected_client_ids.clone(),
             connected_clients.clone(),
             connected_clients_subscribing_immediately.clone(),
@@ -295,7 +289,6 @@ where
             debounce_states: debounce_states.clone(),
             never_debounce,
             program_subs,
-            grpc_only_subscriptions,
             connected_client_ids,
             connected_clients,
             connected_clients_subscribing_immediately,
@@ -310,32 +303,22 @@ where
         me
     }
 
-    /// Token cancelled when the owning mux shuts down; ties background
-    /// tasks to this mux's lifetime.
-    pub(crate) fn shutdown_token(&self) -> CancellationToken {
-        self.shutdown_token.clone()
-    }
-
     // -----------------
     // Reconnection
     // -----------------
     #[allow(clippy::too_many_arguments)]
     fn spawn_reconnectors<U: SubscribedAccountsTracker>(
         clients: Vec<(Arc<T>, mpsc::Receiver<()>)>,
-        all_clients: Arc<Mutex<Vec<Arc<T>>>>,
         subscribed_accounts_tracker: Arc<U>,
         program_subs: Arc<Mutex<HashSet<Pubkey>>>,
-        grpc_only_subscriptions: Arc<Mutex<HashSet<Pubkey>>>,
         connected_client_ids: Arc<Mutex<HashSet<usize>>>,
         connected_clients: Arc<AtomicU16>,
         connected_clients_subscribing_immediately: Arc<AtomicU16>,
     ) {
         for (client, mut abort_rx) in clients.into_iter() {
-            let all_clients = all_clients.clone();
             let subscribed_accounts_tracker =
                 subscribed_accounts_tracker.clone();
             let program_subs = program_subs.clone();
-            let grpc_only_subscriptions = grpc_only_subscriptions.clone();
             let connected_client_ids = connected_client_ids.clone();
             let connected_clients = connected_clients.clone();
             let connected_clients_subscribing_immediately =
@@ -379,10 +362,8 @@ where
 
                     Self::reconnect_client_with_backoff(
                         client.clone(),
-                        all_clients.clone(),
                         subscribed_accounts_tracker.clone(),
                         program_subs.clone(),
-                        grpc_only_subscriptions.clone(),
                         connected_client_ids.clone(),
                         connected_clients.clone(),
                         connected_clients_subscribing_immediately.clone(),
@@ -458,172 +439,11 @@ where
         })
     }
 
-    fn account_subscriptions_for_client<U: SubscribedAccountsTracker>(
-        tracker: &U,
-        grpc_only_subscriptions: &Arc<Mutex<HashSet<Pubkey>>>,
-        clients: &Mutex<Vec<Arc<T>>>,
-        connected_client_ids: &Arc<Mutex<HashSet<usize>>>,
-        client: &T,
-    ) -> HashSet<Pubkey> {
-        // The tracker is authoritative. The policy set only removes
-        // confirmed misses from websocket reconnects while a connected
-        // gRPC client can cover them; otherwise websocket clients restore
-        // full coverage.
-        let mut subscriptions = tracker.subscribed_accounts();
-        if client.transport() == PubsubTransport::WebSocket
-            && Self::has_connected_grpc_client(clients, connected_client_ids)
-        {
-            let grpc_only = grpc_only_subscriptions
-                .lock()
-                .unwrap_or_else(|poison| poison.into_inner());
-            subscriptions.retain(|pubkey| !grpc_only.contains(pubkey));
-        }
-        subscriptions
-    }
-
-    fn has_connected_grpc_client(
-        clients: &Mutex<Vec<Arc<T>>>,
-        connected_client_ids: &Arc<Mutex<HashSet<usize>>>,
-    ) -> bool {
-        let clients = clients
+    #[cfg(test)]
+    fn program_subs_lock(&self) -> MutexGuard<'_, HashSet<Pubkey>> {
+        self.program_subs
             .lock()
-            .unwrap_or_else(|poison| poison.into_inner())
-            .clone();
-        let connected_ids =
-            Self::connected_client_ids_lock(connected_client_ids);
-        clients.iter().any(|client| {
-            client.transport() == PubsubTransport::Grpc
-                && connected_ids.contains(&Self::client_key(client))
-        })
-    }
-
-    fn remove_client(&self, target: &Arc<T>) {
-        {
-            let mut clients = self.clients_lock();
-            if let Some(pos) =
-                clients.iter().position(|c| Arc::ptr_eq(c, target))
-            {
-                clients.swap_remove(pos);
-            }
-        }
-        Self::connected_client_ids_lock(&self.connected_client_ids)
-            .remove(&Self::client_key(target));
-    }
-
-    pub(crate) async fn add_client<U: SubscribedAccountsTracker>(
-        &self,
-        client: Arc<T>,
-        abort_rx: mpsc::Receiver<()>,
-        subscribed_accounts_tracker: Arc<U>,
-    ) -> RemoteAccountProviderResult<()> {
-        {
-            let mut clients = self.clients_lock();
-            clients.push(client.clone());
-        }
-
-        let programs =
-            self.program_subs_lock().iter().copied().collect::<Vec<_>>();
-        for program_id in programs {
-            if let Err(err) = client.subscribe_program(program_id).await {
-                self.remove_client(&client);
-                return Err(err);
-            }
-        }
-
-        let mut account_subs = Self::account_subscriptions_for_client(
-            subscribed_accounts_tracker.as_ref(),
-            &self.grpc_only_subscriptions,
-            &self.clients,
-            &self.connected_client_ids,
-            client.as_ref(),
-        );
-        account_subs.extend(self.never_debounce.iter().copied());
-        if let Err(err) = client.resub_multiple(account_subs).await {
-            self.remove_client(&client);
-            return Err(err);
-        }
-
-        if self.forwarders_started.load(Ordering::SeqCst) {
-            self.spawn_forwarder_for_client(
-                &client,
-                self.dedup_window,
-                self.debounce_interval,
-                self.debounce_detection_window,
-                self.allowed_in_debounce_window_count(),
-            );
-        }
-
-        Self::connected_client_ids_lock(&self.connected_client_ids)
-            .insert(Self::client_key(&client));
-
-        let connected = self
-            .connected_clients
-            .fetch_add(1, Ordering::SeqCst)
-            .saturating_add(1);
-        metrics::set_connected_pubsub_clients_count(connected as usize);
-        metrics::set_pubsub_client_uptime(client.id(), true);
-        if let Some(delay_ms) = client.current_resub_delay_ms() {
-            metrics::set_pubsub_client_resubscribe_delay(client.id(), delay_ms);
-        }
-        if client.subs_immediately() {
-            let connected = self
-                .connected_clients_subscribing_immediately
-                .fetch_add(1, Ordering::SeqCst)
-                .saturating_add(1);
-            metrics::set_connected_direct_pubsub_clients_count(
-                connected as usize,
-            );
-        }
-
-        Self::spawn_reconnectors(
-            vec![(client.clone(), abort_rx)],
-            self.clients.clone(),
-            subscribed_accounts_tracker.clone(),
-            self.program_subs.clone(),
-            self.grpc_only_subscriptions.clone(),
-            self.connected_client_ids.clone(),
-            self.connected_clients.clone(),
-            self.connected_clients_subscribing_immediately.clone(),
-        );
-
-        // Catch-up pass, mirroring reconnect_client: subscriptions added
-        // after the snapshots above but before this client became visible
-        // in connected_clients_snapshot() would otherwise be missed.
-        // Already-subscribed keys dedup, so this is cheap. Failures don't
-        // roll the client back - foreground subscribes may already count
-        // it toward their confirmations - recovery is owned by the
-        // standard machinery: connection-level failures signal the
-        // reconnector spawned above, account stragglers are repaired by
-        // the reconciler.
-        let programs =
-            self.program_subs_lock().iter().copied().collect::<Vec<_>>();
-        for program_id in programs {
-            if let Err(err) = client.subscribe_program(program_id).await {
-                warn!(
-                    client_id = %client.id(),
-                    program_id = %program_id,
-                    error = %err,
-                    "Catch-up program subscription failed after attach"
-                );
-            }
-        }
-        let mut account_subs = Self::account_subscriptions_for_client(
-            subscribed_accounts_tracker.as_ref(),
-            &self.grpc_only_subscriptions,
-            &self.clients,
-            &self.connected_client_ids,
-            client.as_ref(),
-        );
-        account_subs.extend(self.never_debounce.iter().copied());
-        if let Err(err) = client.resub_multiple(account_subs).await {
-            warn!(
-                client_id = %client.id(),
-                error = %err,
-                "Catch-up account resubscription failed after attach"
-            );
-        }
-
-        Ok(())
+            .expect("program_subs lock poisoned")
     }
 
     fn clients_lock(&self) -> MutexGuard<'_, Vec<Arc<T>>> {
@@ -632,21 +452,11 @@ where
         self.clients.lock().expect("clients lock poisoned")
     }
 
-    fn program_subs_lock(&self) -> MutexGuard<'_, HashSet<Pubkey>> {
-        // Lock poisoning means a thread panicked while mutating mux state;
-        // treating that as unrecoverable is safer than continuing with it.
-        self.program_subs
-            .lock()
-            .expect("program_subs lock poisoned")
-    }
-
     #[instrument(
         skip(
             client,
-            all_clients,
             accounts_tracker,
             program_subs,
-            grpc_only_subscriptions,
             connected_client_ids,
             connected_clients,
             connected_clients_subscribing_immediately
@@ -656,10 +466,8 @@ where
     #[allow(clippy::too_many_arguments)]
     async fn reconnect_client_with_backoff<U: SubscribedAccountsTracker>(
         client: Arc<T>,
-        all_clients: Arc<Mutex<Vec<Arc<T>>>>,
         accounts_tracker: Arc<U>,
         program_subs: Arc<Mutex<HashSet<Pubkey>>>,
-        grpc_only_subscriptions: Arc<Mutex<HashSet<Pubkey>>>,
         connected_client_ids: Arc<Mutex<HashSet<usize>>>,
         connected_clients: Arc<AtomicU16>,
         connected_clients_subscribing_immediately: Arc<AtomicU16>,
@@ -686,10 +494,8 @@ where
             }
             match Self::reconnect_client(
                 client.clone(),
-                &all_clients,
                 &accounts_tracker,
                 &program_subs,
-                &grpc_only_subscriptions,
                 connected_client_ids.clone(),
                 connected_clients.clone(),
                 connected_clients_subscribing_immediately.clone(),
@@ -752,16 +558,14 @@ where
     }
 
     #[instrument(
-        skip(client, all_clients, accounts_tracker, program_subs, grpc_only_subscriptions, connected_client_ids, connected_clients, connected_clients_subscribing_immediately),
+        skip(client, accounts_tracker, program_subs, connected_client_ids, connected_clients, connected_clients_subscribing_immediately),
         fields(client_id = %client.id())
     )]
     #[allow(clippy::too_many_arguments)]
     async fn reconnect_client<U: SubscribedAccountsTracker>(
         client: Arc<T>,
-        all_clients: &Arc<Mutex<Vec<Arc<T>>>>,
         accounts_tracker: &Arc<U>,
         program_subs: &Arc<Mutex<HashSet<Pubkey>>>,
-        grpc_only_subscriptions: &Arc<Mutex<HashSet<Pubkey>>>,
         connected_client_ids: Arc<Mutex<HashSet<usize>>>,
         connected_clients: Arc<AtomicU16>,
         connected_clients_subscribing_immediately: Arc<AtomicU16>,
@@ -793,13 +597,7 @@ where
         // Resubscribe all accounts from the authoritative tracker.
         // This ensures subscriptions are restored even if all clients lost their state
         // during disconnect/abort.
-        let account_subs = Self::account_subscriptions_for_client(
-            accounts_tracker.as_ref(),
-            grpc_only_subscriptions,
-            all_clients,
-            &connected_client_ids,
-            client.as_ref(),
-        );
+        let account_subs = accounts_tracker.subscribed_accounts();
 
         if let Err(err) = client.resub_multiple(account_subs).await {
             debug!(
@@ -830,13 +628,7 @@ where
                 }
             }
 
-            let account_subs = Self::account_subscriptions_for_client(
-                accounts_tracker.as_ref(),
-                grpc_only_subscriptions,
-                all_clients,
-                &connected_client_ids,
-                client.as_ref(),
-            );
+            let account_subs = accounts_tracker.subscribed_accounts();
             if let Err(err) = client.resub_multiple(account_subs).await {
                 Self::connected_client_ids_lock(&connected_client_ids)
                     .remove(&client_key);
@@ -1176,7 +968,6 @@ where
             debounce_states: self.debounce_states.clone(),
             never_debounce: self.never_debounce.clone(),
             program_subs: self.program_subs.clone(),
-            grpc_only_subscriptions: self.grpc_only_subscriptions.clone(),
             connected_client_ids: self.connected_client_ids.clone(),
             connected_clients: self.connected_clients.clone(),
             connected_clients_subscribing_immediately: self
@@ -1210,25 +1001,13 @@ where
         pubkey: Pubkey,
         retries: Option<usize>,
     ) -> RemoteAccountProviderResult<()> {
-        let was_grpc_only = self
-            .grpc_only_subscriptions
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner())
-            .remove(&pubkey);
-        let result = AccountSubscriptionTask::Subscribe(
+        AccountSubscriptionTask::Subscribe(
             pubkey,
             retries,
             self.required_account_subscription_confirmations(),
         )
         .process(self.connected_clients_snapshot())
-        .await;
-        if result.is_err() && was_grpc_only {
-            self.grpc_only_subscriptions
-                .lock()
-                .unwrap_or_else(|poison| poison.into_inner())
-                .insert(pubkey);
-        }
-        result
+        .await
     }
 
     async fn subscribe_program(
@@ -1281,126 +1060,9 @@ where
         &self,
         pubkey: Pubkey,
     ) -> RemoteAccountProviderResult<()> {
-        let was_grpc_only = self
-            .grpc_only_subscriptions
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner())
-            .remove(&pubkey);
-        let result = AccountSubscriptionTask::Unsubscribe(pubkey)
+        AccountSubscriptionTask::Unsubscribe(pubkey)
             .process(self.connected_clients_snapshot())
-            .await;
-        if result.is_err() && was_grpc_only {
-            self.grpc_only_subscriptions
-                .lock()
-                .unwrap_or_else(|poison| poison.into_inner())
-                .insert(pubkey);
-        }
-        result
-    }
-
-    async fn prefer_grpc_subscription(
-        &self,
-        pubkey: Pubkey,
-    ) -> RemoteAccountProviderResult<()> {
-        let clients = self.connected_clients_snapshot();
-
-        // Only drop websocket legs once at least one gRPC client holds the
-        // subscription; otherwise leave existing coverage untouched. Calls
-        // run concurrently and bounded so a stalled client cannot wedge
-        // subscription transitions.
-        let grpc_results = futures_util::future::join_all(
-            clients
-                .iter()
-                .filter(|c| c.transport() == PubsubTransport::Grpc)
-                .map(|client| async move {
-                    match tokio::time::timeout(
-                        SUBSCRIBE_TIMEOUT,
-                        client.subscribe(pubkey, None),
-                    )
-                    .await
-                    {
-                        Ok(result) => result,
-                        Err(_) => Err(
-                            RemoteAccountProviderError::AccountSubscriptionsTaskFailed(
-                                format!(
-                                    "Subscribe timed out after {SUBSCRIBE_TIMEOUT:?} for client {}",
-                                    client.id()
-                                ),
-                            ),
-                        ),
-                    }
-                }),
-        )
-        .await;
-        let mut grpc_covered = false;
-        let mut last_err = None;
-        for result in grpc_results {
-            match result {
-                Ok(()) => grpc_covered = true,
-                Err(err) => last_err = Some(err),
-            }
-        }
-        // A no-op subscribe can mask lost coverage; trust only the snapshot.
-        if grpc_covered {
-            grpc_covered = self
-                .subscription_reconciliation_snapshot_for_transport(
-                    PubsubTransport::Grpc,
-                )
-                .is_some_and(|snapshot| snapshot.union.contains(&pubkey));
-        }
-        if !grpc_covered {
-            return Err(last_err.unwrap_or_else(|| {
-                RemoteAccountProviderError::AccountSubscriptionsTaskFailed(
-                    format!(
-                        "No connected gRPC client to hold subscription for {pubkey}"
-                    ),
-                )
-            }));
-        }
-
-        self.grpc_only_subscriptions
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner())
-            .insert(pubkey);
-
-        futures_util::future::join_all(
-            clients
-                .iter()
-                .filter(|c| c.transport() == PubsubTransport::WebSocket)
-                .map(|client| async move {
-                    match tokio::time::timeout(
-                        UNSUBSCRIBE_TIMEOUT,
-                        client.unsubscribe(pubkey),
-                    )
-                    .await
-                    {
-                        Ok(Ok(()))
-                        | Ok(Err(
-                            RemoteAccountProviderError::AccountSubscriptionDoesNotExist(
-                                _,
-                            ),
-                        )) => {}
-                        Ok(Err(err)) => {
-                            warn!(
-                                pubkey = %pubkey,
-                                client_id = %client.id(),
-                                error = ?err,
-                                "Failed to drop websocket leg for gRPC-only coverage"
-                            );
-                        }
-                        Err(_) => {
-                            warn!(
-                                pubkey = %pubkey,
-                                client_id = %client.id(),
-                                timeout_ms = UNSUBSCRIBE_TIMEOUT.as_millis() as u64,
-                                "Timed out dropping websocket leg for gRPC-only coverage"
-                            );
-                        }
-                    }
-                }),
-        )
-        .await;
-        Ok(())
+            .await
     }
 
     async fn shutdown(&self) -> RemoteAccountProviderResult<()> {
@@ -1655,48 +1317,6 @@ mod tests {
         let mut lams = vec![lamports(&u1), lamports(&u2)];
         lams.sort();
         assert_eq!(lams, vec![10, 20]);
-
-        mux.shutdown().await.unwrap();
-    }
-
-    #[tokio::test]
-    async fn test_submux_add_client_resubscribes_and_forwards_updates() {
-        init_logger();
-
-        let pk = Pubkey::new_unique();
-        let (tx1, rx1) = mpsc::channel(10_000);
-        let (tx2, rx2) = mpsc::channel(10_000);
-        let client1 = Arc::new(ChainPubsubClientMock::new(tx1, rx1));
-        let client2 = Arc::new(ChainPubsubClientMock::new(tx2, rx2));
-        let (_abort_tx1, abort_rx1) = mpsc::channel(1);
-        let (_abort_tx2, abort_rx2) = mpsc::channel(1);
-        let tracker = Arc::new(MockSubscribedAccountsTracker::new(vec![pk]));
-
-        let mux: SubMuxClient<ChainPubsubClientMock> = SubMuxClient::new(
-            vec![(client1, abort_rx1)],
-            tracker.clone(),
-            None,
-        );
-        let mut mux_rx = mux.take_updates();
-
-        mux.add_client(client2.clone(), abort_rx2, tracker)
-            .await
-            .unwrap();
-
-        assert!(client2.subscriptions_union().contains(&pk));
-        client2
-            .send_account_update(pk, 1, &account_with_lamports(42))
-            .await;
-
-        let update = tokio::time::timeout(
-            std::time::Duration::from_millis(100),
-            mux_rx.recv(),
-        )
-        .await
-        .expect("update expected")
-        .expect("stream open");
-        assert_eq!(update.pubkey, pk);
-        assert_eq!(update.account.unwrap().lamports, 42);
 
         mux.shutdown().await.unwrap();
     }
@@ -2465,112 +2085,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_prefer_grpc_subscription_drops_ws_legs() {
-        init_logger();
-
-        let (tx1, rx1) = mpsc::channel(10_000);
-        let (tx2, rx2) = mpsc::channel(10_000);
-        let ws_client = Arc::new(ChainPubsubClientMock::new(tx1, rx1));
-        let grpc_client = Arc::new(ChainPubsubClientMock::new(tx2, rx2));
-        grpc_client.set_transport(PubsubTransport::Grpc);
-
-        let pk = Pubkey::new_unique();
-        let (mux, _aborts) = new_submux_with_abort(
-            vec![ws_client.clone(), grpc_client.clone()],
-            vec![pk],
-            Some(100),
-        );
-
-        mux.subscribe(pk, None).await.unwrap();
-        assert!(ws_client.subscriptions_union().contains(&pk));
-        assert!(grpc_client.subscriptions_union().contains(&pk));
-
-        mux.prefer_grpc_subscription(pk).await.unwrap();
-        assert!(!ws_client.subscriptions_union().contains(&pk));
-        assert!(grpc_client.subscriptions_union().contains(&pk));
-
-        mux.shutdown().await.unwrap();
-    }
-
-    #[tokio::test]
-    async fn test_grpc_only_subscription_is_restored_on_grpc_reconnect() {
-        init_logger();
-
-        let (tx1, rx1) = mpsc::channel(10_000);
-        let (tx2, rx2) = mpsc::channel(10_000);
-        let ws_client = Arc::new(ChainPubsubClientMock::new(tx1, rx1));
-        let grpc_client = Arc::new(ChainPubsubClientMock::new(tx2, rx2));
-        grpc_client.set_transport(PubsubTransport::Grpc);
-
-        let pubkey = Pubkey::new_unique();
-        let (mux, aborts) = new_submux_with_abort(
-            vec![ws_client.clone(), grpc_client.clone()],
-            vec![pubkey],
-            Some(100),
-        );
-
-        mux.subscribe(pubkey, None).await.unwrap();
-        mux.prefer_grpc_subscription(pubkey).await.unwrap();
-        grpc_client.simulate_disconnect();
-        aborts[1].send(()).await.unwrap();
-
-        let deadline = Instant::now() + Duration::from_secs(1);
-        while !grpc_client.subscriptions_union().contains(&pubkey) {
-            assert!(
-                Instant::now() < deadline,
-                "gRPC subscription did not recover"
-            );
-            sleep_ms(10).await;
-        }
-
-        assert!(!ws_client.subscriptions_union().contains(&pubkey));
-        mux.shutdown().await.unwrap();
-    }
-
-    #[tokio::test]
-    async fn test_reconcile_replaces_lingering_ws_with_grpc_coverage() {
-        init_logger();
-
-        let (tx1, rx1) = mpsc::channel(10_000);
-        let (tx2, rx2) = mpsc::channel(10_000);
-        let ws_client = Arc::new(ChainPubsubClientMock::new(tx1, rx1));
-        let grpc_client = Arc::new(ChainPubsubClientMock::new(tx2, rx2));
-        grpc_client.set_transport(PubsubTransport::Grpc);
-
-        let pubkey = Pubkey::new_unique();
-        let (mux, _aborts) = new_submux_with_abort(
-            vec![ws_client.clone(), grpc_client.clone()],
-            vec![pubkey],
-            Some(100),
-        );
-        ws_client.insert_subscription(pubkey);
-
-        let primary = AccountsLruCache::new(NonZeroUsize::new(10).unwrap());
-        let secondary = AccountsLruCache::new(NonZeroUsize::new(10).unwrap());
-        secondary.add(pubkey);
-        let (removed_tx, mut removed_rx) = mpsc::channel(10);
-
-        reconcile_subscriptions(
-            &primary,
-            &secondary,
-            &Mutex::new(HashSet::from([pubkey])),
-            &mux,
-            &[],
-            &removed_tx,
-            None,
-            None,
-            None,
-            None,
-        )
-        .await;
-
-        assert!(!ws_client.subscriptions_union().contains(&pubkey));
-        assert!(grpc_client.subscriptions_union().contains(&pubkey));
-        assert!(removed_rx.try_recv().is_err());
-        mux.shutdown().await.unwrap();
-    }
-
-    #[tokio::test]
     async fn test_reconcile_keeps_pending_secondary_fully_covered() {
         init_logger();
 
@@ -2610,24 +2124,6 @@ mod tests {
         assert!(ws_client.subscriptions_union().contains(&pubkey));
         assert!(grpc_client.subscriptions_union().contains(&pubkey));
         assert!(removed_rx.try_recv().is_err());
-        mux.shutdown().await.unwrap();
-    }
-
-    #[tokio::test]
-    async fn test_prefer_grpc_subscription_without_grpc_keeps_ws_legs() {
-        init_logger();
-
-        let (tx1, rx1) = mpsc::channel(10_000);
-        let ws_client = Arc::new(ChainPubsubClientMock::new(tx1, rx1));
-
-        let pk = Pubkey::new_unique();
-        let (mux, _aborts) =
-            new_submux_with_abort(vec![ws_client.clone()], vec![pk], Some(100));
-
-        mux.subscribe(pk, None).await.unwrap();
-        assert!(mux.prefer_grpc_subscription(pk).await.is_err());
-        assert!(ws_client.subscriptions_union().contains(&pk));
-
         mux.shutdown().await.unwrap();
     }
 

--- a/magicblock-config/src/config/chain.rs
+++ b/magicblock-config/src/config/chain.rs
@@ -80,6 +80,13 @@ pub struct ChainLinkConfig {
 
     /// Delegation-record mirror fed from the magicblock-sync record firehose.
     pub record_sync: RecordSyncConfig,
+
+    /// Subscription transport for base-chain account updates. `grpc` is the
+    /// only supported production transport; `ws` exists for local/dev
+    /// validators without a geyser gRPC endpoint. With `grpc` configured but
+    /// no gRPC remote available, the validator logs an error and runs
+    /// degraded on websockets.
+    pub subscription_transport: SubscriptionTransport,
 }
 
 impl Default for ChainLinkConfig {
@@ -98,8 +105,24 @@ impl Default for ChainLinkConfig {
             ),
             risk: RiskConfig::default(),
             record_sync: RecordSyncConfig::default(),
+            subscription_transport: SubscriptionTransport::default(),
         }
     }
+}
+
+/// Transport used for base-chain account subscriptions.
+#[derive(
+    Deserialize, Serialize, Debug, Clone, Copy, PartialEq, Eq, Default,
+)]
+#[serde(rename_all = "kebab-case")]
+pub enum SubscriptionTransport {
+    /// Yellowstone gRPC (laserstream): the production transport, with
+    /// confirmed filtering and from-slot replay.
+    #[default]
+    Grpc,
+    /// WebSocket pubsub: local/dev only (solana-test-validator has no
+    /// geyser gRPC plugin).
+    Ws,
 }
 
 /// Configuration for the in-memory delegation-record mirror streamed from

--- a/magicblock-config/src/config/mod.rs
+++ b/magicblock-config/src/config/mod.rs
@@ -15,7 +15,7 @@ pub use accounts::{AccountsDbConfig, BlockSize};
 pub use aperture::ApertureConfig;
 pub use chain::{
     AllowedProgram, ChainLinkConfig, ChainOperationConfig, CommittorConfig,
-    RecordSyncConfig, RiskConfig,
+    RecordSyncConfig, RiskConfig, SubscriptionTransport,
 };
 pub use grpc::GrpcConfig;
 pub use ledger::LedgerConfig;

--- a/magicblock-metrics/src/metrics/mod.rs
+++ b/magicblock-metrics/src/metrics/mod.rs
@@ -258,6 +258,11 @@ lazy_static::lazy_static! {
         "On-chain delegation records naming this validator as authority, from the periodic sweep",
     ).expect("static name is a valid metric identifier");
 
+    static ref SUBSCRIPTION_TRANSPORT_GRPC_GAUGE: IntGauge = IntGauge::new(
+        "chainlink_subscription_transport_grpc",
+        "1 while base-chain subscriptions run on gRPC (the supported production transport), 0 when degraded to or configured for websockets",
+    ).expect("static name is a valid metric identifier");
+
     static ref GRPC_ACCOUNT_FILTER_UPDATES_COUNT: IntCounter = IntCounter::new(
         "grpc_account_filter_updates_count",
         "Subscription filter updates written to gRPC account streams (churn indicator)",
@@ -822,6 +827,7 @@ pub(crate) fn register() {
         register!(CHAINLINK_RECORD_MIRROR_LOOKUPS_TOTAL);
         register!(CHAINLINK_AUTHORITY_RECORDS_ON_CHAIN_GAUGE);
         register!(GRPC_ACCOUNT_FILTER_UPDATES_COUNT);
+        register!(SUBSCRIPTION_TRANSPORT_GRPC_GAUGE);
         register!(CHAINLINK_RECORD_MIRROR_LIVE_GAUGE);
         register!(CHAINLINK_RECORD_MIRROR_WATERMARK_GAUGE);
         register!(PROGRAM_SUBSCRIPTION_ACCOUNT_UPDATES_COUNT);
@@ -1142,6 +1148,10 @@ pub fn inc_record_mirror_lookup(outcome: RecordMirrorLookupOutcome) {
 
 pub fn set_authority_records_on_chain(count: i64) {
     CHAINLINK_AUTHORITY_RECORDS_ON_CHAIN_GAUGE.set(count);
+}
+
+pub fn set_subscription_transport_grpc(grpc: bool) {
+    SUBSCRIPTION_TRANSPORT_GRPC_GAUGE.set(grpc as i64);
 }
 
 pub fn inc_grpc_account_filter_updates() {


### PR DESCRIPTION
## Summary

Stacked on #1516. Final PR of the demand-collapse stack ([plan](https://github.com/magicblock-labs/magicblock-validator/pull/1512)): with record-stream discovery removing the DLP program-sub and record-fetch churn, production no longer needs to run websockets and gRPC side by side. This PR makes the subscription transport an explicit single choice and deletes the dual-transport runtime machinery.

## Config

```toml
[chainlink]
# "grpc" (default): production transport, requires a geyser gRPC remote.
# "ws": local/dev validators without gRPC (e.g. solana-test-validator).
subscription-transport = "grpc"
```

Enforcement is warn-and-degrade, not hard-fail: `grpc` configured with no gRPC remote logs a prominent error and runs on websockets; `ws` logs a dev/test-only warning. The effective transport is exposed via the new `chainlink_subscription_transport_grpc` gauge so degraded fleet nodes are alertable.

## Deleted (−824 / +135)

- **Deferred websocket attach**: `spawn_deferred_pubsub_clients` + `SubMuxClient::add_client`/`remove_client` and the retry/backoff task that attached WS clients after gRPC-only startup. With a single transport there is nothing to attach later.
- **Mixed-transport submux policy**: `grpc_only_subscriptions` tracking, `has_connected_grpc_client`, transport-aware `account_subscriptions_for_client` restoration, and the was-grpc-only subscribe/unsubscribe dance.
- **`prefer_grpc_subscription`** client surface and the subscription reconciler's grpc-preference repair path (a same-transport fleet has no preferred leg).
- The prefer-on-confirmed-missing block in `try_new_from_endpoints` and its test.

All remaining submux multiplexing (N same-transport clients, reconnectors, reconciler) is unchanged.

## Testing

- `cargo test -p magicblock-chainlink --lib`: 391 passed
- `cargo test -p magicblock-config`: 34 passed (example-config coverage includes the new key)
- clippy clean, nightly fmt, full workspace `cargo check` clean