### PR TITLE
fix: deflake integration tests so CI retries are unnecessary

### DIFF
--- a/.github/workflows/ci-test-integration.yml
+++ b/.github/workflows/ci-test-integration.yml
@@ -548,6 +548,3 @@ jobs:
           INTEGRATION_TEST_BIN_DIR: ${{ github.workspace }}/magicblock-validator/_integration_test_bins
           CARGO_PROFILE_DEV_DEBUG: "0"
           CARGO_PROFILE_TEST_DEBUG: "0"
-          # A few integration tests have validator-timing races; allow up to
-          # 3 retries before failing the shard.
-          RUN_TEST_RETRIES: "3"

--- a/test-integration/schedulecommit/test-scenarios/tests/02_commit_and_undelegate.rs
+++ b/test-integration/schedulecommit/test-scenarios/tests/02_commit_and_undelegate.rs
@@ -35,7 +35,7 @@ use solana_sdk::{
     pubkey::Pubkey,
     signature::{Keypair, Signature},
     signer::Signer,
-    transaction::Transaction,
+    transaction::{Transaction, TransactionError},
 };
 use test_kit::init_logger;
 use tracing::*;
@@ -589,6 +589,11 @@ fn assert_cannot_increase_committee_count(
         );
     let (tx_result_err, tx_err) = extract_transaction_error(tx_res);
     if let Some(tx_err) = tx_err {
+        // The account may become undelegated between the simulation above and
+        // this send; the same InvalidWritableAccount signal then surfaces here.
+        if matches!(tx_err, TransactionError::InvalidWritableAccount) {
+            return;
+        }
         assert_is_one_of_instruction_errors(
             tx_err,
             &tx_result_err,

--- a/test-integration/test-chainlink/src/ixtest_context.rs
+++ b/test-integration/test-chainlink/src/ixtest_context.rs
@@ -178,6 +178,22 @@ impl IxtestContext {
             .request_airdrop(&counter_auth.pubkey(), 777 * LAMPORTS_PER_SOL)
             .await
             .unwrap();
+        // Wait for the airdrop to land before the init tx tries to debit it.
+        let deadline =
+            std::time::Instant::now() + std::time::Duration::from_secs(30);
+        while self
+            .rpc_client
+            .get_balance(&counter_auth.pubkey())
+            .await
+            .unwrap_or(0)
+            < 777 * LAMPORTS_PER_SOL
+        {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "airdrop to counter auth not visible after 30s"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
         debug!("Airdropped to counter auth: {} SOL", 777 * LAMPORTS_PER_SOL);
 
         let init_counter_ix =

--- a/test-integration/test-chainlink/src/programs.rs
+++ b/test-integration/test-chainlink/src/programs.rs
@@ -77,10 +77,24 @@ pub async fn airdrop_sol(
         .await
         .expect("Failed to request airdrop");
 
-    rpc_client
-        .confirm_transaction(&airdrop_signature)
-        .await
-        .expect("Failed to confirm airdrop");
+    // confirm_transaction returns Ok(false) while the airdrop is still in
+    // flight; poll until it actually confirms.
+    let deadline =
+        std::time::Instant::now() + std::time::Duration::from_secs(30);
+    loop {
+        let confirmed = rpc_client
+            .confirm_transaction(&airdrop_signature)
+            .await
+            .expect("Failed to confirm airdrop");
+        if confirmed {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "airdrop to {pubkey} not confirmed after 30s"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
 
     debug!("Airdropped {sol} SOL to account {pubkey}");
 }

--- a/test-integration/test-chainlink/tests/ix_remote_account_provider.rs
+++ b/test-integration/test-chainlink/tests/ix_remote_account_provider.rs
@@ -82,12 +82,16 @@ async fn ixtest_existing_account_for_future_slot() {
     await_next_slot(rpc_client).await;
 
     let cs = current_slot(rpc_client).await;
+    // Use a slot far enough ahead that the validator cannot reach it between
+    // reading the current slot and issuing the fetch; `cs + 1` raced with
+    // slot production.
+    let future_slot = cs + 1_000;
     let res = rpc_client
         .get_ui_account_with_config(
             &pubkey,
             RpcAccountInfoConfig {
                 commitment: Some(CommitmentConfig::processed()),
-                min_context_slot: Some(cs + 1),
+                min_context_slot: Some(future_slot),
                 ..Default::default()
             },
         )

--- a/test-integration/test-cloning/tests/01_program-deploy.rs
+++ b/test-integration/test-cloning/tests/01_program-deploy.rs
@@ -190,8 +190,9 @@ async fn test_clone_mini_v4_loader_program_and_upgrade() {
                 .send_and_confirm_instructions_with_payer_ephem(&[ix], &payer)
                 .unwrap();
 
-            assert!(found);
-            if check_logs!(ctx, sig, format!("{msg} upgraded")) {
+            // While the upgrade reclone is in flight the transaction may not
+            // confirm; retry it like a stale-log result instead of panicking.
+            if found && check_logs!(ctx, sig, format!("{msg} upgraded")) {
                 break;
             }
 

--- a/test-integration/test-committor-service/tests/common.rs
+++ b/test-integration/test-committor-service/tests/common.rs
@@ -37,6 +37,25 @@ use solana_sdk::{
     signer::Signer,
 };
 
+// Poll until an airdrop is reflected in the account's balance. On a freshly
+// started validator the first airdrop can take a few slots to land.
+async fn wait_for_funding(rpc_client: &MagicblockRpcClient, pubkey: &Pubkey) {
+    const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+    const POLL_INTERVAL: std::time::Duration =
+        std::time::Duration::from_millis(50);
+
+    let start = std::time::Instant::now();
+    loop {
+        match rpc_client.get_account(pubkey).await {
+            Ok(Some(account)) if account.lamports > 0 => return,
+            _ if start.elapsed() > TIMEOUT => {
+                panic!("airdrop to {pubkey} not visible after {TIMEOUT:?}")
+            }
+            _ => tokio::time::sleep(POLL_INTERVAL).await,
+        }
+    }
+}
+
 // Helper function to create a test RPC client
 pub async fn create_test_client() -> MagicblockRpcClient {
     let url = "http://localhost:7799".to_string();
@@ -78,6 +97,10 @@ impl TestFixture {
             )
             .await
             .unwrap();
+        // request_airdrop only submits the transfer; wait until the funds are
+        // visible or the first transaction a test sends may fail to debit the
+        // authority ("no record of a prior credit").
+        wait_for_funding(&rpc_client, &authority.pubkey()).await;
 
         let compute_budget_config = ComputeBudgetConfig::new(1_000_000);
         Self {

--- a/test-integration/test-committor-service/tests/common.rs
+++ b/test-integration/test-committor-service/tests/common.rs
@@ -37,9 +37,13 @@ use solana_sdk::{
     signer::Signer,
 };
 
-// Poll until an airdrop is reflected in the account's balance. On a freshly
+// Poll until the account holds at least `min_lamports`. On a freshly
 // started validator the first airdrop can take a few slots to land.
-async fn wait_for_funding(rpc_client: &MagicblockRpcClient, pubkey: &Pubkey) {
+async fn wait_for_funding(
+    rpc_client: &MagicblockRpcClient,
+    pubkey: &Pubkey,
+    min_lamports: u64,
+) {
     const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
     const POLL_INTERVAL: std::time::Duration =
         std::time::Duration::from_millis(50);
@@ -47,7 +51,7 @@ async fn wait_for_funding(rpc_client: &MagicblockRpcClient, pubkey: &Pubkey) {
     let start = std::time::Instant::now();
     loop {
         match rpc_client.get_account(pubkey).await {
-            Ok(Some(account)) if account.lamports > 0 => return,
+            Ok(Some(account)) if account.lamports >= min_lamports => return,
             _ if start.elapsed() > TIMEOUT => {
                 panic!("airdrop to {pubkey} not visible after {TIMEOUT:?}")
             }
@@ -90,17 +94,16 @@ impl TestFixture {
             TableMania::new(rpc_client.clone(), &authority, Some(gc_config));
 
         // Airdrop some SOL to the authority for testing
+        const AIRDROP_LAMPORTS: u64 = 100_000_000_000; // 100 SOL
         rpc_client
-            .request_airdrop(
-                &authority.pubkey(),
-                100_000_000_000, // 100 SOL
-            )
+            .request_airdrop(&authority.pubkey(), AIRDROP_LAMPORTS)
             .await
             .unwrap();
         // request_airdrop only submits the transfer; wait until the funds are
         // visible or the first transaction a test sends may fail to debit the
         // authority ("no record of a prior credit").
-        wait_for_funding(&rpc_client, &authority.pubkey()).await;
+        wait_for_funding(&rpc_client, &authority.pubkey(), AIRDROP_LAMPORTS)
+            .await;
 
         let compute_budget_config = ComputeBudgetConfig::new(1_000_000);
         Self {

--- a/test-integration/test-committor-service/tests/test_delivery_preparator.rs
+++ b/test-integration/test-committor-service/tests/test_delivery_preparator.rs
@@ -371,7 +371,12 @@ async fn test_reprepare_closed_buffer_with_distinct_intent_nonce() {
         fixture.compute_budget_config.buffer_init.instructions(1);
     init_instructions
         .push(preparation_task.init_instruction(&fixture.authority.pubkey()));
-    send_with_blockhash(&fixture, &init_instructions, cached_blockhash).await;
+    let init_signature =
+        send_with_blockhash(&fixture, &init_instructions, cached_blockhash)
+            .await;
+    // The write below touches the buffer the init creates; without this wait
+    // the two transactions can execute in either order within a slot.
+    wait_for_processed(&fixture, &init_signature, &cached_blockhash).await;
 
     let write_instruction = preparation_task
         .write_instructions(&fixture.authority.pubkey())

--- a/test-integration/test-committor-service/tests/test_intent_executor.rs
+++ b/test-integration/test-committor-service/tests/test_intent_executor.rs
@@ -4,8 +4,7 @@ use std::{
         atomic::{AtomicU64, Ordering},
         Arc,
     },
-    thread::sleep,
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use borsh::to_vec;
@@ -54,7 +53,6 @@ use program_flexi_counter::{
     state::{FlexiCounter, FAIL_UNDELEGATION_LABEL},
 };
 use solana_account::Account;
-use solana_commitment_config::CommitmentConfig;
 use solana_pubkey::Pubkey;
 use solana_rpc_client::nonblocking::rpc_client::RpcClient;
 use solana_sdk::{
@@ -1604,19 +1602,26 @@ async fn setup_payer_with_keypair(
     payer: &Keypair,
     rpc_client: &Arc<RpcClient>,
 ) {
-    let sig = rpc_client
+    rpc_client
         .request_airdrop(&payer.pubkey(), LAMPORTS_PER_SOL)
         .await
         .unwrap();
-    rpc_client
-        .confirm_transaction_with_commitment(
-            &sig,
-            CommitmentConfig::finalized(),
-        )
-        .await
-        .unwrap();
-
-    sleep(Duration::from_secs(1));
+    // confirm_transaction_with_commitment returns Ok(false) while the airdrop
+    // is still in flight, so poll the balance until the funds are spendable.
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        if rpc_client.get_balance(&payer.pubkey()).await.unwrap()
+            >= LAMPORTS_PER_SOL
+        {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "airdrop to {} not visible after 30s",
+            payer.pubkey()
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
     // Create actor escrow
     let ix = dlp_api::instruction_builder::top_up_ephemeral_balance(
         payer.pubkey(),

--- a/test-integration/test-table-mania/tests/ix_lookup_table.rs
+++ b/test-integration/test-table-mania/tests/ix_lookup_table.rs
@@ -29,10 +29,12 @@ pub async fn setup_lookup_table(
         );
         MagicblockRpcClient::from(client)
     };
-    rpc_client
-        .request_airdrop(&validator_auth.pubkey(), 777 * LAMPORTS_PER_SOL)
-        .await
-        .unwrap();
+    utils::airdrop_and_wait(
+        &rpc_client,
+        validator_auth,
+        777 * LAMPORTS_PER_SOL,
+    )
+    .await;
 
     let latest_slot = rpc_client.get_slot().await.unwrap();
     let sub_slot = 0;

--- a/test-integration/test-table-mania/tests/utils/mod.rs
+++ b/test-integration/test-table-mania/tests/utils/mod.rs
@@ -16,6 +16,30 @@ pub async fn sleep_millis(millis: u64) {
     tokio::time::sleep(tokio::time::Duration::from_millis(millis)).await;
 }
 
+// request_airdrop only submits the transfer; wait until the funds are visible
+// so the first transaction a test sends can debit the authority.
+#[allow(unused)] // used in tests
+pub async fn airdrop_and_wait(
+    rpc_client: &MagicblockRpcClient,
+    auth: &Keypair,
+    lamports: u64,
+) {
+    rpc_client
+        .request_airdrop(&auth.pubkey(), lamports)
+        .await
+        .unwrap();
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        match rpc_client.get_account(&auth.pubkey()).await {
+            Ok(Some(account)) if account.lamports >= lamports => return,
+            _ if Instant::now() > deadline => {
+                panic!("airdrop to {} not visible after 30s", auth.pubkey())
+            }
+            _ => sleep_millis(50).await,
+        }
+    }
+}
+
 #[allow(unused)] // used in tests
 pub async fn setup_table_mania(validator_auth: &Keypair) -> TableMania {
     let rpc_client = {
@@ -25,10 +49,7 @@ pub async fn setup_table_mania(validator_auth: &Keypair) -> TableMania {
         );
         MagicblockRpcClient::from(client)
     };
-    rpc_client
-        .request_airdrop(&validator_auth.pubkey(), 777 * LAMPORTS_PER_SOL)
-        .await
-        .unwrap();
+    airdrop_and_wait(&rpc_client, validator_auth, 777 * LAMPORTS_PER_SOL).await;
 
     if TEST_TABLE_CLOSE {
         TableMania::new(

--- a/test-integration/test-tools/src/validator.rs
+++ b/test-integration/test-tools/src/validator.rs
@@ -341,7 +341,9 @@ pub const TMP_DIR_CONFIG: &str = "TMP_DIR_CONFIG";
 // Stay below the kernel's ephemeral source-port range (32768+ on Linux,
 // 49152+ on macOS): the probed port is released before the validator binds
 // it, and an outbound connection grabbing it as source port in that window
-// fails the validator with EADDRINUSE.
+// fails the validator with EADDRINUSE. The remaining ~31k candidate ports
+// are far more than concurrent test validators ever need, so the narrower
+// range does not meaningfully increase probe collisions.
 const MIN_RANDOM_PORT: u16 = 1024;
 const MAX_RANDOM_PORT: u16 = 32767;
 const RANDOM_PORT_ATTEMPTS: usize = 128;

--- a/test-integration/test-tools/src/validator.rs
+++ b/test-integration/test-tools/src/validator.rs
@@ -338,8 +338,12 @@ fn validator_startup_max_retries() -> usize {
 
 pub const TMP_DIR_CONFIG: &str = "TMP_DIR_CONFIG";
 
+// Stay below the kernel's ephemeral source-port range (32768+ on Linux,
+// 49152+ on macOS): the probed port is released before the validator binds
+// it, and an outbound connection grabbing it as source port in that window
+// fails the validator with EADDRINUSE.
 const MIN_RANDOM_PORT: u16 = 1024;
-const MAX_RANDOM_PORT: u16 = u16::MAX;
+const MAX_RANDOM_PORT: u16 = 32767;
 const RANDOM_PORT_ATTEMPTS: usize = 128;
 
 fn resolve_port(bind_ip: IpAddr, exclude: &[u16]) -> u16 {


### PR DESCRIPTION
## Problem

Integration-test CI has been masking flaky tests behind `RUN_TEST_RETRIES=3`. Mining the retry marker (`run_test attempt N/M failed`) across **97 CI runs** (Jul 15 – Aug 1) showed the retry firing in the vast majority of *successful* runs — the flakes were invisible but very real, and a genuinely broken shard burned up to 4 attempts (~12–16 min) before failing.

## Root causes and fixes

| Flake | Frequency | Root cause → fix |
|---|---|---|
| `test_already_initialized_error_handled` (committor_preparators) | ~73% of runs | `TestFixture` fired `request_airdrop` and never waited; the first tx on a fresh validator failed with *"no record of a prior credit"*. On retry the validator was warm, so it always passed attempt 2. → poll until funds are visible |
| `test_reprepare_closed_buffer_with_distinct_intent_nonce` | ~25% | init and write txs sent back-to-back with the same blockhash; conflicting txs in one slot have no order guarantee, so the write could run first (`OffsetChunkOutOfRange`) → wait for init to process |
| `test_commit_id_and_action_errors_recovery`, `test_action_callback_fired_on_failure` | rare | `confirm_transaction_with_commitment` returns `Ok(false)` when unconfirmed — the `.unwrap()` only catches transport errors, so the result was silently ignored → poll balance |
| `ixtest_existing_account_for_future_slot` (chainlink) | ~10% | `min_context_slot = current+1` raced slot production between the two RPC calls → `current+1000` |
| `test_clone_mini_v4_loader_program_and_upgrade` (cloning) | rare | `assert!(found)` panicked when a tx didn't confirm while the upgrade reclone was in flight → retry like the existing stale-log path |
| `test_committed_and_undelegated_accounts_redelegation` (schedulecommit) | rare | the account can turn `InvalidWritableAccount` between the simulation shortcut and the real send; that error proves exactly what the test asserts → accept it at the send stage too |
| restore_ledger `EADDRINUSE` startup deaths | rare | `resolve_port` drew from 1024–65535, overlapping the kernel ephemeral source-port range (32768+); an outbound connection could grab the probed port as its source port before the validator bound it → cap at 32767 |

Also hardened the remaining fire-and-forget airdrop helpers (table-mania ×2, chainlink context + `airdrop_sol`) that shared the same latent race, and confirmed the old task-scheduler flake was already fixed by #1477 (no master retries since Jul 23).

## Retry removal

`RUN_TEST_RETRIES` is removed from the workflow: each batch now runs exactly once, so a new flake shows up as a red run on day one instead of accumulating behind retries, and broken shards fail ~3× faster under `fail-fast`. The env var still works in the test runner as an explicit opt-in escape hatch.

## Verification

All six affected batches run green locally on first attempt (retries disabled): `committor_preparators`, `cloning`, `chainlink`, `schedulecommit`, `committor_intent_executor`, `table_mania` — plus `cargo check` and `cargo fmt --check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved integration test reliability by waiting for airdrops and transaction confirmations before proceeding.
  * Reduced race conditions in cloning, account lookup, funding, and transaction-ordering tests.
  * Improved handling of accounts that become undelegated during transaction submission.
  * Adjusted test port selection to avoid conflicts with ephemeral system ports.
* **Chores**
  * Removed the integration test retry configuration from CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->