### PR TITLE
fix: restore sub-second perceived downtime on restart

### DIFF
--- a/magicblock-api/src/errors.rs
+++ b/magicblock-api/src/errors.rs
@@ -31,6 +31,11 @@ pub enum ApiError {
     #[error("Failed to delegate magic fee vault for validator '{0}': {1}")]
     FailedToDelegateMagicFeeVault(Pubkey, String),
 
+    #[error(
+        "On-chain setup transaction for validator '{0}' was rejected: {1}"
+    )]
+    OnchainSetupTransactionRejected(Pubkey, String),
+
     #[error("CommittorServiceError")]
     CommittorServiceError(
         Box<magicblock_committor_service::error::CommittorServiceError>,

--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -975,88 +975,100 @@ impl MagicValidator {
         let block_time_ms = self.config.ledger.block_time_ms();
         let base_fee = self.config.validator.basefee;
 
+        let token = self.token.clone();
         // Ephemeral mode does a non-blocking startup balance check.
         // Intentionally fire-and-forget: the task itself exits the process on failure.
         tokio::spawn(async move {
-            let step_start = Instant::now();
-            let result = Self::with_onchain_setup_retries(
-                "ensure_funded_on_chain",
-                || {
-                    MagicValidator::ensure_validator_funded_on_chain(
-                        rpc_url.clone(),
-                        identity,
-                    )
-                },
-            )
-            .await;
-            log_timing(
-                "startup_background",
-                "ensure_funded_on_chain",
-                step_start,
-            );
-            if let Err(err) = result {
-                error!(error = ?err, "Validator balance check failed");
-                error!("Exiting process");
-                std::process::exit(1);
-            }
+            let setup = async move {
+                let step_start = Instant::now();
+                let result = Self::with_onchain_setup_retries(
+                    "ensure_funded_on_chain",
+                    || {
+                        MagicValidator::ensure_validator_funded_on_chain(
+                            rpc_url.clone(),
+                            identity,
+                        )
+                    },
+                )
+                .await;
+                log_timing(
+                    "startup_background",
+                    "ensure_funded_on_chain",
+                    step_start,
+                );
+                if let Err(err) = result {
+                    error!(error = ?err, "Validator balance check failed");
+                    error!("Exiting process");
+                    std::process::exit(1);
+                }
 
-            let step_start = Instant::now();
-            let result = Self::with_onchain_setup_retries(
-                "ensure_magic_fee_vault_on_chain",
-                || {
-                    MagicValidator::ensure_magic_fee_vault_on_chain(
-                        rpc_url.clone(),
-                    )
-                },
-            )
-            .await;
-            log_timing(
-                "startup_background",
-                "ensure_magic_fee_vault_on_chain",
-                step_start,
-            );
+                let step_start = Instant::now();
+                let result = Self::with_onchain_setup_retries(
+                    "ensure_magic_fee_vault_on_chain",
+                    || {
+                        MagicValidator::ensure_magic_fee_vault_on_chain(
+                            rpc_url.clone(),
+                        )
+                    },
+                )
+                .await;
+                log_timing(
+                    "startup_background",
+                    "ensure_magic_fee_vault_on_chain",
+                    step_start,
+                );
 
-            // Without magic fee vault being properly set up
-            // transactions scheduling commits will fail
-            if let Err(err) = result {
-                error!(error = ?err, "Magic fee vault setup failed");
-                error!("Exiting process");
-                std::process::exit(1);
-            }
-            if let Some(ref config) = chain_operation_config {
-                if !config.claim_fees_frequency.is_zero() {
-                    let step_start = Instant::now();
-                    if let Err(err) = claim_fees(rpc_url.clone()).await {
-                        error!(
-                            error = ?err,
-                            "Failed to claim validator fees on startup"
+                // Without magic fee vault being properly set up
+                // transactions scheduling commits will fail
+                if let Err(err) = result {
+                    error!(error = ?err, "Magic fee vault setup failed");
+                    error!("Exiting process");
+                    std::process::exit(1);
+                }
+                if let Some(ref config) = chain_operation_config {
+                    if !config.claim_fees_frequency.is_zero() {
+                        let step_start = Instant::now();
+                        if let Err(err) = claim_fees(rpc_url.clone()).await {
+                            error!(
+                                error = ?err,
+                                "Failed to claim validator fees on startup"
+                            );
+                        }
+                        log_timing(
+                            "startup_background",
+                            "claim_fees_on_startup",
+                            step_start,
                         );
+                    }
+                }
+                if let Some(ref config) = chain_operation_config {
+                    let step_start = Instant::now();
+                    if let Err(error) =
+                        MagicValidator::register_validator_on_chain(
+                            &rpc_url,
+                            config,
+                            block_time_ms,
+                            base_fee,
+                        )
+                        .await
+                    {
+                        error!(%error, "Validator registration failed, exitting");
+                        std::process::exit(1);
                     }
                     log_timing(
                         "startup_background",
-                        "claim_fees_on_startup",
+                        "register_validator_on_chain",
                         step_start,
                     );
                 }
-            }
-            if let Some(ref config) = chain_operation_config {
-                let step_start = Instant::now();
-                if let Err(error) = MagicValidator::register_validator_on_chain(
-                    &rpc_url,
-                    config,
-                    block_time_ms,
-                    base_fee,
-                )
-                .await
-                {
-                    error!(%error, "Validator registration failed, exitting");
-                    std::process::exit(1);
+            };
+            // Cancellation guard: a retry backoff must not outlive shutdown
+            // and exit(1) mid-flush or re-register after unregister.
+            tokio::select! {
+                _ = token.cancelled() => {
+                    debug!("On-chain setup cancelled by shutdown")
                 }
-                log_timing(
-                    "startup_background",
-                    "register_validator_on_chain",
-                    step_start,
-                );
+                _ = setup => {}
             }
         });
     }
@@ -1444,47 +1456,5 @@ mod tests {
                 },
             )
         );
-    }
-
-    #[tokio::test(start_paused = true)]
-    async fn onchain_setup_retries_absorb_transient_failures() {
-        use std::sync::atomic::{AtomicU32, Ordering};
-        let attempts = AtomicU32::new(0);
-        let result =
-            MagicValidator::with_onchain_setup_retries("test_step", || {
-                let attempt = attempts.fetch_add(1, Ordering::SeqCst) + 1;
-                async move {
-                    if attempt < 3 {
-                        Err(ApiError::FailedToInitMagicFeeVault(
-                            Pubkey::new_unique(),
-                            "transient".to_string(),
-                        ))
-                    } else {
-                        Ok(())
-                    }
-                }
-            })
-            .await;
-        assert!(result.is_ok());
-        assert_eq!(attempts.load(Ordering::SeqCst), 3);
-    }
-
-    #[tokio::test(start_paused = true)]
-    async fn onchain_setup_retries_surface_persistent_failures() {
-        use std::sync::atomic::{AtomicU32, Ordering};
-        let attempts = AtomicU32::new(0);
-        let result =
-            MagicValidator::with_onchain_setup_retries("test_step", || {
-                attempts.fetch_add(1, Ordering::SeqCst);
-                async {
-                    Err(ApiError::FailedToInitMagicFeeVault(
-                        Pubkey::new_unique(),
-                        "persistent".to_string(),
-                    ))
-                }
-            })
-            .await;
-        assert!(result.is_err());
-        assert_eq!(attempts.load(Ordering::SeqCst), 5);
     }
 }

--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -916,6 +916,43 @@ impl MagicValidator {
         Ok(())
     }
 
+    /// Retries a transient on-chain setup failure with backoff; definitive
+    /// outcomes like insufficient funds surface immediately.
+    async fn with_onchain_setup_retries<F, Fut>(
+        step: &str,
+        op: F,
+    ) -> ApiResult<()>
+    where
+        F: Fn() -> Fut,
+        Fut: std::future::Future<Output = ApiResult<()>>,
+    {
+        const MAX_ATTEMPTS: u32 = 5;
+        let mut delay = Duration::from_secs(2);
+        let mut attempt = 0;
+        loop {
+            attempt += 1;
+            match op().await {
+                Ok(()) => return Ok(()),
+                Err(err @ ApiError::ValidatorInsufficientlyFunded(..)) => {
+                    return Err(err)
+                }
+                Err(err) if attempt < MAX_ATTEMPTS => {
+                    warn!(
+                        step,
+                        attempt,
+                        max_attempts = MAX_ATTEMPTS,
+                        retry_in_secs = delay.as_secs(),
+                        error = ?err,
+                        "On-chain setup step failed; retrying"
+                    );
+                    tokio::time::sleep(delay).await;
+                    delay *= 2;
+                }
+                Err(err) => return Err(err),
+            }
+        }
+    }
+
     fn spawn_primary_onchain_setup(&self) {
         let rpc_url = self.config.rpc_url().to_owned();
         let identity = self.identity;
@@ -927,9 +964,14 @@ impl MagicValidator {
         // Intentionally fire-and-forget: the task itself exits the process on failure.
         tokio::spawn(async move {
             let step_start = Instant::now();
-            let result = MagicValidator::ensure_validator_funded_on_chain(
-                rpc_url.clone(),
-                identity,
+            let result = Self::with_onchain_setup_retries(
+                "ensure_funded_on_chain",
+                || {
+                    MagicValidator::ensure_validator_funded_on_chain(
+                        rpc_url.clone(),
+                        identity,
+                    )
+                },
             )
             .await;
             log_timing(
@@ -944,8 +986,13 @@ impl MagicValidator {
             }
 
             let step_start = Instant::now();
-            let result = MagicValidator::ensure_magic_fee_vault_on_chain(
-                rpc_url.clone(),
+            let result = Self::with_onchain_setup_retries(
+                "ensure_magic_fee_vault_on_chain",
+                || {
+                    MagicValidator::ensure_magic_fee_vault_on_chain(
+                        rpc_url.clone(),
+                    )
+                },
             )
             .await;
             log_timing(
@@ -1382,5 +1429,47 @@ mod tests {
                 },
             )
         );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn onchain_setup_retries_absorb_transient_failures() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        let attempts = AtomicU32::new(0);
+        let result =
+            MagicValidator::with_onchain_setup_retries("test_step", || {
+                let attempt = attempts.fetch_add(1, Ordering::SeqCst) + 1;
+                async move {
+                    if attempt < 3 {
+                        Err(ApiError::FailedToInitMagicFeeVault(
+                            Pubkey::new_unique(),
+                            "transient".to_string(),
+                        ))
+                    } else {
+                        Ok(())
+                    }
+                }
+            })
+            .await;
+        assert!(result.is_ok());
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn onchain_setup_retries_surface_persistent_failures() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        let attempts = AtomicU32::new(0);
+        let result =
+            MagicValidator::with_onchain_setup_retries("test_step", || {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                async {
+                    Err(ApiError::FailedToInitMagicFeeVault(
+                        Pubkey::new_unique(),
+                        "persistent".to_string(),
+                    ))
+                }
+            })
+            .await;
+        assert!(result.is_err());
+        assert_eq!(attempts.load(Ordering::SeqCst), 5);
     }
 }

--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -873,10 +873,18 @@ impl MagicValidator {
                 blockhash,
             );
             rpc.send_and_confirm_transaction(&tx).await.map_err(|err| {
-                ApiError::FailedToInitMagicFeeVault(
-                    validator_pubkey,
-                    err.to_string(),
-                )
+                // A rejected transaction is deterministic; only transport
+                // failures are worth retrying.
+                match err.get_transaction_error() {
+                    Some(tx_err) => ApiError::OnchainSetupTransactionRejected(
+                        validator_pubkey,
+                        tx_err.to_string(),
+                    ),
+                    None => ApiError::FailedToInitMagicFeeVault(
+                        validator_pubkey,
+                        err.to_string(),
+                    ),
+                }
             })?;
             info!(%validator_pubkey, "Magic fee vault initialized");
         } else {
@@ -902,12 +910,18 @@ impl MagicValidator {
                 &[&validator_keypair],
                 blockhash,
             );
-            rpc.send_and_confirm_transaction(&tx).await.map_err(|err| {
-                ApiError::FailedToDelegateMagicFeeVault(
-                    validator_pubkey,
-                    err.to_string(),
-                )
-            })?;
+            rpc.send_and_confirm_transaction(&tx).await.map_err(
+                |err| match err.get_transaction_error() {
+                    Some(tx_err) => ApiError::OnchainSetupTransactionRejected(
+                        validator_pubkey,
+                        tx_err.to_string(),
+                    ),
+                    None => ApiError::FailedToDelegateMagicFeeVault(
+                        validator_pubkey,
+                        err.to_string(),
+                    ),
+                },
+            )?;
             info!(%validator_pubkey, "Magic fee vault delegated");
         } else {
             info!(%validator_pubkey, "Magic fee vault already delegated, skipping");
@@ -933,9 +947,10 @@ impl MagicValidator {
             attempt += 1;
             match op().await {
                 Ok(()) => return Ok(()),
-                Err(err @ ApiError::ValidatorInsufficientlyFunded(..)) => {
-                    return Err(err)
-                }
+                Err(
+                    err @ (ApiError::ValidatorInsufficientlyFunded(..)
+                    | ApiError::OnchainSetupTransactionRejected(..)),
+                ) => return Err(err),
                 Err(err) if attempt < MAX_ATTEMPTS => {
                     warn!(
                         step,

--- a/magicblock-validator/src/main.rs
+++ b/magicblock-validator/src/main.rs
@@ -34,7 +34,9 @@ fn main() {
         .build()
         .expect("failed to build async runtime");
     runtime.block_on(run());
-    drop(runtime);
+    // All durable state is flushed inside stop(); don't let lingering
+    // blocking tasks keep the dead process (and RPC downtime) alive.
+    runtime.shutdown_timeout(std::time::Duration::from_millis(250));
 
     info!("main runtime shutdown!");
 }


### PR DESCRIPTION
## Problem

A restart incurs ~3.3s of RPC unavailability instead of ~1s:

1. After `stop()` returns, all durable state is already flushed (accountsdb flush, ledger/RocksDB shutdown), but `drop(runtime)` joins the tokio blocking pool, keeping the dead process alive for 2–3s while systemd waits for it to exit before starting the replacement. That wait is pure added downtime.
2. The background on-chain setup steps (balance check, fee-vault ensure) call `std::process::exit(1)` on any error — a single transient RPC timeout crashes an already-serving validator, turning one restart into two outage windows.

## Solution

1. Bound runtime teardown with `shutdown_timeout(250ms)` — safe to abandon stragglers since everything durable is flushed inside `stop()`.
2. Retry both setup steps with exponential backoff (5 attempts over ~1min) before surfacing the failure. Both operations are idempotent (existence-checked before init/delegate). Definitive outcomes (`ValidatorInsufficientlyFunded`) are not retried; persistent failures still exit as before.

## Testing

- Unit tests for the retry helper: transient-recovery and persistent-failure paths (`start_paused` tokio time)
- clippy clean, nightly fmt


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validator startup reliability by retrying temporary failures when funding the validator and initializing fee vaults.
  - Insufficient-funds errors are reported immediately, while other failures use backoff before retrying.
  - Improved shutdown handling with a brief timeout to allow pending operations to complete cleanly.
- **Tests**
  - Added coverage for successful recovery after temporary failures and for persistent startup failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->