### PR TITLE
fix: detect program upgrades via persistent programdata subscriptions

### DIFF
--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -95,6 +95,7 @@ use crate::{
     remote_account_provider::{
         program_account::{
             get_loaderv3_get_program_data_address, LoadedProgram,
+            RemoteProgramLoader, LOADER_V3,
         },
         pubsub_common::{
             is_delegation_record_data, is_internal_dlp_account_data,
@@ -149,6 +150,12 @@ where
     /// resolve without re-pulling full program data. Entries for programs
     /// evicted from the bank are pruned on their next notification.
     program_verify_cache: Arc<PlMutex<LruCache<Pubkey, ProgramVerifyState>>>,
+
+    /// Maps the programdata pubkey of every loaded LoaderV3 program back to
+    /// its program id, routing programdata updates into the program-reload
+    /// path. Upgrades rewrite the program account byte-identically, so the
+    /// programdata notification is the only reliable upgrade signal.
+    programdata_index: Arc<HashMap<Pubkey, Pubkey>>,
 
     /// Recognizes freshly delegated accounts whose app data collides with an
     /// internal DLP discriminator via delegation-record sightings.
@@ -365,6 +372,7 @@ where
             programs_not_to_subscribe: self.programs_not_to_subscribe.clone(),
             known_empty_eatas: self.known_empty_eatas.clone(),
             program_verify_cache: self.program_verify_cache.clone(),
+            programdata_index: self.programdata_index.clone(),
             dlp_collision_tracker: self.dlp_collision_tracker.clone(),
             pending_clones: self.pending_clones.clone(),
             pending_undelegations: self.pending_undelegations.clone(),
@@ -487,6 +495,7 @@ where
             program_verify_cache: Arc::new(PlMutex::new(LruCache::new(
                 PROGRAM_VERIFY_CACHE_CAPACITY,
             ))),
+            programdata_index: Arc::new(HashMap::new()),
             dlp_collision_tracker: Arc::new(PlMutex::new(
                 DlpCollisionTracker::new(),
             )),
@@ -507,10 +516,12 @@ where
                     .map(|account| CapacityEvictionProtection {
                         delegated: account.delegated(),
                         undelegating: account.undelegating(),
+                        executable: account.executable(),
                     })
                     .unwrap_or(CapacityEvictionProtection {
                         delegated: false,
                         undelegating: false,
+                        executable: false,
                     })
             },
         );
@@ -1093,6 +1104,43 @@ where
         );
     }
 
+    /// Holds a persistent programdata subscription for a loaded LoaderV3
+    /// program so upgrades stay observable; both pubkeys are preferred onto
+    /// gRPC transport. Held once per program (idempotent across reloads).
+    async fn watch_programdata(&self, program_id: Pubkey) {
+        let program_data_pubkey =
+            get_loaderv3_get_program_data_address(&program_id);
+        if self
+            .programdata_index
+            .insert(program_data_pubkey, program_id)
+            .is_err()
+        {
+            return;
+        }
+        if let Err(err) = self
+            .acquire_subscription_reason(
+                &program_data_pubkey,
+                SubscriptionReason::ProgramData,
+            )
+            .await
+        {
+            warn!(
+                program_id = %program_id,
+                program_data = %program_data_pubkey,
+                error = %err,
+                "Failed to hold programdata subscription; upgrades of this program may go undetected"
+            );
+            self.programdata_index.remove(&program_data_pubkey);
+            return;
+        }
+        self.remote_account_provider
+            .prefer_grpc_subscription(&program_id)
+            .await;
+        self.remote_account_provider
+            .prefer_grpc_subscription(&program_data_pubkey)
+            .await;
+    }
+
     fn record_program_materialization(
         &self,
         program_id: &Pubkey,
@@ -1296,6 +1344,7 @@ where
     ) -> ClonerResult<Signature> {
         let program_id = program.program_id;
         let remote_slot = program.remote_slot;
+        let is_loaderv3 = matches!(program.loader, RemoteProgramLoader::V3);
         let remote_result = ChainlinkCloneRemoteResult::Found;
         let clone_intent = ChainlinkCloneIntent::ProgramData;
 
@@ -1354,6 +1403,9 @@ where
                                 remote_slot,
                                 fetch_context,
                             );
+                            if is_loaderv3 {
+                                self.watch_programdata(program_id).await;
+                            }
                         } else {
                             metrics::inc_chainlink_clone_accounts_total_with_context(
                                 fetch_context.clone(),
@@ -1898,6 +1950,22 @@ where
             primary_pubkey: pubkey,
             context_slot: update_slot,
         };
+
+        // Programdata updates signal upgrades: route them to the
+        // program-reload path instead of cloning them into the bank.
+        if let Some(program_id) =
+            self.programdata_index.read(&pubkey, |_, program_id| *program_id)
+        {
+            let mut program_account = AccountSharedData::new(1, 0, &LOADER_V3);
+            program_account.set_remote_slot(update_slot);
+            self.handle_executable_sub_update(
+                program_id,
+                program_account,
+                &companion_fetch_log_context,
+            )
+            .await;
+            return;
+        }
 
         let update_source = update.source;
         let (resolved_account, deleg_record, delegation_actions) = self

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -1140,6 +1140,18 @@ where
                     SubscriptionReason::ProgramData,
                 )
                 .await;
+            // Without a watch the program would execute stale bytes past its
+            // next upgrade; evict it so the next use re-clones fresh state
+            // (and re-installs a watch) instead.
+            if let Err(err) =
+                self.cloner.evict_account(evicted_program_id).await
+            {
+                warn!(
+                    program_id = %evicted_program_id,
+                    error = %err,
+                    "Failed to evict program whose upgrade watch was released"
+                );
+            }
         }
         if let Err(err) = self
             .acquire_subscription_reason(
@@ -1155,6 +1167,23 @@ where
                 "Failed to hold programdata subscription; upgrades of this program may go undetected"
             );
             self.programdata_index.lock().pop(&program_data_pubkey);
+            return false;
+        }
+        // A concurrent load at capacity can evict this entry between the
+        // push above and the acquisition; without the entry nothing routes
+        // or releases this subscription, so drop it again.
+        if self
+            .programdata_index
+            .lock()
+            .get(&program_data_pubkey)
+            .is_none()
+        {
+            self.remote_account_provider
+                .forget_subscription_reason(
+                    &program_data_pubkey,
+                    SubscriptionReason::ProgramData,
+                )
+                .await;
             return false;
         }
         self.remote_account_provider

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -212,11 +212,25 @@ const PROGRAM_VERIFY_CACHE_CAPACITY: NonZeroUsize = match NonZeroUsize::new(64)
 
 /// Bound on persistent programdata upgrade watches. Watches evicted here
 /// release their subscription, so untrusted program loads cannot pin an
-/// unbounded share of the subscription LRU.
-const PROGRAMDATA_WATCH_CAPACITY: NonZeroUsize = match NonZeroUsize::new(256) {
+/// unbounded share of the subscription LRU. Sized generously: eviction
+/// also evicts the program itself (forcing a re-clone on next use), while
+/// each watch only costs one subscription.
+const PROGRAMDATA_WATCH_CAPACITY: NonZeroUsize = match NonZeroUsize::new(512) {
     Some(n) => n,
     None => panic!("PROGRAMDATA_WATCH_CAPACITY must be non-zero"),
 };
+
+/// Outcome of [FetchCloner::watch_programdata].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProgramDataWatch {
+    /// A new persistent watch was installed.
+    Installed,
+    /// A watch for this program was already held.
+    AlreadyInstalled,
+    /// The watch was rolled back: a concurrent load at capacity evicted the
+    /// index entry before installation completed.
+    EvictedConcurrently,
+}
 
 /// Capacity for recently sighted delegation-record update slots; sized to
 /// outlast DLP firehose churn across the SubMux debounce window.
@@ -1117,14 +1131,18 @@ where
     /// upgrades stay observable; both pubkeys are preferred onto gRPC
     /// transport. Installed before the clone so an upgrade notification
     /// landing mid-clone already routes; held once per program (idempotent
-    /// across reloads). Returns whether a new watch was installed.
-    async fn watch_programdata(&self, program_id: Pubkey) -> bool {
+    /// across reloads). Failing to hold the subscription is an error but
+    /// non-fatal to the clone: the watch is retried on the next load.
+    async fn watch_programdata(
+        &self,
+        program_id: Pubkey,
+    ) -> ChainlinkResult<ProgramDataWatch> {
         let program_data_pubkey =
             get_loaderv3_get_program_data_address(&program_id);
         let evicted = {
             let mut index = self.programdata_index.lock();
             if index.get(&program_data_pubkey).is_some() {
-                return false;
+                return Ok(ProgramDataWatch::AlreadyInstalled);
             }
             index.push(program_data_pubkey, program_id)
         };
@@ -1160,14 +1178,14 @@ where
             )
             .await
         {
-            warn!(
+            error!(
                 program_id = %program_id,
                 program_data = %program_data_pubkey,
                 error = %err,
                 "Failed to hold programdata subscription; upgrades of this program may go undetected"
             );
             self.programdata_index.lock().pop(&program_data_pubkey);
-            return false;
+            return Err(err);
         }
         // A concurrent load at capacity can evict this entry between the
         // push above and the acquisition; without the entry nothing routes
@@ -1184,7 +1202,7 @@ where
                     SubscriptionReason::ProgramData,
                 )
                 .await;
-            return false;
+            return Ok(ProgramDataWatch::EvictedConcurrently);
         }
         self.remote_account_provider
             .prefer_grpc_subscription(&program_id)
@@ -1192,7 +1210,7 @@ where
         self.remote_account_provider
             .prefer_grpc_subscription(&program_data_pubkey)
             .await;
-        true
+        Ok(ProgramDataWatch::Installed)
     }
 
     /// Drops a watch installed by [Self::watch_programdata], releasing its
@@ -1436,8 +1454,9 @@ where
                 );
                 // A fresh bank copy can predate this process (e.g. a
                 // restored bank), so ensure the upgrade watch regardless.
+                // Watch failure is non-fatal and logged at the source.
                 if is_loaderv3 {
-                    self.watch_programdata(program_id).await;
+                    let _ = self.watch_programdata(program_id).await;
                 }
                 return Ok(Signature::default());
             }
@@ -1461,8 +1480,9 @@ where
                             clone_intent,
                             ChainlinkCloneOutcome::Skipped,
                         );
+                        // Watch failure is non-fatal, logged at the source.
                         if is_loaderv3 {
-                            self.watch_programdata(program_id).await;
+                            let _ = self.watch_programdata(program_id).await;
                         }
                         Ok(Signature::default())
                     } else {
@@ -1476,7 +1496,10 @@ where
                         // notification landing mid-clone already routes;
                         // rolled back below if the clone fails.
                         let installed_watch = is_loaderv3
-                            && self.watch_programdata(program_id).await;
+                            && matches!(
+                                self.watch_programdata(program_id).await,
+                                Ok(ProgramDataWatch::Installed)
+                            );
                         let result = self.cloner.clone_program(program).await;
                         if result.is_ok() {
                             metrics::inc_chainlink_clone_accounts_total_with_context(

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -1953,8 +1953,9 @@ where
 
         // Programdata updates signal upgrades: route them to the
         // program-reload path instead of cloning them into the bank.
-        if let Some(program_id) =
-            self.programdata_index.read(&pubkey, |_, program_id| *program_id)
+        if let Some(program_id) = self
+            .programdata_index
+            .read(&pubkey, |_, program_id| *program_id)
         {
             let mut program_account = AccountSharedData::new(1, 0, &LOADER_V3);
             program_account.set_remote_slot(update_slot);

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -1134,14 +1134,12 @@ where
                 program_data = %evicted_program_data,
                 "Releasing least-recently loaded programdata watch at capacity"
             );
-            release_subs(
-                &self.remote_account_provider,
-                [SubscriptionRelease::Pubkey {
-                    pubkey: evicted_program_data,
-                    reason: SubscriptionReason::ProgramData,
-                }],
-            )
-            .await;
+            self.remote_account_provider
+                .forget_subscription_reason(
+                    &evicted_program_data,
+                    SubscriptionReason::ProgramData,
+                )
+                .await;
         }
         if let Err(err) = self
             .acquire_subscription_reason(
@@ -1179,14 +1177,12 @@ where
             .pop(&program_data_pubkey)
             .is_some()
         {
-            release_subs(
-                &self.remote_account_provider,
-                [SubscriptionRelease::Pubkey {
-                    pubkey: program_data_pubkey,
-                    reason: SubscriptionReason::ProgramData,
-                }],
-            )
-            .await;
+            self.remote_account_provider
+                .forget_subscription_reason(
+                    &program_data_pubkey,
+                    SubscriptionReason::ProgramData,
+                )
+                .await;
         }
     }
 
@@ -1409,6 +1405,11 @@ where
                     clone_intent,
                     ChainlinkCloneOutcome::Skipped,
                 );
+                // A fresh bank copy can predate this process (e.g. a
+                // restored bank), so ensure the upgrade watch regardless.
+                if is_loaderv3 {
+                    self.watch_programdata(program_id).await;
+                }
                 return Ok(Signature::default());
             }
 
@@ -1431,6 +1432,9 @@ where
                             clone_intent,
                             ChainlinkCloneOutcome::Skipped,
                         );
+                        if is_loaderv3 {
+                            self.watch_programdata(program_id).await;
+                        }
                         Ok(Signature::default())
                     } else {
                         metrics::inc_chainlink_clone_accounts_total_with_context(

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -155,7 +155,8 @@ where
     /// its program id, routing programdata updates into the program-reload
     /// path. Upgrades rewrite the program account byte-identically, so the
     /// programdata notification is the only reliable upgrade signal.
-    programdata_index: Arc<HashMap<Pubkey, Pubkey>>,
+    /// Bounded; entries evicted at capacity release their subscription.
+    programdata_index: Arc<PlMutex<LruCache<Pubkey, Pubkey>>>,
 
     /// Recognizes freshly delegated accounts whose app data collides with an
     /// internal DLP discriminator via delegation-record sightings.
@@ -207,6 +208,14 @@ const PROGRAM_VERIFY_CACHE_CAPACITY: NonZeroUsize = match NonZeroUsize::new(64)
 {
     Some(n) => n,
     None => panic!("PROGRAM_VERIFY_CACHE_CAPACITY must be non-zero"),
+};
+
+/// Bound on persistent programdata upgrade watches. Watches evicted here
+/// release their subscription, so untrusted program loads cannot pin an
+/// unbounded share of the subscription LRU.
+const PROGRAMDATA_WATCH_CAPACITY: NonZeroUsize = match NonZeroUsize::new(256) {
+    Some(n) => n,
+    None => panic!("PROGRAMDATA_WATCH_CAPACITY must be non-zero"),
 };
 
 /// Capacity for recently sighted delegation-record update slots; sized to
@@ -495,7 +504,9 @@ where
             program_verify_cache: Arc::new(PlMutex::new(LruCache::new(
                 PROGRAM_VERIFY_CACHE_CAPACITY,
             ))),
-            programdata_index: Arc::new(HashMap::new()),
+            programdata_index: Arc::new(PlMutex::new(LruCache::new(
+                PROGRAMDATA_WATCH_CAPACITY,
+            ))),
             dlp_collision_tracker: Arc::new(PlMutex::new(
                 DlpCollisionTracker::new(),
             )),
@@ -516,12 +527,10 @@ where
                     .map(|account| CapacityEvictionProtection {
                         delegated: account.delegated(),
                         undelegating: account.undelegating(),
-                        executable: account.executable(),
                     })
                     .unwrap_or(CapacityEvictionProtection {
                         delegated: false,
                         undelegating: false,
-                        executable: false,
                     })
             },
         );
@@ -1104,18 +1113,35 @@ where
         );
     }
 
-    /// Holds a persistent programdata subscription for a loaded LoaderV3
-    /// program so upgrades stay observable; both pubkeys are preferred onto
-    /// gRPC transport. Held once per program (idempotent across reloads).
-    async fn watch_programdata(&self, program_id: Pubkey) {
+    /// Holds a persistent programdata subscription for a LoaderV3 program so
+    /// upgrades stay observable; both pubkeys are preferred onto gRPC
+    /// transport. Installed before the clone so an upgrade notification
+    /// landing mid-clone already routes; held once per program (idempotent
+    /// across reloads). Returns whether a new watch was installed.
+    async fn watch_programdata(&self, program_id: Pubkey) -> bool {
         let program_data_pubkey =
             get_loaderv3_get_program_data_address(&program_id);
-        if self
-            .programdata_index
-            .insert(program_data_pubkey, program_id)
-            .is_err()
-        {
-            return;
+        let evicted = {
+            let mut index = self.programdata_index.lock();
+            if index.get(&program_data_pubkey).is_some() {
+                return false;
+            }
+            index.push(program_data_pubkey, program_id)
+        };
+        if let Some((evicted_program_data, evicted_program_id)) = evicted {
+            debug!(
+                program_id = %evicted_program_id,
+                program_data = %evicted_program_data,
+                "Releasing least-recently loaded programdata watch at capacity"
+            );
+            release_subs(
+                &self.remote_account_provider,
+                [SubscriptionRelease::Pubkey {
+                    pubkey: evicted_program_data,
+                    reason: SubscriptionReason::ProgramData,
+                }],
+            )
+            .await;
         }
         if let Err(err) = self
             .acquire_subscription_reason(
@@ -1130,8 +1156,8 @@ where
                 error = %err,
                 "Failed to hold programdata subscription; upgrades of this program may go undetected"
             );
-            self.programdata_index.remove(&program_data_pubkey);
-            return;
+            self.programdata_index.lock().pop(&program_data_pubkey);
+            return false;
         }
         self.remote_account_provider
             .prefer_grpc_subscription(&program_id)
@@ -1139,6 +1165,29 @@ where
         self.remote_account_provider
             .prefer_grpc_subscription(&program_data_pubkey)
             .await;
+        true
+    }
+
+    /// Drops a watch installed by [Self::watch_programdata], releasing its
+    /// subscription only when the index entry is still present.
+    async fn unwatch_programdata(&self, program_id: Pubkey) {
+        let program_data_pubkey =
+            get_loaderv3_get_program_data_address(&program_id);
+        if self
+            .programdata_index
+            .lock()
+            .pop(&program_data_pubkey)
+            .is_some()
+        {
+            release_subs(
+                &self.remote_account_provider,
+                [SubscriptionRelease::Pubkey {
+                    pubkey: program_data_pubkey,
+                    reason: SubscriptionReason::ProgramData,
+                }],
+            )
+            .await;
+        }
     }
 
     fn record_program_materialization(
@@ -1390,6 +1439,11 @@ where
                             clone_intent,
                             ChainlinkCloneOutcome::Submitted,
                         );
+                        // Installed before the clone so an upgrade
+                        // notification landing mid-clone already routes;
+                        // rolled back below if the clone fails.
+                        let installed_watch = is_loaderv3
+                            && self.watch_programdata(program_id).await;
                         let result = self.cloner.clone_program(program).await;
                         if result.is_ok() {
                             metrics::inc_chainlink_clone_accounts_total_with_context(
@@ -1403,10 +1457,10 @@ where
                                 remote_slot,
                                 fetch_context,
                             );
-                            if is_loaderv3 {
-                                self.watch_programdata(program_id).await;
-                            }
                         } else {
+                            if installed_watch {
+                                self.unwatch_programdata(program_id).await;
+                            }
                             metrics::inc_chainlink_clone_accounts_total_with_context(
                                 fetch_context.clone(),
                                 remote_result,
@@ -1953,10 +2007,9 @@ where
 
         // Programdata updates signal upgrades: route them to the
         // program-reload path instead of cloning them into the bank.
-        if let Some(program_id) = self
-            .programdata_index
-            .read(&pubkey, |_, program_id| *program_id)
-        {
+        let routed_program_id =
+            self.programdata_index.lock().get(&pubkey).copied();
+        if let Some(program_id) = routed_program_id {
             let mut program_account = AccountSharedData::new(1, 0, &LOADER_V3);
             program_account.set_remote_slot(update_slot);
             self.handle_executable_sub_update(

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -210,15 +210,23 @@ const PROGRAM_VERIFY_CACHE_CAPACITY: NonZeroUsize = match NonZeroUsize::new(64)
     None => panic!("PROGRAM_VERIFY_CACHE_CAPACITY must be non-zero"),
 };
 
-/// Bound on persistent programdata upgrade watches. Watches evicted here
-/// release their subscription, so untrusted program loads cannot pin an
-/// unbounded share of the subscription LRU. Sized generously: eviction
-/// also evicts the program itself (forcing a re-clone on next use), while
-/// each watch only costs one subscription.
-const PROGRAMDATA_WATCH_CAPACITY: NonZeroUsize = match NonZeroUsize::new(512) {
-    Some(n) => n,
-    None => panic!("PROGRAMDATA_WATCH_CAPACITY must be non-zero"),
-};
+/// Floor on persistent programdata upgrade watches. Watches evicted from
+/// the index release their subscription, so untrusted program loads cannot
+/// pin an unbounded share of the subscription LRU. Sized generously:
+/// eviction also evicts the program itself (forcing a re-clone on next
+/// use), while each watch only costs one subscription.
+const PROGRAMDATA_WATCH_MIN_CAPACITY: usize = 512;
+
+/// Bound on persistent programdata upgrade watches, scaling with the
+/// primary subscription LRU so large deployments watch more programs.
+fn programdata_watch_capacity(
+    subscribed_accounts_capacity: usize,
+) -> NonZeroUsize {
+    NonZeroUsize::new(
+        PROGRAMDATA_WATCH_MIN_CAPACITY.max(subscribed_accounts_capacity / 10),
+    )
+    .expect("programdata watch capacity has a non-zero floor")
+}
 
 /// Outcome of [FetchCloner::watch_programdata].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -519,7 +527,9 @@ where
                 PROGRAM_VERIFY_CACHE_CAPACITY,
             ))),
             programdata_index: Arc::new(PlMutex::new(LruCache::new(
-                PROGRAMDATA_WATCH_CAPACITY,
+                programdata_watch_capacity(
+                    remote_account_provider.subscribed_accounts_capacity(),
+                ),
             ))),
             dlp_collision_tracker: Arc::new(PlMutex::new(
                 DlpCollisionTracker::new(),

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/program_loader.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/program_loader.rs
@@ -116,7 +116,11 @@ where
         // cache; drop the stale entry (and the persistent programdata
         // watch held for it) and reload.
         this.program_verify_cache.lock().pop(&pubkey);
-        if this.programdata_index.remove(&program_data_pubkey).is_some() {
+        if this
+            .programdata_index
+            .remove(&program_data_pubkey)
+            .is_some()
+        {
             release_program_data_subs(
                 &this.remote_account_provider,
                 program_data_pubkey,

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/program_loader.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/program_loader.rs
@@ -113,8 +113,16 @@ where
     };
     if this.accounts_bank.get_account(&pubkey).is_none() {
         // The bank copy was evicted since the load that populated the
-        // cache; drop the stale entry and reload.
+        // cache; drop the stale entry (and the persistent programdata
+        // watch held for it) and reload.
         this.program_verify_cache.lock().pop(&pubkey);
+        if this.programdata_index.remove(&program_data_pubkey).is_some() {
+            release_program_data_subs(
+                &this.remote_account_provider,
+                program_data_pubkey,
+            )
+            .await;
+        }
         return false;
     }
 

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/program_loader.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/program_loader.rs
@@ -118,7 +118,8 @@ where
         this.program_verify_cache.lock().pop(&pubkey);
         if this
             .programdata_index
-            .remove(&program_data_pubkey)
+            .lock()
+            .pop(&program_data_pubkey)
             .is_some()
         {
             release_program_data_subs(

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/program_loader.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/program_loader.rs
@@ -122,11 +122,12 @@ where
             .pop(&program_data_pubkey)
             .is_some()
         {
-            release_program_data_subs(
-                &this.remote_account_provider,
-                program_data_pubkey,
-            )
-            .await;
+            this.remote_account_provider
+                .forget_subscription_reason(
+                    &program_data_pubkey,
+                    SubscriptionReason::ProgramData,
+                )
+                .await;
         }
         return false;
     }

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -12211,3 +12211,57 @@ async fn test_programdata_update_alone_detects_program_upgrade() {
     // The programdata account itself must not be cloned into the bank.
     assert_not_cloned!(cloner, &[program_data_pubkey]);
 }
+
+/// A fresh bank copy can predate this process (e.g. a restored bank), in
+/// which case the clone is skipped — the upgrade watch must be installed
+/// anyway so upgrades of that program stay observable.
+#[tokio::test]
+async fn test_skipped_program_clone_still_installs_programdata_watch() {
+    use crate::remote_account_provider::program_account::{
+        get_loaderv3_get_program_data_address, LoadedProgram,
+        RemoteProgramLoader, LOADER_V3,
+    };
+
+    init_logger();
+    let validator_keypair = Keypair::new();
+    let program_pubkey = random_pubkey();
+    let program_data_pubkey =
+        get_loaderv3_get_program_data_address(&program_pubkey);
+    const CURRENT_SLOT: u64 = 100;
+
+    let FetcherTestCtx {
+        fetch_cloner,
+        remote_account_provider,
+        accounts_bank,
+        cloner,
+        ..
+    } = setup([], CURRENT_SLOT, validator_keypair.insecure_clone()).await;
+
+    // Program already in the bank at a slot as fresh as the load below.
+    let mut bank_program = AccountSharedData::new(1_000_000, 36, &LOADER_V3);
+    bank_program.set_remote_slot(CURRENT_SLOT);
+    accounts_bank.insert(program_pubkey, bank_program);
+
+    let program = LoadedProgram {
+        program_id: program_pubkey,
+        authority: random_pubkey(),
+        program_data: vec![7; 64],
+        loader: RemoteProgramLoader::V3,
+        loader_status:
+            solana_loader_v4_interface::state::LoaderV4Status::Deployed,
+        remote_slot: CURRENT_SLOT,
+    };
+    fetch_cloner
+        .clone_program_with_ownership(
+            program,
+            AccountFetchContext::rpc_get_account(),
+        )
+        .await
+        .expect("skipped clone must succeed");
+
+    assert_eq!(cloner.program_clone_count(), 0, "clone must be skipped");
+    assert!(
+        remote_account_provider.is_watching(&program_data_pubkey),
+        "skipped clone must still install the programdata watch"
+    );
+}

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -12110,3 +12110,104 @@ async fn test_replay_subscription_update_for_unwatched_account_is_processed() {
     assert_eq!(in_bank.remote_slot(), 50);
     assert_eq!(in_bank.lamports(), 2_000_000);
 }
+
+/// An upgrade rewrites the program account byte-identically, so no
+/// program-account notification may be emitted at all. The programdata
+/// notification alone — routed through the full subscription pipeline —
+/// must reload the program, and must not clone the programdata account
+/// into the bank.
+#[tokio::test]
+async fn test_programdata_update_alone_detects_program_upgrade() {
+    use crate::remote_account_provider::program_account::get_loaderv3_get_program_data_address;
+
+    init_logger();
+    let validator_keypair = Keypair::new();
+    let program_pubkey = random_pubkey();
+    let program_data_pubkey =
+        get_loaderv3_get_program_data_address(&program_pubkey);
+    const DEPLOY_SLOT: u64 = 90;
+    const CURRENT_SLOT: u64 = 100;
+    const UPGRADE_SLOT: u64 = 150;
+
+    let (program_account, program_data_account) =
+        loaderv3_program_accounts(&program_data_pubkey, DEPLOY_SLOT, &[7; 64]);
+
+    let FetcherTestCtx {
+        fetch_cloner,
+        remote_account_provider,
+        rpc_client,
+        cloner,
+        subscription_tx,
+        ..
+    } = setup(
+        [
+            (program_pubkey, program_account.clone()),
+            (program_data_pubkey, program_data_account),
+        ],
+        CURRENT_SLOT,
+        validator_keypair.insecure_clone(),
+    )
+    .await;
+
+    let mut update = AccountSharedData::from(program_account.clone());
+    update.set_remote_slot(CURRENT_SLOT);
+    handle_executable_sub_update(&fetch_cloner, program_pubkey, update).await;
+    assert_eq!(cloner.program_clone_count(), 1);
+
+    // The load must leave a persistent programdata watch behind; without it
+    // the upgrade notification below would be dropped as unwatched.
+    assert!(
+        remote_account_provider.is_watching(&program_data_pubkey),
+        "programdata subscription must persist after the clone"
+    );
+
+    // Upgrade on chain. Only the programdata account changes bytes, so only
+    // it notifies — no program-account update is sent.
+    let upgraded_elf = [9u8; 64];
+    let (_, upgraded_program_data) = loaderv3_program_accounts(
+        &program_data_pubkey,
+        UPGRADE_SLOT,
+        &upgraded_elf,
+    );
+    rpc_client.set_current_slot(UPGRADE_SLOT);
+    rpc_client.account_override_slot(&program_pubkey, UPGRADE_SLOT);
+    rpc_client.add_account(program_data_pubkey, upgraded_program_data.clone());
+
+    // Clear the program verify throttle window.
+    tokio::time::sleep(Duration::from_millis(350)).await;
+
+    subscription_tx
+        .send(ForwardedSubscriptionUpdate {
+            pubkey: program_data_pubkey,
+            account: RemoteAccount::from_fresh_account(
+                upgraded_program_data,
+                UPGRADE_SLOT,
+                RemoteAccountUpdateSource::Subscription,
+            ),
+            source: SubscriptionSource::Account,
+        })
+        .await
+        .expect("subscription update must be accepted");
+
+    let mut reloaded = false;
+    for _ in 0..100 {
+        if cloner.program_clone_count() == 2 {
+            reloaded = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert!(
+        reloaded,
+        "programdata notification alone must trigger a program reload"
+    );
+    let reloaded_program = cloner
+        .get_cloned_program(&program_pubkey)
+        .expect("program must be cloned");
+    assert_eq!(
+        reloaded_program.program_data, upgraded_elf,
+        "reload must pick up the upgraded program data"
+    );
+    // The programdata account itself must not be cloned into the bank.
+    assert_not_cloned!(cloner, &[program_data_pubkey]);
+}

--- a/magicblock-chainlink/src/remote_account_provider/lru_cache.rs
+++ b/magicblock-chainlink/src/remote_account_provider/lru_cache.rs
@@ -61,6 +61,10 @@ impl AccountsLruCache {
         }
     }
 
+    pub fn capacity(&self) -> usize {
+        self.subscribed_accounts.lock().cap().get()
+    }
+
     /// Lock-free emptiness hint. Exact whenever no mutation is mid-flight;
     /// callers use it to skip the mutex on hot paths where a missed
     /// concurrent insert is harmless (e.g. skipping an LRU promote).

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -614,7 +614,6 @@ impl<U: ChainPubsubClient> SubscriptionTierCtx<U> {
             CapacityEvictionProtection {
                 delegated: false,
                 undelegating: false,
-                executable: false,
             },
         )
     }
@@ -1308,12 +1307,11 @@ pub(crate) enum SubscriptionReleaseMode {
 pub(crate) struct CapacityEvictionProtection {
     pub delegated: bool,
     pub undelegating: bool,
-    pub executable: bool,
 }
 
 impl CapacityEvictionProtection {
     pub fn is_protected(self) -> bool {
-        self.delegated || self.undelegating || self.executable
+        self.delegated || self.undelegating
     }
 }
 

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -3782,6 +3782,27 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
         Ok(())
     }
 
+    /// Drops `reason` from `pubkey`'s ownership without attempting an
+    /// unsubscribe. The entry loses any reason-based eviction protection
+    /// immediately and the subscription is cleaned up by normal capacity
+    /// eviction, so a failed provider unsubscribe can never leave orphaned
+    /// protection behind.
+    pub(crate) async fn forget_subscription_reason(
+        &self,
+        pubkey: &Pubkey,
+        reason: SubscriptionReason,
+    ) {
+        let subscription_key_lock = self.subscription_key_lock(pubkey).await;
+        let _subscription_guard = subscription_key_lock.lock().await;
+        let mut ownership = self.subscription_ownership.lock().await;
+        if let Some(existing) = ownership.get_mut(pubkey) {
+            existing.release(reason);
+            if existing.is_empty() {
+                ownership.remove(pubkey);
+            }
+        }
+    }
+
     /// Prefers gRPC-only coverage for `pubkey`. The multiplexer drops
     /// websocket legs only after confirming gRPC coverage; on failure full
     /// coverage stays, so this can never reduce delivery below the default.

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -3250,6 +3250,11 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
             || self.secondary_subscriptions.contains(pubkey)
     }
 
+    /// Capacity of the primary subscription LRU.
+    pub(crate) fn subscribed_accounts_capacity(&self) -> usize {
+        self.lrucache_subscribed_accounts.capacity()
+    }
+
     /// Removes a pubkey from the secondary LRU; safe for never-evict keys.
     fn remove_from_secondary(&self, pubkey: &Pubkey) {
         if self.secondary_subscriptions.contains(pubkey) {
@@ -3782,11 +3787,13 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
         Ok(())
     }
 
-    /// Drops `reason` from `pubkey`'s ownership without attempting an
-    /// unsubscribe. The entry loses any reason-based eviction protection
-    /// immediately and the subscription is cleaned up by normal capacity
-    /// eviction, so a failed provider unsubscribe can never leave orphaned
-    /// protection behind.
+    /// Drops `reason` from `pubkey`'s ownership. The entry loses any
+    /// reason-based eviction protection immediately — even when the
+    /// provider unsubscribe fails — so no orphaned protection is ever left
+    /// behind. When the final reason is released the subscription and tier
+    /// entries are also dropped, so an unowned watch neither lingers until
+    /// capacity pressure nor routes later updates into the account-clone
+    /// path.
     pub(crate) async fn forget_subscription_reason(
         &self,
         pubkey: &Pubkey,
@@ -3794,12 +3801,34 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
     ) {
         let subscription_key_lock = self.subscription_key_lock(pubkey).await;
         let _subscription_guard = subscription_key_lock.lock().await;
-        let mut ownership = self.subscription_ownership.lock().await;
-        if let Some(existing) = ownership.get_mut(pubkey) {
-            existing.release(reason);
-            if existing.is_empty() {
-                ownership.remove(pubkey);
+        let now_unowned = {
+            let mut ownership = self.subscription_ownership.lock().await;
+            match ownership.get_mut(pubkey) {
+                Some(existing) => {
+                    existing.release(reason);
+                    let empty = existing.is_empty();
+                    if empty {
+                        ownership.remove(pubkey);
+                    }
+                    empty
+                }
+                None => false,
             }
+        };
+        if now_unowned {
+            // Best-effort unsubscribe; tier entries are removed regardless
+            // so a failed unsubscribe cannot keep the watch alive.
+            subscription_reconciler::unsubscribe_and_notify_removal(
+                *pubkey,
+                &self.pubsub_client,
+                &self.removed_account_tx,
+                SubscriptionCleanupSource::NormalRelease,
+            )
+            .await;
+            let _transition_guard =
+                self.subscription_transition_lock.lock().await;
+            self.lrucache_subscribed_accounts.remove(pubkey);
+            self.remove_from_secondary(pubkey);
         }
     }
 

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -614,6 +614,7 @@ impl<U: ChainPubsubClient> SubscriptionTierCtx<U> {
             CapacityEvictionProtection {
                 delegated: false,
                 undelegating: false,
+                executable: false,
             },
         )
     }
@@ -815,6 +816,7 @@ impl<U: ChainPubsubClient> SubscriptionTierCtx<U> {
                     .is_protected()
                 && !ownership.get(candidate).is_some_and(|ownership| {
                     ownership.contains(SubscriptionReason::UndelegationTracking)
+                        || ownership.contains(SubscriptionReason::ProgramData)
                 })
         })
     }
@@ -839,6 +841,7 @@ impl<U: ChainPubsubClient> SubscriptionTierCtx<U> {
                     .is_protected()
                 && !ownership.get(candidate).is_some_and(|ownership| {
                     ownership.contains(SubscriptionReason::UndelegationTracking)
+                        || ownership.contains(SubscriptionReason::ProgramData)
                 })
         })
     }
@@ -1305,11 +1308,12 @@ pub(crate) enum SubscriptionReleaseMode {
 pub(crate) struct CapacityEvictionProtection {
     pub delegated: bool,
     pub undelegating: bool,
+    pub executable: bool,
 }
 
 impl CapacityEvictionProtection {
     pub fn is_protected(self) -> bool {
-        self.delegated || self.undelegating
+        self.delegated || self.undelegating || self.executable
     }
 }
 
@@ -3778,6 +3782,21 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
         }
 
         Ok(())
+    }
+
+    /// Prefers gRPC-only coverage for `pubkey`. The multiplexer drops
+    /// websocket legs only after confirming gRPC coverage; on failure full
+    /// coverage stays, so this can never reduce delivery below the default.
+    pub(crate) async fn prefer_grpc_subscription(&self, pubkey: &Pubkey) {
+        if let Err(err) =
+            self.pubsub_client.prefer_grpc_subscription(*pubkey).await
+        {
+            debug!(
+                pubkey = %pubkey,
+                error = ?err,
+                "Keeping full subscription coverage; gRPC-only preference not applied"
+            );
+        }
     }
 
     /// Fetches a byte range of an account via `dataSlice`, retrying until the

--- a/magicblock-chainlink/src/remote_account_provider/subscription_reconciler.rs
+++ b/magicblock-chainlink/src/remote_account_provider/subscription_reconciler.rs
@@ -653,7 +653,6 @@ mod tests {
             Some(Arc::new(|_| CapacityEvictionProtection {
                 delegated: true,
                 undelegating: false,
-                executable: false,
             }));
         mock_client.silently_noop_next_subscriptions(2);
         reconcile_subscriptions(

--- a/magicblock-chainlink/src/remote_account_provider/subscription_reconciler.rs
+++ b/magicblock-chainlink/src/remote_account_provider/subscription_reconciler.rs
@@ -653,6 +653,7 @@ mod tests {
             Some(Arc::new(|_| CapacityEvictionProtection {
                 delegated: true,
                 undelegating: false,
+                executable: false,
             }));
         mock_client.silently_noop_next_subscriptions(2);
         reconcile_subscriptions(

--- a/magicblock-chainlink/src/testing/mod.rs
+++ b/magicblock-chainlink/src/testing/mod.rs
@@ -89,6 +89,28 @@ macro_rules! assert_subscribed_without_loaderv3_program_data_account {
     }};
 }
 
+/// Asserts LoaderV3 programs are subscribed together with their programdata
+/// account, which is held persistently for upgrade detection.
+#[macro_export]
+macro_rules! assert_subscribed_with_loaderv3_program_data_account {
+    ($provider:expr, $pubkeys:expr) => {{
+        for pubkey in $pubkeys {
+            let program_data_account_pubkey =
+                $crate::remote_account_provider::program_account::get_loaderv3_get_program_data_address(pubkey);
+            assert!(
+                $provider.is_watching(pubkey),
+                "Expected {} to be subscribed",
+                pubkey
+            );
+            assert!(
+                $provider.is_watching(&program_data_account_pubkey),
+                "Expected programdata {} to be subscribed for upgrade detection",
+                program_data_account_pubkey
+            );
+        }
+    }};
+}
+
 #[macro_export]
 macro_rules! assert_cloned_as_undelegated {
     ($cloner:expr, $pubkeys:expr) => {{

--- a/test-integration/test-chainlink/tests/ix_full_scenarios.rs
+++ b/test-integration/test-chainlink/tests/ix_full_scenarios.rs
@@ -1,8 +1,9 @@
 use magicblock_chainlink::{
     assert_cloned_as_delegated, assert_cloned_as_undelegated,
     assert_loaded_program_with_min_size, assert_loaded_program_with_size,
-    assert_not_subscribed, assert_subscribed_without_delegation_record,
+    assert_not_subscribed,
     assert_subscribed_with_loaderv3_program_data_account,
+    assert_subscribed_without_delegation_record,
     assert_subscribed_without_loaderv3_program_data_account,
     remote_account_provider::program_account::RemoteProgramLoader,
     testing::{init_logger, utils::random_pubkey},

--- a/test-integration/test-chainlink/tests/ix_full_scenarios.rs
+++ b/test-integration/test-chainlink/tests/ix_full_scenarios.rs
@@ -2,6 +2,7 @@ use magicblock_chainlink::{
     assert_cloned_as_delegated, assert_cloned_as_undelegated,
     assert_loaded_program_with_min_size, assert_loaded_program_with_size,
     assert_not_subscribed, assert_subscribed_without_delegation_record,
+    assert_subscribed_with_loaderv3_program_data_account,
     assert_subscribed_without_loaderv3_program_data_account,
     remote_account_provider::program_account::RemoteProgramLoader,
     testing::{init_logger, utils::random_pubkey},
@@ -137,9 +138,13 @@ async fn ixtest_accounts_for_tx_2_delegated_3_readonly_3_programs_one_native() {
             readonly_counter_pda3,
         ]
     );
+    assert_subscribed_with_loaderv3_program_data_account!(
+        ctx.chainlink,
+        &[program_flexi_counter]
+    );
     assert_subscribed_without_loaderv3_program_data_account!(
         ctx.chainlink,
-        &[program_flexi_counter, MEMOV2]
+        &[MEMOV2]
     );
     assert_not_subscribed!(
         ctx.chainlink,

--- a/test-integration/test-chainlink/tests/ix_programs.rs
+++ b/test-integration/test-chainlink/tests/ix_programs.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use magicblock_chainlink::{
     assert_data_has_size, assert_loaded_program_with_size,
+    assert_subscribed_with_loaderv3_program_data_account,
     assert_subscribed_without_loaderv3_program_data_account,
     remote_account_provider::program_account::{
         LoadedProgram, ProgramAccountResolver, RemoteProgramLoader,
@@ -533,7 +534,7 @@ async fn ixtest_clone_mini_v3_loader_program() {
         LoaderV4Status::Deployed,
         MINI_SIZE
     );
-    assert_subscribed_without_loaderv3_program_data_account!(
+    assert_subscribed_with_loaderv3_program_data_account!(
         ctx.chainlink,
         &pubkeys
     );
@@ -632,6 +633,10 @@ async fn ixtest_clone_multiple_programs_v1_v2_v3() {
     );
     assert_subscribed_without_loaderv3_program_data_account!(
         ctx.chainlink,
-        &pubkeys
+        &[MEMOV1, MEMOV2]
+    );
+    assert_subscribed_with_loaderv3_program_data_account!(
+        ctx.chainlink,
+        &[MINIV3]
     );
 }


### PR DESCRIPTION
## Problem

A LoaderV3 upgrade rewrites the program account byte-identically (its 36 bytes only point at the programdata account, which is where the new bytecode and deploy slot land). Starting with Agave 4.2, the runtime skips storing accounts whose contents did not change — and unstored writes produce no account notifications, on websocket or geyser/gRPC alike. The program-account notification that our upgrade detection was keyed on therefore no longer exists: verified by subscribing to both accounts across upgrades — only the programdata account notifies. Devnet already runs Agave 4.2, so in-place upgrades are currently invisible to validators there; mainnet will behave the same once 4.2 rolls out.

Since programdata subscriptions were acquired per-clone and always released afterwards, nothing remained to observe upgrades with: an already-cloned program would serve stale bytecode indefinitely (fresh clones were unaffected, as the fetch path reads current state).

## Change

- Hold a persistent programdata subscription for every loaded LoaderV3 program (`watch_programdata`, called from the single clone funnel `clone_program_with_ownership`; idempotent across reloads via a programdata → program index).
- Route incoming programdata updates into the existing program-reload path (`handle_executable_sub_update`) instead of cloning them into the bank; the existing header check / throttle / full-reload machinery is reused unchanged.
- Prefer gRPC transport for program and programdata subscriptions via the existing submux `prefer_grpc_subscription` (websocket legs are dropped only after confirmed gRPC coverage; on failure full coverage stays).
- Protect executable accounts and held programdata subscriptions from LRU capacity eviction, mirroring the existing `UndelegationTracking` treatment.
- Release the subscription and index entry when the program leaves the bank.

## Tests

- New `test_programdata_update_alone_detects_program_upgrade`: a programdata notification alone — with no program-account update — reloads the program with the upgraded bytes, keeps the programdata watch persistent, and does not clone programdata into the bank.
- Full `magicblock-chainlink` suite passes (388 lib tests + integration).

Closes #1528

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added monitoring for LoaderV3 program data, enabling automatic detection and reloading of upgraded programs.
  * Improved subscription handling with persistent monitoring and gRPC-preferred account coverage.
  * Added safeguards to maintain program monitoring when subscription capacity changes.

* **Bug Fixes**
  * Correctly cleans up stale program data after missing or outdated program accounts.
  * Prevents unnecessary cloning of program data accounts.

* **Tests**
  * Added coverage for LoaderV3 upgrades, persistent monitoring, subscription throttling, and capacity eviction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->