### PR TITLE
fix: websocket subscription reliability and scalability

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -274,6 +274,11 @@ remove-confined-accounts = false
 # Env: MBV_CHAINLINK__UNDELEGATION_REQUEST_POLL_INTERVAL
 # undelegation-request-poll-interval = "5m"
 
+# Maximum subscriptions per websocket connection. When unset, per-provider
+# defaults apply (Helius: 900, QuickNode: 1500, others: 2000).
+# Env: MBV_CHAINLINK__WS_SUBS_PER_CONNECTION
+# ws-subs-per-connection = 900
+
 # ------------------------------------------------------------------------------
 # Optional: Range Risk API validation for post-delegation actions signers
 # ------------------------------------------------------------------------------

--- a/config.example.toml
+++ b/config.example.toml
@@ -274,8 +274,8 @@ remove-confined-accounts = false
 # Env: MBV_CHAINLINK__UNDELEGATION_REQUEST_POLL_INTERVAL
 # undelegation-request-poll-interval = "5m"
 
-# Maximum subscriptions per websocket connection. When unset, per-provider
-# defaults apply (Helius: 900, QuickNode: 1500, others: 2000).
+# Maximum subscriptions per websocket connection.
+# Default: 900
 # Env: MBV_CHAINLINK__WS_SUBS_PER_CONNECTION
 # ws-subs-per-connection = 900
 

--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -592,6 +592,11 @@ impl MagicValidator {
                     config.chainlink.secondary_max_monitored_accounts,
                 )
             })
+            .and_then(|conf| {
+                conf.with_ws_subs_per_connection(
+                    config.chainlink.ws_subs_per_connection,
+                )
+            })
             .map(|conf| conf.with_grpc(config.grpc.clone()))
             .map_err(|err| {
                 ApiError::from(

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/ata_projection.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/ata_projection.rs
@@ -337,7 +337,8 @@ where
     let was_watching = this.remote_account_provider.is_watching(&eata_pubkey);
 
     // Ensure before cache checks; this keeps the subscription LRU warm
-    // without refcounting the projection reason on every ATA update.
+    // without refcounting the projection reason on every ATA update. The
+    // reason is released when the base ATA is removed from the bank.
     let subscribed = match this
         .ensure_subscription(&eata_pubkey, SubscriptionReason::AtaProjection)
         .await

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -3350,7 +3350,7 @@ where
         // Handle ATAs: for each detected ATA, we derive the eATA PDA, subscribe to both,
         // and, if the ATA is delegated to us and the eATA exists, we clone the eATA data
         // into the ATA in the bank.
-        // eATA subscriptions are kept implicitly (not tracked for release).
+        // eATA projection subscriptions are released when the ATA is removed.
         let ata_accounts = ata_projection::resolve_ata_with_eata_projection(
             self,
             atas,

--- a/magicblock-chainlink/src/chainlink/mod.rs
+++ b/magicblock-chainlink/src/chainlink/mod.rs
@@ -21,6 +21,10 @@ use tokio::{
 };
 use tracing::*;
 
+use magicblock_core::token_programs::{
+    is_ata, try_derive_eata_address_and_bump,
+};
+
 use crate::{
     cloner::Cloner,
     config::ChainlinkConfig,
@@ -29,6 +33,7 @@ use crate::{
     remote_account_provider::{
         chain_updates_client::ChainUpdatesClient, ChainPubsubClient,
         ChainRpcClient, ChainRpcClientImpl, Endpoints, RemoteAccountProvider,
+        SubscriptionReason,
     },
     submux::SubMuxClient,
 };
@@ -454,7 +459,9 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
                 // Ephemeral accounts are local-validator state and must not update on
                 // base chain, so losing the remote subscription cannot make the local
                 // ephemeral bank state stale.
-                let should_evict = match accounts_bank.get_account(&pubkey) {
+                let (should_evict, ata_info) = match accounts_bank
+                    .get_account(&pubkey)
+                {
                     Some(account) => {
                         let undelegating = account.undelegating();
                         let delegated = account.delegated();
@@ -472,15 +479,44 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
                                  transaction will be submitted"
                             );
                         }
-                        evict
+                        (evict, is_ata(&pubkey, &account))
                     }
-                    None => false,
+                    None => (false, None),
                 };
                 // Skipping a delegated/undelegating/ephemeral LRU candidate is not a
                 // removal event; protected bank state must not be translated
                 // into a downstream bank eviction.
                 if !should_evict {
                     continue;
+                }
+
+                // An evicted ATA no longer needs its companion eATA watched;
+                // release the projection reason so that subscription can be
+                // dropped instead of occupying the monitored set forever.
+                // It is re-ensured when the ATA is next resolved.
+                if let Some(ata_info) = ata_info {
+                    if let Some((eata_pubkey, _)) =
+                        try_derive_eata_address_and_bump(
+                            &ata_info.owner,
+                            &ata_info.mint,
+                        )
+                    {
+                        if let Err(err) = remote_account_provider
+                            .release_single_subscription(
+                                &eata_pubkey,
+                                SubscriptionReason::AtaProjection,
+                            )
+                            .await
+                        {
+                            warn!(
+                                pubkey = %pubkey,
+                                eata_pubkey = %eata_pubkey,
+                                error = ?err,
+                                "Failed to release eATA projection \
+                                 subscription for evicted ATA"
+                            );
+                        }
+                    }
                 }
 
                 // Removal notifications can race with a new acquire_subscription for the same
@@ -1152,5 +1188,59 @@ mod tests {
 
         assert!(subscribe_result.is_ok());
         assert!(remote_account_provider.is_watching(&pubkey));
+    }
+
+    #[tokio::test]
+    async fn removal_of_ata_releases_eata_projection_subscription() {
+        use magicblock_core::token_programs::{
+            derive_ata, try_derive_eata_address_and_bump, TOKEN_PROGRAM_ID,
+        };
+        use solana_account::WritableAccount;
+
+        init_logger();
+        let provider = test_remote_account_provider().await;
+        let accounts_bank = Arc::new(AccountsBankStub::default());
+        let cloner = Arc::new(ClonerStub::new(accounts_bank.clone()));
+
+        let wallet = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let ata = derive_ata(&wallet, &mint);
+        let (eata, _) = try_derive_eata_address_and_bump(&wallet, &mint)
+            .expect("eATA derivation");
+
+        // Plain (non-delegated) ATA in the bank; is_ata only needs
+        // mint + wallet in the first 64 data bytes.
+        let mut account =
+            AccountSharedData::new(1_000_000, 64, &TOKEN_PROGRAM_ID);
+        account.data_as_mut_slice()[0..32].copy_from_slice(mint.as_ref());
+        account.data_as_mut_slice()[32..64].copy_from_slice(wallet.as_ref());
+        accounts_bank.insert(ata, account);
+
+        provider
+            .acquire_subscription(&eata, SubscriptionReason::AtaProjection)
+            .await
+            .expect("eATA subscription");
+        assert!(provider.is_watching(&eata));
+
+        let (removed_tx, removed_rx) = mpsc::channel(4);
+        let handle = InnerChainlink::subscribe_account_removals(
+            &accounts_bank,
+            &cloner,
+            &provider,
+            removed_rx,
+        );
+
+        removed_tx.send(ata).await.expect("send removal");
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        while provider.is_watching(&eata) {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "eATA projection subscription should be released when its \
+                 ATA is removed"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        handle.abort();
     }
 }

--- a/magicblock-chainlink/src/chainlink/mod.rs
+++ b/magicblock-chainlink/src/chainlink/mod.rs
@@ -1246,4 +1246,79 @@ mod tests {
         }
         handle.abort();
     }
+
+    #[tokio::test]
+    async fn stale_ata_removal_keeps_eata_projection_subscription() {
+        use magicblock_core::token_programs::{
+            derive_ata, try_derive_eata_address_and_bump, TOKEN_PROGRAM_ID,
+        };
+        use solana_account::WritableAccount;
+
+        init_logger();
+        let provider = test_remote_account_provider().await;
+        let accounts_bank = Arc::new(AccountsBankStub::default());
+        let cloner = Arc::new(ClonerStub::new(accounts_bank.clone()));
+
+        fn ata_setup(
+            accounts_bank: &AccountsBankStub,
+        ) -> (Pubkey, Pubkey, Pubkey) {
+            let wallet = Pubkey::new_unique();
+            let mint = Pubkey::new_unique();
+            let ata = derive_ata(&wallet, &mint);
+            let (eata, _) = try_derive_eata_address_and_bump(&wallet, &mint)
+                .expect("eATA derivation");
+            let mut account =
+                AccountSharedData::new(1_000_000, 64, &TOKEN_PROGRAM_ID);
+            account.data_as_mut_slice()[0..32].copy_from_slice(mint.as_ref());
+            account.data_as_mut_slice()[32..64]
+                .copy_from_slice(wallet.as_ref());
+            accounts_bank.insert(ata, account);
+            (ata, eata, wallet)
+        }
+
+        // ATA1: watched again by the time the (stale) removal notification
+        // is processed. ATA2: genuinely unwatched; its release is used as
+        // the fence proving the first notification was handled.
+        let (ata1, eata1, _) = ata_setup(&accounts_bank);
+        let (ata2, eata2, _) = ata_setup(&accounts_bank);
+        for (pk, reason) in [
+            (ata1, SubscriptionReason::DirectAccount),
+            (eata1, SubscriptionReason::AtaProjection),
+            (eata2, SubscriptionReason::AtaProjection),
+        ] {
+            provider
+                .acquire_subscription(&pk, reason)
+                .await
+                .expect("subscription");
+        }
+
+        let (removed_tx, removed_rx) = mpsc::channel(4);
+        let handle = InnerChainlink::subscribe_account_removals(
+            &accounts_bank,
+            &cloner,
+            &provider,
+            removed_rx,
+        );
+
+        removed_tx.send(ata1).await.expect("send stale removal");
+        removed_tx.send(ata2).await.expect("send removal");
+
+        // The handler is sequential: once eATA2 is released, the stale
+        // notification for ATA1 has been fully processed.
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        while provider.is_watching(&eata2) {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "eATA2 projection subscription should be released"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        assert!(
+            provider.is_watching(&eata1),
+            "a stale removal notification for a still-watched ATA must not \
+             release its eATA projection subscription"
+        );
+        handle.abort();
+    }
 }

--- a/magicblock-chainlink/src/chainlink/mod.rs
+++ b/magicblock-chainlink/src/chainlink/mod.rs
@@ -9,6 +9,9 @@ use fetch_cloner::FetchCloner;
 use magicblock_accounts_db::{traits::AccountsBank, AccountsDb};
 use magicblock_aml::RiskService;
 use magicblock_config::config::ChainLinkConfig;
+use magicblock_core::token_programs::{
+    is_ata, try_derive_eata_address_and_bump,
+};
 use magicblock_metrics::metrics::AccountFetchContext;
 use solana_account::{AccountSharedData, ReadableAccount};
 use solana_commitment_config::CommitmentConfig;
@@ -20,10 +23,6 @@ use tokio::{
     task,
 };
 use tracing::*;
-
-use magicblock_core::token_programs::{
-    is_ata, try_derive_eata_address_and_bump,
-};
 
 use crate::{
     cloner::Cloner,

--- a/magicblock-chainlink/src/chainlink/mod.rs
+++ b/magicblock-chainlink/src/chainlink/mod.rs
@@ -1,6 +1,9 @@
 use std::{
     path::Path,
-    sync::{atomic::AtomicU64, Arc},
+    sync::{
+        atomic::{AtomicBool, AtomicU64, Ordering},
+        Arc,
+    },
 };
 
 use dlp_api::pda::ephemeral_balance_pda_from_payer;
@@ -496,18 +499,26 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
                 // subscription has made the account watched again, without blocking unrelated
                 // pubkeys on the defensive-eviction slow path.
                 let cloner = cloner.clone();
+                let eviction_submitted = Arc::new(AtomicBool::new(false));
+                let eviction_submitted_in_cb = eviction_submitted.clone();
                 let evicted = remote_account_provider
                     .evict_unwatched_with_subscription_lock(&pubkey, || async move {
                         trace!(
                             pubkey = %pubkey,
                             "Submitting eviction transaction for unwatched account"
                         );
-                        if let Err(err) = cloner.evict_account(pubkey).await {
-                            warn!(
-                                pubkey = %pubkey,
-                                error = ?err,
-                                "Failed to submit eviction transaction"
-                            );
+                        match cloner.evict_account(pubkey).await {
+                            Ok(()) => {
+                                eviction_submitted_in_cb
+                                    .store(true, Ordering::SeqCst);
+                            }
+                            Err(err) => {
+                                warn!(
+                                    pubkey = %pubkey,
+                                    error = ?err,
+                                    "Failed to submit eviction transaction"
+                                );
+                            }
                         }
                     })
                     .await;
@@ -519,14 +530,17 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
                     );
                     continue;
                 }
+                if !eviction_submitted.load(Ordering::SeqCst) {
+                    // The ATA is still in the bank; keep its eATA coverage.
+                    continue;
+                }
 
                 // An evicted ATA no longer needs its companion eATA watched;
                 // release the projection reason so that subscription can be
                 // dropped instead of occupying the monitored set forever.
                 // It is re-ensured when the ATA is next resolved. Done only
                 // after the defensive recheck confirmed the ATA is still
-                // unwatched, so a racing fresh ATA subscription keeps its
-                // eATA coverage.
+                // unwatched and the eviction was actually submitted.
                 if let Some(ata_info) = ata_info {
                     if let Some((eata_pubkey, _)) =
                         try_derive_eata_address_and_bump(

--- a/magicblock-chainlink/src/chainlink/mod.rs
+++ b/magicblock-chainlink/src/chainlink/mod.rs
@@ -489,35 +489,6 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
                     continue;
                 }
 
-                // An evicted ATA no longer needs its companion eATA watched;
-                // release the projection reason so that subscription can be
-                // dropped instead of occupying the monitored set forever.
-                // It is re-ensured when the ATA is next resolved.
-                if let Some(ata_info) = ata_info {
-                    if let Some((eata_pubkey, _)) =
-                        try_derive_eata_address_and_bump(
-                            &ata_info.owner,
-                            &ata_info.mint,
-                        )
-                    {
-                        if let Err(err) = remote_account_provider
-                            .release_single_subscription(
-                                &eata_pubkey,
-                                SubscriptionReason::AtaProjection,
-                            )
-                            .await
-                        {
-                            warn!(
-                                pubkey = %pubkey,
-                                eata_pubkey = %eata_pubkey,
-                                error = ?err,
-                                "Failed to release eATA projection \
-                                 subscription for evicted ATA"
-                            );
-                        }
-                    }
-                }
-
                 // Removal notifications can race with a new acquire_subscription for the same
                 // pubkey. The provider helper holds the same per-pubkey subscription lock used
                 // by acquire/release while it re-checks is_watching and submits eviction. This
@@ -546,6 +517,39 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
                         pubkey = %pubkey,
                         "Skipping removal notification because account is watched again"
                     );
+                    continue;
+                }
+
+                // An evicted ATA no longer needs its companion eATA watched;
+                // release the projection reason so that subscription can be
+                // dropped instead of occupying the monitored set forever.
+                // It is re-ensured when the ATA is next resolved. Done only
+                // after the defensive recheck confirmed the ATA is still
+                // unwatched, so a racing fresh ATA subscription keeps its
+                // eATA coverage.
+                if let Some(ata_info) = ata_info {
+                    if let Some((eata_pubkey, _)) =
+                        try_derive_eata_address_and_bump(
+                            &ata_info.owner,
+                            &ata_info.mint,
+                        )
+                    {
+                        if let Err(err) = remote_account_provider
+                            .release_single_subscription(
+                                &eata_pubkey,
+                                SubscriptionReason::AtaProjection,
+                            )
+                            .await
+                        {
+                            warn!(
+                                pubkey = %pubkey,
+                                eata_pubkey = %eata_pubkey,
+                                error = ?err,
+                                "Failed to release eATA projection \
+                                 subscription for evicted ATA"
+                            );
+                        }
+                    }
                 }
             }
             warn!("Removed accounts channel closed");

--- a/magicblock-chainlink/src/remote_account_provider/chain_pubsub_actor.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_pubsub_actor.rs
@@ -114,9 +114,14 @@ impl ChainPubsubActor {
         client_id: &str,
         abort_sender: mpsc::Sender<()>,
         commitment: CommitmentConfig,
+        subs_per_connection: Option<usize>,
     ) -> RemoteAccountProviderResult<(Self, mpsc::Receiver<SubscriptionUpdate>)>
     {
-        let config = PubsubClientConfig::from_url(pubsub_url, commitment);
+        let config = PubsubClientConfig::from_url_with_limit(
+            pubsub_url,
+            commitment,
+            subs_per_connection,
+        );
         Self::new(client_id, abort_sender, config).await
     }
 
@@ -314,6 +319,11 @@ impl ChainPubsubActor {
                 .remove(&pubkey);
         }
         result
+    }
+
+    /// Whether the actor currently considers its transport connected.
+    pub fn is_connected(&self) -> bool {
+        self.is_connected.load(Ordering::SeqCst)
     }
 
     pub fn subscriptions(&self) -> HashSet<Pubkey> {

--- a/magicblock-chainlink/src/remote_account_provider/chain_pubsub_client.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_pubsub_client.rs
@@ -149,6 +149,11 @@ pub trait ReconnectableClient {
     fn current_resub_delay_ms(&self) -> Option<u64> {
         None
     }
+    /// Whether the underlying transport is currently connected; `None` when
+    /// unknown (callers must then assume a reconnect is required).
+    fn transport_connected(&self) -> Option<bool> {
+        None
+    }
 }
 
 // -----------------
@@ -172,12 +177,14 @@ impl ChainPubsubClientImpl {
         abort_sender: mpsc::Sender<()>,
         commitment: CommitmentConfig,
         resubscription_delay: Duration,
+        subs_per_connection: Option<usize>,
     ) -> RemoteAccountProviderResult<Self> {
         let (actor, updates) = ChainPubsubActor::new_from_url(
             pubsub_url,
             &client_id,
             abort_sender,
             commitment,
+            subs_per_connection,
         )
         .await?;
         let initial_resub_delay_ms = resubscription_delay.as_millis() as u64;
@@ -401,6 +408,10 @@ impl ReconnectableClient for ChainPubsubClientImpl {
     fn current_resub_delay_ms(&self) -> Option<u64> {
         Some(self.current_resub_delay_ms.load(Ordering::SeqCst))
     }
+
+    fn transport_connected(&self) -> Option<bool> {
+        Some(self.actor.is_connected())
+    }
 }
 
 // -----------------
@@ -450,6 +461,7 @@ pub mod mock {
         subscribe_continue_notify: Arc<Notify>,
         subscribe_attempts: Arc<AtomicU64>,
         program_subscribe_attempts: Arc<AtomicU64>,
+        reconnect_calls: Arc<AtomicU64>,
         subscribe_notify: Arc<Notify>,
         client_id: String,
         transport: Arc<Mutex<PubsubTransport>>,
@@ -482,6 +494,7 @@ pub mod mock {
                 subscribe_continue_notify: Arc::new(Notify::new()),
                 subscribe_attempts: Arc::new(AtomicU64::new(0)),
                 program_subscribe_attempts: Arc::new(AtomicU64::new(0)),
+                reconnect_calls: Arc::new(AtomicU64::new(0)),
                 subscribe_notify: Arc::new(Notify::new()),
                 client_id: format!(
                     "mock:{}",
@@ -638,6 +651,10 @@ pub mod mock {
 
         pub fn subscribe_attempts(&self) -> u64 {
             self.subscribe_attempts.load(AtomicOrdering::SeqCst)
+        }
+
+        pub fn reconnect_calls(&self) -> u64 {
+            self.reconnect_calls.load(AtomicOrdering::SeqCst)
         }
 
         pub fn is_connected_and_resubscribed(&self) -> bool {
@@ -837,6 +854,7 @@ pub mod mock {
     #[async_trait]
     impl ReconnectableClient for ChainPubsubClientMock {
         async fn try_reconnect(&self) -> RemoteAccountProviderResult<()> {
+            self.reconnect_calls.fetch_add(1, AtomicOrdering::SeqCst);
             if !*self.reconnectable.lock() {
                 return Err(
                     RemoteAccountProviderError::AccountSubscriptionsTaskFailed(
@@ -870,6 +888,10 @@ pub mod mock {
                 tokio::time::sleep(Duration::from_millis(10)).await;
             }
             Ok(())
+        }
+
+        fn transport_connected(&self) -> Option<bool> {
+            Some(*self.connected.lock())
         }
     }
 }

--- a/magicblock-chainlink/src/remote_account_provider/chain_updates_client.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_updates_client.rs
@@ -28,12 +28,14 @@ pub enum ChainUpdatesClient {
 }
 
 impl ChainUpdatesClient {
+    #[allow(clippy::too_many_arguments)]
     pub async fn try_new_from_endpoint(
         endpoint: &Endpoint,
         commitment: CommitmentConfig,
         abort_sender: mpsc::Sender<()>,
         chain_slot: Arc<AtomicU64>,
         resubscription_delay: std::time::Duration,
+        ws_subs_per_connection: Option<usize>,
         rpc_client: ChainRpcClientImpl,
         grpc_config: &GrpcConfig,
     ) -> RemoteAccountProviderResult<Self> {
@@ -54,6 +56,7 @@ impl ChainUpdatesClient {
                         abort_sender,
                         commitment,
                         resubscription_delay,
+                        ws_subs_per_connection,
                     )
                     .await?,
                 ))

--- a/magicblock-chainlink/src/remote_account_provider/chain_updates_client.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_updates_client.rs
@@ -210,4 +210,12 @@ impl ReconnectableClient for ChainUpdatesClient {
             Laser(client) => client.current_resub_delay_ms(),
         }
     }
+
+    fn transport_connected(&self) -> Option<bool> {
+        use ChainUpdatesClient::*;
+        match self {
+            WebSocket(client) => client.transport_connected(),
+            Laser(client) => client.transport_connected(),
+        }
+    }
 }

--- a/magicblock-chainlink/src/remote_account_provider/config.rs
+++ b/magicblock-chainlink/src/remote_account_provider/config.rs
@@ -27,6 +27,9 @@ pub struct RemoteAccountProviderConfig {
     /// Delay between resubscribing to accounts after a pubsub
     /// reconnection
     resubscription_delay: Duration,
+    /// Max subscriptions per websocket connection; overrides the
+    /// per-provider defaults when set
+    ws_subs_per_connection: Option<usize>,
     /// Global gRPC configuration
     grpc: GrpcConfig,
 }
@@ -126,6 +129,21 @@ impl RemoteAccountProviderConfig {
         self.resubscription_delay
     }
 
+    pub fn with_ws_subs_per_connection(
+        mut self,
+        limit: Option<usize>,
+    ) -> RemoteAccountProviderResult<Self> {
+        if limit == Some(0) {
+            return Err(RemoteAccountProviderError::InvalidWsSubsPerConnection);
+        }
+        self.ws_subs_per_connection = limit;
+        Ok(self)
+    }
+
+    pub fn ws_subs_per_connection(&self) -> Option<usize> {
+        self.ws_subs_per_connection
+    }
+
     pub fn grpc(&self) -> &GrpcConfig {
         &self.grpc
     }
@@ -148,6 +166,7 @@ impl Default for RemoteAccountProviderConfig {
             resubscription_delay: std::time::Duration::from_millis(
                 DEFAULT_RESUBSCRIPTION_DELAY_MS,
             ),
+            ws_subs_per_connection: None,
             grpc: GrpcConfig::default(),
         }
     }

--- a/magicblock-chainlink/src/remote_account_provider/errors.rs
+++ b/magicblock-chainlink/src/remote_account_provider/errors.rs
@@ -80,6 +80,9 @@ pub enum RemoteAccountProviderError {
     #[error("Resubscription delay must be greater than 0")]
     InvalidResubscriptionDelay,
 
+    #[error("Websocket subscriptions per connection must be greater than 0")]
+    InvalidWsSubsPerConnection,
+
     #[error(
         "Only one listener supported on lru cache removed accounts events"
     )]

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -141,12 +141,14 @@ pub(crate) async fn subscription_key_owned_guard_from_map(
 
 type ChainUpdatesPubsub = (Arc<ChainUpdatesClient>, mpsc::Receiver<()>);
 
+#[allow(clippy::too_many_arguments)]
 async fn connect_pubsub_client(
     ep: Endpoint,
     commitment: CommitmentConfig,
     rpc_client: ChainRpcClientImpl,
     chain_slot: Arc<AtomicU64>,
     resubscription_delay: Duration,
+    ws_subs_per_connection: Option<usize>,
     grpc_cfg: GrpcConfig,
 ) -> (String, RemoteAccountProviderResult<ChainUpdatesPubsub>) {
     let ep_label = ep.label().to_string();
@@ -157,6 +159,7 @@ async fn connect_pubsub_client(
         abort_tx,
         chain_slot,
         resubscription_delay,
+        ws_subs_per_connection,
         rpc_client,
         &grpc_cfg,
     )
@@ -190,6 +193,7 @@ fn spawn_deferred_pubsub_clients(
     rpc_client: ChainRpcClientImpl,
     chain_slot: Arc<AtomicU64>,
     resubscription_delay: Duration,
+    ws_subs_per_connection: Option<usize>,
     grpc_cfg: GrpcConfig,
     submux: SubMuxClient<ChainUpdatesClient>,
     subscribed_accounts: Arc<TieredSubscribedAccountsTracker>,
@@ -216,6 +220,7 @@ fn spawn_deferred_pubsub_clients(
                     rpc_client.clone(),
                     chain_slot.clone(),
                     resubscription_delay,
+                    ws_subs_per_connection,
                     grpc_cfg.clone(),
                 );
                 let (label, result) = tokio::select! {
@@ -1847,6 +1852,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                         rpc_client,
                         chain_slot,
                         config.resubscription_delay(),
+                        config.ws_subs_per_connection(),
                         config.grpc().clone(),
                         provider.pubsub_client.clone(),
                         Arc::new(TieredSubscribedAccountsTracker::new(
@@ -1903,6 +1909,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                 rpc_client.clone(),
                 chain_slot.clone(),
                 resubscription_delay,
+                config.ws_subs_per_connection(),
                 config.grpc().clone(),
             )
         });
@@ -1921,6 +1928,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                         rpc_client.clone(),
                         chain_slot.clone(),
                         resubscription_delay,
+                        config.ws_subs_per_connection(),
                         config.grpc().clone(),
                     )
                 });

--- a/magicblock-chainlink/src/remote_account_provider/pubsub_common.rs
+++ b/magicblock-chainlink/src/remote_account_provider/pubsub_common.rs
@@ -26,20 +26,41 @@ impl PubsubClientConfig {
         pubsub_url: impl Into<String>,
         commitment_config: CommitmentConfig,
     ) -> Self {
+        Self::from_url_with_limit(pubsub_url, commitment_config, None)
+    }
+
+    /// Like [Self::from_url] but with an explicit per-stream subscription
+    /// limit that overrides the per-provider defaults when set.
+    pub fn from_url_with_limit(
+        pubsub_url: impl Into<String>,
+        commitment_config: CommitmentConfig,
+        limit_override: Option<usize>,
+    ) -> Self {
         let pubsub_url = pubsub_url.into();
         let per_stream_subscription_limit =
-            if pubsub_url.to_lowercase().contains("helius") {
-                Some(HELIUS_PER_STREAM_SUBSCRIPTION_LIMIT)
-            } else {
-                // Cap so large subscription sets fan out across the
-                // connection pool instead of serializing on one socket
-                Some(DEFAULT_PER_STREAM_SUBSCRIPTION_LIMIT)
-            };
+            limit_override.or_else(|| Some(default_limit_for_url(&pubsub_url)));
         Self {
             pubsub_url,
             commitment_config,
             per_stream_subscription_limit,
         }
+    }
+}
+
+/// Per-provider defaults for subscriptions per websocket connection, capped
+/// so large subscription sets fan out across the connection pool instead of
+/// serializing on one socket. Limits verified empirically (Aug 2026):
+/// Helius rejects sub #1001 with -32006; Triton accepts 10k+ at ~400 subs/s;
+/// QuickNode accepts 5k+ but subscribes slowly (~86/s), so a lower cap keeps
+/// per-socket reconnect repair time bounded.
+fn default_limit_for_url(pubsub_url: &str) -> usize {
+    let url = pubsub_url.to_lowercase();
+    if url.contains("helius") {
+        HELIUS_PER_STREAM_SUBSCRIPTION_LIMIT
+    } else if url.contains("quiknode") {
+        QUICKNODE_PER_STREAM_SUBSCRIPTION_LIMIT
+    } else {
+        DEFAULT_PER_STREAM_SUBSCRIPTION_LIMIT
     }
 }
 
@@ -190,8 +211,55 @@ pub enum ChainPubsubActorMessage {
     },
 }
 
-pub const HELIUS_PER_STREAM_SUBSCRIPTION_LIMIT: usize = 80;
-pub const DEFAULT_PER_STREAM_SUBSCRIPTION_LIMIT: usize = 500;
+/// Helius enforces a hard cap of 1,000 subscriptions per websocket
+/// connection (error -32006 above it); stay below with headroom.
+pub const HELIUS_PER_STREAM_SUBSCRIPTION_LIMIT: usize = 900;
+/// QuickNode accepts thousands of subs per connection but processes
+/// subscribe calls slowly; keep per-socket reconnect repair time bounded.
+pub const QUICKNODE_PER_STREAM_SUBSCRIPTION_LIMIT: usize = 1_500;
+pub const DEFAULT_PER_STREAM_SUBSCRIPTION_LIMIT: usize = 2_000;
 
 pub const SUBSCRIPTION_UPDATE_CHANNEL_SIZE: usize = 5_000;
 pub const MESSAGE_CHANNEL_SIZE: usize = 1_000;
+
+#[cfg(test)]
+mod limit_tests {
+    use super::*;
+
+    fn limit_for(url: &str, limit_override: Option<usize>) -> Option<usize> {
+        PubsubClientConfig::from_url_with_limit(
+            url,
+            CommitmentConfig::confirmed(),
+            limit_override,
+        )
+        .per_stream_subscription_limit
+    }
+
+    #[test]
+    fn per_provider_default_limits() {
+        assert_eq!(
+            limit_for("wss://mainnet.helius-rpc.com/?api-key=x", None),
+            Some(HELIUS_PER_STREAM_SUBSCRIPTION_LIMIT)
+        );
+        assert_eq!(
+            limit_for("wss://foo.solana-devnet.quiknode.pro/abc/", None),
+            Some(QUICKNODE_PER_STREAM_SUBSCRIPTION_LIMIT)
+        );
+        assert_eq!(
+            limit_for("wss://foo.mainnet.rpcpool.com/abc", None),
+            Some(DEFAULT_PER_STREAM_SUBSCRIPTION_LIMIT)
+        );
+    }
+
+    #[test]
+    fn explicit_limit_overrides_provider_default() {
+        assert_eq!(
+            limit_for("wss://mainnet.helius-rpc.com/?api-key=x", Some(50)),
+            Some(50)
+        );
+        assert_eq!(
+            limit_for("wss://foo.mainnet.rpcpool.com/abc", Some(50)),
+            Some(50)
+        );
+    }
+}

--- a/magicblock-chainlink/src/remote_account_provider/pubsub_common.rs
+++ b/magicblock-chainlink/src/remote_account_provider/pubsub_common.rs
@@ -30,37 +30,20 @@ impl PubsubClientConfig {
     }
 
     /// Like [Self::from_url] but with an explicit per-stream subscription
-    /// limit that overrides the per-provider defaults when set.
+    /// limit that overrides the default when set.
     pub fn from_url_with_limit(
         pubsub_url: impl Into<String>,
         commitment_config: CommitmentConfig,
         limit_override: Option<usize>,
     ) -> Self {
-        let pubsub_url = pubsub_url.into();
-        let per_stream_subscription_limit =
-            limit_override.or_else(|| Some(default_limit_for_url(&pubsub_url)));
+        let per_stream_subscription_limit = Some(
+            limit_override.unwrap_or(DEFAULT_PER_STREAM_SUBSCRIPTION_LIMIT),
+        );
         Self {
-            pubsub_url,
+            pubsub_url: pubsub_url.into(),
             commitment_config,
             per_stream_subscription_limit,
         }
-    }
-}
-
-/// Per-provider defaults for subscriptions per websocket connection, capped
-/// so large subscription sets fan out across the connection pool instead of
-/// serializing on one socket. Limits verified empirically (Aug 2026):
-/// Helius rejects sub #1001 with -32006; Triton accepts 10k+ at ~400 subs/s;
-/// QuickNode accepts 5k+ but subscribes slowly (~86/s), so a lower cap keeps
-/// per-socket reconnect repair time bounded.
-fn default_limit_for_url(pubsub_url: &str) -> usize {
-    let url = pubsub_url.to_lowercase();
-    if url.contains("helius") {
-        HELIUS_PER_STREAM_SUBSCRIPTION_LIMIT
-    } else if url.contains("quiknode") {
-        QUICKNODE_PER_STREAM_SUBSCRIPTION_LIMIT
-    } else {
-        DEFAULT_PER_STREAM_SUBSCRIPTION_LIMIT
     }
 }
 
@@ -211,55 +194,11 @@ pub enum ChainPubsubActorMessage {
     },
 }
 
-/// Helius enforces a hard cap of 1,000 subscriptions per websocket
-/// connection (error -32006 above it); stay below with headroom.
-pub const HELIUS_PER_STREAM_SUBSCRIPTION_LIMIT: usize = 900;
-/// QuickNode accepts thousands of subs per connection but processes
-/// subscribe calls slowly; keep per-socket reconnect repair time bounded.
-pub const QUICKNODE_PER_STREAM_SUBSCRIPTION_LIMIT: usize = 1_500;
-pub const DEFAULT_PER_STREAM_SUBSCRIPTION_LIMIT: usize = 2_000;
+/// Default subscriptions per websocket connection; large subscription sets
+/// fan out across the connection pool instead of serializing on one socket.
+/// Sized with headroom under the strictest known provider cap (1,000 per
+/// connection); override per validator via `chainlink.ws-subs-per-connection`.
+pub const DEFAULT_PER_STREAM_SUBSCRIPTION_LIMIT: usize = 900;
 
 pub const SUBSCRIPTION_UPDATE_CHANNEL_SIZE: usize = 5_000;
 pub const MESSAGE_CHANNEL_SIZE: usize = 1_000;
-
-#[cfg(test)]
-mod limit_tests {
-    use super::*;
-
-    fn limit_for(url: &str, limit_override: Option<usize>) -> Option<usize> {
-        PubsubClientConfig::from_url_with_limit(
-            url,
-            CommitmentConfig::confirmed(),
-            limit_override,
-        )
-        .per_stream_subscription_limit
-    }
-
-    #[test]
-    fn per_provider_default_limits() {
-        assert_eq!(
-            limit_for("wss://mainnet.helius-rpc.com/?api-key=x", None),
-            Some(HELIUS_PER_STREAM_SUBSCRIPTION_LIMIT)
-        );
-        assert_eq!(
-            limit_for("wss://foo.solana-devnet.quiknode.pro/abc/", None),
-            Some(QUICKNODE_PER_STREAM_SUBSCRIPTION_LIMIT)
-        );
-        assert_eq!(
-            limit_for("wss://foo.mainnet.rpcpool.com/abc", None),
-            Some(DEFAULT_PER_STREAM_SUBSCRIPTION_LIMIT)
-        );
-    }
-
-    #[test]
-    fn explicit_limit_overrides_provider_default() {
-        assert_eq!(
-            limit_for("wss://mainnet.helius-rpc.com/?api-key=x", Some(50)),
-            Some(50)
-        );
-        assert_eq!(
-            limit_for("wss://foo.mainnet.rpcpool.com/abc", Some(50)),
-            Some(50)
-        );
-    }
-}

--- a/magicblock-chainlink/src/submux/mod.rs
+++ b/magicblock-chainlink/src/submux/mod.rs
@@ -784,25 +784,12 @@ where
             return Err(err);
         }
 
-        // Resubscribe all program subscriptions
-        let programs: HashSet<Pubkey> =
-            program_subs.lock().unwrap().iter().copied().collect();
-        for program_id in programs {
-            if let Err(err) = client.subscribe_program(program_id).await {
-                debug!(
-                    client_id = %client.id(),
-                    program_id = %program_id,
-                    error = ?err,
-                    "Failed to resubscribe program after reconnect"
-                );
-                return Err(err);
-            }
-        }
-
-        // Mark the client connected BEFORE the account resubscription: the
-        // transport accepts subscriptions from here on, and restoring
-        // thousands of paced subscriptions can take minutes during which an
-        // invisible-but-streaming client would miss new subscriptions.
+        // Mark the client connected BEFORE the resubscriptions: the
+        // transport accepts subscriptions from here on, so new program and
+        // account subscriptions fan out to this client directly (clients
+        // dedup repeated subscribes), while restoring thousands of paced
+        // subscriptions can take minutes during which an
+        // invisible-but-streaming client would miss them.
         let client_key = Self::client_key(&client);
         let was_disconnected = {
             let mut connected_ids =
@@ -824,24 +811,7 @@ where
         }
         metrics::set_pubsub_client_uptime(client.id(), true);
 
-        // Restore account subscriptions from the authoritative tracker;
-        // resub_multiple skips whatever is already covered.
-        let account_subs = Self::account_subscriptions_for_client(
-            accounts_tracker.as_ref(),
-            grpc_only_subscriptions,
-            all_clients,
-            &connected_client_ids,
-            client.as_ref(),
-        );
-        if let Err(err) = client.resub_multiple(account_subs).await {
-            debug!(
-                client_id = %client.id(),
-                resub_delay_ms = ?client.current_resub_delay_ms(),
-                error = ?err,
-                "Failed to resubscribe accounts after reconnect"
-            );
-            // Fatal resub failure: roll back visibility so the backoff
-            // loop retries from a clean state.
+        let rollback_visibility = || {
             let was_connected = {
                 let mut connected_ids =
                     Self::connected_client_ids_lock(&connected_client_ids);
@@ -861,6 +831,43 @@ where
                 }
             }
             metrics::set_pubsub_client_uptime(client.id(), false);
+        };
+
+        // Resubscribe all program subscriptions
+        let programs: HashSet<Pubkey> =
+            program_subs.lock().unwrap().iter().copied().collect();
+        for program_id in programs {
+            if let Err(err) = client.subscribe_program(program_id).await {
+                debug!(
+                    client_id = %client.id(),
+                    program_id = %program_id,
+                    error = ?err,
+                    "Failed to resubscribe program after reconnect"
+                );
+                rollback_visibility();
+                return Err(err);
+            }
+        }
+
+        // Restore account subscriptions from the authoritative tracker;
+        // resub_multiple skips whatever is already covered.
+        let account_subs = Self::account_subscriptions_for_client(
+            accounts_tracker.as_ref(),
+            grpc_only_subscriptions,
+            all_clients,
+            &connected_client_ids,
+            client.as_ref(),
+        );
+        if let Err(err) = client.resub_multiple(account_subs).await {
+            debug!(
+                client_id = %client.id(),
+                resub_delay_ms = ?client.current_resub_delay_ms(),
+                error = ?err,
+                "Failed to resubscribe accounts after reconnect"
+            );
+            // Fatal resub failure: roll back visibility so the backoff
+            // loop retries from a clean state.
+            rollback_visibility();
             return Err(err);
         }
 

--- a/magicblock-chainlink/src/submux/mod.rs
+++ b/magicblock-chainlink/src/submux/mod.rs
@@ -766,7 +766,16 @@ where
         connected_clients: Arc<AtomicU16>,
         connected_clients_subscribing_immediately: Arc<AtomicU16>,
     ) -> RemoteAccountProviderResult<()> {
-        if let Err(err) = client.try_reconnect().await {
+        // A stale abort signal must not tear down a healthy transport
+        // (try_reconnect drains every live subscription first): when the
+        // transport is verifiably up, only restore missing subscriptions.
+        if client.transport_connected() == Some(true) {
+            debug!(
+                client_id = %client.id(),
+                "Transport already connected; skipping reconnect and \
+                 restoring subscriptions"
+            );
+        } else if let Err(err) = client.try_reconnect().await {
             debug!(
                 client_id = %client.id(),
                 error = ?err,
@@ -790,28 +799,10 @@ where
             }
         }
 
-        // Resubscribe all accounts from the authoritative tracker.
-        // This ensures subscriptions are restored even if all clients lost their state
-        // during disconnect/abort.
-        let account_subs = Self::account_subscriptions_for_client(
-            accounts_tracker.as_ref(),
-            grpc_only_subscriptions,
-            all_clients,
-            &connected_client_ids,
-            client.as_ref(),
-        );
-
-        if let Err(err) = client.resub_multiple(account_subs).await {
-            debug!(
-                client_id = %client.id(),
-                resub_delay_ms = ?client.current_resub_delay_ms(),
-                error = ?err,
-                "Failed to resubscribe accounts after reconnect"
-            );
-            return Err(err);
-        }
-
-        // Update connection related metrics to signal successful reconnect
+        // Mark the client connected BEFORE the account resubscription: the
+        // transport accepts subscriptions from here on, and restoring
+        // thousands of paced subscriptions can take minutes during which an
+        // invisible-but-streaming client would miss new subscriptions.
         let client_key = Self::client_key(&client);
         let was_disconnected = {
             let mut connected_ids =
@@ -819,43 +810,58 @@ where
             connected_ids.insert(client_key)
         };
         if was_disconnected {
-            // Catch subscriptions added while this client was reconnecting.
-            let programs: HashSet<Pubkey> =
-                program_subs.lock().unwrap().iter().copied().collect();
-            for program_id in programs {
-                if let Err(err) = client.subscribe_program(program_id).await {
-                    Self::connected_client_ids_lock(&connected_client_ids)
-                        .remove(&client_key);
-                    return Err(err);
-                }
-            }
-
-            let account_subs = Self::account_subscriptions_for_client(
-                accounts_tracker.as_ref(),
-                grpc_only_subscriptions,
-                all_clients,
-                &connected_client_ids,
-                client.as_ref(),
-            );
-            if let Err(err) = client.resub_multiple(account_subs).await {
-                Self::connected_client_ids_lock(&connected_client_ids)
-                    .remove(&client_key);
-                return Err(err);
-            }
-
             connected_clients.fetch_add(1, Ordering::SeqCst);
             metrics::set_connected_pubsub_clients_count(
                 connected_clients.load(Ordering::SeqCst) as usize,
             );
+            if client.subs_immediately() {
+                let previous = connected_clients_subscribing_immediately
+                    .fetch_add(1, Ordering::SeqCst);
+                metrics::set_connected_direct_pubsub_clients_count(
+                    previous.saturating_add(1) as usize,
+                );
+            }
         }
         metrics::set_pubsub_client_uptime(client.id(), true);
-        if was_disconnected && client.subs_immediately() {
-            let previous = connected_clients_subscribing_immediately
-                .fetch_add(1, Ordering::SeqCst);
-            let current = previous.saturating_add(1);
-            metrics::set_connected_direct_pubsub_clients_count(
-                current as usize,
+
+        // Restore account subscriptions from the authoritative tracker;
+        // resub_multiple skips whatever is already covered.
+        let account_subs = Self::account_subscriptions_for_client(
+            accounts_tracker.as_ref(),
+            grpc_only_subscriptions,
+            all_clients,
+            &connected_client_ids,
+            client.as_ref(),
+        );
+        if let Err(err) = client.resub_multiple(account_subs).await {
+            debug!(
+                client_id = %client.id(),
+                resub_delay_ms = ?client.current_resub_delay_ms(),
+                error = ?err,
+                "Failed to resubscribe accounts after reconnect"
             );
+            // Fatal resub failure: roll back visibility so the backoff
+            // loop retries from a clean state.
+            let was_connected = {
+                let mut connected_ids =
+                    Self::connected_client_ids_lock(&connected_client_ids);
+                connected_ids.remove(&client_key)
+            };
+            if was_connected {
+                connected_clients.fetch_sub(1, Ordering::SeqCst);
+                metrics::set_connected_pubsub_clients_count(
+                    connected_clients.load(Ordering::SeqCst) as usize,
+                );
+                if client.subs_immediately() {
+                    let previous = connected_clients_subscribing_immediately
+                        .fetch_sub(1, Ordering::SeqCst);
+                    metrics::set_connected_direct_pubsub_clients_count(
+                        previous.saturating_sub(1) as usize,
+                    );
+                }
+            }
+            metrics::set_pubsub_client_uptime(client.id(), false);
+            return Err(err);
         }
 
         Ok(())
@@ -2404,6 +2410,49 @@ mod tests {
         let up = got.expect("should receive update after retry reconnect");
         assert_eq!(up.pubkey, pk);
         assert!(up.slot >= 100);
+
+        mux.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_stale_abort_on_connected_client_skips_reconnect() {
+        init_logger();
+
+        let (tx1, rx1) = mpsc::channel(10_000);
+        let (tx2, rx2) = mpsc::channel(10_000);
+        let client1 = Arc::new(ChainPubsubClientMock::new(tx1, rx1));
+        let client2 = Arc::new(ChainPubsubClientMock::new(tx2, rx2));
+
+        let pk = Pubkey::new_unique();
+        let (mux, aborts) = new_submux_with_abort(
+            vec![client1.clone(), client2.clone()],
+            vec![pk],
+            Some(100),
+        );
+        let mut mux_rx = mux.take_updates();
+        mux.subscribe(pk, None).await.unwrap();
+
+        // Stale abort: the client is still connected, so the reconnector
+        // must not drain it via try_reconnect.
+        aborts[0].send(()).await.expect("abort send");
+        wait_for_connected_clients(&mux, 2).await;
+
+        assert_eq!(client1.reconnect_calls(), 0);
+        assert!(client1.subscriptions_union().contains(&pk));
+
+        // Client keeps streaming through the mux
+        client1
+            .send_account_update(pk, 7, &account_with_lamports(777))
+            .await;
+        let up = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            mux_rx.recv(),
+        )
+        .await
+        .expect("update after stale abort")
+        .expect("stream open");
+        assert_eq!(up.pubkey, pk);
+        assert_eq!(up.slot, 7);
 
         mux.shutdown().await.unwrap();
     }

--- a/magicblock-chainlink/src/submux/mod.rs
+++ b/magicblock-chainlink/src/submux/mod.rs
@@ -2441,7 +2441,13 @@ mod tests {
 
         // Stale abort: the client is still connected, so the reconnector
         // must not drain it via try_reconnect.
+        let attempts_before = client1.subscribe_attempts();
         aborts[0].send(()).await.expect("abort send");
+        // The reconnect pass re-subscribes tracked accounts; wait for it so
+        // the assertions below run after the abort handler completed.
+        client1
+            .wait_for_subscribe_attempts(attempts_before + 1)
+            .await;
         wait_for_connected_clients(&mux, 2).await;
 
         assert_eq!(client1.reconnect_calls(), 0);

--- a/magicblock-chainlink/src/testing/chain_pubsub.rs
+++ b/magicblock-chainlink/src/testing/chain_pubsub.rs
@@ -22,6 +22,7 @@ pub async fn setup_actor_and_client() -> (
         "test-client",
         tx,
         CommitmentConfig::confirmed(),
+        None,
     )
     .await
     .expect("failed to create ChainPubsubActor");

--- a/magicblock-config/src/config/chain.rs
+++ b/magicblock-config/src/config/chain.rs
@@ -75,8 +75,8 @@ pub struct ChainLinkConfig {
     #[serde(with = "humantime")]
     pub undelegation_request_poll_interval: Duration,
 
-    /// Max subscriptions per websocket connection. When unset, per-provider
-    /// defaults apply (Helius: 900, QuickNode: 1500, others: 2000).
+    /// Max subscriptions per websocket connection. Defaults to 900 when
+    /// unset.
     pub ws_subs_per_connection: Option<usize>,
 
     /// AML/Risk checks for post-delegation actions via Range API.

--- a/magicblock-config/src/config/chain.rs
+++ b/magicblock-config/src/config/chain.rs
@@ -75,6 +75,10 @@ pub struct ChainLinkConfig {
     #[serde(with = "humantime")]
     pub undelegation_request_poll_interval: Duration,
 
+    /// Max subscriptions per websocket connection. When unset, per-provider
+    /// defaults apply (Helius: 900, QuickNode: 1500, others: 2000).
+    pub ws_subs_per_connection: Option<usize>,
+
     /// AML/Risk checks for post-delegation actions via Range API.
     pub risk: RiskConfig,
 }
@@ -93,6 +97,7 @@ impl Default for ChainLinkConfig {
             undelegation_request_poll_interval: Duration::from_secs(
                 consts::DEFAULT_UNDELEGATION_REQUEST_POLL_INTERVAL_SECS,
             ),
+            ws_subs_per_connection: None,
             risk: RiskConfig::default(),
         }
     }

--- a/test-integration/test-chainlink/tests/chain_pubsub_client.rs
+++ b/test-integration/test-chainlink/tests/chain_pubsub_client.rs
@@ -30,6 +30,7 @@ async fn setup() -> (ChainPubsubClientImpl, mpsc::Receiver<SubscriptionUpdate>)
         tx,
         CommitmentConfig::confirmed(),
         Duration::from_millis(200),
+        None,
     )
     .await
     .unwrap();


### PR DESCRIPTION
## Problem

Three issues in the websocket pubsub subscription layer:

1. A pubsub client could remain flagged as disconnected while its underlying connections were healthy and streaming. In that state, new subscribe requests routed to it were silently ignored.
2. eATA projection subscriptions were ensured but never released, so the monitored account set only ever grew, eventually hitting the LRU caps and causing eviction/refetch churn.
3. The subscriptions-per-connection limit was hardcoded, overly conservative for some providers, and not tunable without a rebuild — producing far more pooled websocket connections than necessary.

## Changes

**1. Reconnect state handling (`submux/mod.rs`)**
- `reconnect_client` checks the new `ReconnectableClient::transport_connected()` (delegated through `ChainUpdatesClient`) and skips `try_reconnect` (which drains every live subscription) when the transport is verifiably up, so a stale abort signal no longer tears down a healthy connection pool.
- Clients are marked connected as soon as the transport is up, **before** program and account resubscription, so subscriptions added mid-reconnect fan out to them. A resubscription failure rolls visibility back so the backoff loop retries from a clean state.

**2. eATA projection subscription release (`chainlink/mod.rs`)**
- When an ATA is evicted from the bank, the derived eATA's `AtaProjection` subscription reason is released, allowing the subscription to drop instead of occupying the monitored set indefinitely. The release runs only after the defensive eviction recheck confirms the ATA is still unwatched, so a racing fresh subscription keeps its coverage. It is re-ensured the next time the ATA is resolved.

**3. Per-connection subscription limit (`pubsub_common.rs`, config)**
- Single default of 900 subscriptions per websocket connection (headroom under the strictest known provider cap of 1,000 per connection), replacing the previous provider-specific hardcoded values.
- New optional `ws-subs-per-connection` setting in `[chainlink]` overrides the default, plumbed through `RemoteAccountProviderConfig` like `resubscription-delay`. Higher packing means fewer pooled connections per node, which also reduces pressure on provider concurrent-connection quotas.

## Tests
- `test_stale_abort_on_connected_client_skips_reconnect` (submux): a stale abort leaves subscriptions intact, triggers no reconnect, and updates keep flowing.
- `removal_of_ata_releases_eata_projection_subscription` and `stale_ata_removal_keeps_eata_projection_subscription` (chainlink): ATA removal releases the eATA watch; a stale removal for a re-watched ATA keeps it.
- Full `magicblock-chainlink` lib suite and `magicblock-config` suite pass; both workspaces `cargo check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional configuration to limit WebSocket subscriptions per connection.
  * Added a default limit of 900 subscriptions, with support for explicit overrides.
  * Added connection status reporting and improved reconnection behavior.
  * Automatically releases associated subscriptions when accounts are removed.

* **Bug Fixes**
  * Prevented unnecessary reconnections when a connection is already healthy.
  * Improved rollback handling when account resubscription fails.

* **Documentation**
  * Documented the configuration option, default limit, validation, and example usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->