### PR TITLE
hotfix: processed result trusted instead of committed

### DIFF
--- a/magicblock-rpc-client/src/lib.rs
+++ b/magicblock-rpc-client/src/lib.rs
@@ -203,8 +203,9 @@ impl MagicBlockSendTransactionConfig {
             )),
             wait_for_processed_level: None,
             check_for_processed_interval: None,
-            // NOTE: that this time is after we already verified that the transaction was
-            //       processed
+            // NOTE: we skip the processed check here and wait directly for
+            //       the commitment level, trusting the confirmed result
+            //       even if an earlier processed check would have failed
             wait_for_commitment_level: Some(Duration::from_millis(8_000)),
             check_for_commitment_interval: Some(Duration::from_millis(400)),
         }

--- a/magicblock-rpc-client/src/lib.rs
+++ b/magicblock-rpc-client/src/lib.rs
@@ -179,13 +179,30 @@ impl MagicBlockSendTransactionConfig {
         }
     }
 
-    pub fn ensure_committed() -> Self {
+    /// Waits for processed and committed results
+    /// NOTE: processed may fail, while committed - succeeds
+    pub fn ensure_processed_and_committed() -> Self {
         Self::SendAndConfirm {
             wait_for_blockhash_to_become_valid: Some(Duration::from_millis(
                 2_000,
             )),
             wait_for_processed_level: Some(DEFAULT_MAX_TIME_TO_PROCESSED),
             check_for_processed_interval: Some(Duration::from_millis(400)),
+            // NOTE: that this time is after we already verified that the transaction was
+            //       processed
+            wait_for_commitment_level: Some(Duration::from_millis(8_000)),
+            check_for_commitment_interval: Some(Duration::from_millis(400)),
+        }
+    }
+
+    /// Waits for committed stage results
+    pub fn ensure_committed() -> Self {
+        Self::SendAndConfirm {
+            wait_for_blockhash_to_become_valid: Some(Duration::from_millis(
+                2_000,
+            )),
+            wait_for_processed_level: None,
+            check_for_processed_interval: None,
             // NOTE: that this time is after we already verified that the transaction was
             //       processed
             wait_for_commitment_level: Some(Duration::from_millis(8_000)),
@@ -687,25 +704,29 @@ impl MagicblockRpcClient {
         };
 
         // 1. Wait for processed status
-        let check_for_processed_interval = check_for_processed_interval
-            .unwrap_or_else(|| Duration::from_millis(200));
-        let wait_for_processed_level =
-            wait_for_processed_level.unwrap_or_default();
-        let processed_status = self
-            .wait_for_processed_status(
-                &sig,
-                tx.get_recent_blockhash(),
-                wait_for_processed_level,
-                check_for_processed_interval,
-                wait_for_blockhash_to_become_valid,
-            )
-            .await?;
+        let processed_status = if let Some(wait_for_processed_level) =
+            wait_for_processed_level
+        {
+            let processed_status = self
+                .wait_for_processed_status(
+                    &sig,
+                    tx.get_recent_blockhash(),
+                    wait_for_processed_level,
+                    check_for_processed_interval,
+                    wait_for_blockhash_to_become_valid,
+                )
+                .await?;
 
-        if let Err(err) = processed_status {
-            return Err(MagicBlockRpcClientError::SentTransactionError(
-                err, sig,
-            ));
-        }
+            if let Err(err) = processed_status {
+                return Err(MagicBlockRpcClientError::SentTransactionError(
+                    err, sig,
+                ));
+            }
+
+            Some(processed_status)
+        } else {
+            None
+        };
 
         // 2. Wait for confirmed status if configured
         let confirmed_status = if let Some(wait_for_commitment_level) =
@@ -725,7 +746,7 @@ impl MagicblockRpcClient {
 
         Ok(MagicBlockSendTransactionOutcome {
             signature: sig,
-            processed_err: processed_status.err(),
+            processed_err: processed_status.and_then(|status| status.err()),
             confirmed_err: confirmed_status.and_then(|status| status.err()),
         })
     }
@@ -743,14 +764,16 @@ impl MagicblockRpcClient {
         &self,
         signature: &Signature,
         recent_blockhash: &Hash,
-        timeout: Duration,
-        check_interval: Duration,
+        timeout: &Duration,
+        check_interval: &Option<Duration>,
         _blockhash_valid_timeout: &Option<Duration>,
     ) -> MagicBlockRpcClientResult<TransactionResult<()>> {
+        let check_interval =
+            check_interval.unwrap_or_else(|| Duration::from_millis(200));
         if let Some(status) = Box::pin(self.confirmer.wait_for_status(
             signature,
             CommitmentConfig::processed(),
-            timeout,
+            *timeout,
             check_interval,
         ))
         .await

--- a/magicblock-table-mania/src/lookup_table_rc.rs
+++ b/magicblock-table-mania/src/lookup_table_rc.rs
@@ -957,7 +957,8 @@ impl LookupTableRc {
         match rpc_client.commitment_level() {
             Processed => MagicBlockSendTransactionConfig::ensure_processed(),
             Confirmed | Finalized => {
-                MagicBlockSendTransactionConfig::ensure_committed()
+                MagicBlockSendTransactionConfig::ensure_processed_and_committed(
+                )
             }
         }
     }

--- a/test-integration/test-committor-service/tests/test_delivery_preparator.rs
+++ b/test-integration/test-committor-service/tests/test_delivery_preparator.rs
@@ -338,8 +338,8 @@ async fn test_reprepare_closed_buffer_with_distinct_intent_nonce() {
             .wait_for_processed_status(
                 signature,
                 blockhash,
-                Duration::from_secs(4),
-                Duration::from_millis(10),
+                &Duration::from_secs(4),
+                &Some(Duration::from_millis(10)),
                 &None,
             )
             .await

--- a/test-integration/test-committor-service/tests/test_intent_executor.rs
+++ b/test-integration/test-committor-service/tests/test_intent_executor.rs
@@ -1055,7 +1055,7 @@ async fn test_commit_unfinalized_account_recovery() {
             .rpc_client
             .send_transaction(
                 &tx,
-                &MagicBlockSendTransactionConfig::ensure_committed(),
+                &MagicBlockSendTransactionConfig::ensure_processed_and_committed(),
             )
             .await;
         assert!(result.is_ok());
@@ -1138,7 +1138,7 @@ async fn test_commit_unfinalized_account_recovery_two_stage() {
             .rpc_client
             .send_transaction(
                 &tx,
-                &MagicBlockSendTransactionConfig::ensure_committed(),
+                &MagicBlockSendTransactionConfig::ensure_processed_and_committed(),
             )
             .await;
         assert!(result.is_ok());


### PR DESCRIPTION
<!--
PR title must match: type(scope): summary
Types: feat|fix|docs|chore|refactor|test|perf|ci|build
Examples:
  fix: avoid panic on empty slot
  feat(rpc): add getFoo endpoint
-->

## Summary
<!-- One sentence. Link to issue if applicable. -->
Errors from tx with processed confirmation doesn't mean tx failed. Polling same tx with `Committed` may return success.
Because of that `send_transaction` was modified to optionally skip `wait_for_processed_level` and wait only for `committed`.

Case with commit buffers:
send_transaction : awaits for processed result, then confirmed
1. We initialized - send_transaction successful and tx confirmed(2/3 nodes voted)
2. We write - transaction gets to 1 of 1/3 nodes that could not even see 1, as result we get error in processed status.

Above happened on one of the nodes:
```
[validator] [ERROR] [magicblock_committor_service::service::intent_client] Failed to commit intent: 147503, slot: 204044236, blockhash: 14S5vX4cKkPK62C9YXQevg2hNjFyF6tdaMuxCyfXKR7e. FailedFinalizePreparationError(DeliveryPreparationError(FailedToPrepareBufferAccounts(BufferExecutionError(TransactionSendError(MagicBlockRpcClientError(SentTransactionError(InstructionError(2, Custom(430083)), GW9UhNAGWqGX7rmmAmLga5v55pCD4aoRAc7pMKVVGDbWTGSYa1TPb8RbBCxjTuigvX1N3HAiKcsRTAyf79RvexK)))))))
--
```
Actual tx succeeded see [here](https://explorer.solana.com/tx/GW9UhNAGWqGX7rmmAmLga5v55pCD4aoRAc7pMKVVGDbWTGSYa1TPb8RbBCxjTuigvX1N3HAiKcsRTAyf79RvexK)

This pr introduces new config which await for committed, skipping processed. Having issue as above becomes impossible: at least 1/3 saw both txs.

Performance regression: only for failures as those will have to wait for committed status. As we assume failures rare this is fine.

## Breaking Changes
- [x] None
- [ ] Yes — migration path described below


## Test Plan
<!-- How you verified this works. e.g., "unit tests", "ran locally against testnet", "existing tests pass" -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added separate transaction confirmation options for committed-only status and processed-and-committed status.
  * Processed-status checks now support optional timeouts and polling intervals, with a default interval when unspecified.

* **Bug Fixes**
  * Transactions no longer wait for processed status when no processed timeout is configured.
  * Processed errors are recorded only when a processed-status check occurs.
  * Confirmed-and-finalized transactions now verify both processed and committed status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->