### PR TITLE
feat: log clones of accounts delegated to another validator

### DIFF
--- a/magicblock-chainlink/src/cloner/mod.rs
+++ b/magicblock-chainlink/src/cloner/mod.rs
@@ -14,7 +14,7 @@ use solana_account::{AccountBuilder, AccountMode};
 use solana_instruction::{AccountMeta, Instruction};
 use solana_loader_v4_interface::state::LoaderV4Status;
 use solana_pubkey::Pubkey;
-use tracing::debug;
+use tracing::{debug, warn};
 
 use crate::remote_account_provider::program_account::{
     LOADER_V1, LOADER_V4, LoadedProgram, RemoteProgramLoader,
@@ -152,6 +152,13 @@ pub(crate) async fn clone_account(
     request: AccountCloneRequest,
     materialization: AccountMaterialization,
 ) -> ClonerResult<AccountMode> {
+    if let Some(authority) = request.delegated_to_other {
+        warn!(
+            pubkey = %request.pubkey,
+            delegated_to = %authority,
+            "Cloning account delegated to another validator"
+        );
+    }
     if request.post_delegation_mode.is_rescue_undelegate()
         && materialization == AccountMaterialization::Update
     {


### PR DESCRIPTION
## Summary

Emits a `warn` log when the validator clones an account that is delegated to another validator, including the account pubkey and the delegation authority.

`cloner::clone_account` is the single choke point every clone path funnels through (initial fetch pipeline, subscription updates, ATA projection), and `AccountCloneRequest.delegated_to_other` is already populated there — so one log covers all paths.

Closes #1063