### PR TITLE
ci: always prepare releases from master

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -19,16 +19,16 @@ permissions:
 jobs:
   prepare-release:
     name: Prepare release PR
-    if: github.ref_name == github.event.repository.default_branch
     runs-on: blacksmith-32vcpu-ubuntu-2404
     env:
       HOST_CARGO_JOBS: "8"
     steps:
-      - name: Checkout default branch
+      # Releases are only and always created from master, regardless of the dispatch ref
+      - name: Checkout master
         uses: actions/checkout@v5
         with:
           path: magicblock-validator
-          ref: ${{ github.event.repository.default_branch }}
+          ref: master
           fetch-depth: 0
           persist-credentials: false
 
@@ -175,7 +175,7 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          BASE_BRANCH: ${{ github.event.repository.default_branch }}
+          BASE_BRANCH: master
         run: |
           gh pr create \
             --base "$BASE_BRANCH" \


### PR DESCRIPTION
## Summary

The prepare-release workflow targeted `github.event.repository.default_branch` (currently `dev`) for the checkout, the release-PR base, and the dispatch gate. Releases should only and always be created from `master`, so this pins the workflow to `master`:

- The release branch is always cut from `master` (`ref: master` in the checkout).
- The release PR always targets `master` (`BASE_BRANCH: master`).
- The `github.ref_name == default_branch` gate is removed: dispatching from any branch (including the UI default `dev`) now works and still releases from `master`, instead of silently skipping.