### PR TITLE
fix: align collision record lookup with the effective fetch slot

### DIFF
--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -2505,10 +2505,16 @@ where
             primary_pubkey: candidate.pubkey,
             context_slot: candidate.slot,
         };
+        // The record precheck shares the account fetch's effective slot
+        // floor; a lower floor could settle on an older in-flight record
+        // result and conservatively re-park the candidate.
+        let record_min_context_slot = candidate
+            .slot
+            .max(self.remote_account_provider.chain_slot());
         let Some((deleg_record, _)) = self
             .fetch_and_parse_delegation_record(
                 candidate.pubkey,
-                candidate.slot,
+                record_min_context_slot,
                 record_context,
                 companion_fetch_log_context,
             )

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -6559,6 +6559,143 @@ async fn test_released_collision_candidate_retries_when_clone_settles_stale() {
     );
 }
 
+// A released candidate's record precheck must use the effective account-
+// fetch slot: when chain_slot() > candidate.slot, joining an older
+// in-flight record fetch must not settle the release on its stale result.
+#[tokio::test]
+async fn test_released_collision_candidate_record_lookup_uses_effective_fetch_slot(
+) {
+    init_logger();
+    let validator_keypair = Keypair::new();
+    let validator_pubkey = validator_keypair.pubkey();
+    let other_validator = random_pubkey();
+    let account_pubkey = random_pubkey();
+    let account_owner = random_pubkey();
+    const PARK_SLOT: u64 = 100;
+    const CHAIN_SLOT: u64 = 120;
+
+    let delegated_account = Account {
+        lamports: 1_000_000,
+        data: vec![1, 2, 3, 4],
+        owner: dlp_api::id(),
+        executable: false,
+        rent_epoch: 0,
+    };
+
+    let FetcherTestCtx {
+        remote_account_provider,
+        accounts_bank,
+        rpc_client,
+        fetch_cloner,
+        ..
+    } = setup(
+        [(account_pubkey, delegated_account.clone())],
+        PARK_SLOT,
+        validator_keypair,
+    )
+    .await;
+
+    // The RPC still serves the previous generation's record (delegated to
+    // another validator).
+    let delegation_record_pubkey = add_delegation_record_with_slot_for(
+        &rpc_client,
+        account_pubkey,
+        other_validator,
+        account_owner,
+        PARK_SLOT - 10,
+    );
+
+    // The chain advances past the candidate slot via a clock update.
+    remote_account_provider
+        .pubsub_client()
+        .send_account_update(
+            solana_sdk_ids::sysvar::clock::ID,
+            CHAIN_SLOT,
+            &Account::default(),
+        )
+        .await;
+    tokio::time::timeout(Duration::from_secs(3), async {
+        while remote_account_provider.chain_slot() < CHAIN_SLOT {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("timed out waiting for the chain slot to advance");
+
+    // An older record fetch is in flight: started when the chain was still
+    // at the park slot, it resolves at that slot with the stale record.
+    rpc_client.block_fetches();
+    let fetches_before = rpc_client.single_account_fetches()
+        + rpc_client.multi_account_fetches();
+    let in_flight = tokio::spawn({
+        let provider = remote_account_provider.clone();
+        async move {
+            provider
+                .try_get_multi(
+                    &[delegation_record_pubkey],
+                    None,
+                    AccountFetchContext::rpc_get_account(),
+                    Some(PARK_SLOT),
+                )
+                .await
+        }
+    });
+    tokio::time::timeout(Duration::from_secs(3), async {
+        while rpc_client.single_account_fetches()
+            + rpc_client.multi_account_fetches()
+            == fetches_before
+        {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("timed out waiting for the in-flight record fetch to start");
+
+    // The release's record lookup joins the in-flight fetch as a waiter.
+    let release = tokio::spawn({
+        let fetch_cloner = fetch_cloner.clone();
+        async move {
+            fetch_cloner
+                .clone_released_collision_candidate(ParkedCollisionCandidate {
+                    pubkey: account_pubkey,
+                    slot: PARK_SLOT,
+                })
+                .await
+        }
+    });
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    rpc_client.allow_fetches();
+    let stale = in_flight
+        .await
+        .unwrap()
+        .expect("in-flight record fetch must resolve");
+    assert_eq!(
+        stale[0].slot(),
+        PARK_SLOT,
+        "the joined in-flight result must be older than the chain slot"
+    );
+
+    // The RPC view catches up with the fresh generation delegated to us.
+    rpc_client.set_slot(CHAIN_SLOT);
+    rpc_client.set_clock_sysvar_for_slot(CHAIN_SLOT);
+    add_delegation_record_with_slot_for(
+        &rpc_client,
+        account_pubkey,
+        validator_pubkey,
+        account_owner,
+        CHAIN_SLOT - 10,
+    );
+    release.await.unwrap();
+
+    let in_bank = accounts_bank
+        .get_account(&account_pubkey)
+        .expect("release must clone the candidate from the effective slot");
+    assert!(in_bank.delegated());
+    assert_eq!(in_bank.owner(), &account_owner);
+    assert_eq!(in_bank.remote_slot(), CHAIN_SLOT);
+}
+
 // A released collision candidate delegated to another validator must be
 // ignored like record-first discovery, not force-cloned from the firehose.
 #[tokio::test]

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -6625,8 +6625,6 @@ async fn test_released_collision_candidate_record_lookup_uses_effective_fetch_sl
     // An older record fetch is in flight: started when the chain was still
     // at the park slot, it resolves at that slot with the stale record.
     rpc_client.block_fetches();
-    let fetches_before = rpc_client.single_account_fetches()
-        + rpc_client.multi_account_fetches();
     let in_flight = tokio::spawn({
         let provider = remote_account_provider.clone();
         async move {
@@ -6641,9 +6639,9 @@ async fn test_released_collision_candidate_record_lookup_uses_effective_fetch_sl
         }
     });
     tokio::time::timeout(Duration::from_secs(3), async {
-        while rpc_client.single_account_fetches()
-            + rpc_client.multi_account_fetches()
-            == fetches_before
+        while remote_account_provider
+            .pending_fetch_waiter_count(&delegation_record_pubkey)
+            < 1
         {
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
@@ -6663,7 +6661,16 @@ async fn test_released_collision_candidate_record_lookup_uses_effective_fetch_sl
                 .await
         }
     });
-    tokio::time::sleep(Duration::from_millis(300)).await;
+    tokio::time::timeout(Duration::from_secs(3), async {
+        while remote_account_provider
+            .pending_fetch_waiter_count(&delegation_record_pubkey)
+            < 2
+        {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("timed out waiting for the record lookup to join the fetch");
 
     rpc_client.allow_fetches();
     let stale = in_flight
@@ -6676,9 +6683,9 @@ async fn test_released_collision_candidate_record_lookup_uses_effective_fetch_sl
         "the joined in-flight result must be older than the chain slot"
     );
 
-    // The RPC view catches up with the fresh generation delegated to us.
-    rpc_client.set_slot(CHAIN_SLOT);
-    rpc_client.set_clock_sysvar_for_slot(CHAIN_SLOT);
+    // The RPC view catches up with the fresh generation delegated to us;
+    // the record is swapped before the slot advances so the release's
+    // retries can never observe the stale record at the new slot.
     add_delegation_record_with_slot_for(
         &rpc_client,
         account_pubkey,
@@ -6686,6 +6693,8 @@ async fn test_released_collision_candidate_record_lookup_uses_effective_fetch_sl
         account_owner,
         CHAIN_SLOT - 10,
     );
+    rpc_client.set_slot(CHAIN_SLOT);
+    rpc_client.set_clock_sysvar_for_slot(CHAIN_SLOT);
     release.await.unwrap();
 
     let in_bank = accounts_bank

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -4431,6 +4431,16 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
             .unwrap_or_else(|poison| poison.into_inner());
         fetching.contains_key(pubkey)
     }
+
+    /// Number of callers waiting on the in-flight fetch for `pubkey`
+    /// (the owner included).
+    pub(crate) fn pending_fetch_waiter_count(&self, pubkey: &Pubkey) -> usize {
+        let fetching = self
+            .fetching_accounts
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        fetching.get(pubkey).map_or(0, |state| state.waiters.len())
+    }
 }
 
 #[cfg(any(test, feature = "dev-context"))]


### PR DESCRIPTION
## Problem

Released collision candidates fetch their delegation record with `candidate.slot` as the minimum context slot, while the account fetch runs at `max(candidate.slot, chain_slot())`. When the chain slot has advanced past the candidate slot, the record lookup can join an older in-flight record fetch and settle on its stale result: the candidate is then conservatively re-parked until another update or access occurs, or dropped as delegated elsewhere if the stale record still shows the previous generation's authority.

## Fix

Raise the record precheck's minimum context slot to the same effective floor as the account fetch. The undelegating-account generation guard is unchanged.

## Testing

New regression test `test_released_collision_candidate_record_lookup_uses_effective_fetch_slot` covers `chain_slot() > candidate.slot` with an older in-flight record result (release joins a blocked in-flight record fetch that resolves at the park slot with the previous generation's record). It fails without the fix and passed 20/20 stress runs with it; full `magicblock-chainlink` suite passes (393/393).

Closes #1491

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved delegation handling for released collision candidates by using the most current chain slot available.
  - Prevented stale delegation records from causing candidates to be cloned incorrectly.

- **Tests**
  - Added end-to-end coverage for chain advancement and updated delegation records during candidate processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->