### PR TITLE
fix: surface pubsub abort reason and reset resub pacing on progress

### DIFF
--- a/magicblock-chainlink/src/remote_account_provider/chain_pubsub_actor.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_pubsub_actor.rs
@@ -1103,7 +1103,7 @@ impl ChainPubsubActor {
             return;
         }
 
-        debug!(
+        warn!(
             client_id = client_id,
             reason = reason,
             "Aborting connection"

--- a/magicblock-chainlink/src/remote_account_provider/chain_pubsub_client.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_pubsub_client.rs
@@ -389,11 +389,14 @@ impl ReconnectableClient for ChainPubsubClientImpl {
             warn!(total_subs, "Re-subscription made no progress");
             return Err(err);
         }
-        if remaining.is_empty() {
-            // Clean pass: restore the configured pacing
+        if remaining.len() < total_subs {
+            // Any progress restores the configured pacing: an escalated
+            // delay stretches the restore window past the connection's
+            // lifetime and wedges reconnects into a permanent loop.
             self.current_resub_delay_ms
                 .store(self.initial_resub_delay_ms, Ordering::SeqCst);
-        } else {
+        }
+        if !remaining.is_empty() {
             // Leftovers are repaired by the subscription reconciler
             warn!(
                 total_subs,


### PR DESCRIPTION
## Problem

WS pubsub legs on nodes running v0.13.20 enter a permanent teardown/reconnect loop 

Two contributing defects:

1. The reason a connection is torn down (`abort_and_signal_connection_issue`) is logged at `debug`, so production logs never show what killed the connection. Root-causing the loop required a debug-log restart on testnet-asia, which surfaced `reason="(Program) subscription ended for <pubkey>"` immediately.
2. The adaptive resubscription delay doubles on any failed restore pass (50ms → 800ms cap) but only resets on a *fully clean* pass. Once wedged at 800ms, restoring 63 subs takes ~50s while the flaky connection lives ~19s — a clean pass can never happen, so the delay never recovers and every reconnect fails partway, forever.
