### PR TITLE
feat: per-remote override for ws-subs-per-connection

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -58,6 +58,10 @@ lifecycle = "ephemeral"
 # Note: gRPC remote requires a Helius API key/token.
 # Example format: grpcs://<network>.helius-rpc.com?api-key=<YOUR_API_KEY>
 # See Helius gRPC docs for available network endpoints.
+#
+# A WebSocket remote may also be written as a table to cap subscriptions
+# per connection for that endpoint (overrides chainlink.ws-subs-per-connection):
+# remotes = [{ url = "wss://api.devnet.solana.com", ws-subs-per-connection = 100 }]
 remotes = [
     "grpcs://laserstream-devnet-ewr.helius-rpc.com?api-key=YOUR_API_KEY",
     "https://api.devnet.solana.com",

--- a/magicblock-chainlink/src/remote_account_provider/chain_updates_client.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_updates_client.rs
@@ -43,7 +43,11 @@ impl ChainUpdatesClient {
         static CLIENT_ID: AtomicU16 = AtomicU16::new(0);
 
         match endpoint {
-            WebSocket { url, label } => {
+            WebSocket {
+                url,
+                label,
+                subs_per_connection,
+            } => {
                 debug!(url = %url, "Initializing WebSocket client");
                 let client_id = format!(
                     "ws:{label}-{}",
@@ -56,7 +60,7 @@ impl ChainUpdatesClient {
                         abort_sender,
                         commitment,
                         resubscription_delay,
-                        ws_subs_per_connection,
+                        (*subs_per_connection).or(ws_subs_per_connection),
                     )
                     .await?,
                 ))

--- a/magicblock-chainlink/src/remote_account_provider/endpoint.rs
+++ b/magicblock-chainlink/src/remote_account_provider/endpoint.rs
@@ -14,6 +14,9 @@ pub enum Endpoint {
     WebSocket {
         url: String,
         label: String,
+        /// Per-endpoint max subscriptions per connection; falls back to
+        /// the global `ws-subs-per-connection` when unset.
+        subs_per_connection: Option<usize>,
     },
     Grpc {
         url: String,
@@ -79,11 +82,12 @@ impl TryFrom<&Remote> for Endpoint {
                     label,
                 })
             }
-            Remote::Websocket(url) => {
+            Remote::Websocket(url, subs_per_connection) => {
                 let label = extract_label(url);
                 Ok(Endpoint::WebSocket {
                     url: url.to_string(),
                     label,
+                    subs_per_connection: *subs_per_connection,
                 })
             }
             Remote::Grpc(url) => {

--- a/magicblock-config/src/lib.rs
+++ b/magicblock-config/src/lib.rs
@@ -149,7 +149,7 @@ impl ValidatorParams {
         if self
             .remotes
             .iter()
-            .any(|r| matches!(r, Remote::Websocket(_)))
+            .any(|r| matches!(r, Remote::Websocket(..)))
         {
             return;
         }
@@ -186,7 +186,7 @@ impl ValidatorParams {
     pub fn websocket_urls(&self) -> impl Iterator<Item = &str> + '_ {
         self.remotes
             .iter()
-            .filter(|r| matches!(r, Remote::Websocket(_)))
+            .filter(|r| matches!(r, Remote::Websocket(..)))
             .map(|r| r.url_str())
     }
 

--- a/magicblock-config/src/tests.rs
+++ b/magicblock-config/src/tests.rs
@@ -448,7 +448,7 @@ fn test_example_config_full_coverage() {
         matches!(r, Remote::Http(_)) && r.url_str() == consts::DEVNET_URL
     }));
     assert!(config.remotes.iter().any(|r| {
-        matches!(r, Remote::Websocket(_))
+        matches!(r, Remote::Websocket(..))
             && r.url_str() == "wss://api.devnet.solana.com/"
     }));
     assert_eq!(config.aperture.listen.0.port(), 8899);
@@ -749,7 +749,35 @@ fn test_parse_http_remote() {
 #[parallel]
 fn test_parse_websocket_remote() {
     let remote: Remote = "ws://localhost:8900".parse().unwrap();
-    assert!(matches!(remote, Remote::Websocket(_)));
+    assert!(matches!(remote, Remote::Websocket(..)));
+}
+
+#[test]
+#[parallel]
+fn test_deserialize_remotes_with_per_endpoint_ws_subs_limit() {
+    #[derive(serde::Deserialize)]
+    struct Cfg {
+        remotes: Vec<Remote>,
+    }
+    let cfg: Cfg = toml::from_str(
+        "remotes = [\n\
+             \"http://localhost:8899\",\n\
+             { url = \"ws://localhost:8900\", ws-subs-per-connection = 100 },\n\
+         ]\n",
+    )
+    .unwrap();
+    assert!(matches!(cfg.remotes[0], Remote::Http(_)));
+    assert!(matches!(cfg.remotes[1], Remote::Websocket(_, Some(100))));
+
+    // The option is rejected on non-websocket remotes and when zero
+    assert!(toml::from_str::<Cfg>(
+        "remotes = [{ url = \"http://localhost:8899\", ws-subs-per-connection = 100 }]"
+    )
+    .is_err());
+    assert!(toml::from_str::<Cfg>(
+        "remotes = [{ url = \"ws://localhost:8900\", ws-subs-per-connection = 0 }]"
+    )
+    .is_err());
 }
 
 #[test]
@@ -774,7 +802,7 @@ fn test_parse_alias() {
 fn test_to_websocket_from_http() {
     let remote: Remote = "http://localhost:8899".parse().unwrap();
     let ws_remote = remote.to_websocket().unwrap();
-    assert!(matches!(ws_remote, Remote::Websocket(_)));
+    assert!(matches!(ws_remote, Remote::Websocket(..)));
     assert_eq!(ws_remote.url_str(), "ws://localhost:8900/");
 }
 

--- a/magicblock-config/src/types/network.rs
+++ b/magicblock-config/src/types/network.rs
@@ -2,7 +2,7 @@ use std::{net::SocketAddr, str::FromStr};
 
 use derive_more::{Deref, Display};
 use serde::{de, Deserialize, Deserializer, Serialize};
-use serde_with::{DeserializeFromStr, SerializeDisplay};
+use serde_with::SerializeDisplay;
 use url::Url;
 
 use crate::consts;
@@ -89,11 +89,59 @@ impl<'de> Deserialize<'de> for BindAddress {
 /// - **Http**: JSON-RPC HTTP endpoint (scheme: `http` or `https`)
 /// - **Websocket**: WebSocket endpoint for PubSub subscriptions (scheme: `ws` or `wss`)
 /// - **Grpc**: gRPC endpoint for streaming (schemes `grpc`/`grpcs` are converted to `http`/`https`)
-#[derive(Clone, DeserializeFromStr, SerializeDisplay, Display, Debug)]
+#[derive(Clone, SerializeDisplay, Display, Debug)]
 pub enum Remote {
     Http(ResolvedUrl),
-    Websocket(ResolvedUrl),
+    /// WebSocket endpoint with an optional per-endpoint max subscriptions
+    /// per connection, overriding `chainlink.ws-subs-per-connection`.
+    #[display("{_0}")]
+    Websocket(ResolvedUrl, Option<usize>),
     Grpc(ResolvedUrl),
+}
+
+/// Accepts either a plain URL string or
+/// `{ url = "wss://…", ws-subs-per-connection = N }`.
+impl<'de> Deserialize<'de> for Remote {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Repr {
+            Plain(String),
+            Detailed {
+                url: String,
+                #[serde(rename = "ws-subs-per-connection")]
+                ws_subs_per_connection: Option<usize>,
+            },
+        }
+        match Repr::deserialize(deserializer)? {
+            Repr::Plain(url) => url.parse().map_err(de::Error::custom),
+            Repr::Detailed {
+                url,
+                ws_subs_per_connection,
+            } => {
+                if ws_subs_per_connection == Some(0) {
+                    return Err(de::Error::custom(
+                        "ws-subs-per-connection must be greater than 0",
+                    ));
+                }
+                match url.parse().map_err(de::Error::custom)? {
+                    Self::Websocket(url, _) => {
+                        Ok(Self::Websocket(url, ws_subs_per_connection))
+                    }
+                    _ if ws_subs_per_connection.is_some() => {
+                        Err(de::Error::custom(
+                            "ws-subs-per-connection only applies to \
+                             ws/wss remotes",
+                        ))
+                    }
+                    other => Ok(other),
+                }
+            }
+        }
+    }
 }
 
 impl FromStr for Remote {
@@ -111,7 +159,7 @@ impl FromStr for Remote {
         let remote = match parsed.0.scheme() {
             _ if is_grpc => Self::Grpc(parsed),
             "http" | "https" => Self::Http(parsed),
-            "ws" | "wss" => Self::Websocket(parsed),
+            "ws" | "wss" => Self::Websocket(parsed, None),
             _ => return Err(url::ParseError::InvalidDomainCharacter),
         };
         Ok(remote)
@@ -123,7 +171,7 @@ impl Remote {
     pub fn url_str(&self) -> &str {
         match self {
             Self::Http(u) => u.as_str(),
-            Self::Websocket(u) => u.as_str(),
+            Self::Websocket(u, _) => u.as_str(),
             Self::Grpc(u) => u.as_str(),
         }
     }
@@ -131,7 +179,7 @@ impl Remote {
     /// Converts an HTTP remote to a WebSocket remote by deriving the appropriate WebSocket URL.
     pub(crate) fn to_websocket(&self) -> Option<Self> {
         let mut url = match self {
-            Self::Websocket(_) => return Some(self.clone()),
+            Self::Websocket(..) => return Some(self.clone()),
             Self::Grpc(_) => return None,
             Self::Http(u) => u.0.clone(),
         };
@@ -144,7 +192,7 @@ impl Remote {
             // As per solana convention websocket port is one greater than http
             let _ = url.set_port(Some(port + 1));
         }
-        Some(Self::Websocket(ResolvedUrl(url)))
+        Some(Self::Websocket(ResolvedUrl(url), None))
     }
 }
 

--- a/test-integration/test-chainlink/src/ixtest_context.rs
+++ b/test-integration/test-chainlink/src/ixtest_context.rs
@@ -88,6 +88,7 @@ impl IxtestContext {
                 Endpoint::WebSocket {
                     url: "ws://localhost:7800".to_string(),
                     label: "test-ws".to_string(),
+                    subs_per_connection: None,
                 },
             ];
             let endpoints = Endpoints::from(endpoints_vec.as_slice());

--- a/test-integration/test-chainlink/tests/ix_remote_account_provider.rs
+++ b/test-integration/test-chainlink/tests/ix_remote_account_provider.rs
@@ -34,6 +34,7 @@ async fn init_remote_account_provider(
         Endpoint::WebSocket {
             url: PUBSUB_URL.to_string(),
             label: "test-ws".to_string(),
+            subs_per_connection: None,
         },
     ];
     let endpoints = Endpoints::from(endpoints_vec.as_slice());


### PR DESCRIPTION
Allows capping subscriptions per websocket connection for a single endpoint, e.g. for providers with stricter per-connection limits or for local testing:

```toml
remotes = [
    "https://api.devnet.solana.com",
    { url = "wss://api.devnet.solana.com", ws-subs-per-connection = 100 },
]
```

- Backward compatible: plain string entries deserialize exactly as before (untagged string-or-table); the table form is opt-in.
- Precedence: per-remote value → `chainlink.ws-subs-per-connection` → built-in default (900).
- Rejected on non-websocket remotes and when set to 0.
- `Remote::Websocket` carries the optional limit through `Endpoint::WebSocket` into the existing #1530 plumbing; gRPC/laser clients are unaffected.

Tests: new serde round-trip/rejection test; magicblock-config 35 passed, magicblock-chainlink 393 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

