### PR TITLE
fix(aperture): use cached slots for subscription contexts

### DIFF
--- a/magicblock-aperture/src/requests/websocket/account_subscribe.rs
+++ b/magicblock-aperture/src/requests/websocket/account_subscribe.rs
@@ -23,10 +23,11 @@ impl WsDispatcher {
         let id = next_subid();
         let mut rx = self.engine.accounts().subscribe(pubkey).await;
         let tx = self.chan.tx.clone();
+        let engine = self.engine.clone();
         let handle = tokio::spawn(async move {
             while let Some(account) = rx.recv().await {
                 let account: AccountSharedData = account;
-                let slot = account.slot();
+                let slot = context_slot(&engine);
                 let Some(bytes) = encoder.encode(slot, &pubkey, &account, id)
                 else {
                     continue;

--- a/magicblock-aperture/src/requests/websocket/log_subscribe.rs
+++ b/magicblock-aperture/src/requests/websocket/log_subscribe.rs
@@ -42,7 +42,7 @@ impl WsDispatcher {
         let engine = self.engine.clone();
         let handle = tokio::spawn(async move {
             while let Some(logs) = rx.recv().await {
-                let slot = engine.blocks().latest().slot;
+                let slot = context_slot(&engine);
                 let value = LogsValue {
                     signature: logs.signature.to_string(),
                     err: logs.result.as_ref().err().cloned(),

--- a/magicblock-aperture/src/requests/websocket/mod.rs
+++ b/magicblock-aperture/src/requests/websocket/mod.rs
@@ -1,10 +1,17 @@
+use engine::Engine;
+
 mod prelude {
+    pub(super) use super::context_slot;
     pub(super) use crate::{
         RpcResult,
         requests::{JsonWsRequest as JsonRequest, params::Serde32Bytes},
         server::websocket::dispatch::{SubResult, WsDispatcher},
         state::subscriptions::next_subid,
     };
+}
+
+fn context_slot(engine: &Engine) -> u64 {
+    engine.blocks().latest().slot
 }
 
 pub(crate) mod account_subscribe;

--- a/magicblock-aperture/src/requests/websocket/program_subscribe.rs
+++ b/magicblock-aperture/src/requests/websocket/program_subscribe.rs
@@ -32,9 +32,10 @@ impl WsDispatcher {
         let id = next_subid();
         let mut rx = self.engine.accounts().subscribe_program(pubkey).await;
         let tx = self.chan.tx.clone();
+        let engine = self.engine.clone();
         let handle = tokio::spawn(async move {
             while let Some((pubkey, account)) = rx.recv().await {
-                let slot = account.slot();
+                let slot = context_slot(&engine);
                 let Some(bytes) = encoder.encode(slot, &pubkey, &account, id)
                 else {
                     continue;

--- a/magicblock-aperture/src/requests/websocket/signature_subscribe.rs
+++ b/magicblock-aperture/src/requests/websocket/signature_subscribe.rs
@@ -28,18 +28,19 @@ impl WsDispatcher {
             .await
             .map_err(crate::error::RpcError::internal)?
         {
-            if let Some(bytes) = encoder.encode(status.slot, &status.result, id)
-            {
+            let slot = context_slot(&self.engine);
+            if let Some(bytes) = encoder.encode(slot, &status.result, id) {
                 let _ = self.chan.tx.send(bytes).await;
             }
             return Ok(SubResult::SubId(id));
         }
 
         let tx = self.chan.tx.clone();
+        let engine = self.engine.clone();
         let handle = tokio::spawn(async move {
             if let Ok(status) = rx.await
                 && let Some(bytes) =
-                    encoder.encode(status.slot, &status.result, id)
+                    encoder.encode(context_slot(&engine), &status.result, id)
             {
                 let _ = tx.send(bytes).await;
             }


### PR DESCRIPTION
## What changed
Use the Engine blocks cache slot when encoding context-bearing account, program, logs, and signature WebSocket notifications. Keep `slotSubscribe` unchanged because its slot is the notification value.

Closes #1559

## Impact
WebSocket response contexts now report the validator's current cached slot instead of an event-specific slot. There are no API, storage, or serialization changes.

## Reviewer notes
The slot is read at notification encoding time through one shared helper. 
