### PR TITLE
feat(magicblock): add RPC healthcheck

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3620,20 +3620,31 @@ dependencies = [
  "anyhow",
  "borsh 1.7.0",
  "clap",
+ "futures-util",
+ "humantime-serde",
  "isocountry",
  "magic-domain-program",
  "magicblock-config",
+ "magicblock-engine-nucleus",
+ "rand 0.9.4",
+ "serde",
  "solana-account 4.3.1",
  "solana-commitment-config",
  "solana-instruction 3.4.0",
  "solana-keypair",
  "solana-pubkey 4.2.0",
+ "solana-pubsub-client",
  "solana-rpc-client",
+ "solana-rpc-client-api",
  "solana-sdk-ids 3.1.0",
+ "solana-signature 3.4.1",
  "solana-signer",
  "solana-transaction 4.1.5",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
  "url",
+ "v42-calculator-interface",
 ]
 
 [[package]]
@@ -4248,8 +4259,10 @@ dependencies = [
  "solana-program-runtime",
  "solana-pubkey 4.2.0",
  "solana-rent 4.3.0",
+ "solana-sdk-ids 3.1.0",
  "spl-token-interface",
  "thiserror 2.0.18",
+ "v42-calculator-interface",
 ]
 
 [[package]]

--- a/bins/magicblock/Cargo.toml
+++ b/bins/magicblock/Cargo.toml
@@ -11,17 +11,28 @@ version.workspace = true
 anyhow = { workspace = true }
 borsh = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
+futures-util = { workspace = true }
+humantime = { workspace = true }
 isocountry = { workspace = true }
 magic-domain-program = { git = "https://github.com/magicblock-labs/magic-domain-program.git", rev = "64c7c5e3", default-features = false }
 magicblock-config = { workspace = true }
+nucleus = { workspace = true, features = ["metrics"] }
+rand = { workspace = true }
+serde = { workspace = true }
 solana-account = { workspace = true }
 solana-commitment-config = { workspace = true }
 solana-instruction = { workspace = true }
 solana-keypair = { workspace = true }
 solana-pubkey = { workspace = true }
+solana-pubsub-client = { workspace = true }
 solana-rpc-client = { workspace = true }
+solana-rpc-client-api = { workspace = true }
 solana-sdk-ids = { workspace = true }
+solana-signature = { workspace = true }
 solana-signer = { workspace = true }
 solana-transaction = { workspace = true }
 tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 url = { workspace = true }
+v42-calculator-interface = { workspace = true, features = ["builder"] }

--- a/bins/magicblock/README.md
+++ b/bins/magicblock/README.md
@@ -1,0 +1,67 @@
+# MagicBlock CLI
+
+`magicblock` provides explicit operator commands for managing a leader's Magic
+Domain record and checking a validator's RPC, execution, and PubSub paths.
+
+## Build
+
+```bash
+cargo build -p magicblock --locked
+```
+
+The binary is written to `target/debug/magicblock`.
+
+## Domain records
+
+Domain commands load the leader configuration, including `MBV_` environment
+overlays, and use its first HTTP remote and local authority. They submit and
+confirm a Magic Domain Program transaction.
+
+Register a record:
+
+```bash
+magicblock domain register \
+  --config config.toml \
+  --country-code US \
+  --fqdn https://validator.example.com
+```
+
+Synchronize its mutable fields:
+
+```bash
+magicblock domain sync \
+  --config config.toml \
+  --country-code US \
+  --fqdn https://validator.example.com
+```
+
+Remove it:
+
+```bash
+magicblock domain unregister --config config.toml
+```
+
+## Healthcheck
+
+The healthcheck requires a validator configured with the v42 calculator
+program. It derives the WebSocket endpoint from the HTTP URL using the
+adjacent-port Solana convention.
+
+```bash
+magicblock healthcheck \
+  --url http://127.0.0.1:8899 \
+  --timeout 10s
+```
+
+Within one end-to-end deadline, the command:
+
+1. builds one bounded randomized v42 expression containing recursive CPIs;
+2. signs one transaction with a fresh keypair;
+3. registers signature and target-account subscriptions before submission;
+4. requires `sendTransaction` to return the locally derived signature;
+5. requires successful signature notification and `getSignatureStatuses`;
+6. requires an account notification before the deadline.
+
+The account notification's value and context slot are intentionally ignored.
+Success is written as one line to stdout. Structured progress and timing are
+written to stderr; set `RUST_LOG` to control their verbosity.

--- a/bins/magicblock/src/domain/client.rs
+++ b/bins/magicblock/src/domain/client.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use anyhow::{Context, Result, bail};
 use borsh::BorshDeserialize;
 use mdp::{
@@ -18,21 +16,17 @@ use solana_sdk_ids::system_program;
 use solana_signer::Signer;
 use solana_transaction::Transaction;
 
-pub struct DomainClient {
-    client: Arc<RpcClient>,
-}
+pub(super) struct Client(RpcClient);
 
-impl DomainClient {
-    pub fn new(url: impl ToString) -> Self {
-        Self {
-            client: Arc::new(RpcClient::new_with_commitment(
-                url.to_string(),
-                CommitmentConfig::confirmed(),
-            )),
-        }
+impl Client {
+    pub(super) fn new(url: &str) -> Self {
+        Self(RpcClient::new_with_commitment(
+            url.to_owned(),
+            CommitmentConfig::confirmed(),
+        ))
     }
 
-    pub async fn register(
+    pub(super) async fn register(
         &self,
         payer: &Keypair,
         record: ErRecord,
@@ -46,7 +40,11 @@ impl DomainClient {
         .context("failed to register domain record")
     }
 
-    pub async fn sync(&self, payer: &Keypair, record: &ErRecord) -> Result<()> {
+    pub(super) async fn sync(
+        &self,
+        payer: &Keypair,
+        record: &ErRecord,
+    ) -> Result<()> {
         let update = SyncRecordV0 {
             identity: *record.identity(),
             status: Some(record.status()),
@@ -66,7 +64,7 @@ impl DomainClient {
         .context("failed to synchronize domain record")
     }
 
-    pub async fn unregister(&self, payer: &Keypair) -> Result<()> {
+    pub(super) async fn unregister(&self, payer: &Keypair) -> Result<()> {
         let pda = record_pda(&payer.pubkey());
         if self.fetch(&pda).await?.is_none() {
             bail!("no domain record exists for {}", payer.pubkey());
@@ -82,13 +80,13 @@ impl DomainClient {
 
     async fn fetch(&self, pubkey: &Pubkey) -> Result<Option<ErRecord>> {
         let response = self
-            .client
-            .get_account_with_commitment(pubkey, self.client.commitment())
+            .0
+            .get_account_with_commitment(pubkey, self.0.commitment())
             .await
             .with_context(|| {
                 format!(
                     "failed to fetch domain record {pubkey} from {}",
-                    self.client.url()
+                    self.0.url()
                 )
             })?;
         response
@@ -114,7 +112,7 @@ impl DomainClient {
         let instruction =
             Instruction::new_with_borsh(ID, &instruction, accounts);
         let blockhash = self
-            .client
+            .0
             .get_latest_blockhash()
             .await
             .context("failed to get latest blockhash")?;
@@ -124,7 +122,7 @@ impl DomainClient {
             &[payer],
             blockhash,
         );
-        self.client
+        self.0
             .send_and_confirm_transaction(&transaction)
             .await
             .context("failed to send and confirm domain transaction")?;

--- a/bins/magicblock/src/domain/mod.rs
+++ b/bins/magicblock/src/domain/mod.rs
@@ -1,0 +1,131 @@
+mod client;
+
+use std::{path::PathBuf, sync::Arc, time::Duration};
+
+use anyhow::{Context, Result};
+use clap::{Args as ClapArgs, Subcommand};
+use isocountry::CountryCode as IsoCountryCode;
+use magicblock_config::LeaderParams;
+use mdp::state::{
+    features::FeaturesSet,
+    record::{CountryCode, ErRecord},
+    status::ErStatus,
+    version::v0::RecordV0,
+};
+use solana_keypair::Keypair;
+use solana_signer::Signer;
+
+use self::client::Client;
+
+#[derive(ClapArgs)]
+pub struct Args {
+    #[command(subcommand)]
+    command: Command,
+}
+
+impl Args {
+    pub async fn run(self) -> Result<()> {
+        match self.command {
+            Command::Register(args) => {
+                let (operator, record) = args.load()?;
+                operator.client.register(&operator.signer, record).await
+            }
+            Command::Sync(args) => {
+                let (operator, record) = args.load()?;
+                operator.client.sync(&operator.signer, &record).await
+            }
+            Command::Unregister(args) => {
+                let operator = args.load()?;
+                operator.client.unregister(&operator.signer).await
+            }
+        }
+    }
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Create a domain record.
+    Register(RecordArgs),
+    /// Replace the mutable fields of an existing domain record.
+    Sync(RecordArgs),
+    /// Remove the leader's domain record.
+    Unregister(ConfigArgs),
+}
+
+#[derive(ClapArgs)]
+struct ConfigArgs {
+    /// Leader configuration supplying RPC and signing identity.
+    #[arg(long)]
+    config: PathBuf,
+}
+
+impl ConfigArgs {
+    fn load(self) -> Result<Operator> {
+        Operator::load(self.config)
+    }
+}
+
+#[derive(ClapArgs)]
+struct RecordArgs {
+    #[command(flatten)]
+    common: ConfigArgs,
+    /// ISO 3166-1 alpha-2 country code.
+    #[arg(long)]
+    country_code: String,
+    /// Public URL at which the leader is reachable.
+    #[arg(long)]
+    fqdn: String,
+}
+
+impl RecordArgs {
+    fn load(self) -> Result<(Operator, ErRecord)> {
+        let Self {
+            common,
+            country_code,
+            fqdn,
+        } = self;
+        let operator = common.load()?;
+        let country = IsoCountryCode::for_alpha2_caseless(&country_code)
+            .with_context(|| {
+                format!("invalid ISO alpha-2 country code {country_code}")
+            })?;
+        let fqdn = url::Url::parse(&fqdn)
+            .with_context(|| format!("invalid FQDN URL {fqdn}"))?;
+        let block_time_ms = u16::try_from(operator.block_time.as_millis())
+            .context(
+                "leader block time exceeds the domain program u16 range",
+            )?;
+        let record = ErRecord::V0(RecordV0 {
+            identity: operator.signer.pubkey(),
+            status: ErStatus::Active,
+            block_time_ms,
+            base_fee: 0,
+            features: FeaturesSet::default(),
+            load_average: 0,
+            country_code: CountryCode::from(country.alpha3()),
+            addr: fqdn.to_string(),
+        });
+        Ok((operator, record))
+    }
+}
+
+struct Operator {
+    client: Client,
+    signer: Arc<Keypair>,
+    block_time: Duration,
+}
+
+impl Operator {
+    fn load(path: PathBuf) -> Result<Self> {
+        let config = LeaderParams::load(&path)
+            .map_err(|error| anyhow::anyhow!(error.to_string()))
+            .with_context(|| {
+                format!("failed to load leader config {}", path.display())
+            })?;
+        Ok(Self {
+            client: Client::new(config.rpc_url()),
+            signer: config.engine.authority.local,
+            block_time: config.engine.blockstore.blocktime,
+        })
+    }
+}

--- a/bins/magicblock/src/healthcheck/deadline.rs
+++ b/bins/magicblock/src/healthcheck/deadline.rs
@@ -1,0 +1,42 @@
+use std::{error::Error as StdError, future::Future, time::Duration};
+
+use anyhow::{Context, Error, Result};
+use futures_util::{Stream, StreamExt};
+use tokio::time::{Instant, timeout_at};
+use tracing::info;
+
+#[derive(Clone, Copy)]
+pub(super) struct Deadline(Instant);
+
+impl Deadline {
+    pub(super) fn new(timeout: Duration) -> Self {
+        Self(Instant::now() + timeout)
+    }
+
+    pub(super) async fn run<T, E>(
+        self,
+        stage: &'static str,
+        future: impl Future<Output = Result<T, E>>,
+    ) -> Result<T>
+    where
+        E: StdError + Send + Sync + 'static,
+    {
+        info!(stage, "Starting healthcheck stage");
+        timeout_at(self.0, future)
+            .await
+            .with_context(|| format!("healthcheck timed out while {stage}"))?
+            .map_err(Error::new)
+    }
+
+    pub(super) async fn next<T>(
+        self,
+        stage: &'static str,
+        stream: &mut (impl Stream<Item = T> + Unpin),
+    ) -> Result<T> {
+        info!(stage, "Starting healthcheck stage");
+        timeout_at(self.0, stream.next())
+            .await
+            .with_context(|| format!("healthcheck timed out while {stage}"))?
+            .with_context(|| format!("subscription closed while {stage}"))
+    }
+}

--- a/bins/magicblock/src/healthcheck/expression.rs
+++ b/bins/magicblock/src/healthcheck/expression.rs
@@ -1,0 +1,63 @@
+use rand::Rng;
+use v42_calculator_interface::builder::Expr;
+
+const MAX_TERM: i64 = 4;
+
+pub(super) fn random() -> Expr {
+    let mut rng = rand::rng();
+    let mut expr = Expr::lit(term(&mut rng)).cpi();
+
+    // Even eight multiplications peak at 4^9, so every intermediate fits i64.
+    for index in 0..rng.random_range(4..=8) {
+        let op = Op::random(&mut rng);
+        let mut rhs = Expr::lit(op.term(&mut rng));
+        if index == 0 || rng.random() {
+            rhs = rhs.cpi();
+        }
+        expr = op.compose(expr, rhs);
+    }
+
+    expr
+}
+
+#[derive(Clone, Copy)]
+enum Op {
+    Add,
+    Subtract,
+    Multiply,
+    Divide,
+}
+
+impl Op {
+    fn random(rng: &mut impl Rng) -> Self {
+        match (rng.random(), rng.random()) {
+            (false, false) => Self::Add,
+            (false, true) => Self::Subtract,
+            (true, false) => Self::Multiply,
+            (true, true) => Self::Divide,
+        }
+    }
+
+    fn term(self, rng: &mut impl Rng) -> i64 {
+        match self {
+            Self::Divide => {
+                let value = rng.random_range(1..=MAX_TERM);
+                if rng.random() { value } else { -value }
+            }
+            _ => term(rng),
+        }
+    }
+
+    fn compose(self, lhs: Expr, rhs: Expr) -> Expr {
+        match self {
+            Self::Add => lhs + rhs,
+            Self::Subtract => lhs - rhs,
+            Self::Multiply => lhs * rhs,
+            Self::Divide => lhs / rhs,
+        }
+    }
+}
+
+fn term(rng: &mut impl Rng) -> i64 {
+    rng.random_range(-MAX_TERM..=MAX_TERM)
+}

--- a/bins/magicblock/src/healthcheck/mod.rs
+++ b/bins/magicblock/src/healthcheck/mod.rs
@@ -1,0 +1,151 @@
+mod deadline;
+mod expression;
+
+use std::time::Duration;
+
+use anyhow::{Context, Result, anyhow, ensure};
+use futures_util::Stream;
+use humantime::re::humantime as ht;
+use magicblock_config::{consts::HEALTHCHECK_ACCOUNT_PUBKEY, types::Remote};
+use nucleus::metrics::EventTimer;
+use serde::Deserialize;
+use solana_commitment_config::CommitmentConfig;
+use solana_keypair::Keypair;
+use solana_pubsub_client::nonblocking::pubsub_client::PubsubClient;
+use solana_rpc_client::nonblocking::rpc_client::RpcClient;
+use solana_rpc_client_api::response::{Response, RpcSignatureResult};
+use solana_signature::Signature;
+use solana_signer::Signer;
+use solana_transaction::Transaction;
+use tracing::info;
+
+use self::{deadline::Deadline, expression::random};
+
+#[derive(clap::Args, Deserialize)]
+pub struct Args {
+    /// Validator HTTP RPC URL.
+    #[arg(long)]
+    url: Remote,
+    /// End-to-end deadline, such as 5s or 1m.
+    #[arg(long, value_parser = ht::parse_duration)]
+    timeout: Duration,
+}
+
+impl Args {
+    pub async fn run(self) -> Result<()> {
+        let mut timer = EventTimer::new("healthcheck");
+        let deadline = Deadline::new(self.timeout);
+        let rpc_url = self.url.url_str().to_owned();
+        let ws_url = self
+            .url
+            .to_websocket()
+            .context("healthcheck requires an HTTP RPC URL")?
+            .url_str()
+            .to_owned();
+        let rpc = RpcClient::new_with_commitment(
+            rpc_url.clone(),
+            CommitmentConfig::processed(),
+        );
+        info!(rpc = %rpc_url, websocket = %ws_url, timeout = ?self.timeout, "Starting healthcheck");
+
+        let signer = Keypair::new();
+        let blockhash = deadline
+            .run("fetching latest blockhash", rpc.get_latest_blockhash())
+            .await
+            .with_context(|| format!("RPC {rpc_url}"))?;
+        let transaction = Transaction::new_signed_with_payer(
+            &[random().compose(HEALTHCHECK_ACCOUNT_PUBKEY, &[])],
+            Some(&signer.pubkey()),
+            &[&signer],
+            blockhash,
+        );
+        let signature = transaction.signatures[0];
+        timer.record("transaction built");
+        info!(%signature, "Built randomized v42 transaction");
+
+        let pubsub = deadline
+            .run("connecting to WebSocket RPC", PubsubClient::new(&ws_url))
+            .await
+            .with_context(|| format!("WebSocket {ws_url}"))?;
+        let (signatures, _) = deadline
+            .run(
+                "registering signature subscription",
+                pubsub.signature_subscribe(&signature, None),
+            )
+            .await
+            .with_context(|| format!("signatureSubscribe {signature}"))?;
+        let (accounts, _) = deadline
+            .run(
+                "registering account subscription",
+                pubsub.account_subscribe(&HEALTHCHECK_ACCOUNT_PUBKEY, None),
+            )
+            .await
+            .with_context(|| {
+                format!("accountSubscribe {HEALTHCHECK_ACCOUNT_PUBKEY}")
+            })?;
+        timer.record("subscriptions registered");
+
+        let returned = deadline
+            .run("sending transaction", rpc.send_transaction(&transaction))
+            .await
+            .with_context(|| format!("sendTransaction via {rpc_url}"))?;
+        ensure!(
+            returned == signature,
+            "sendTransaction returned {returned}, expected {signature}"
+        );
+        timer.record("transaction submitted");
+        info!(%signature, "Submitted healthcheck transaction");
+
+        info!(%signature, "Waiting for execution and account update");
+        tokio::try_join!(
+            verify_signature(deadline, &rpc, signature, signatures),
+            wait_for_update(deadline, accounts),
+        )?;
+        timer.record("execution and account update verified");
+
+        println!("healthcheck succeeded: {signature}");
+        Ok(())
+    }
+}
+
+async fn verify_signature(
+    deadline: Deadline,
+    rpc: &RpcClient,
+    signature: Signature,
+    mut stream: impl Stream<Item = Response<RpcSignatureResult>> + Unpin,
+) -> Result<()> {
+    deadline
+        .next("waiting for signature notification", &mut stream)
+        .await?;
+    info!(%signature,  "Received successful signature notification");
+
+    let statuses = deadline
+        .run(
+            "checking signature status",
+            rpc.get_signature_statuses(&[signature]),
+        )
+        .await
+        .context("getSignatureStatuses failed")?;
+    let status = statuses
+        .value
+        .into_iter()
+        .next()
+        .flatten()
+        .context("getSignatureStatuses returned no transaction status")?;
+    status.status.map_err(|error| {
+        anyhow!("getSignatureStatuses reported execution failure: {error:?}")
+    })?;
+    info!(%signature, "Verified signature status");
+    Ok(())
+}
+
+async fn wait_for_update<T>(
+    deadline: Deadline,
+    mut stream: impl Stream<Item = T> + Unpin,
+) -> Result<()> {
+    deadline
+        .next("waiting for account notification", &mut stream)
+        .await?;
+    info!("Received account notification");
+    Ok(())
+}

--- a/bins/magicblock/src/main.rs
+++ b/bins/magicblock/src/main.rs
@@ -1,19 +1,11 @@
 mod domain;
+mod healthcheck;
 
-use std::path::PathBuf;
+use std::io;
 
-use anyhow::{Context, Result};
-use clap::{Args, Parser, Subcommand};
-use domain::DomainClient;
-use isocountry::CountryCode as IsoCountryCode;
-use magicblock_config::LeaderParams;
-use mdp::state::{
-    features::FeaturesSet,
-    record::{CountryCode, ErRecord},
-    status::ErStatus,
-    version::v0::RecordV0,
-};
-use solana_signer::Signer;
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+use tracing_subscriber::EnvFilter;
 
 #[derive(Parser)]
 #[command(name = "magicblock", about = "MagicBlock operator tools")]
@@ -25,101 +17,31 @@ struct Cli {
 #[derive(Subcommand)]
 enum Command {
     /// Manage the Magic Domain Program record for a leader.
-    Domain {
-        #[command(subcommand)]
-        command: DomainCommand,
-    },
+    Domain(domain::Args),
+    /// Check a validator's RPC, execution, and subscription paths.
+    Healthcheck(healthcheck::Args),
 }
 
-#[derive(Subcommand)]
-enum DomainCommand {
-    /// Create a domain record.
-    Register(RecordArgs),
-    /// Replace the mutable fields of an existing domain record.
-    Sync(RecordArgs),
-    /// Remove the leader's domain record.
-    Unregister(ConfigArgs),
-}
-
-#[derive(Args)]
-struct ConfigArgs {
-    /// Leader configuration supplying RPC and signing identity.
-    #[arg(long)]
-    config: PathBuf,
-}
-
-#[derive(Args)]
-struct RecordArgs {
-    #[command(flatten)]
-    common: ConfigArgs,
-    /// ISO 3166-1 alpha-2 country code.
-    #[arg(long)]
-    country_code: String,
-    /// Public URL at which the leader is reachable.
-    #[arg(long)]
-    fqdn: String,
+impl Command {
+    async fn run(self) -> Result<()> {
+        match self {
+            Self::Domain(args) => args.run().await,
+            Self::Healthcheck(args) => args.run().await,
+        }
+    }
 }
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
-    match Cli::parse().command {
-        Command::Domain { command } => run_domain(command).await,
-    }
+    init_tracing();
+    Cli::parse().command.run().await
 }
 
-async fn run_domain(command: DomainCommand) -> Result<()> {
-    match command {
-        DomainCommand::Register(args) => {
-            let (config, record) = record(args)?;
-            DomainClient::new(config.rpc_url())
-                .register(&config.engine.authority.local, record)
-                .await
-        }
-        DomainCommand::Sync(args) => {
-            let (config, record) = record(args)?;
-            DomainClient::new(config.rpc_url())
-                .sync(&config.engine.authority.local, &record)
-                .await
-        }
-        DomainCommand::Unregister(args) => {
-            let config = load(args.config)?;
-            DomainClient::new(config.rpc_url())
-                .unregister(&config.engine.authority.local)
-                .await
-        }
-    }
-}
-
-fn record(args: RecordArgs) -> Result<(LeaderParams, ErRecord)> {
-    let config = load(args.common.config)?;
-    let country = IsoCountryCode::for_alpha2_caseless(&args.country_code)
-        .with_context(|| {
-            format!("invalid ISO alpha-2 country code {}", args.country_code)
-        })?;
-    let fqdn = url::Url::parse(&args.fqdn)
-        .with_context(|| format!("invalid FQDN URL {}", args.fqdn))?;
-    let block_time_ms = u16::try_from(
-        config.engine.blockstore.blocktime.as_millis(),
-    )
-    .context("leader block time exceeds the domain program u16 range")?;
-    let identity = config.engine.authority.local.pubkey();
-    let record = ErRecord::V0(RecordV0 {
-        identity,
-        status: ErStatus::Active,
-        block_time_ms,
-        base_fee: 0,
-        features: FeaturesSet::default(),
-        load_average: 0,
-        country_code: CountryCode::from(country.alpha3()),
-        addr: fqdn.to_string(),
-    });
-    Ok((config, record))
-}
-
-fn load(path: PathBuf) -> Result<LeaderParams> {
-    LeaderParams::load(&path)
-        .map_err(|error| anyhow::anyhow!(error.to_string()))
-        .with_context(|| {
-            format!("failed to load leader config {}", path.display())
-        })
+fn init_tracing() {
+    let filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new("info"));
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_writer(io::stderr)
+        .try_init();
 }

--- a/magicblock-config/src/consts.rs
+++ b/magicblock-config/src/consts.rs
@@ -1,3 +1,9 @@
+use solana_pubkey::Pubkey;
+
+/// Validator-controlled scratch account used by the RPC healthcheck.
+pub const HEALTHCHECK_ACCOUNT_PUBKEY: Pubkey =
+    Pubkey::from_str_const("V42Hea1thCheckTargetMagicb1ock1111111111111");
+
 /// CLI Default Values
 /// Default remote endpoint: devnet HTTP URL
 pub const DEFAULT_REMOTE: &str = DEVNET_URL;

--- a/magicblock-config/src/types/network.rs
+++ b/magicblock-config/src/types/network.rs
@@ -129,7 +129,7 @@ impl Remote {
     }
 
     /// Converts an HTTP remote to a WebSocket remote by deriving the appropriate WebSocket URL.
-    pub(crate) fn to_websocket(&self) -> Option<Self> {
+    pub fn to_websocket(&self) -> Option<Self> {
         let mut url = match self {
             Self::Websocket(_) => return Some(self.clone()),
             Self::Grpc(_) => return None,

--- a/magicblock-runtime/Cargo.toml
+++ b/magicblock-runtime/Cargo.toml
@@ -19,5 +19,7 @@ solana-program-pack = { workspace = true }
 solana-program-runtime = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-rent = { workspace = true }
+solana-sdk-ids = { workspace = true }
 spl-token = { workspace = true }
 thiserror = { workspace = true }
+v42-calculator-interface = { workspace = true }

--- a/magicblock-runtime/src/accounts.rs
+++ b/magicblock-runtime/src/accounts.rs
@@ -9,7 +9,6 @@ use solana_program_option::COption;
 use solana_program_pack::Pack;
 use solana_pubkey::Pubkey;
 use solana_rent::Rent;
-use solana_sdk_ids::system_program;
 use spl_token::{native_mint, state::Mint};
 
 /// Builds validator-controlled accounts that must exist before execution starts.

--- a/magicblock-runtime/src/accounts.rs
+++ b/magicblock-runtime/src/accounts.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use magicblock_config::consts::HEALTHCHECK_ACCOUNT_PUBKEY;
 use magicblock_magic_program_api as magic_program;
 use magicblock_program::MagicContext;
 use solana_account::{AccountBuilder, AccountMode, AccountSharedData};
@@ -8,10 +9,13 @@ use solana_program_option::COption;
 use solana_program_pack::Pack;
 use solana_pubkey::Pubkey;
 use solana_rent::Rent;
+use solana_sdk_ids::system_program;
 use spl_token::{native_mint, state::Mint};
 
 /// Builds validator-controlled accounts that must exist before execution starts.
-pub(crate) fn initial_accounts() -> HashMap<Pubkey, AccountSharedData> {
+pub(crate) fn initial_accounts(
+    programs: &HashMap<Pubkey, Vec<u8>>,
+) -> HashMap<Pubkey, AccountSharedData> {
     let mut accounts = HashMap::new();
 
     let magic_context = AccountBuilder::default()
@@ -44,6 +48,26 @@ pub(crate) fn initial_accounts() -> HashMap<Pubkey, AccountSharedData> {
         .owner(spl_token::id())
         .build();
     accounts.insert(native_mint::id(), native_mint);
+
+    let healthcheck = AccountBuilder::default()
+        .lamports(0)
+        .data(vec![0; size_of::<i64>()])
+        .owner(v42_calculator_interface::ID)
+        .executable(false)
+        .mode(AccountMode::Ephemeral)
+        .build();
+    accounts.insert(HEALTHCHECK_ACCOUNT_PUBKEY, healthcheck);
+
+    if !programs.contains_key(&v42_calculator_interface::ID) {
+        let sentinel = AccountBuilder::default()
+            .lamports(0)
+            .data(Vec::new())
+            .owner(system_program::ID)
+            .executable(false)
+            .mode(AccountMode::System)
+            .build();
+        accounts.insert(v42_calculator_interface::ID, sentinel);
+    }
 
     accounts
 }

--- a/magicblock-runtime/src/accounts.rs
+++ b/magicblock-runtime/src/accounts.rs
@@ -50,23 +50,15 @@ pub(crate) fn initial_accounts(
     accounts.insert(native_mint::id(), native_mint);
 
     let healthcheck = AccountBuilder::default()
-        .lamports(0)
         .data(vec![0; size_of::<i64>()])
         .owner(v42_calculator_interface::ID)
-        .executable(false)
         .mode(AccountMode::Ephemeral)
         .build();
     accounts.insert(HEALTHCHECK_ACCOUNT_PUBKEY, healthcheck);
 
     if !programs.contains_key(&v42_calculator_interface::ID) {
-        let sentinel = AccountBuilder::default()
-            .lamports(0)
-            .data(Vec::new())
-            .owner(system_program::ID)
-            .executable(false)
-            .mode(AccountMode::System)
-            .build();
-        accounts.insert(v42_calculator_interface::ID, sentinel);
+        let sentinel = AccountBuilder::default().mode(AccountMode::System);
+        accounts.insert(v42_calculator_interface::ID, sentinel.build());
     }
 
     accounts

--- a/magicblock-runtime/src/lib.rs
+++ b/magicblock-runtime/src/lib.rs
@@ -21,14 +21,15 @@ pub fn keeper_builder<R>(
     engine: &EngineConfig<R>,
     programs: &[LoadableProgram],
 ) -> Result<KeeperBuilder, Error> {
+    let programs = load_programs(programs)?;
     Ok(KeeperBuilder {
         authority: engine.authority.clone(),
         accountsdb: engine.accountsdb.clone(),
         ledger: engine.ledger.clone(),
         blockstore: engine.blockstore,
         builtins: builtins(),
-        programs: load_programs(programs)?,
-        accounts: accounts::initial_accounts(),
+        accounts: accounts::initial_accounts(&programs),
+        programs,
         rent: Rent::default(),
     })
 }


### PR DESCRIPTION
## What changed
Add `magicblock healthcheck` with one absolute end-to-end deadline, derived WebSocket connectivity, and tracing plus `EventTimer` stage observability. The command builds one infallible bounded randomized v42 expression with recursive CPIs, registers signature and account subscriptions before sending, verifies the returned signature, successful subscription result, and `getSignatureStatuses`, and requires an account update to be present.

Restructure the operator binary around command-owned domain and healthcheck modules, and add its README. Seed the shared vanity healthcheck target in `magicblock-runtime`; when v42 is not configured, seed its program address as a non-executable system-owned sentinel without replacing a configured executable.

Closes #1548

## Impact
Leaders and verifiers share the same ephemeral healthcheck target. `Remote::to_websocket` becomes public for operator tooling. The conditional sentinel makes unsupported v42 execution fail deterministically instead of triggering remote program materialization. Existing domain commands retain their signing and confirmation behavior.

## Reviewer notes
The healthcheck intentionally verifies account-update presence only; it does not correlate or decode the shared account payload. The absolute deadline covers RPC, WebSocket connection, subscriptions, submission, status, and account-update waits.

