### PR TITLE
ci: make prepare-release lockfile validation real

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -149,8 +149,10 @@ jobs:
           set -euo pipefail
           cargo build --workspace --jobs "$HOST_CARGO_JOBS"
           cargo build --workspace --manifest-path test-integration/Cargo.toml --jobs "$HOST_CARGO_JOBS"
-          cargo metadata --locked --no-deps --format-version 1 >/dev/null
-          cargo metadata --manifest-path test-integration/Cargo.toml --locked --no-deps --format-version 1 >/dev/null
+          # Full dependency resolution so --locked actually validates the
+          # lockfiles (--no-deps skips resolution and never trips --locked).
+          cargo metadata --locked --format-version 1 >/dev/null
+          cargo metadata --manifest-path test-integration/Cargo.toml --locked --format-version 1 >/dev/null
 
       - name: Commit and push release branch
         working-directory: magicblock-validator


### PR DESCRIPTION
## Problem

The release PR #1570 was created with a stale `test-integration/Cargo.lock`, so every `--locked` CI build on it failed.

Two things lined up:

1. The workflow was dispatched from the `dev` branch, so its **old copy** of `prepare-release.yml` ran (workflow_dispatch executes the definition on the dispatched ref): that copy only builds the root workspace, so the test-integration lockfile was never refreshed after the version bump. The `if: ref == default branch` guard only exists in master's newer copy, which didn't run.
2. Its lockfile "validation" — `cargo metadata --locked --no-deps` — is vacuous: `--no-deps` skips dependency resolution entirely, so `--locked` never trips. The same vacuous check is still present in master's copy.

## Change

Drop `--no-deps` from both verification calls so `cargo metadata --locked` resolves the full graph in both workspaces — a stale lockfile now fails the prepare step loudly instead of surfacing as CI failures on the generated release PR.

A companion PR syncs this workflow to `dev` so a dispatch from there can no longer run the outdated definition.

#1570 itself has been fixed by committing the refreshed `test-integration/Cargo.lock`.