### PR TITLE
ci: sync prepare-release workflow from master

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -19,22 +19,23 @@ permissions:
 jobs:
   prepare-release:
     name: Prepare release PR
+    if: github.ref_name == github.event.repository.default_branch
     runs-on: blacksmith-32vcpu-ubuntu-2404
     env:
       HOST_CARGO_JOBS: "8"
     steps:
-      # Releases are only and always created from master, regardless of the dispatch ref
-      - name: Checkout master
+      - name: Checkout default branch
         uses: actions/checkout@v5
         with:
           path: magicblock-validator
-          ref: master
+          ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 0
           persist-credentials: false
 
       - uses: ./magicblock-validator/.github/actions/setup-build-env
         with:
           build_cache_key_name: "magicblock-validator-prepare-release-v001"
+          rust_toolchain_release: "1.94.1"
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Determine release version
@@ -141,15 +142,17 @@ jobs:
         shell: bash
         run: ./version-align.sh
 
-      - name: Build project
+      - name: Build project and integration tests
         working-directory: magicblock-validator
         shell: bash
         run: |
           set -euo pipefail
           cargo build --workspace --jobs "$HOST_CARGO_JOBS"
-          cargo metadata --locked --no-deps --format-version 1 >/dev/null
-          cargo metadata --manifest-path test-integration/Cargo.toml \
-            --locked --no-deps --format-version 1 >/dev/null
+          cargo build --workspace --manifest-path test-integration/Cargo.toml --jobs "$HOST_CARGO_JOBS"
+          # Full dependency resolution so --locked actually validates the
+          # lockfiles (--no-deps skips resolution and never trips --locked).
+          cargo metadata --locked --format-version 1 >/dev/null
+          cargo metadata --manifest-path test-integration/Cargo.toml --locked --format-version 1 >/dev/null
 
       - name: Commit and push release branch
         working-directory: magicblock-validator
@@ -175,7 +178,7 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          BASE_BRANCH: master
+          BASE_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           gh pr create \
             --base "$BASE_BRANCH" \


### PR DESCRIPTION
`workflow_dispatch` executes the workflow definition on the dispatched ref. This branch still carried the old `prepare-release.yml` — no default-branch guard, no test-integration build, and a lockfile check neutralized by `--no-deps` — and a dispatch from here produced release PR #1570 with a stale `test-integration/Cargo.lock` that failed every `--locked` CI build.

This syncs master's current version of the workflow (plus the strengthened `--locked` validation from #1571): the default-branch guard makes future dispatches from this branch no-ops, and the prepare step now resolves the full dependency graph of both workspaces so a stale lockfile fails loudly before a PR is created.