### PR TITLE
fix(chainlink): return error on lagging fetch response slot

### DIFF
--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -4132,9 +4132,19 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
                 };
             };
 
-            // TODO: should we retry if not or respond with an error?
+            // The retry loop above already re-requests when the response slot is
+            // behind min_context_slot. If we still observe a lagging slot here,
+            // fail waiters like the cardinality mismatch path below and like
+            // `fetch_multi_rpc_only` (return Err instead of panicking).
             let (response_slot, response_value) = response;
-            assert!(response_slot >= min_context_slot);
+            if response_slot < min_context_slot {
+                let err_msg = format!(
+                    "Response slot {response_slot} < {min_context_slot} fetching accounts {}",
+                    pubkeys_str(&pubkeys)
+                );
+                notify_error(&err_msg);
+                return;
+            }
 
             if response_value.len() != pubkeys.len() {
                 let err_msg = format!(


### PR DESCRIPTION
## Summary
- After the `min_context_slot` retry loop in `RemoteAccountProvider::fetch`, a lagging response slot used `assert!`, which panics in release builds
- Sibling path `fetch_multi_rpc_only` already returns `Err` for the same condition
- Replace the assert with `notify_error` + `return` so waiters get `AccountResolutionsFailed` instead of crashing the process
- Resolves the open TODO: retry is already handled above; remaining lag is treated as an error

## Test plan
- [x] `cargo +nightly fmt --check -p magicblock-chainlink -- --config-path rustfmt-nightly.toml`
- [x] `cargo test -p magicblock-chainlink remote_account_provider`