### PR TITLE
ci: always cut releases from master

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -23,12 +23,14 @@ jobs:
     runs-on: blacksmith-32vcpu-ubuntu-2404
     env:
       HOST_CARGO_JOBS: "8"
+      # Releases are always cut from master, regardless of the default branch.
+      RELEASE_BASE_BRANCH: master
     steps:
-      - name: Checkout default branch
+      - name: Checkout release base branch
         uses: actions/checkout@v5
         with:
           path: magicblock-validator
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ env.RELEASE_BASE_BRANCH }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -111,7 +113,7 @@ jobs:
             echo "RELEASE_BRANCH=$release_branch"
           } >> "$GITHUB_ENV"
 
-          echo "Preparing v${version} from v${current_version}" >> "$GITHUB_STEP_SUMMARY"
+          echo "Preparing v${version} from v${current_version} (base: ${RELEASE_BASE_BRANCH})" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Set workspace version
         working-directory: magicblock-validator
@@ -178,10 +180,9 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          BASE_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           gh pr create \
-            --base "$BASE_BRANCH" \
+            --base "$RELEASE_BASE_BRANCH" \
             --head "$RELEASE_BRANCH" \
             --title "release v${VERSION}" \
             --body ""


### PR DESCRIPTION
## Problem

`prepare-release.yml` checks out the **default branch** (`dev`) and opens the release PR against it. Releases are actually cut on `master` (e.g. [v0.14.10](https://github.com/magicblock-labs/magicblock-validator/releases/tag/v0.14.10) via #1570), so the workflow's behavior depends on which branch happens to be default rather than on the release process.

## Fix

Introduce a single `RELEASE_BASE_BRANCH: master` job env and use it everywhere the base matters:

- the checkout now uses `ref: master` instead of the default branch, so the version bump and `release/vX.Y.Z` branch are always created from `master`
- the generated release PR now targets `master` instead of the default branch
- the step summary states the base branch used

The `workflow_dispatch` gate (`github.ref_name == default_branch`) is unchanged on purpose: the workflow is still dispatched from `dev` so the canonical copy of the workflow file runs, while the release content itself always comes from `master`.

No changes needed in `publish-packages.yml` — it is tag/release-driven and already packages whatever commit the release tag points to.