### PR TITLE
fix: backstop program upgrade detection with periodic programdata sweep

### DIFF
--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -1164,8 +1164,9 @@ where
     }
 
     /// Holds a persistent programdata subscription for a LoaderV3 program so
-    /// upgrades stay observable; both pubkeys are preferred onto gRPC
-    /// transport. Installed before the clone so an upgrade notification
+    /// upgrades stay observable; it keeps full coverage on every transport
+    /// leg, while the program account is preferred onto gRPC.
+    /// Installed before the clone so an upgrade notification
     /// landing mid-clone already routes; held once per program (idempotent
     /// across reloads). Failing to hold the subscription is an error but
     /// non-fatal to the clone: the watch is retried on the next load.
@@ -1240,11 +1241,14 @@ where
                 .await;
             return Ok(ProgramDataWatch::EvictedConcurrently);
         }
+        // Only the program account is narrowed to gRPC: pre-Agave-4.2
+        // chains notify hot program accounts every slot without changes,
+        // which would flood websocket legs. The programdata sub — the
+        // actual upgrade signal, quiet outside deploys — keeps default
+        // full coverage on every leg so one dead transport cannot
+        // silence upgrade detection.
         self.remote_account_provider
             .prefer_grpc_subscription(&program_id)
-            .await;
-        self.remote_account_provider
-            .prefer_grpc_subscription(&program_data_pubkey)
             .await;
         Ok(ProgramDataWatch::Installed)
     }

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -158,6 +158,10 @@ where
     /// Bounded; entries evicted at capacity release their subscription.
     programdata_index: Arc<PlMutex<LruCache<Pubkey, Pubkey>>>,
 
+    /// Rotates the starting entry of each programdata sweep pass so an
+    /// abandoned pass cannot starve the same tail entries every time.
+    programdata_sweep_cursor: Arc<AtomicU64>,
+
     /// Recognizes freshly delegated accounts whose app data collides with an
     /// internal DLP discriminator via delegation-record sightings.
     dlp_collision_tracker: Arc<PlMutex<DlpCollisionTracker>>,
@@ -227,6 +231,25 @@ fn programdata_watch_capacity(
     )
     .expect("programdata watch capacity has a non-zero floor")
 }
+
+/// Interval between transport-independent sweeps over the programdata
+/// watches. A watch whose upstream subscription silently dies stops
+/// delivering upgrade notifications entirely; the sweep bounds upgrade
+/// detection for such programs to roughly this interval, at a cost of one
+/// 12-byte header fetch per watched program.
+const PROGRAMDATA_SWEEP_INTERVAL: Duration = Duration::from_secs(300);
+
+/// Programdata prefix holding the state tag (4 bytes) and deploy slot
+/// (8 bytes) of `UpgradeableLoaderState::ProgramData`.
+const PROGRAMDATA_DEPLOY_SLOT_PREFIX_LEN: usize = 12;
+
+/// Enum tag of `UpgradeableLoaderState::ProgramData`.
+const PROGRAMDATA_STATE_TAG: u32 = 3;
+
+/// Consecutive header-fetch failures after which a sweep pass is
+/// abandoned until the next interval, bounding a pass against an
+/// unhealthy RPC endpoint.
+const PROGRAMDATA_SWEEP_MAX_CONSECUTIVE_FAILURES: usize = 3;
 
 /// Outcome of [FetchCloner::watch_programdata].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -404,6 +427,7 @@ where
             known_empty_eatas: self.known_empty_eatas.clone(),
             program_verify_cache: self.program_verify_cache.clone(),
             programdata_index: self.programdata_index.clone(),
+            programdata_sweep_cursor: self.programdata_sweep_cursor.clone(),
             dlp_collision_tracker: self.dlp_collision_tracker.clone(),
             pending_clones: self.pending_clones.clone(),
             pending_undelegations: self.pending_undelegations.clone(),
@@ -531,6 +555,7 @@ where
                     remote_account_provider.subscribed_accounts_capacity(),
                 ),
             ))),
+            programdata_sweep_cursor: Arc::new(AtomicU64::new(0)),
             dlp_collision_tracker: Arc::new(PlMutex::new(
                 DlpCollisionTracker::new(),
             )),
@@ -560,6 +585,7 @@ where
         );
         me.clone()
             .start_subscription_listener(subscription_updates_rx);
+        me.start_programdata_sweep();
 
         me
     }
@@ -1243,6 +1269,137 @@ where
         }
     }
 
+    /// Runs the upgrade-detection backstop on a fixed interval. Holds only
+    /// a weak handle so the loop neither keeps the FetchCloner alive nor
+    /// outlives it.
+    fn start_programdata_sweep(self: &Arc<Self>) {
+        let this = Arc::downgrade(self);
+        tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(PROGRAMDATA_SWEEP_INTERVAL).await;
+                let Some(this) = this.upgrade() else {
+                    break;
+                };
+                this.sweep_programdata_watches().await;
+            }
+        });
+    }
+
+    /// One pass of the upgrade-detection backstop: compares each watched
+    /// program's on-chain deploy slot against the bank copy's remote slot
+    /// and routes stale programs into the reload path. Runs on the fetch
+    /// transport, so upgrades surface even when a watch subscription died
+    /// upstream while local bookkeeping kept it. Metadata-only changes
+    /// (e.g. authority rotations) keep the deploy slot and are left to the
+    /// subscription path.
+    async fn sweep_programdata_watches(&self) {
+        let watched: Vec<(Pubkey, Pubkey)> = self
+            .programdata_index
+            .lock()
+            .iter()
+            .map(|(program_data, program_id)| (*program_data, *program_id))
+            .collect();
+        if watched.is_empty() {
+            return;
+        }
+        // Rotate the starting entry so a pass abandoned by the failure
+        // breaker below cannot starve the same tail entries every time.
+        let start = self
+            .programdata_sweep_cursor
+            .fetch_add(1, Ordering::Relaxed) as usize
+            % watched.len();
+        let len = watched.len();
+        let mut consecutive_failures = 0usize;
+        for (program_data_pubkey, program_id) in
+            watched.into_iter().cycle().skip(start).take(len)
+        {
+            let Some(bank_slot) = self
+                .accounts_bank
+                .get_account(&program_id)
+                .map(|account| account.remote_slot())
+            else {
+                // Bank copy gone: nothing to verify. Watch cleanup stays
+                // with the notification path — releasing here would race
+                // an in-flight clone that already saw the index entry.
+                continue;
+            };
+            let prefix = match self
+                .remote_account_provider
+                .get_account_data_slice(
+                    &program_data_pubkey,
+                    0,
+                    PROGRAMDATA_DEPLOY_SLOT_PREFIX_LEN,
+                    bank_slot,
+                )
+                .await
+            {
+                Ok(Some(prefix))
+                    if prefix.len() >= PROGRAMDATA_DEPLOY_SLOT_PREFIX_LEN
+                        && prefix[..4]
+                            == PROGRAMDATA_STATE_TAG.to_le_bytes() =>
+                {
+                    consecutive_failures = 0;
+                    prefix
+                }
+                // Missing or non-programdata state: nothing to verify
+                // against; live-subscription paths handle closures.
+                Ok(_) => {
+                    consecutive_failures = 0;
+                    continue;
+                }
+                // Transient fetch failure: the next sweep retries. An
+                // unhealthy RPC fails every fetch after its full retry
+                // budget, so abandon the pass instead of crawling on.
+                Err(err) => {
+                    debug!(
+                        program_id = %program_id,
+                        program_data = %program_data_pubkey,
+                        error = %err,
+                        "Programdata sweep header fetch failed"
+                    );
+                    consecutive_failures += 1;
+                    if consecutive_failures
+                        >= PROGRAMDATA_SWEEP_MAX_CONSECUTIVE_FAILURES
+                    {
+                        break;
+                    }
+                    continue;
+                }
+            };
+            let Ok(deploy_slot_bytes) = <[u8; 8]>::try_from(&prefix[4..12])
+            else {
+                continue;
+            };
+            let deploy_slot = u64::from_le_bytes(deploy_slot_bytes);
+            // The bank copy was fetched at `bank_slot`, so it already
+            // reflects every deploy up to that slot.
+            if deploy_slot <= bank_slot {
+                continue;
+            }
+            info!(
+                program_id = %program_id,
+                deploy_slot,
+                bank_slot,
+                "Programdata sweep detected missed program upgrade"
+            );
+            let companion_fetch_log_context = CompanionFetchLogContext {
+                origin: AccountFetchContext::subscription_update(
+                    AccountFetchReason::SubscriptionUpdateClone,
+                ),
+                primary_pubkey: program_id,
+                context_slot: deploy_slot,
+            };
+            let mut program_account = AccountSharedData::new(1, 0, &LOADER_V3);
+            program_account.set_remote_slot(deploy_slot);
+            self.handle_executable_sub_update(
+                program_id,
+                program_account,
+                &companion_fetch_log_context,
+            )
+            .await;
+        }
+    }
+
     fn record_program_materialization(
         &self,
         program_id: &Pubkey,
@@ -1512,6 +1669,15 @@ where
                             );
                         let result = self.cloner.clone_program(program).await;
                         if result.is_ok() {
+                            // Re-assert the watch after the bank insert: a
+                            // concurrent bank-miss cleanup may have released
+                            // it in the meantime (cleanups pop only while
+                            // the bank copy is absent, so none can follow
+                            // this point). Idempotent when it survived.
+                            if is_loaderv3 {
+                                let _ =
+                                    self.watch_programdata(program_id).await;
+                            }
                             metrics::inc_chainlink_clone_accounts_total_with_context(
                                 fetch_context.clone(),
                                 remote_result,

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/program_loader.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/program_loader.rs
@@ -116,12 +116,20 @@ where
         // cache; drop the stale entry (and the persistent programdata
         // watch held for it) and reload.
         this.program_verify_cache.lock().pop(&pubkey);
-        if this
-            .programdata_index
-            .lock()
-            .pop(&program_data_pubkey)
-            .is_some()
-        {
+        // Rechecked under the index lock: a concurrent clone that saw the
+        // entry (AlreadyInstalled) may have re-materialized the program
+        // after the miss above — its watch must survive. Both sides
+        // serialize on this lock and the clone re-asserts its watch after
+        // inserting into the bank, so every interleaving keeps a watch.
+        let released_watch = {
+            let mut index = this.programdata_index.lock();
+            if this.accounts_bank.get_account(&pubkey).is_none() {
+                index.pop(&program_data_pubkey).is_some()
+            } else {
+                false
+            }
+        };
+        if released_watch {
             this.remote_account_provider
                 .forget_subscription_reason(
                     &program_data_pubkey,

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -12411,3 +12411,84 @@ async fn test_skipped_program_clone_still_installs_programdata_watch() {
         "skipped clone must still install the programdata watch"
     );
 }
+
+/// A watch subscription can die upstream while local bookkeeping keeps it
+/// (e.g. lost across a provider reconnect), so no programdata notification
+/// ever arrives again. The periodic sweep must detect the upgrade over the
+/// fetch transport alone — and must stay a no-op while nothing changed.
+#[tokio::test]
+async fn test_programdata_sweep_detects_upgrade_without_notification() {
+    use crate::remote_account_provider::program_account::get_loaderv3_get_program_data_address;
+
+    init_logger();
+    let validator_keypair = Keypair::new();
+    let program_pubkey = random_pubkey();
+    let program_data_pubkey =
+        get_loaderv3_get_program_data_address(&program_pubkey);
+    const DEPLOY_SLOT: u64 = 90;
+    const CURRENT_SLOT: u64 = 100;
+    const UPGRADE_SLOT: u64 = 150;
+
+    let (program_account, program_data_account) =
+        loaderv3_program_accounts(&program_data_pubkey, DEPLOY_SLOT, &[7; 64]);
+
+    let FetcherTestCtx {
+        fetch_cloner,
+        rpc_client,
+        cloner,
+        ..
+    } = setup(
+        [
+            (program_pubkey, program_account.clone()),
+            (program_data_pubkey, program_data_account),
+        ],
+        CURRENT_SLOT,
+        validator_keypair.insecure_clone(),
+    )
+    .await;
+
+    let mut update = AccountSharedData::from(program_account.clone());
+    update.set_remote_slot(CURRENT_SLOT);
+    handle_executable_sub_update(&fetch_cloner, program_pubkey, update).await;
+    assert_eq!(cloner.program_clone_count(), 1);
+
+    // A sweep against unchanged chain state must not reload anything.
+    fetch_cloner.sweep_programdata_watches().await;
+    assert_eq!(cloner.program_clone_count(), 1);
+
+    // Upgrade on chain, but deliver NO subscription update: the watch's
+    // upstream subscription is dead.
+    let upgraded_elf = [9u8; 64];
+    let (_, upgraded_program_data) = loaderv3_program_accounts(
+        &program_data_pubkey,
+        UPGRADE_SLOT,
+        &upgraded_elf,
+    );
+    rpc_client.set_current_slot(UPGRADE_SLOT);
+    rpc_client.account_override_slot(&program_pubkey, UPGRADE_SLOT);
+    rpc_client.add_account(program_data_pubkey, upgraded_program_data);
+
+    // Clear the program verify throttle window.
+    tokio::time::sleep(Duration::from_millis(350)).await;
+
+    fetch_cloner.sweep_programdata_watches().await;
+
+    assert_eq!(
+        cloner.program_clone_count(),
+        2,
+        "sweep must reload the upgraded program"
+    );
+    let reloaded = cloner
+        .get_cloned_program(&program_pubkey)
+        .expect("program must be cloned");
+    assert_eq!(
+        reloaded.program_data, upgraded_elf,
+        "sweep reload must pick up the upgraded program data"
+    );
+    // The programdata account itself must not be cloned into the bank.
+    assert_not_cloned!(cloner, &[program_data_pubkey]);
+
+    // Once the reload settled, further sweeps are no-ops again.
+    fetch_cloner.sweep_programdata_watches().await;
+    assert_eq!(cloner.program_clone_count(), 2);
+}


### PR DESCRIPTION
## Problem

The persistent programdata watches from #1529 detect LoaderV3 upgrades only while their pubsub subscription is alive. A subscription can silently die upstream while local bookkeeping keeps it (ghost — e.g. lost across a provider reconnect), after which **no notification ever arrives again** and nothing detects or repairs the loss:

- `watch_programdata` returns `AlreadyInstalled` on a bare `programdata_index` hit, so re-clones (including read-forced ones) never re-subscribe.
- All upgrade checks were notification-driven: zero notifications ⇒ zero checks, forever.

## Fix

**Periodic transport-independent sweep** (`sweep_programdata_watches`, every 5 min): fetch a 12-byte programdata prefix (state tag + deploy slot) per watched program over RPC and route the program into the existing `handle_executable_sub_update` reload path when

```
deploy_slot > bank_program.remote_slot()
```

The bank copy was fetched at `remote_slot`, so it already reflects every deploy up to that slot — the criterion needs no stored baseline and cannot false-positive into spurious re-clones. Heals every ghost cause since it never touches pubsub. Bounded against unhealthy RPC endpoints by a rotating start cursor (no tail starvation) and a consecutive-failure breaker. Cost: one 12-byte `dataSlice` fetch per watched program per interval; detection latency for ghosted watches drops from ∞ to ≤ ~6 min.

**Watch-lifecycle race closed** (found during adversarial review): the notification-side bank-miss cleanup could pop the watch while a concurrent clone that had seen `AlreadyInstalled` was in flight, leaving the materialized program permanently unwatched. The cleanup now re-checks the bank under the index lock before popping, and the clone success path re-asserts the watch after materialization — every interleaving now ends with a materialized program holding a watch.

Known scope limit (documented): authority-only rotations keep the deploy slot and remain covered only by the live-subscription path; the sweep targets missed bytecode upgrades.

## Testing

- New test: upgrade with no notification delivered — the sweep alone must reload the program; sweeps are no-ops before the upgrade and after the reload; programdata is not cloned into the bank.
- Full `magicblock-chainlink` suite: 394 passed, including both #1529 regression tests. Clippy clean.
- Live-validated the diagnosis end-to-end on devnet-tee via probe-program upgrade experiments (fresh watches detect within 1 slot; deferred-verify burst path works).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and handling of program upgrades, including upgrades that occur without notifications.
  * Preserved upgrade monitoring when program cloning is skipped or temporarily fails.
  * Cleaned up outdated monitoring state when programs are removed or evicted.
* **Reliability**
  * Added bounded, automatically maintained monitoring for program data.
  * Improved executable reload behavior after detected updates.
  * Expanded coverage for delegation, collision, concurrency, and upgrade scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->