### PR TITLE
hotfix: restrict large commits

### DIFF
--- a/programs/magicblock/src/magic_scheduled_base_intent.rs
+++ b/programs/magicblock/src/magic_scheduled_base_intent.rs
@@ -19,6 +19,7 @@ use magicblock_magic_program_api::args::{
 };
 use serde::{Deserialize, Serialize};
 use solana_account::ReadableAccount;
+use solana_account_info::MAX_PERMITTED_DATA_INCREASE;
 use solana_hash::Hash;
 use solana_log_collector::ic_msg;
 use solana_program_runtime::{
@@ -533,6 +534,17 @@ fn validate_commit_type_accounts(
                 pubkey
             );
             return Err(InstructionError::IllegalOwner)
+        }
+
+        // Accounts larger than 10_240 bytes can't be committed
+        // TDOO: enable large commits and remove this
+        if account.to_account_shared_data()?.data().len() > MAX_PERMITTED_DATA_INCREASE {
+            ic_msg!(
+                context.invoke_context,
+                "ScheduleCommit ERR: account {} is too large to be committed",
+                pubkey
+            );
+            return Err(InstructionError::InvalidAccountData);
         }
 
         // Validate committed account was scheduled by valid authority

--- a/programs/magicblock/src/schedule_transactions/process_schedule_commit.rs
+++ b/programs/magicblock/src/schedule_transactions/process_schedule_commit.rs
@@ -6,6 +6,7 @@ use magicblock_core::intent::{
 };
 // no direct token remap helpers needed here; handled in CommittedAccount builder
 use solana_account::{ReadableAccount, WritableAccount};
+use solana_account_info::MAX_PERMITTED_DATA_INCREASE;
 use solana_instruction::error::InstructionError;
 use solana_log_collector::ic_msg;
 use solana_program_runtime::invoke_context::InvokeContext;
@@ -164,6 +165,19 @@ pub(crate) fn process_schedule_commit(
             ic_msg!(
                 invoke_context,
                 "ScheduleCommit ERR: account {} is ephemeral and cannot be committed to base chain",
+                acc_pubkey
+            );
+            return Err(InstructionError::InvalidAccountData);
+        }
+
+        // Accounts larger than 10_240 bytes can't be committed
+        // TDOO: enable large commits and remove this
+        if acc.to_account_shared_data()?.data().len()
+            > MAX_PERMITTED_DATA_INCREASE
+        {
+            ic_msg!(
+                invoke_context,
+                "ScheduleCommit ERR: account {} is too large to be committed",
                 acc_pubkey
             );
             return Err(InstructionError::InvalidAccountData);

--- a/programs/magicblock/src/schedule_transactions/process_schedule_commit_tests.rs
+++ b/programs/magicblock/src/schedule_transactions/process_schedule_commit_tests.rs
@@ -12,6 +12,7 @@ use magicblock_magic_program_api::{
 use solana_account::{
     create_account_shared_data_for_test, AccountSharedData, ReadableAccount,
 };
+use solana_account_info::MAX_PERMITTED_DATA_INCREASE;
 use solana_clock::Clock;
 use solana_fee_calculator::DEFAULT_TARGET_LAMPORTS_PER_SIGNATURE;
 use solana_instruction::{error::InstructionError, AccountMeta, Instruction};
@@ -1291,6 +1292,91 @@ mod tests {
             ix.accounts,
             Err(InstructionError::InvalidAccountData),
         );
+    }
+
+    #[test]
+    #[serial]
+    fn test_schedule_commit_with_too_large_account() {
+        init_logger!();
+
+        let payer =
+            Keypair::from_seed(b"schedule_commit_with_too_large_account")
+                .unwrap();
+        let program = Pubkey::new_unique();
+        let committee = Pubkey::new_unique();
+
+        let (mut account_data, mut transaction_accounts) =
+            prepare_transaction_with_single_committee(
+                &payer, program, committee,
+            );
+        // One byte past the cap: the delegated account could not be grown to
+        // this size on base chain within a single instruction.
+        account_data.get_mut(&committee).unwrap().set_data(vec![
+            7u8;
+            MAX_PERMITTED_DATA_INCREASE
+                + 1
+        ]);
+
+        let ix = InstructionUtils::schedule_commit_instruction(
+            &payer.pubkey(),
+            vec![committee],
+        );
+        extend_transaction_accounts_from_ix(
+            &ix,
+            &mut account_data,
+            &mut transaction_accounts,
+        );
+
+        process_instruction(
+            ix.data.as_slice(),
+            transaction_accounts.clone(),
+            ix.accounts,
+            Err(InstructionError::InvalidAccountData),
+        );
+    }
+
+    /// Pins the boundary: `MAX_PERMITTED_DATA_INCREASE` is the largest
+    /// *permitted* size, not the first rejected one. Solana's realloc check is
+    /// `post_len - pre_len > MAX_PERMITTED_DATA_INCREASE` (strictly greater),
+    /// so an account of exactly that size can still be grown/committed in one
+    /// instruction. This test fails if the check is ever tightened to `>=`.
+    #[test]
+    #[serial]
+    fn test_schedule_commit_with_max_size_account_succeeds() {
+        init_logger!();
+
+        let payer =
+            Keypair::from_seed(b"schedule_commit_with_max_size_account")
+                .unwrap();
+        let program = Pubkey::new_unique();
+        let committee = Pubkey::new_unique();
+
+        let (mut account_data, mut transaction_accounts) =
+            prepare_transaction_with_single_committee(
+                &payer, program, committee,
+            );
+        account_data
+            .get_mut(&committee)
+            .unwrap()
+            .set_data(vec![7u8; MAX_PERMITTED_DATA_INCREASE]);
+
+        let ix = InstructionUtils::schedule_commit_instruction(
+            &payer.pubkey(),
+            vec![committee],
+        );
+        extend_transaction_accounts_from_ix(
+            &ix,
+            &mut account_data,
+            &mut transaction_accounts,
+        );
+
+        let processed_scheduled = process_instruction(
+            ix.data.as_slice(),
+            transaction_accounts.clone(),
+            ix.accounts,
+            Ok(()),
+        );
+        assert_non_accepted_actions(&processed_scheduled, &payer.pubkey(), 1);
     }
 
     #[test]


### PR DESCRIPTION
<!--
Title: use `<type>: <description>`, with a Conventional Commit type and a
concise lowercase imperative description, without terminal punctuation.
Example: `feat: add state replicator crate`
-->

## What changed
<!-- Summarize the change at the immediate-parent diff boundary. -->
Here we prohibit scheduling commit of account that is larger than 10_240 threshold. 
TODO: This restriction will be removed once #878 will be resolved.

We consider this to be non-breaking(likely) change for users as on mainnet currently there're 0 delegated accounts larger than 10_240 cap on mainnet.

<!-- Replace ISSUE with the dedicated issue number. -->
Closes #ISSUE

## Impact
<!-- Note behavior, API, storage, compatibility, security, or performance effects. -->

## Reviewer notes
<!-- Point reviewers to invariants, sharp edges, or the highest-risk part of the diff. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented scheduling or committing accounts that exceed the permitted data-growth limit.
  * Oversized accounts now fail with an invalid account data error instead of being processed.

* **Tests**
  * Added coverage confirming oversized accounts are rejected.
  * Added coverage confirming accounts exactly at the permitted limit succeed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->