### PR TITLE
refactor(validator): unify shutdown coordination

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,7 +126,7 @@ dependencies = [
 [[package]]
 name = "agave-transaction-view"
 version = "4.1.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.1#cd021975429a9504f35d52dc9d5b0393a3c3e302"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.2#ea0a1581ee21670a0676f7c1f7583e0e49565523"
 dependencies = [
  "ahash 0.8.12",
  "solana-hash 4.4.0",
@@ -710,7 +710,7 @@ dependencies = [
  "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -3696,8 +3696,8 @@ dependencies = [
 
 [[package]]
 name = "magic-root-interface"
-version = "0.3.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.1#cd021975429a9504f35d52dc9d5b0393a3c3e302"
+version = "0.3.2"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.2#ea0a1581ee21670a0676f7c1f7583e0e49565523"
 dependencies = [
  "solana-account 4.3.1",
  "solana-instruction 3.4.0",
@@ -3707,8 +3707,8 @@ dependencies = [
 
 [[package]]
 name = "magic-root-program"
-version = "0.3.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.1#cd021975429a9504f35d52dc9d5b0393a3c3e302"
+version = "0.3.2"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.2#ea0a1581ee21670a0676f7c1f7583e0e49565523"
 dependencies = [
  "magic-root-interface",
  "magicblock-engine-nucleus",
@@ -3757,8 +3757,8 @@ dependencies = [
 
 [[package]]
 name = "magicblock-accountsdb"
-version = "0.3.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.1#cd021975429a9504f35d52dc9d5b0393a3c3e302"
+version = "0.3.2"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.2#ea0a1581ee21670a0676f7c1f7583e0e49565523"
 dependencies = [
  "ahash 0.8.12",
  "bincode",
@@ -3936,6 +3936,7 @@ dependencies = [
  "magicblock-core",
  "magicblock-delegation-program-api",
  "magicblock-engine",
+ "magicblock-engine-nucleus",
  "magicblock-metrics",
  "magicblock-program",
  "magicblock-rpc-client",
@@ -3985,6 +3986,7 @@ dependencies = [
  "solana-pubkey 4.2.0",
  "solana-signer",
  "tempfile",
+ "thiserror 2.0.18",
  "url",
 ]
 
@@ -4046,8 +4048,8 @@ dependencies = [
 
 [[package]]
 name = "magicblock-engine"
-version = "0.3.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.1#cd021975429a9504f35d52dc9d5b0393a3c3e302"
+version = "0.3.2"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.2#ea0a1581ee21670a0676f7c1f7583e0e49565523"
 dependencies = [
  "agave-transaction-view",
  "derive_more",
@@ -4079,8 +4081,8 @@ dependencies = [
 
 [[package]]
 name = "magicblock-engine-nucleus"
-version = "0.3.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.1#cd021975429a9504f35d52dc9d5b0393a3c3e302"
+version = "0.3.2"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.2#ea0a1581ee21670a0676f7c1f7583e0e49565523"
 dependencies = [
  "agave-transaction-view",
  "derive_more",
@@ -4111,8 +4113,8 @@ dependencies = [
 
 [[package]]
 name = "magicblock-keeper"
-version = "0.3.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.1#cd021975429a9504f35d52dc9d5b0393a3c3e302"
+version = "0.3.2"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.2#ea0a1581ee21670a0676f7c1f7583e0e49565523"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.12",
@@ -4150,8 +4152,8 @@ dependencies = [
 
 [[package]]
 name = "magicblock-ledger"
-version = "0.3.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.1#cd021975429a9504f35d52dc9d5b0393a3c3e302"
+version = "0.3.2"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.2#ea0a1581ee21670a0676f7c1f7583e0e49565523"
 dependencies = [
  "agave-transaction-view",
  "bitcode",
@@ -4224,17 +4226,17 @@ dependencies = [
  "hyper",
  "hyper-util",
  "lazy_static",
+ "magicblock-engine-nucleus",
  "prometheus",
  "solana-signature 3.4.1",
  "tokio",
- "tokio-util",
  "tracing",
 ]
 
 [[package]]
 name = "magicblock-processor"
-version = "0.3.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.1#cd021975429a9504f35d52dc9d5b0393a3c3e302"
+version = "0.3.2"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.2#ea0a1581ee21670a0676f7c1f7583e0e49565523"
 dependencies = [
  "agave-feature-set",
  "agave-precompiles",
@@ -4306,8 +4308,8 @@ dependencies = [
 
 [[package]]
 name = "magicblock-replicator"
-version = "0.3.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.1#cd021975429a9504f35d52dc9d5b0393a3c3e302"
+version = "0.3.2"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.2#ea0a1581ee21670a0676f7c1f7583e0e49565523"
 dependencies = [
  "derive_more",
  "flume",
@@ -4383,6 +4385,7 @@ dependencies = [
  "magicblock-core",
  "magicblock-delegation-program-api",
  "magicblock-engine",
+ "magicblock-engine-nucleus",
  "magicblock-magic-program-api",
  "magicblock-metrics",
  "magicblock-program",
@@ -4439,6 +4442,7 @@ dependencies = [
  "magicblock-config",
  "magicblock-core",
  "magicblock-engine",
+ "magicblock-engine-nucleus",
  "magicblock-keeper",
  "magicblock-program",
  "rusqlite",
@@ -4460,6 +4464,7 @@ dependencies = [
 name = "magicblock-validator"
 version = "0.14.11"
 dependencies = [
+ "anyhow",
  "console-subscriber",
  "magicblock-aperture",
  "magicblock-chainlink",
@@ -4486,12 +4491,12 @@ dependencies = [
  "solana-program 4.0.0",
  "solana-pubkey 4.2.0",
  "solana-rpc-client",
+ "solana-rpc-client-api",
  "solana-signer",
  "solana-transaction 4.1.5",
  "solana-transaction-error 3.3.1",
  "thiserror 2.0.18",
  "tokio",
- "tokio-util",
  "tracing",
 ]
 
@@ -4501,6 +4506,7 @@ version = "0.14.11"
 dependencies = [
  "magicblock-delegation-program-api",
  "magicblock-engine",
+ "magicblock-engine-nucleus",
  "magicblock-rpc-client",
  "solana-commitment-config",
  "solana-pubkey 4.2.0",
@@ -4510,7 +4516,6 @@ dependencies = [
  "solana-transaction 4.1.5",
  "thiserror 2.0.18",
  "tokio",
- "tokio-util",
  "tracing",
 ]
 
@@ -4547,7 +4552,6 @@ dependencies = [
  "magicblock-replicator",
  "magicblock-runtime",
  "tokio",
- "tokio-util",
  "tracing",
 ]
 
@@ -6740,7 +6744,7 @@ dependencies = [
 [[package]]
 name = "solana-account"
 version = "4.3.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.1#cd021975429a9504f35d52dc9d5b0393a3c3e302"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.2#ea0a1581ee21670a0676f7c1f7583e0e49565523"
 dependencies = [
  "bincode",
  "bitflags 2.13.0",
@@ -8353,7 +8357,7 @@ dependencies = [
 [[package]]
 name = "solana-program-runtime"
 version = "4.1.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.1#cd021975429a9504f35d52dc9d5b0393a3c3e302"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.2#ea0a1581ee21670a0676f7c1f7583e0e49565523"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -9078,7 +9082,7 @@ dependencies = [
 [[package]]
 name = "solana-svm"
 version = "4.1.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.1#cd021975429a9504f35d52dc9d5b0393a3c3e302"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.2#ea0a1581ee21670a0676f7c1f7583e0e49565523"
 dependencies = [
  "ahash 0.8.12",
  "magic-root-interface",
@@ -9465,7 +9469,7 @@ dependencies = [
 [[package]]
 name = "solana-transaction-context"
 version = "4.1.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.1#cd021975429a9504f35d52dc9d5b0393a3c3e302"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.2#ea0a1581ee21670a0676f7c1f7583e0e49565523"
 dependencies = [
  "bincode",
  "serde",
@@ -10103,7 +10107,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10382,10 +10386,7 @@ checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
- "futures-io",
  "futures-sink",
- "futures-util",
- "hashbrown 0.15.5",
  "pin-project-lite",
  "slab",
  "tokio",
@@ -10905,8 +10906,8 @@ dependencies = [
 
 [[package]]
 name = "v42-calculator-interface"
-version = "0.3.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.1#cd021975429a9504f35d52dc9d5b0393a3c3e302"
+version = "0.3.2"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.2#ea0a1581ee21670a0676f7c1f7583e0e49565523"
 dependencies = [
  "solana-instruction 3.4.0",
  "solana-pubkey 4.2.0",
@@ -11178,7 +11179,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,12 +65,12 @@ magicblock-task-scheduler = { path = "magicblock-task-scheduler" }
 magicblock-validator-admin = { path = "magicblock-validator-admin" }
 magicblock-version = { path = "magicblock-version" }
 
-engine = { package = "magicblock-engine", git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.1" }
-keeper = { package = "magicblock-keeper", git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.1" }
-ledger = { package = "magicblock-ledger", git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.1" }
-nucleus = { package = "magicblock-engine-nucleus", git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.1" }
-replicator = { package = "magicblock-replicator", git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.1" }
-v42-calculator-interface = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.1" }
+engine = { package = "magicblock-engine", git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.2" }
+keeper = { package = "magicblock-keeper", git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.2" }
+ledger = { package = "magicblock-ledger", git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.2" }
+nucleus = { package = "magicblock-engine-nucleus", git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.2" }
+replicator = { package = "magicblock-replicator", git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.2" }
+v42-calculator-interface = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.2" }
 
 agave-geyser-plugin-interface = { version = "4.1" }
 agave-precompiles = { version = "4.1", features = ["agave-unstable-api"] }
@@ -231,8 +231,8 @@ spl-token-2022 = { package = "spl-token-2022-interface", version = "2.1" }
 [patch.crates-io]
 libsodium-rs = { git = "https://github.com/jedisct1/libsodium-rs.git", rev = "0397a6c5785233f9f2ac91f3eedc3cceb74e0060" }
 
-agave-transaction-view = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.1" }
-solana-account = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.1" }
-solana-program-runtime = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.1" }
-solana-svm = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.1" }
-solana-transaction-context = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.1" }
+agave-transaction-view = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.2" }
+solana-account = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.2" }
+solana-program-runtime = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.2" }
+solana-svm = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.2" }
+solana-transaction-context = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.2" }

--- a/bins/magicblock-validator/Cargo.toml
+++ b/bins/magicblock-validator/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
+anyhow = { workspace = true }
 engine = { workspace = true }
 magicblock-aperture = { workspace = true }
 magicblock-chainlink = { workspace = true }
@@ -34,12 +35,12 @@ solana-native-token = { workspace = true }
 solana-program = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-rpc-client = { workspace = true }
+solana-rpc-client-api = { workspace = true }
 solana-signer = { workspace = true }
 solana-transaction = { workspace = true }
 solana-transaction-error = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
-tokio-util = { workspace = true }
 tracing = { workspace = true }
 
 console-subscriber = { workspace = true, optional = true }

--- a/bins/magicblock-validator/src/errors.rs
+++ b/bins/magicblock-validator/src/errors.rs
@@ -1,5 +1,16 @@
-use magicblock_committor_service::service::IntentExecutionServiceError;
+use std::io;
+
+use engine::EngineError;
+use magicblock_aperture::ApertureError;
+use magicblock_chainlink::errors::ChainlinkError;
+use magicblock_committor_service::error::CommittorServiceError;
+use magicblock_ledger_deprecated::errors::LedgerError;
+use magicblock_runtime::Error as RuntimeError;
+use magicblock_task_scheduler::TaskSchedulerError;
+use replicator::ReplicationError;
 use solana_pubkey::Pubkey;
+use solana_rpc_client_api::client_error::Error as RpcClientError;
+use solana_transaction_error::TransactionError;
 use thiserror::Error;
 
 pub type ApiResult<T> = std::result::Result<T, ApiError>;
@@ -7,28 +18,31 @@ pub type ApiResult<T> = std::result::Result<T, ApiError>;
 #[derive(Debug, Error)]
 pub enum ApiError {
     #[error("IO error: {0}")]
-    IoError(#[from] std::io::Error),
+    IoError(#[from] io::Error),
 
     #[error("Aperture service error: {0}")]
-    Aperture(#[from] magicblock_aperture::ApertureError),
+    Aperture(#[from] ApertureError),
 
     #[error("Ledger error: {0}")]
-    LedgerError(Box<magicblock_ledger_deprecated::errors::LedgerError>),
+    LedgerError(Box<LedgerError>),
 
     #[error("Engine error: {0}")]
-    Engine(#[from] engine::EngineError),
+    Engine(#[from] EngineError),
 
     #[error("Replication error: {0}")]
-    Replication(#[from] replicator::ReplicationError),
+    Replication(#[from] ReplicationError),
 
     #[error("Runtime image error: {0}")]
-    Runtime(#[from] magicblock_runtime::Error),
+    Runtime(#[from] RuntimeError),
 
     #[error("Chainlink error: {0}")]
-    ChainlinkError(Box<magicblock_chainlink::errors::ChainlinkError>),
+    ChainlinkError(Box<ChainlinkError>),
 
-    #[error("Failed to obtain balance for validator '{0}' from chain. ({1})")]
-    FailedToObtainValidatorOnChainBalance(Pubkey, String),
+    #[error("Failed to obtain balance for validator '{0}' from chain: {1}")]
+    FailedToObtainValidatorOnChainBalance(
+        Pubkey,
+        #[source] Box<RpcClientError>,
+    ),
 
     #[error(
         "Validator '{0}' is insufficiently funded on chain. Minimum is ({1} SOL)"
@@ -36,66 +50,53 @@ pub enum ApiError {
     ValidatorInsufficientlyFunded(Pubkey, u64),
 
     #[error("Failed to initialize magic fee vault for validator '{0}': {1}")]
-    FailedToInitMagicFeeVault(Pubkey, String),
+    FailedToInitMagicFeeVault(Pubkey, #[source] Box<RpcClientError>),
 
     #[error("Failed to delegate magic fee vault for validator '{0}': {1}")]
-    FailedToDelegateMagicFeeVault(Pubkey, String),
+    FailedToDelegateMagicFeeVault(Pubkey, #[source] Box<RpcClientError>),
 
     #[error("On-chain setup transaction for validator '{0}' was rejected: {1}")]
-    OnchainSetupTransactionRejected(Pubkey, String),
+    OnchainSetupTransactionRejected(Pubkey, #[source] TransactionError),
 
     #[error("CommittorServiceError")]
-    CommittorServiceError(
-        Box<magicblock_committor_service::error::CommittorServiceError>,
-    ),
-
-    #[error("IntentExecutionServiceError: {0}")]
-    IntentExecutionServiceError(#[from] IntentExecutionServiceError),
+    CommittorServiceError(Box<CommittorServiceError>),
 
     #[error("Unable to clean ledger directory at '{0}'")]
     UnableToCleanLedgerDirectory(String),
 
     #[error("Failed to start metrics service: {0}")]
-    FailedToStartMetricsService(std::io::Error),
+    FailedToStartMetricsService(io::Error),
 
     #[error("Ledger Path is missing a parent directory: {0}")]
     LedgerPathIsMissingParent(String),
 
     #[error("TaskSchedulerServiceError")]
-    TaskSchedulerServiceError(
-        Box<magicblock_task_scheduler::TaskSchedulerError>,
-    ),
+    TaskSchedulerServiceError(Box<TaskSchedulerError>),
 
     #[error("Failed to sanitize transaction: {0}")]
-    FailedToSanitizeTransaction(
-        #[from] solana_transaction_error::TransactionError,
-    ),
+    FailedToSanitizeTransaction(#[from] TransactionError),
 }
 
-impl From<magicblock_ledger_deprecated::errors::LedgerError> for ApiError {
-    fn from(e: magicblock_ledger_deprecated::errors::LedgerError) -> Self {
+impl From<LedgerError> for ApiError {
+    fn from(e: LedgerError) -> Self {
         Self::LedgerError(Box::new(e))
     }
 }
 
-impl From<magicblock_chainlink::errors::ChainlinkError> for ApiError {
-    fn from(e: magicblock_chainlink::errors::ChainlinkError) -> Self {
+impl From<ChainlinkError> for ApiError {
+    fn from(e: ChainlinkError) -> Self {
         Self::ChainlinkError(Box::new(e))
     }
 }
 
-impl From<magicblock_committor_service::error::CommittorServiceError>
-    for ApiError
-{
-    fn from(
-        e: magicblock_committor_service::error::CommittorServiceError,
-    ) -> Self {
+impl From<CommittorServiceError> for ApiError {
+    fn from(e: CommittorServiceError) -> Self {
         Self::CommittorServiceError(Box::new(e))
     }
 }
 
-impl From<magicblock_task_scheduler::TaskSchedulerError> for ApiError {
-    fn from(e: magicblock_task_scheduler::TaskSchedulerError) -> Self {
+impl From<TaskSchedulerError> for ApiError {
+    fn from(e: TaskSchedulerError) -> Self {
         Self::TaskSchedulerServiceError(Box::new(e))
     }
 }

--- a/bins/magicblock-validator/src/leader.rs
+++ b/bins/magicblock-validator/src/leader.rs
@@ -1,13 +1,13 @@
 use std::{
     sync::{Arc, atomic::AtomicU64},
-    thread,
     time::Duration,
 };
 
 use engine::Engine;
 use magicblock_aperture::{SharedState, initialize_aperture};
 use magicblock_chainlink::{
-    ProdChainlink, config::ChainlinkConfig, remote_account_provider::Endpoints,
+    ProdChainlink, config::ChainlinkConfig, errors::ChainlinkError,
+    remote_account_provider::Endpoints,
 };
 use magicblock_committor_service::{
     ComputeBudgetConfig, DEFAULT_ACTIONS_TIMEOUT,
@@ -24,16 +24,17 @@ use magicblock_services::{
     undelegation_request_service::UndelegationRequestService,
 };
 use magicblock_task_scheduler::{SchedulerDatabase, TaskSchedulerService};
-use magicblock_validator_admin::claim_fees::{ClaimFeesTask, claim_fees};
-use nucleus::{metrics::EventTimer, shutdown::ShutdownManager};
+use magicblock_validator_admin::claim_fees::{claim_fees, run_claim_fees_loop};
+use nucleus::{
+    metrics::EventTimer,
+    shutdown::{Service, ShutdownManager, ShutdownReason},
+};
 use replicator::ReplicationDispatcher;
 use solana_commitment_config::{CommitmentConfig, CommitmentLevel};
 use solana_native_token::LAMPORTS_PER_SOL;
 use solana_pubkey::Pubkey;
 use solana_rpc_client::nonblocking::rpc_client::RpcClient;
 use solana_signer::Signer;
-use tokio::runtime::Builder;
-use tokio_util::sync::CancellationToken;
 use tracing::*;
 
 use crate::{
@@ -52,14 +53,11 @@ type IntentExecutionServiceImpl =
 // -----------------
 pub struct Leader {
     config: LeaderParams,
-    token: CancellationToken,
     engine: Engine,
-    pub(crate) shutdown: ShutdownManager,
-    intent_execution_service: IntentExecutionServiceImpl,
-    undelegation_request_service: Arc<UndelegationRequestService>,
-    rpc_handle: thread::JoinHandle<()>,
-    _metrics: MetricsService,
-    claim_fees_task: ClaimFeesTask,
+    shutdown: ShutdownManager,
+    intent_execution_service: Option<IntentExecutionServiceImpl>,
+    undelegation_request_service: Option<UndelegationRequestService>,
+    metrics: Option<MetricsService>,
     task_scheduler: Option<TaskSchedulerService>,
 }
 
@@ -70,7 +68,6 @@ impl Leader {
     #[instrument(skip_all, fields(last_slot = tracing::field::Empty))]
     pub async fn try_from_config(config: LeaderParams) -> ApiResult<Self> {
         let mut timer = EventTimer::new("init");
-        let token = CancellationToken::new();
 
         let engine_ledger = config.engine.ledger.directory.clone();
         init_validator_authority(config.engine.authority.local.clone());
@@ -101,7 +98,7 @@ impl Leader {
         )
         .await;
         if let Err(error) = replication {
-            shutdown.terminate().await;
+            let _ = shutdown.terminate().await;
             return Err(error.into());
         }
         timer.record("Replication dispatcher started");
@@ -127,7 +124,6 @@ impl Leader {
             &engine,
             &committor_processor,
             config.engine.blockstore.blocktime,
-            &token,
         );
         timer.record("Committor service initialized");
         init_magic_sys(Arc::new(MagicSysAdapter::new(
@@ -136,41 +132,38 @@ impl Leader {
         )));
         timer.record("Magic syscall adapter initialized");
 
-        let metrics_service = magicblock_metrics::try_start_metrics_service(
-            config.metrics.address.0,
-            token.clone(),
-        )
-        .map_err(ApiError::FailedToStartMetricsService)?;
-        timer.record("Metrics service started");
+        let metrics = MetricsService::bind(config.metrics.address.0)
+            .await
+            .map_err(ApiError::FailedToStartMetricsService)?;
+        timer.record("Metrics service bound");
 
-        let undelegation_request_service =
-            Arc::new(UndelegationRequestService::new(
-                chainlink.clone(),
-                engine.clone(),
-                config.chainlink.undelegation_request_poll_interval,
-            ));
+        let undelegation_request_service = UndelegationRequestService::new(
+            chainlink.clone(),
+            engine.clone(),
+            config.chainlink.undelegation_request_poll_interval,
+        );
         let shared_state = SharedState::new(
             engine.clone(),
             ledger.clone(),
             chainlink.clone(),
             config.engine.blockstore.blocktime.as_millis() as u64,
         );
-        let rpc =
-            initialize_aperture(&config.aperture, shared_state, token.clone())
-                .await?;
+        let mut rpc_shutdown = shutdown.handle(Service::Rpc);
+        let rpc = initialize_aperture(
+            &config.aperture,
+            shared_state,
+            rpc_shutdown.child(),
+        )
+        .await?;
         timer.record("RPC service initialized");
-        let rpc_handle = thread::spawn(move || {
-            let workers = (num_cpus::get() / 2).saturating_sub(1).max(1);
-            let runtime = Builder::new_multi_thread()
-                .worker_threads(workers)
-                .enable_all()
-                .thread_name("rpc-worker")
-                .build()
-                .expect("failed to bulid async runtime for rpc service");
-            runtime.block_on(rpc.run());
-
-            drop(runtime);
-            info!("RPC runtime shutdown");
+        tokio::spawn(async move {
+            rpc.run().await;
+            let reason = if rpc_shutdown.requested() {
+                ShutdownReason::Signalled
+            } else {
+                ShutdownReason::Unexpected
+            };
+            rpc_shutdown.terminate(reason);
         });
 
         let task_scheduler_db_path = SchedulerDatabase::path(&engine_ledger);
@@ -180,20 +173,16 @@ impl Leader {
             &config.task_scheduler,
             engine.clone(),
             config.engine.blockstore.blocktime,
-            token.clone(),
         )?);
         timer.record("Task scheduler initialized");
 
         Ok(Self {
             config,
-            _metrics: metrics_service,
             engine,
             shutdown,
-            intent_execution_service,
-            undelegation_request_service,
-            token,
-            claim_fees_task: ClaimFeesTask::new(),
-            rpc_handle,
+            intent_execution_service: Some(intent_execution_service),
+            undelegation_request_service: Some(undelegation_request_service),
+            metrics: Some(metrics),
             task_scheduler,
         })
     }
@@ -242,7 +231,6 @@ impl Leader {
         engine: &Engine,
         committor_processor: &Arc<CommittorProcessor>,
         slot_interval: Duration,
-        cancellation_token: &CancellationToken,
     ) -> IntentExecutionServiceImpl {
         let intent_client = InternalIntentRpcClient::new(engine.clone());
 
@@ -251,7 +239,6 @@ impl Leader {
             intent_client,
             committor_processor.clone(),
             slot_interval,
-            cancellation_token.clone(),
         )
     }
 
@@ -262,11 +249,7 @@ impl Leader {
         chain_slot: Arc<AtomicU64>,
     ) -> ApiResult<ChainlinkImpl> {
         let endpoints = Endpoints::try_from(config.remotes.as_slice())
-            .map_err(|e| {
-                ApiError::from(
-                    magicblock_chainlink::errors::ChainlinkError::from(e),
-                )
-            })?;
+            .map_err(ChainlinkError::from)?;
 
         let mut chainlink_config = ChainlinkConfig::default_with_lifecycle_mode(
             LifecycleMode::Ephemeral,
@@ -275,11 +258,7 @@ impl Leader {
             .remote_account_provider
             .with_resubscription_delay(config.chainlink.resubscription_delay)
             .map(|conf| conf.with_grpc(config.grpc.clone()))
-            .map_err(|err| {
-                ApiError::from(
-                    magicblock_chainlink::errors::ChainlinkError::from(err),
-                )
-            })?;
+            .map_err(ChainlinkError::from)?;
         let commitment_config = {
             let level = CommitmentLevel::Confirmed;
             CommitmentConfig { commitment: level }
@@ -316,7 +295,7 @@ impl Leader {
         .map_err(|err| {
             ApiError::FailedToObtainValidatorOnChainBalance(
                 identity,
-                err.to_string(),
+                Box::new(err),
             )
         })?;
         if lamports < MIN_BALANCE_SOL * LAMPORTS_PER_SOL {
@@ -353,7 +332,7 @@ impl Leader {
             .map_err(|err| {
                 ApiError::FailedToInitMagicFeeVault(
                     validator_pubkey,
-                    err.to_string(),
+                    Box::new(err),
                 )
             })?;
 
@@ -370,7 +349,7 @@ impl Leader {
                 rpc.get_latest_blockhash().await.map_err(|err| {
                     ApiError::FailedToInitMagicFeeVault(
                         validator_pubkey,
-                        err.to_string(),
+                        Box::new(err),
                     )
                 })?;
             let tx = solana_transaction::Transaction::new_signed_with_payer(
@@ -383,11 +362,11 @@ impl Leader {
                 |err| match err.get_transaction_error() {
                     Some(tx_err) => ApiError::OnchainSetupTransactionRejected(
                         validator_pubkey,
-                        tx_err.to_string(),
+                        tx_err,
                     ),
                     None => ApiError::FailedToInitMagicFeeVault(
                         validator_pubkey,
-                        err.to_string(),
+                        Box::new(err),
                     ),
                 },
             )?;
@@ -406,7 +385,7 @@ impl Leader {
                 rpc.get_latest_blockhash().await.map_err(|err| {
                     ApiError::FailedToDelegateMagicFeeVault(
                         validator_pubkey,
-                        err.to_string(),
+                        Box::new(err),
                     )
                 })?;
             let tx = solana_transaction::Transaction::new_signed_with_payer(
@@ -419,11 +398,11 @@ impl Leader {
                 |err| match err.get_transaction_error() {
                     Some(tx_err) => ApiError::OnchainSetupTransactionRejected(
                         validator_pubkey,
-                        tx_err.to_string(),
+                        tx_err,
                     ),
                     None => ApiError::FailedToDelegateMagicFeeVault(
                         validator_pubkey,
-                        err.to_string(),
+                        Box::new(err),
                     ),
                 },
             )?;
@@ -473,19 +452,18 @@ impl Leader {
         }
     }
 
-    fn spawn_primary_onchain_setup(&self) {
+    fn spawn_primary_onchain_setup(&mut self) {
         let engine = self.engine.clone();
         let rpc_url = self.config.rpc_url().to_owned();
         let identity = self.engine.authority();
         let admin = self.config.admin.clone();
-        let token = self.token.clone();
 
+        let mut shutdown = self.shutdown.handle(Service::OnchainSetup);
         // Ephemeral mode does a non-blocking startup balance check.
-        // Intentionally fire-and-forget: the task itself exits the process on failure.
         tokio::spawn(async move {
             let setup = async move {
                 let mut timer = EventTimer::new("onchain-setup");
-                let result = Self::with_onchain_setup_retries(
+                Self::with_onchain_setup_retries(
                     "ensure_funded_on_chain",
                     || {
                         Leader::ensure_validator_funded_on_chain(
@@ -494,15 +472,10 @@ impl Leader {
                         )
                     },
                 )
-                .await;
+                .await?;
                 timer.record("Validator balance checked");
-                if let Err(err) = result {
-                    error!(error = ?err, "Validator balance check failed");
-                    error!("Exiting process");
-                    std::process::exit(1);
-                }
 
-                let result = Self::with_onchain_setup_retries(
+                Self::with_onchain_setup_retries(
                     "ensure_magic_fee_vault_on_chain",
                     || {
                         Leader::ensure_magic_fee_vault_on_chain(
@@ -511,16 +484,9 @@ impl Leader {
                         )
                     },
                 )
-                .await;
+                .await?;
                 timer.record("Magic fee vault setup attempt completed");
 
-                // Without magic fee vault being properly set up
-                // transactions scheduling commits will fail
-                if let Err(err) = result {
-                    error!(error = ?err, "Magic fee vault setup failed");
-                    error!("Exiting process");
-                    std::process::exit(1);
-                }
                 if let Some(ref config) = admin
                     && !config.claim_fees_frequency.is_zero()
                 {
@@ -533,24 +499,39 @@ impl Leader {
                     }
                     timer.record("Startup fee claim attempt completed");
                 }
+                ApiResult::Ok(())
             };
-            tokio::select! {
-                _ = token.cancelled() => {
-                    debug!("On-chain setup cancelled by shutdown")
+            let result = tokio::select! {
+                _ = shutdown.signalled() => {
+                    debug!("On-chain setup cancelled by shutdown");
+                    ApiResult::Ok(())
                 }
-                _ = setup => {}
-            }
+                result = setup => result,
+            };
+            let reason = match result {
+                Err(error) => ShutdownReason::Error(Box::new(error)),
+                Ok(()) => {
+                    shutdown.signalled().await;
+                    ShutdownReason::Signalled
+                }
+            };
+            shutdown.terminate(reason);
         });
     }
 
     #[instrument(skip(self))]
-    pub async fn start(&mut self) -> ApiResult<()> {
+    pub fn start(&mut self) {
         let mut timer = EventTimer::new("startup");
         if matches!(self.config.lifecycle, LifecycleMode::Ephemeral) {
             self.spawn_primary_onchain_setup();
         }
 
-        self.undelegation_request_service.start();
+        let undelegation_request_service = self
+            .undelegation_request_service
+            .take()
+            .expect("undelegation request service starts once");
+        let shutdown = self.shutdown.handle(Service::UndelegationRequests);
+        tokio::spawn(undelegation_request_service.run(shutdown));
         timer.record("Undelegation request service started");
 
         // Now we are ready to start all services and are ready to accept transactions
@@ -561,81 +542,38 @@ impl Leader {
             .filter(|co| !co.claim_fees_frequency.is_zero())
             .map(|co| co.claim_fees_frequency)
         {
-            self.claim_fees_task.start(
-                self.engine.clone(),
-                frequency,
-                self.config.rpc_url().to_owned(),
-            );
+            let engine = self.engine.clone();
+            let rpc_url = self.config.rpc_url().to_owned();
+            let shutdown = self.shutdown.handle(Service::FeeClaim);
+            tokio::spawn(run_claim_fees_loop(
+                engine, shutdown, frequency, rpc_url,
+            ));
             timer.record("Fee claim task started");
         }
 
-        self.intent_execution_service.start()?;
+        let intent_execution_service = self
+            .intent_execution_service
+            .take()
+            .expect("intent execution service starts once");
+        let shutdown = self.shutdown.handle(Service::IntentExecution);
+        tokio::spawn(intent_execution_service.run(shutdown));
         timer.record("Intent execution service started");
 
-        // TODO: we should shutdown gracefully.
-        // This is discussed in this comment:
-        // https://github.com/magicblock-labs/magicblock-validator/pull/493#discussion_r2324560798
-        // However there is no proper solution for this right now.
-        // An issue to create a shutdown system is open here:
-        // https://github.com/magicblock-labs/magicblock-validator/issues/524
         if let Some(task_scheduler) = self.task_scheduler.take() {
-            tokio::spawn(async move {
-                let join_handle = {
-                    let mut timer = EventTimer::new("task-scheduler");
-                    let handle = match task_scheduler.start().await {
-                        Ok(join_handle) => join_handle,
-                        Err(err) => {
-                            error!(error = ?err, "Failed to start task scheduler");
-                            error!("Exiting process");
-                            std::process::exit(1);
-                        }
-                    };
-                    timer.record("Task scheduler started");
-                    handle
-                };
-
-                match join_handle.await {
-                    Ok(Ok(())) => {}
-                    Ok(Err(err)) => {
-                        error!(error = ?err, "Task scheduler failed");
-                        error!("Exiting process");
-                        std::process::exit(1);
-                    }
-                    Err(err) => {
-                        error!(error = ?err, "Task scheduler join failed");
-                        error!("Exiting process");
-                        std::process::exit(1);
-                    }
-                }
-            });
+            let shutdown = self.shutdown.handle(Service::TaskScheduler);
+            tokio::spawn(task_scheduler.run(shutdown));
+            timer.record("Task scheduler started");
         }
 
-        Ok(())
+        let metrics = self.metrics.take().expect("metrics service starts once");
+        let shutdown = self.shutdown.handle(Service::Metrics);
+        tokio::spawn(metrics.run(shutdown));
+        timer.record("Metrics service started");
     }
 
     #[instrument(skip(self))]
-    pub async fn stop(mut self) {
-        let mut timer = EventTimer::new("shutdown");
-
-        // Stop request ingress before stopping intent execution so shutdown
-        // does not admit new local undelegation scheduling work.
-        self.token.cancel();
-
-        let _ = self.rpc_handle.join();
-        timer.record("RPC thread stopped");
-
-        self.undelegation_request_service.stop();
-        timer.record("Undelegation request service stopped");
-
-        if let Err(err) = self.intent_execution_service.stop().await {
-            error!(error =? err, "Failure during stopping Intent Execution Service")
-        }
-        timer.record("Intent execution service stopped");
-
-        self.claim_fees_task.stop().await;
-        timer.record("Fee claim task stopped");
-
-        self.shutdown.terminate().await;
-        timer.record("Validator shutdown completed");
+    pub async fn wait(&mut self) -> ShutdownReason {
+        let reason = self.shutdown.wait().await;
+        reason.combine(self.shutdown.terminate().await)
     }
 }

--- a/bins/magicblock-validator/src/main.rs
+++ b/bins/magicblock-validator/src/main.rs
@@ -28,8 +28,9 @@ fn main() -> ExitCode {
 }
 
 fn try_main() -> Result<ShutdownReason> {
-    // Reserve most CPUs for blocking I/O, RPC, and engine execution.
-    let workers = (num_cpus::get() / 4).max(1);
+    // RPC and other async services share this runtime. Use half the CPUs minus
+    // one, leaving capacity for engine execution and blocking work.
+    let workers = (num_cpus::get() / 2).saturating_sub(1).max(1);
     let runtime = Builder::new_multi_thread()
         .worker_threads(workers)
         .enable_all()

--- a/bins/magicblock-validator/src/main.rs
+++ b/bins/magicblock-validator/src/main.rs
@@ -3,8 +3,11 @@ mod leader;
 mod ledger;
 mod magic_sys_adapter;
 
+use std::process::ExitCode;
+
+use anyhow::{Context, Result};
 use leader::Leader;
-use magicblock_config::LeaderParams;
+use magicblock_config::{ConfigError, LeaderParams};
 use nucleus::shutdown::ShutdownReason;
 use solana_signer::Signer;
 use tokio::runtime::Builder;
@@ -17,7 +20,14 @@ fn init_logger() {
     });
 }
 
-fn main() {
+fn main() -> ExitCode {
+    init_logger();
+    let reason =
+        try_main().unwrap_or_else(|error| ShutdownReason::Error(error.into()));
+    exit(reason)
+}
+
+fn try_main() -> Result<ShutdownReason> {
     // Reserve most CPUs for blocking I/O, RPC, and engine execution.
     let workers = (num_cpus::get() / 4).max(1);
     let runtime = Builder::new_multi_thread()
@@ -25,21 +35,17 @@ fn main() {
         .enable_all()
         .thread_name("async-runtime")
         .build()
-        .expect("failed to build async runtime");
-    runtime.block_on(run());
+        .context("failed to build leader async runtime")?;
+    let result = runtime.block_on(run());
     info!("main runtime shutdown");
+    result
 }
 
 #[instrument(skip_all)]
-async fn run() {
-    let config = match LeaderParams::try_new(std::env::args_os()) {
-        Ok(config) => config,
-        Err(error) => {
-            eprintln!("Failed to read leader config: {error}");
-            std::process::exit(1);
-        }
+async fn run() -> Result<ShutdownReason> {
+    let Some(config) = load_config()? else {
+        return Ok(ShutdownReason::Signalled);
     };
-    init_logger();
 
     info!("Starting leader\n{config}");
     let rpc_url = config.aperture.listen.http();
@@ -47,30 +53,34 @@ async fn run() {
     let identity = config.engine.authority.local.pubkey().to_string();
     let remote_rpc_url = config.rpc_url().to_owned();
 
-    let mut leader = match Leader::try_from_config(config).await {
-        Ok(leader) => leader,
-        Err(error) => {
-            error!(%error, "Failed to create leader runtime");
-            std::process::exit(1);
-        }
-    };
+    let mut leader = Leader::try_from_config(config)
+        .await
+        .context("failed to create leader runtime")?;
 
-    if let Err(error) = leader.start().await {
-        error!(%error, "Failed to start leader services");
-        leader.stop().await;
-        std::process::exit(1);
-    }
+    leader.start();
 
     print_startup(&rpc_url, &ws_url, &remote_rpc_url, &identity);
-    let cause = leader.shutdown.wait().await;
-    let failed = !matches!(cause, ShutdownReason::Signalled);
-    if failed {
-        error!(?cause, "Engine service terminated before leader shutdown");
-    }
+    Ok(leader.wait().await)
+}
 
-    leader.stop().await;
-    if failed {
-        std::process::exit(1);
+fn exit(reason: ShutdownReason) -> ExitCode {
+    let code = reason.exit_code();
+    if code == 0 {
+        info!(exit_code = code, "process terminated cleanly");
+    } else {
+        error!(?reason, exit_code = code, "process terminated");
+    }
+    ExitCode::from(code)
+}
+
+fn load_config() -> Result<Option<LeaderParams>> {
+    match LeaderParams::try_new(std::env::args_os()) {
+        Ok(config) => Ok(Some(config)),
+        Err(ConfigError::Cli(error)) if error.exit_code() == 0 => {
+            error.print().context("failed to print leader help")?;
+            Ok(None)
+        }
+        Err(error) => Err(error).context("failed to load leader config"),
     }
 }
 

--- a/bins/magicblock-verifier/Cargo.toml
+++ b/bins/magicblock-verifier/Cargo.toml
@@ -18,5 +18,4 @@ magicblock-runtime = { workspace = true }
 nucleus = { workspace = true }
 replicator = { workspace = true }
 tokio = { workspace = true }
-tokio-util = { workspace = true }
 tracing = { workspace = true }

--- a/bins/magicblock-verifier/src/main.rs
+++ b/bins/magicblock-verifier/src/main.rs
@@ -1,11 +1,12 @@
+use std::process::ExitCode;
+
 use anyhow::{Context, Result};
 use engine::Engine;
-use magicblock_config::VerifierParams;
-use nucleus::shutdown::{ShutdownManager, ShutdownReason};
+use magicblock_config::{ConfigError, VerifierParams};
+use nucleus::shutdown::{Service, ShutdownManager, ShutdownReason};
 use replicator::ReplicationClient;
 use tokio::sync::mpsc;
-use tokio_util::sync::CancellationToken;
-use tracing::info;
+use tracing::{error, info};
 
 fn init_logger() {
     use magicblock_core::logger::{LogStyle, LoggingConfig, init_with_config};
@@ -15,31 +16,52 @@ fn init_logger() {
 }
 
 #[tokio::main(flavor = "current_thread")]
-async fn main() -> Result<()> {
+async fn main() -> ExitCode {
     init_logger();
-    let config = VerifierParams::try_new(std::env::args_os())
-        .map_err(|error| anyhow::anyhow!(error.to_string()))
-        .context("failed to load verifier config")?;
+    let reason = run()
+        .await
+        .unwrap_or_else(|error| ShutdownReason::Error(error.into()));
+    exit(reason)
+}
+
+async fn run() -> Result<ShutdownReason> {
+    let Some(config) = load_config()? else {
+        return Ok(ShutdownReason::Signalled);
+    };
     info!(config = ?config, "starting verifier");
 
-    let metrics_token = CancellationToken::new();
-    let _metrics = magicblock_metrics::try_start_metrics_service(
-        config.metrics.address.0,
-        metrics_token.clone(),
-    )
-    .context("failed to start metrics service")?;
-    let _metrics_guard = metrics_token.drop_guard();
+    let metrics =
+        magicblock_metrics::MetricsService::bind(config.metrics.address.0)
+            .await
+            .context("failed to bind metrics service")?;
+    let mut metrics_shutdown = ShutdownManager::default();
+    let shutdown = metrics_shutdown.handle(Service::Metrics);
+    tokio::spawn(metrics.run(shutdown));
 
     loop {
-        let restart = run(&config).await?;
-        if !restart {
-            return Ok(());
+        let reason = run_engine(&config, &mut metrics_shutdown).await?;
+        if !matches!(&reason, ShutdownReason::RestartRequired) {
+            return Ok(reason.combine(metrics_shutdown.terminate().await));
         }
         info!("restarting the verifier");
     }
 }
 
-async fn run(config: &VerifierParams) -> Result<bool> {
+fn load_config() -> Result<Option<VerifierParams>> {
+    match VerifierParams::try_new(std::env::args_os()) {
+        Ok(config) => Ok(Some(config)),
+        Err(ConfigError::Cli(error)) if error.exit_code() == 0 => {
+            error.print().context("failed to print verifier help")?;
+            Ok(None)
+        }
+        Err(error) => Err(error).context("failed to load verifier config"),
+    }
+}
+
+async fn run_engine(
+    config: &VerifierParams,
+    metrics_shutdown: &mut ShutdownManager,
+) -> Result<ShutdownReason> {
     let mut shutdown = ShutdownManager::default();
     let builder =
         magicblock_runtime::keeper_builder(&config.engine, &config.programs)
@@ -56,9 +78,22 @@ async fn run(config: &VerifierParams) -> Result<bool> {
     )
     .context("failed to start replication client")?;
 
-    let reason = shutdown.wait().await;
-    shutdown.terminate().await;
+    let reason = tokio::select! {
+        biased;
+        reason = metrics_shutdown.wait() => reason,
+        reason = shutdown.wait() => reason,
+    };
+    let reason = reason.combine(shutdown.terminate().await);
     drop(engine);
-    let restart = matches!(reason, ShutdownReason::RestartRequired);
-    Ok(restart)
+    Ok(reason)
+}
+
+fn exit(reason: ShutdownReason) -> ExitCode {
+    let code = reason.exit_code();
+    if code == 0 {
+        info!(exit_code = code, "process terminated cleanly");
+    } else {
+        error!(?reason, exit_code = code, "process terminated");
+    }
+    ExitCode::from(code)
 }

--- a/magicblock-aperture/src/error.rs
+++ b/magicblock-aperture/src/error.rs
@@ -15,6 +15,8 @@ pub(crate) const PARSE_ERROR: i16 = -32700;
 
 #[derive(thiserror::Error, Debug)]
 pub enum ApertureError {
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
     #[error("RPC error: {0}")]
     Rpc(#[from] RpcError),
     #[error("Geyser error: {0}")]

--- a/magicblock-aperture/src/lib.rs
+++ b/magicblock-aperture/src/lib.rs
@@ -1,4 +1,4 @@
-use std::net::SocketAddr;
+use std::{io, net::SocketAddr};
 
 pub use error::{ApertureError, RpcError};
 use magicblock_config::config::aperture::ApertureConfig;
@@ -38,10 +38,8 @@ impl JsonRpcServer {
         cancel: CancellationToken,
     ) -> ApertureResult<Self> {
         // try to bind to socket before spawning anything (handy in tests)
-        let http = TcpListener::bind(config.listen.0)
-            .await
-            .map_err(RpcError::internal)?;
-        let http_addr = http.local_addr().map_err(RpcError::internal)?;
+        let http = TcpListener::bind(config.listen.0).await?;
+        let http_addr = http.local_addr()?;
 
         let mut ws_addr = http_addr;
         let listen_port = config.listen.0.port();
@@ -50,17 +48,18 @@ impl JsonRpcServer {
             ws_addr.set_port(0);
         } else {
             let ws_port = listen_port.checked_add(1).ok_or_else(|| {
-                RpcError::internal(format!(
-                    "RPC listen port {listen_port} leaves no room for the \
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!(
+                        "RPC listen port {listen_port} leaves no room for the \
                      derived WebSocket port (listen + 1)."
-                ))
+                    ),
+                )
             })?;
             ws_addr.set_port(ws_port);
         }
-        let ws = TcpListener::bind(ws_addr)
-            .await
-            .map_err(RpcError::internal)?;
-        let ws_addr = ws.local_addr().map_err(RpcError::internal)?;
+        let ws = TcpListener::bind(ws_addr).await?;
+        let ws_addr = ws.local_addr()?;
 
         // Initialize HTTP and Websocket servers before starting any background
         // delivery tasks, so a bind failure cannot leak engine subscriptions.

--- a/magicblock-committor-service/Cargo.toml
+++ b/magicblock-committor-service/Cargo.toml
@@ -24,6 +24,7 @@ magicblock-metrics = { workspace = true }
 magicblock-program = { workspace = true }
 magicblock-rpc-client = { workspace = true }
 magicblock-table-mania = { workspace = true }
+nucleus = { workspace = true }
 rusqlite = { workspace = true }
 solana-account = { workspace = true }
 solana-account-decoder = { workspace = true }

--- a/magicblock-committor-service/src/service.rs
+++ b/magicblock-committor-service/src/service.rs
@@ -25,7 +25,6 @@ use nucleus::shutdown::{ShutdownHandle, ShutdownReason};
 use tokio::{
     sync::{Notify, broadcast},
     task,
-    task::JoinError,
 };
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, instrument};
@@ -103,25 +102,22 @@ where
         let processing_results = self.processing_results.clone();
         let intents_changed = self.intents_changed.clone();
         let intent_rpc_client = self.intent_rpc_client.clone();
-        let mut result_worker = tokio::spawn(async move {
-            Self::result_processor(
-                result_subscriber,
-                result_shutdown,
-                intents_meta_map,
-                processing_results,
-                intents_changed,
-                intent_rpc_client,
-            )
-            .await;
-        });
+        let result_worker = Self::result_processor(
+            result_subscriber,
+            result_shutdown,
+            intents_meta_map,
+            processing_results,
+            intents_changed,
+            intent_rpc_client,
+        );
+        tokio::pin!(result_worker);
         let accept_token = CancellationToken::new();
         let accept_shutdown = accept_token.clone();
         let pending_intents = self.intents_meta_map.clone();
         let processing_results = self.processing_results.clone();
         let pending_changed = self.intents_changed.clone();
-        let mut accept_worker = tokio::spawn(async move {
-            self.accept_worker(accept_shutdown).await;
-        });
+        let accept_worker = self.accept_worker(accept_shutdown);
+        tokio::pin!(accept_worker);
 
         tokio::select! {
             biased;
@@ -129,7 +125,7 @@ where
                 // Do not drop completion notifications for already accepted
                 // intents: stop ingress, drain results, then stop observation.
                 accept_token.cancel();
-                accept_worker.await.map_err(IntentExecutionServiceError::WorkerJoin)?;
+                accept_worker.await;
 
                 tokio::select! {
                     biased;
@@ -138,24 +134,30 @@ where
                         processing_results,
                         pending_changed,
                     ) => {}
-                    result = &mut result_worker => {
-                        return Err(Self::worker_failure("result processor", result));
+                    _ = &mut result_worker => {
+                        return Err(IntentExecutionServiceError::WorkerStopped(
+                            "result processor",
+                        ));
                     }
                 }
 
                 result_token.cancel();
-                result_worker.await.map_err(IntentExecutionServiceError::WorkerJoin)?;
+                result_worker.await;
                 Ok(())
             }
-            result = &mut accept_worker => {
+            _ = &mut accept_worker => {
                 result_token.cancel();
-                let _ = result_worker.await;
-                Err(Self::worker_failure("intent acceptor", result))
+                result_worker.await;
+                Err(IntentExecutionServiceError::WorkerStopped(
+                    "intent acceptor",
+                ))
             }
-            result = &mut result_worker => {
+            _ = &mut result_worker => {
                 accept_token.cancel();
-                let _ = accept_worker.await;
-                Err(Self::worker_failure("result processor", result))
+                accept_worker.await;
+                Err(IntentExecutionServiceError::WorkerStopped(
+                    "result processor",
+                ))
             }
         }
     }
@@ -174,16 +176,6 @@ where
                 return;
             }
             intents_changed.notified().await;
-        }
-    }
-
-    fn worker_failure(
-        worker: &'static str,
-        result: Result<(), JoinError>,
-    ) -> IntentExecutionServiceError {
-        match result {
-            Ok(()) => IntentExecutionServiceError::WorkerStopped(worker),
-            Err(error) => IntentExecutionServiceError::WorkerJoin(error),
         }
     }
 
@@ -549,8 +541,6 @@ where
 pub enum IntentExecutionServiceError {
     #[error("Intent execution worker '{0}' stopped unexpectedly")]
     WorkerStopped(&'static str),
-    #[error("Intent execution worker failed: {0}")]
-    WorkerJoin(#[from] JoinError),
     #[error("IntentRpcClientError: {0}")]
     IntentRpcClientError(#[from] InternalIntentClientError),
 }

--- a/magicblock-committor-service/src/service.rs
+++ b/magicblock-committor-service/src/service.rs
@@ -3,7 +3,10 @@ pub mod intent_client;
 use std::{
     collections::{HashMap, HashSet},
     future::Future,
-    sync::{Arc, Mutex},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicUsize, Ordering},
+    },
     time::Duration,
 };
 
@@ -20,9 +23,9 @@ use magicblock_program::{
 };
 use nucleus::shutdown::{ShutdownHandle, ShutdownReason};
 use tokio::{
-    sync::broadcast,
+    sync::{Notify, broadcast},
     task,
-    task::{JoinError, JoinSet},
+    task::JoinError,
 };
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, instrument};
@@ -49,8 +52,11 @@ pub struct IntentExecutionService<R> {
     /// Time interval to scrape MagicContext(ER slot interval)
     // TODO(edwin): can be removed if LatestBlocK moved into magicblock-core
     slot_interval: Duration,
-    /// Meta for ongoing executing intents
+    /// Accepted intents whose execution result has not been handled yet.
     intents_meta_map: Arc<Mutex<HashMap<u64, ScheduledBaseIntentMeta>>>,
+    /// Result notifications currently being submitted back to the Engine.
+    processing_results: Arc<AtomicUsize>,
+    intents_changed: Arc<Notify>,
 }
 
 impl<R> IntentExecutionService<R>
@@ -70,6 +76,8 @@ where
             processor,
             slot_interval,
             intents_meta_map: Arc::new(Mutex::default()),
+            processing_results: Arc::new(AtomicUsize::new(0)),
+            intents_changed: Arc::new(Notify::new()),
         }
     }
 
@@ -89,47 +97,94 @@ where
         cancellation_token: CancellationToken,
     ) -> Result<(), IntentExecutionServiceError> {
         let result_subscriber = self.processor.subscribe_for_results();
-        let mut workers = JoinSet::new();
-        let result_token = cancellation_token.clone();
+        let result_token = CancellationToken::new();
+        let result_shutdown = result_token.clone();
         let intents_meta_map = self.intents_meta_map.clone();
+        let processing_results = self.processing_results.clone();
+        let intents_changed = self.intents_changed.clone();
         let intent_rpc_client = self.intent_rpc_client.clone();
-        workers.spawn(async move {
+        let mut result_worker = tokio::spawn(async move {
             Self::result_processor(
                 result_subscriber,
-                result_token,
+                result_shutdown,
                 intents_meta_map,
+                processing_results,
+                intents_changed,
                 intent_rpc_client,
             )
             .await;
-            "result processor"
         });
-        let accept_token = cancellation_token.clone();
-        workers.spawn(async move {
-            self.accept_worker(accept_token).await;
-            "intent acceptor"
+        let accept_token = CancellationToken::new();
+        let accept_shutdown = accept_token.clone();
+        let pending_intents = self.intents_meta_map.clone();
+        let processing_results = self.processing_results.clone();
+        let pending_changed = self.intents_changed.clone();
+        let mut accept_worker = tokio::spawn(async move {
+            self.accept_worker(accept_shutdown).await;
         });
 
         tokio::select! {
             biased;
-            _ = cancellation_token.cancelled() => {}
-            result = workers.join_next() => {
-                let failure = match result.expect("intent workers are registered") {
-                    Ok(worker) => IntentExecutionServiceError::WorkerStopped(worker),
-                    Err(error) => IntentExecutionServiceError::WorkerJoin(error),
-                };
-                cancellation_token.cancel();
-                workers.shutdown().await;
-                return Err(failure);
-            }
-        }
+            _ = cancellation_token.cancelled() => {
+                // Do not drop completion notifications for already accepted
+                // intents: stop ingress, drain results, then stop observation.
+                accept_token.cancel();
+                accept_worker.await.map_err(IntentExecutionServiceError::WorkerJoin)?;
 
-        while let Some(result) = workers.join_next().await {
-            if let Err(error) = result {
-                workers.shutdown().await;
-                return Err(error.into());
+                tokio::select! {
+                    biased;
+                    _ = Self::wait_for_intents(
+                        pending_intents,
+                        processing_results,
+                        pending_changed,
+                    ) => {}
+                    result = &mut result_worker => {
+                        return Err(Self::worker_failure("result processor", result));
+                    }
+                }
+
+                result_token.cancel();
+                result_worker.await.map_err(IntentExecutionServiceError::WorkerJoin)?;
+                Ok(())
+            }
+            result = &mut accept_worker => {
+                result_token.cancel();
+                let _ = result_worker.await;
+                Err(Self::worker_failure("intent acceptor", result))
+            }
+            result = &mut result_worker => {
+                accept_token.cancel();
+                let _ = accept_worker.await;
+                Err(Self::worker_failure("result processor", result))
             }
         }
-        Ok(())
+    }
+
+    async fn wait_for_intents(
+        intents_meta_map: Arc<Mutex<HashMap<u64, ScheduledBaseIntentMeta>>>,
+        processing_results: Arc<AtomicUsize>,
+        intents_changed: Arc<Notify>,
+    ) {
+        loop {
+            let intents_empty = intents_meta_map
+                .lock()
+                .expect(POISONED_MUTEX_MSG)
+                .is_empty();
+            if intents_empty && processing_results.load(Ordering::SeqCst) == 0 {
+                return;
+            }
+            intents_changed.notified().await;
+        }
+    }
+
+    fn worker_failure(
+        worker: &'static str,
+        result: Result<(), JoinError>,
+    ) -> IntentExecutionServiceError {
+        match result {
+            Ok(()) => IntentExecutionServiceError::WorkerStopped(worker),
+            Err(error) => IntentExecutionServiceError::WorkerJoin(error),
+        }
     }
 
     async fn accept_worker(self, cancellation_token: CancellationToken) {
@@ -261,6 +316,7 @@ where
             intent_ids.iter().for_each(|id| {
                 intent_metas.remove(id);
             });
+            self.intents_changed.notify_one();
         }
         result
     }
@@ -304,6 +360,8 @@ where
         result_subscription,
         cancellation_token,
         intents_meta_map,
+        processing_results,
+        intents_changed,
         intent_client
     ))]
     async fn result_processor(
@@ -312,6 +370,8 @@ where
         >,
         cancellation_token: CancellationToken,
         intents_meta_map: Arc<Mutex<HashMap<u64, ScheduledBaseIntentMeta>>>,
+        processing_results: Arc<AtomicUsize>,
+        intents_changed: Arc<Notify>,
         intent_client: Arc<R>,
     ) {
         loop {
@@ -342,6 +402,8 @@ where
                 &intent_client,
                 execution_result,
                 &intents_meta_map,
+                &processing_results,
+                &intents_changed,
             )
             .await
             {
@@ -354,25 +416,33 @@ where
         intent_client: &Arc<R>,
         execution_result: BroadcastedIntentExecutionResult,
         intents_meta_map: &Arc<Mutex<HashMap<u64, ScheduledBaseIntentMeta>>>,
+        processing_results: &AtomicUsize,
+        intents_changed: &Notify,
     ) -> Result<(), R::Error> {
         let intent_id = execution_result.id;
-        let Some(intent_meta) = intents_meta_map
-            .lock()
-            .expect(POISONED_MUTEX_MSG)
-            .remove(&intent_id)
-        else {
-            // Possible if we have duplicate Intents
-            // First one will remove id from map and second could fail.
-            // This should not happen and needs investigation!
-            error!(intent_id, "Failed to find intent metadata");
-            return Ok(());
+        let intent_meta = {
+            let Some(intent_meta) = intents_meta_map
+                .lock()
+                .expect(POISONED_MUTEX_MSG)
+                .remove(&intent_id)
+            else {
+                // Possible if we have duplicate Intents
+                // First one will remove id from map and second could fail.
+                // This should not happen and needs investigation!
+                error!(intent_id, "Failed to find intent metadata");
+                return Ok(());
+            };
+            processing_results.fetch_add(1, Ordering::SeqCst);
+            intent_meta
         };
 
-        intent_client
+        let result = intent_client
             .notify_commit_sent(intent_meta, execution_result)
-            .await?;
+            .await;
+        processing_results.fetch_sub(1, Ordering::SeqCst);
+        intents_changed.notify_one();
 
-        Ok(())
+        result
     }
 
     async fn retain_recoverable_intents(

--- a/magicblock-committor-service/src/service.rs
+++ b/magicblock-committor-service/src/service.rs
@@ -3,7 +3,6 @@ pub mod intent_client;
 use std::{
     collections::{HashMap, HashSet},
     future::Future,
-    mem,
     sync::{Arc, Mutex},
     time::Duration,
 };
@@ -19,10 +18,11 @@ use magicblock_metrics::metrics::{
 use magicblock_program::{
     Pubkey, magic_scheduled_base_intent::ScheduledIntentBundle,
 };
+use nucleus::shutdown::{ShutdownHandle, ShutdownReason};
 use tokio::{
     sync::broadcast,
     task,
-    task::{JoinError, JoinHandle},
+    task::{JoinError, JoinSet},
 };
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, instrument};
@@ -34,15 +34,23 @@ use crate::{
     persist::RecoveredIntent,
 };
 
-const POISONED_MUTEX_MSG: &str = "ServiceInner intents_meta_map mutex poisoned";
+const POISONED_MUTEX_MSG: &str =
+    "IntentExecutionService intents_meta_map mutex poisoned";
 
 pub type ChainlinkImpl = ProdChainlink;
 
-pub enum IntentExecutionService<R> {
-    Created(ServiceInner<R>),
-    Started(JoinHandle<()>),
-    Stopped,
-    Error,
+pub struct IntentExecutionService<R> {
+    /// Chainlink for notifying of undelegations
+    chainlink: Arc<ChainlinkImpl>,
+    /// ER client specific for Intent needs. Could be switched to RpcClient
+    intent_rpc_client: Arc<R>,
+    /// Processor of accepted intents
+    processor: Arc<CommittorProcessor>,
+    /// Time interval to scrape MagicContext(ER slot interval)
+    // TODO(edwin): can be removed if LatestBlocK moved into magicblock-core
+    slot_interval: Duration,
+    /// Meta for ongoing executing intents
+    intents_meta_map: Arc<Mutex<HashMap<u64, ScheduledBaseIntentMeta>>>,
 }
 
 impl<R> IntentExecutionService<R>
@@ -55,98 +63,76 @@ where
         intent_rpc_client: R,
         processor: Arc<CommittorProcessor>,
         slot_interval: Duration,
-        cancellation_token: CancellationToken,
-    ) -> Self {
-        Self::Created(ServiceInner::new(
-            chainlink,
-            intent_rpc_client,
-            processor,
-            slot_interval,
-            cancellation_token,
-        ))
-    }
-
-    fn take(&mut self) -> Self {
-        mem::replace(self, Self::Error)
-    }
-
-    pub fn start(&mut self) -> Result<(), IntentExecutionServiceError> {
-        let Self::Created(service) = self.take() else {
-            return Err(IntentExecutionServiceError::InvalidState(
-                "service must be in Created state to start".into(),
-            ));
-        };
-
-        let handle = service.start();
-        *self = Self::Started(handle);
-        Ok(())
-    }
-
-    pub async fn stop(&mut self) -> Result<(), IntentExecutionServiceError> {
-        let Self::Started(handle) = self.take() else {
-            return Err(IntentExecutionServiceError::InvalidState(
-                "service must be in Started state to stop".into(),
-            ));
-        };
-
-        handle.await?;
-        *self = Self::Stopped;
-        Ok(())
-    }
-}
-
-pub struct ServiceInner<R> {
-    /// Chainlink for notifying of undelegations
-    chainlink: Arc<ChainlinkImpl>,
-    /// ER client specific for Intent needs. Could be switched to RpcClient
-    intent_rpc_client: Arc<R>,
-    /// Processor of accepted intents
-    processor: Arc<CommittorProcessor>,
-    /// Time interval to scrape MagicContext(ER slot interval)
-    // TODO(edwin): can be removed if LatestBlocK moved into magicblock-core
-    slot_interval: Duration,
-    cancellation_token: CancellationToken,
-    /// Meta for ongoing executing intents
-    intents_meta_map: Arc<Mutex<HashMap<u64, ScheduledBaseIntentMeta>>>,
-}
-
-impl<R> ServiceInner<R>
-where
-    R: ERIntentClient,
-    R::Error: Into<IntentExecutionServiceError>,
-{
-    pub fn new(
-        chainlink: Arc<ChainlinkImpl>,
-        intent_rpc_client: R,
-        processor: Arc<CommittorProcessor>,
-        slot_interval: Duration,
-        cancellation_token: CancellationToken,
     ) -> Self {
         Self {
             chainlink,
             intent_rpc_client: Arc::new(intent_rpc_client),
             processor,
             slot_interval,
-            cancellation_token,
             intents_meta_map: Arc::new(Mutex::default()),
         }
     }
 
-    /// Starts 2 workers: one accepting intents, another awaiting and handling results
-    fn start(self) -> JoinHandle<()> {
-        let result_subscriber = self.processor.subscribe_for_results();
-        let cancellation_token = self.cancellation_token.clone();
-        tokio::spawn(Self::result_processor(
-            result_subscriber,
-            cancellation_token,
-            self.intents_meta_map.clone(),
-            self.intent_rpc_client.clone(),
-        ));
-
-        tokio::task::spawn(self.accept_worker())
+    /// Runs both intent workers and reports after they have stopped.
+    pub async fn run(self, mut shutdown: ShutdownHandle) {
+        let result = self.run_workers(shutdown.child()).await;
+        let reason = match result {
+            Err(error) => ShutdownReason::Error(Box::new(error)),
+            Ok(()) if shutdown.requested() => ShutdownReason::Signalled,
+            Ok(()) => ShutdownReason::Unexpected,
+        };
+        shutdown.terminate(reason);
     }
 
-    async fn accept_worker(self) {
+    async fn run_workers(
+        self,
+        cancellation_token: CancellationToken,
+    ) -> Result<(), IntentExecutionServiceError> {
+        let result_subscriber = self.processor.subscribe_for_results();
+        let mut workers = JoinSet::new();
+        let result_token = cancellation_token.clone();
+        let intents_meta_map = self.intents_meta_map.clone();
+        let intent_rpc_client = self.intent_rpc_client.clone();
+        workers.spawn(async move {
+            Self::result_processor(
+                result_subscriber,
+                result_token,
+                intents_meta_map,
+                intent_rpc_client,
+            )
+            .await;
+            "result processor"
+        });
+        let accept_token = cancellation_token.clone();
+        workers.spawn(async move {
+            self.accept_worker(accept_token).await;
+            "intent acceptor"
+        });
+
+        tokio::select! {
+            biased;
+            _ = cancellation_token.cancelled() => {}
+            result = workers.join_next() => {
+                let failure = match result.expect("intent workers are registered") {
+                    Ok(worker) => IntentExecutionServiceError::WorkerStopped(worker),
+                    Err(error) => IntentExecutionServiceError::WorkerJoin(error),
+                };
+                cancellation_token.cancel();
+                workers.shutdown().await;
+                return Err(failure);
+            }
+        }
+
+        while let Some(result) = workers.join_next().await {
+            if let Err(error) = result {
+                workers.shutdown().await;
+                return Err(error.into());
+            }
+        }
+        Ok(())
+    }
+
+    async fn accept_worker(self, cancellation_token: CancellationToken) {
         if let Err(err) = self.reschedule_pending_bundles().await {
             error!(error = ?err, "Failed to reschedule pending bundles")
         }
@@ -155,7 +141,7 @@ where
         loop {
             tokio::select! {
                 biased;
-                _ = self.cancellation_token.cancelled() => {
+                _ = cancellation_token.cancelled() => {
                     break;
                 }
                 _ = interval.tick() => {
@@ -352,7 +338,7 @@ where
                 }
             };
 
-            if let Err(err) = ServiceInner::<R>::process_execution_result(
+            if let Err(err) = Self::process_execution_result(
                 &intent_client,
                 execution_result,
                 &intents_meta_map,
@@ -491,10 +477,10 @@ where
 
 #[derive(thiserror::Error, Debug)]
 pub enum IntentExecutionServiceError {
-    #[error("Invalid state: {0}")]
-    InvalidState(String),
-    #[error("JoinError: {0}")]
-    JoinError(#[from] JoinError),
+    #[error("Intent execution worker '{0}' stopped unexpectedly")]
+    WorkerStopped(&'static str),
+    #[error("Intent execution worker failed: {0}")]
+    WorkerJoin(#[from] JoinError),
     #[error("IntentRpcClientError: {0}")]
     IntentRpcClientError(#[from] InternalIntentClientError),
 }

--- a/magicblock-config/Cargo.toml
+++ b/magicblock-config/Cargo.toml
@@ -14,6 +14,7 @@ figment = { workspace = true, features = ["env", "toml"] }
 humantime = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_with = { workspace = true }
+thiserror = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 
 nucleus = { workspace = true, features = ["config"] }

--- a/magicblock-config/src/lib.rs
+++ b/magicblock-config/src/lib.rs
@@ -4,14 +4,14 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use clap::Parser;
+use clap::{Error as CliError, Parser};
 use config::{
     EngineConfig, FollowerReplication, LeaderReplication, LifecycleMode,
     aperture::ApertureConfig, cli::CliParams, grpc::GrpcConfig,
     metrics::MetricsConfig,
 };
 use figment::{
-    Figment, Profile,
+    Error as FigmentError, Figment, Profile,
     providers::{Env, Format, Serialized, Toml},
     value::Uncased,
 };
@@ -33,6 +33,17 @@ use crate::{
 };
 
 const VERIFIER_ENV_VAR_PREFIX: &str = "MBV_VERIFIER_";
+
+/// Failure while parsing process arguments or assembling configuration.
+#[derive(Debug, thiserror::Error)]
+pub enum ConfigError {
+    /// Command-line parsing failed or requested display-only output.
+    #[error(transparent)]
+    Cli(#[from] CliError),
+    /// Layered configuration could not be loaded or validated.
+    #[error(transparent)]
+    Config(#[from] Box<FigmentError>),
+}
 
 /// Leader configuration assembled from defaults, TOML, environment, and CLI.
 #[derive(Clone, Deserialize, Serialize, Default)]
@@ -83,9 +94,9 @@ impl LeaderParams {
     /// - At least one WebSocket endpoint is configured (for subscriptions)
     pub fn try_new(
         args: impl Iterator<Item = OsString>,
-    ) -> Result<Self, Box<figment::error::Error>> {
+    ) -> Result<Self, ConfigError> {
         // 1. Parse CLI arguments into the "Overlay" struct
-        let cli = CliParams::parse_from(args);
+        let cli = CliParams::try_parse_from(args)?;
 
         // 2. Start with system defaults (Figment will use serde defaults for each field)
         let mut figment = Figment::new();
@@ -107,7 +118,7 @@ impl LeaderParams {
         figment = figment.merge(Serialized::from(&cli, Profile::Default));
 
         let params: Self = figment.extract().map_err(Box::new)?;
-        params.validate()
+        params.validate().map_err(Into::into)
     }
 
     /// Loads a leader config file with the same defaults and environment
@@ -127,9 +138,9 @@ impl LeaderParams {
         params.validate()
     }
 
-    fn validate(mut self) -> Result<Self, Box<figment::error::Error>> {
+    fn validate(mut self) -> Result<Self, Box<FigmentError>> {
         if self.engine.authority.remote.is_some() {
-            return Err(Box::new(figment::error::Error::from(
+            return Err(Box::new(FigmentError::from(
                 "engine.authority.remote is reserved for follower validators",
             )));
         }
@@ -139,12 +150,10 @@ impl LeaderParams {
         Ok(self)
     }
 
-    fn ensure_valid_aperture_listen(
-        &self,
-    ) -> Result<(), Box<figment::error::Error>> {
+    fn ensure_valid_aperture_listen(&self) -> Result<(), Box<FigmentError>> {
         let port = self.aperture.listen.0.port();
         if port == u16::MAX {
-            return Err(Box::new(figment::error::Error::from(format!(
+            return Err(Box::new(FigmentError::from(format!(
                 "aperture.listen port {port} is invalid: the WebSocket server \
                  binds to port + 1, which has no valid value at {}. Use a \
                  listen port <= {}.",
@@ -372,8 +381,8 @@ impl VerifierParams {
     /// Loads a verifier config from TOML followed by `MBV_VERIFIER_` overrides.
     pub fn try_new(
         args: impl Iterator<Item = OsString>,
-    ) -> Result<Self, Box<figment::error::Error>> {
-        let cli = VerifierCli::parse_from(args);
+    ) -> Result<Self, ConfigError> {
+        let cli = VerifierCli::try_parse_from(args)?;
         let figment = Figment::new()
             .merge(Toml::file(&cli.config).profile(Profile::Default))
             .merge(
@@ -384,20 +393,23 @@ impl VerifierParams {
             );
         let mut params: Self = figment.extract().map_err(Box::new)?;
         if params.engine.authority.remote.is_some() {
-            return Err(Box::new(figment::error::Error::from(
+            return Err(Box::new(FigmentError::from(
                 "engine.authority.remote is derived from replication.upstream-authority",
-            )));
+            ))
+            .into());
         }
         if params.engine.replication.upstream_address.port() == 0 {
-            return Err(Box::new(figment::error::Error::from(
+            return Err(Box::new(FigmentError::from(
                 "engine.replication.upstream-address must use a non-zero port",
-            )));
+            ))
+            .into());
         }
         if params.engine.replication.upstream_authority.0 == Default::default()
         {
-            return Err(Box::new(figment::error::Error::from(
+            return Err(Box::new(FigmentError::from(
                 "engine.replication.upstream-authority is required",
-            )));
+            ))
+            .into());
         }
         params.engine.authority.remote =
             Some(params.engine.replication.upstream_authority.0);

--- a/magicblock-metrics/Cargo.toml
+++ b/magicblock-metrics/Cargo.toml
@@ -16,8 +16,8 @@ http-body-util = { workspace = true }
 hyper = { workspace = true, features = ["http1", "server"] }
 hyper-util = { workspace = true, features = ["tokio"] }
 lazy_static = { workspace = true }
+nucleus = { workspace = true }
 prometheus = { workspace = true }
 solana-signature = { workspace = true }
 tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread"] }
-tokio-util = { workspace = true }
 tracing = { workspace = true }

--- a/magicblock-metrics/src/lib.rs
+++ b/magicblock-metrics/src/lib.rs
@@ -3,4 +3,4 @@
 pub mod metrics;
 mod service;
 
-pub use service::{MetricsService, try_start_metrics_service};
+pub use service::MetricsService;

--- a/magicblock-metrics/src/service.rs
+++ b/magicblock-metrics/src/service.rs
@@ -6,96 +6,77 @@ use hyper::{
     service::service_fn,
 };
 use hyper_util::rt::TokioIo;
+use nucleus::shutdown::{ShutdownHandle, ShutdownReason};
 use prometheus::TextEncoder;
-use tokio::{net::TcpListener, select};
-use tokio_util::sync::CancellationToken;
+use tokio::{net::TcpListener, select, task::JoinSet};
 use tracing::{instrument, *};
 
 use crate::metrics;
 
-pub fn try_start_metrics_service(
-    addr: SocketAddr,
-    cancellation_token: CancellationToken,
-) -> std::io::Result<MetricsService> {
-    metrics::register();
-    let service = MetricsService::try_new(addr, cancellation_token)?;
-    service.spawn();
-    Ok(service)
-}
-
 pub struct MetricsService {
     addr: SocketAddr,
-    cancellation_token: CancellationToken,
+    listener: TcpListener,
 }
 
 impl MetricsService {
-    fn try_new(
-        addr: SocketAddr,
-        cancellation_token: CancellationToken,
-    ) -> std::io::Result<MetricsService> {
-        Ok(MetricsService {
-            addr,
-            cancellation_token,
-        })
+    pub async fn bind(addr: SocketAddr) -> std::io::Result<Self> {
+        metrics::register();
+        let listener = TcpListener::bind(addr).await?;
+        let addr = listener.local_addr()?;
+        Ok(Self { addr, listener })
     }
 
-    fn spawn(&self) {
-        let addr = self.addr;
-        let cancellation_token = self.cancellation_token.clone();
-        tokio::spawn(async move {
-            Self::run(addr, cancellation_token).await;
-        });
-    }
-
-    async fn run(addr: SocketAddr, cancellation_token: CancellationToken) {
-        start_metrics_server(addr, cancellation_token).await;
+    /// Serves metrics until its shutdown tier is cancelled.
+    pub async fn run(self, mut shutdown: ShutdownHandle) {
+        let reason = match serve(self.addr, self.listener, &shutdown).await {
+            Err(error) => ShutdownReason::Error(Box::new(error)),
+            Ok(()) if shutdown.requested() => ShutdownReason::Signalled,
+            Ok(()) => ShutdownReason::Unexpected,
+        };
+        shutdown.terminate(reason);
     }
 }
 
-#[instrument(skip(cancellation_token), fields(addr = %addr))]
-async fn start_metrics_server(
+#[instrument(skip(shutdown), fields(addr = %addr))]
+async fn serve(
     addr: SocketAddr,
-    cancellation_token: CancellationToken,
-) {
-    let listener = match TcpListener::bind(&addr).await {
-        Ok(listener) => {
-            info!("Metrics server started");
-            listener
-        }
-        Err(err) => {
-            error!(error = ?err, "Failed to bind");
-            return;
-        }
-    };
+    listener: TcpListener,
+    shutdown: &ShutdownHandle,
+) -> std::io::Result<()> {
+    info!("Metrics server started");
+    let mut connections = JoinSet::new();
 
-    loop {
+    let result = loop {
         select!(
-            _ = cancellation_token.cancelled() => {
-                break;
+            _ = shutdown.signalled() => {
+                break Ok(());
+            }
+            Some(result) = connections.join_next(), if !connections.is_empty() => {
+                if let Err(error) = result {
+                    debug!(?error, "Metrics connection task failed");
+                }
             }
             result = listener.accept() => {
-                match result {
-                    Ok((stream, _)) => {
-                        let io = TokioIo::new(stream);
-                        tokio::task::spawn(async move {
-                            if let Err(err) = http1::Builder::new()
+                let (stream, _) = match result {
+                    Ok(connection) => connection,
+                    Err(error) => break Err(error),
+                };
+                let io = TokioIo::new(stream);
+                connections.spawn(async move {
+                    if let Err(err) = http1::Builder::new()
                             .serve_connection(io, service_fn(metrics_service_router))
                             .await
-                        {
-                            debug!(error = ?err, "Metrics connection closed");
-                        }
-                        });
+                    {
+                        debug!(error = ?err, "Metrics connection closed");
                     }
-                    Err(err) => error!(
-                        error = ?err,
-                        "Failed to accept connection"
-                    ),
-                };
+                });
             }
         );
-    }
+    };
 
+    connections.shutdown().await;
     info!("Metrics server shutdown");
+    result
 }
 
 #[instrument(

--- a/magicblock-services/Cargo.toml
+++ b/magicblock-services/Cargo.toml
@@ -17,6 +17,7 @@ magicblock-delegation-program-api = { workspace = true }
 magicblock-magic-program-api = { workspace = true }
 magicblock-metrics = { workspace = true }
 magicblock-program = { workspace = true }
+nucleus = { workspace = true }
 solana-hash = { workspace = true }
 solana-instruction = { workspace = true, features = ["wincode"] }
 solana-keypair = { workspace = true }

--- a/magicblock-services/src/undelegation_request_service.rs
+++ b/magicblock-services/src/undelegation_request_service.rs
@@ -7,8 +7,13 @@ use magicblock_chainlink::{
 };
 use magicblock_metrics::metrics::AccountFetchContext;
 use magicblock_program::instruction_utils::InstructionUtils;
+use nucleus::shutdown::{ShutdownHandle, ShutdownReason};
 use solana_transaction_error::TransactionError;
-use tokio::{sync::broadcast, time::MissedTickBehavior};
+use tokio::{
+    sync::broadcast,
+    task::{JoinError, JoinSet},
+    time::MissedTickBehavior,
+};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
@@ -43,7 +48,6 @@ impl fmt::Display for ObservedUndelegationRequestError {
 
 pub struct UndelegationRequestService {
     chainlink: Arc<ChainlinkImpl>,
-    cancellation_token: CancellationToken,
     engine: Engine,
     undelegation_request_poll_interval: Duration,
 }
@@ -56,7 +60,6 @@ impl UndelegationRequestService {
     ) -> Self {
         Self {
             chainlink,
-            cancellation_token: CancellationToken::new(),
             engine,
             undelegation_request_poll_interval,
         }
@@ -374,31 +377,81 @@ impl UndelegationRequestService {
         Ok(())
     }
 
-    pub fn start(self: &Arc<Self>) {
-        let requests = self.chainlink.subscribe_undelegation_requests();
-        tokio::spawn(Self::undelegation_request_processor(
-            requests,
-            self.cancellation_token.clone(),
-            self.chainlink.clone(),
-            self.engine.clone(),
-        ));
-        self.spawn_undelegation_request_poll_processor();
+    /// Runs and supervises the subscription and optional polling workers.
+    pub async fn run(self, mut shutdown: ShutdownHandle) {
+        let result = self.run_workers(shutdown.child()).await;
+        let reason = match result {
+            Err(error) => ShutdownReason::Error(Box::new(error)),
+            Ok(()) if shutdown.requested() => ShutdownReason::Signalled,
+            Ok(()) => ShutdownReason::Unexpected,
+        };
+        shutdown.terminate(reason);
     }
 
-    fn spawn_undelegation_request_poll_processor(self: &Arc<Self>) {
+    async fn run_workers(
+        self,
+        cancellation_token: CancellationToken,
+    ) -> Result<(), UndelegationRequestServiceError> {
+        let mut workers = JoinSet::new();
+        let requests = self.chainlink.subscribe_undelegation_requests();
+        let token = cancellation_token.clone();
+        let chainlink = self.chainlink.clone();
+        let engine = self.engine.clone();
+        workers.spawn(async move {
+            Self::undelegation_request_processor(
+                requests, token, chainlink, engine,
+            )
+            .await;
+            "subscription processor"
+        });
+
         if self.undelegation_request_poll_interval.is_zero() {
             debug!("Skipping DLP undelegation request poll processor");
-            return;
+        } else {
+            let token = cancellation_token.clone();
+            let chainlink = self.chainlink;
+            let engine = self.engine;
+            let poll_interval = self.undelegation_request_poll_interval;
+            workers.spawn(async move {
+                Self::undelegation_request_poll_processor(
+                    poll_interval,
+                    token,
+                    chainlink,
+                    engine,
+                )
+                .await;
+                "poll processor"
+            });
         }
-        tokio::spawn(Self::undelegation_request_poll_processor(
-            self.undelegation_request_poll_interval,
-            self.cancellation_token.clone(),
-            self.chainlink.clone(),
-            self.engine.clone(),
-        ));
-    }
 
-    pub fn stop(&self) {
-        self.cancellation_token.cancel();
+        tokio::select! {
+            biased;
+            _ = cancellation_token.cancelled() => {}
+            result = workers.join_next() => {
+                let failure = match result.expect("undelegation workers are registered") {
+                    Ok(worker) => UndelegationRequestServiceError::WorkerStopped(worker),
+                    Err(error) => UndelegationRequestServiceError::WorkerJoin(error),
+                };
+                cancellation_token.cancel();
+                workers.shutdown().await;
+                return Err(failure);
+            }
+        }
+
+        while let Some(result) = workers.join_next().await {
+            if let Err(error) = result {
+                workers.shutdown().await;
+                return Err(error.into());
+            }
+        }
+        Ok(())
     }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum UndelegationRequestServiceError {
+    #[error("Undelegation request worker '{0}' stopped unexpectedly")]
+    WorkerStopped(&'static str),
+    #[error("Undelegation request worker failed: {0}")]
+    WorkerJoin(#[from] JoinError),
 }

--- a/magicblock-task-scheduler/Cargo.toml
+++ b/magicblock-task-scheduler/Cargo.toml
@@ -14,6 +14,7 @@ futures-util = { workspace = true }
 keeper = { workspace = true }
 magicblock-config = { workspace = true }
 magicblock-program = { workspace = true }
+nucleus = { workspace = true }
 rusqlite = { workspace = true }
 solana-instruction = { workspace = true, features = ["wincode"] }
 solana-message = { workspace = true }

--- a/magicblock-task-scheduler/src/errors.rs
+++ b/magicblock-task-scheduler/src/errors.rs
@@ -25,6 +25,9 @@ pub enum TaskSchedulerError {
     #[error(transparent)]
     Keeper(#[from] keeper::error::KeeperError),
 
+    #[error("Crank worker failed: {0}")]
+    CrankWorker(#[from] tokio::task::JoinError),
+
     #[error("Task {0} already exists and is owned by {1}, not {2}")]
     UnauthorizedReplacing(i64, String, String),
 

--- a/magicblock-task-scheduler/src/service.rs
+++ b/magicblock-task-scheduler/src/service.rs
@@ -14,17 +14,15 @@ use magicblock_program::{
     args::{CancelTaskRequest, ScheduleTaskRequest, TaskRequest},
     instruction_utils::InstructionUtils,
 };
+use nucleus::shutdown::{ShutdownHandle, ShutdownReason};
 use solana_message::Message;
 use tokio::{
     select,
     sync::mpsc,
-    task::{JoinHandle, JoinSet},
+    task::JoinSet,
     time::{Duration, MissedTickBehavior, interval},
 };
-use tokio_util::{
-    sync::CancellationToken,
-    time::{DelayQueue, delay_queue::Key},
-};
+use tokio_util::time::{DelayQueue, delay_queue::Key};
 use tracing::*;
 
 use crate::{
@@ -56,8 +54,6 @@ pub struct TaskSchedulerService {
     task_versions: HashMap<i64, i64>,
     /// Number of consecutive failed execution attempts for each task
     task_execution_retries: HashMap<i64, u32>,
-    /// Token used to cancel the task scheduler
-    token: CancellationToken,
     /// Minimum interval between task executions
     min_interval: Duration,
     /// How long failed task and scheduling records are retained.
@@ -75,9 +71,9 @@ enum ProcessingOutcome {
     Recoverable(Box<TaskSchedulerError>),
 }
 
-// SAFETY: TaskSchedulerService is moved into a single Tokio task in `start()` and never cloned.
+// SAFETY: TaskSchedulerService is moved into a single Tokio task in `run()` and never cloned.
 // It runs exclusively on that task's thread. All fields (SchedulerDatabase, Engine,
-// mpsc::Receiver, DelayQueue, HashMap, AtomicU64, CancellationToken) are Send+Sync,
+// mpsc::Receiver, DelayQueue, HashMap, and AtomicU64) are Send+Sync,
 // and the service maintains exclusive ownership throughout its lifetime.
 unsafe impl Send for TaskSchedulerService {}
 unsafe impl Sync for TaskSchedulerService {}
@@ -88,7 +84,6 @@ impl TaskSchedulerService {
         config: &TaskSchedulerConfig,
         engine: Engine,
         slot_interval: Duration,
-        token: CancellationToken,
     ) -> TaskSchedulerResult<Self> {
         if config.min_interval.as_millis() > u32::MAX as u128 {
             return Err(TaskSchedulerError::InvalidConfiguration(format!(
@@ -122,7 +117,6 @@ impl TaskSchedulerService {
             task_versions: HashMap::new(),
             task_execution_retries: HashMap::new(),
             tx_counter: Arc::new(AtomicU64::default()),
-            token,
             min_interval: config.min_interval,
             failed_task_retention: config.failed_task_retention,
             failed_task_cleanup_interval: config.failed_task_cleanup_interval,
@@ -130,12 +124,20 @@ impl TaskSchedulerService {
         })
     }
 
-    /// Starts the `TaskSchedulerService` and returns a handle to the task.
-    pub async fn start(
-        mut self,
-    ) -> TaskSchedulerResult<JoinHandle<TaskSchedulerResult<()>>> {
-        self.load_persisted_tasks().await?;
-        Ok(tokio::spawn(self.run()))
+    /// Runs the task scheduler and reports its terminal status after all crank
+    /// workers have stopped.
+    pub async fn run(mut self, mut shutdown: ShutdownHandle) {
+        let result = async {
+            self.load_persisted_tasks().await?;
+            self.run_loop(&shutdown).await
+        }
+        .await;
+        let reason = match result {
+            Err(error) => ShutdownReason::Error(Box::new(error)),
+            Ok(()) if shutdown.requested() => ShutdownReason::Signalled,
+            Ok(()) => ShutdownReason::Unexpected,
+        };
+        shutdown.terminate(reason);
     }
 
     async fn load_persisted_tasks(&mut self) -> TaskSchedulerResult<()> {
@@ -185,16 +187,20 @@ impl TaskSchedulerService {
     }
 
     /// Main loop of the task scheduler.
-    async fn run(mut self) -> TaskSchedulerResult<()> {
+    async fn run_loop(
+        mut self,
+        shutdown: &ShutdownHandle,
+    ) -> TaskSchedulerResult<()> {
         let mut failed_task_cleanup = interval(
             self.failed_task_cleanup_interval
                 .max(Duration::from_millis(1)),
         );
         failed_task_cleanup.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
-        let (crank_tx, mut crank_rx) = mpsc::unbounded_channel();
+        let mut crank_tasks = JoinSet::new();
 
-        loop {
+        let result = async {
+            loop {
             select! {
                 Some(expired) = self.task_queue.next() => {
                     // A task expired, batch all expired tasks
@@ -212,15 +218,15 @@ impl TaskSchedulerService {
 
                     let engine = self.engine.clone();
                     let tx_counter = self.tx_counter.clone();
-                    let crank_tx = crank_tx.clone();
 
-                    tokio::spawn(async move {
+                    crank_tasks.spawn(async move {
                         let result =
                             Self::send_crank_batch(&engine, tx_counter, &batch).await;
-                        let _ = crank_tx.send((batch, result));
+                        (batch, result)
                     });
                 }
-                Some((batch, result)) = crank_rx.recv() => {
+                Some(result) = crank_tasks.join_next(), if !crank_tasks.is_empty() => {
+                    let (batch, result) = result?;
                     // The batch has been sent, updates queue and db
                     self.on_crank_batch_completed(batch, result).await?;
                 }
@@ -269,19 +275,35 @@ impl TaskSchedulerService {
                         );
                     }
                 }
-                _ = self.token.cancelled() => {
+                _ = shutdown.signalled() => {
                     break;
                 }
             }
+            }
+
+            Ok(())
         }
+        .await;
 
         info!("TaskSchedulerService shutdown!");
-        drop(crank_tx);
-        while let Some((batch, result)) = crank_rx.recv().await {
-            self.on_crank_batch_completed(batch, result).await?;
+        if let Err(error) = result {
+            crank_tasks.shutdown().await;
+            return Err(error);
         }
 
-        Ok(())
+        let result = async {
+            while let Some(worker) = crank_tasks.join_next().await {
+                let (batch, worker_result) = worker?;
+                self.on_crank_batch_completed(batch, worker_result).await?;
+            }
+            Ok(())
+        }
+        .await;
+        if result.is_err() {
+            crank_tasks.shutdown().await;
+        }
+
+        result
     }
 
     /// Processes [TaskRequest] provided by the transaction executor.
@@ -800,6 +822,7 @@ mod tests {
         args::ScheduleTaskRequest,
         validator::generate_validator_authority_if_needed,
     };
+    use nucleus::shutdown::{Service, ShutdownManager};
     use solana_pubkey::Pubkey;
     use tokio::time::timeout;
 
@@ -822,7 +845,6 @@ mod tests {
             task_versions: HashMap::new(),
             task_execution_retries: HashMap::new(),
             tx_counter: Arc::new(AtomicU64::default()),
-            token: CancellationToken::new(),
             min_interval: Duration::from_millis(1000),
             failed_task_retention: Duration::from_secs(60),
             failed_task_cleanup_interval: Duration::from_secs(60),
@@ -865,7 +887,9 @@ mod tests {
 
         let (_engine, tx, service) = setup(db.clone()).await;
 
-        let handle = service.start().await.unwrap();
+        let mut shutdown = ShutdownManager::default();
+        let handle =
+            tokio::spawn(service.run(shutdown.handle(Service::TaskScheduler)));
 
         // Invalid task interval
         tx.try_send(encode_task(&TaskRequest::Schedule(ScheduleTaskRequest {
@@ -902,7 +926,8 @@ mod tests {
         .await
         .unwrap_err();
 
-        handle.abort();
+        let _ = shutdown.terminate().await;
+        handle.await.unwrap();
     }
 
     #[tokio::test]
@@ -936,7 +961,9 @@ mod tests {
         .unwrap();
         let (_engine, _tx, service) = setup(db.clone()).await;
 
-        let handle = service.start().await.unwrap();
+        let mut shutdown = ShutdownManager::default();
+        let handle =
+            tokio::spawn(service.run(shutdown.handle(Service::TaskScheduler)));
 
         // After starting, only one task should be in the database
         timeout(Duration::from_secs(1), async move {
@@ -951,7 +978,8 @@ mod tests {
         .await
         .unwrap()
         .unwrap();
-        handle.abort();
+        let _ = shutdown.terminate().await;
+        handle.await.unwrap();
     }
 
     #[tokio::test]
@@ -985,7 +1013,9 @@ mod tests {
         let (_engine, _tx, mut service) = setup(db.clone()).await;
         service.min_interval = Duration::from_millis(10);
 
-        let handle = service.start().await.unwrap();
+        let mut shutdown = ShutdownManager::default();
+        let handle =
+            tokio::spawn(service.run(shutdown.handle(Service::TaskScheduler)));
 
         timeout(Duration::from_secs(1), async move {
             loop {
@@ -999,7 +1029,8 @@ mod tests {
         .await
         .unwrap()
         .unwrap();
-        handle.abort();
+        let _ = shutdown.terminate().await;
+        handle.await.unwrap();
     }
 
     #[tokio::test]
@@ -1070,7 +1101,9 @@ mod tests {
         service.failed_task_retention = Duration::from_millis(1);
         service.failed_task_cleanup_interval = Duration::from_millis(5);
 
-        let handle = service.start().await.unwrap();
+        let mut shutdown = ShutdownManager::default();
+        let handle =
+            tokio::spawn(service.run(shutdown.handle(Service::TaskScheduler)));
 
         timeout(Duration::from_secs(1), async move {
             loop {
@@ -1085,6 +1118,7 @@ mod tests {
         .await
         .unwrap()
         .unwrap();
-        handle.abort();
+        let _ = shutdown.terminate().await;
+        handle.await.unwrap();
     }
 }

--- a/magicblock-validator-admin/Cargo.toml
+++ b/magicblock-validator-admin/Cargo.toml
@@ -14,6 +14,7 @@ tracing = { workspace = true }
 engine = { workspace = true }
 magicblock-delegation-program-api = { workspace = true }
 magicblock-rpc-client = { workspace = true }
+nucleus = { workspace = true }
 
 
 solana-commitment-config = { workspace = true }
@@ -23,4 +24,3 @@ solana-signature = { workspace = true }
 solana-signer = { workspace = true }
 solana-transaction = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
-tokio-util = { workspace = true, features = ["full"] }

--- a/magicblock-validator-admin/src/claim_fees.rs
+++ b/magicblock-validator-admin/src/claim_fees.rs
@@ -3,13 +3,13 @@ use std::time::Duration;
 use dlp_api::instruction_builder::validator_claim_fees;
 use engine::Engine;
 use magicblock_rpc_client::MagicBlockRpcClientError;
+use nucleus::shutdown::{ShutdownHandle, ShutdownReason};
 use solana_commitment_config::CommitmentConfig;
 use solana_pubkey::Pubkey;
 use solana_rpc_client::nonblocking::rpc_client::RpcClient;
 use solana_signer::Signer;
 use solana_transaction::Transaction;
-use tokio::{task::JoinHandle, time::Instant};
-use tokio_util::sync::CancellationToken;
+use tokio::time::Instant;
 use tracing::{error, info, instrument};
 
 const MIN_CLAIMABLE_LAMPORTS: u64 = 100_000_000;
@@ -25,61 +25,10 @@ pub enum ClaimFeesError {
     Rpc(#[from] MagicBlockRpcClientError),
 }
 
-pub struct ClaimFeesTask {
-    pub handle: Option<JoinHandle<()>>,
-    token: CancellationToken,
-}
-
-impl ClaimFeesTask {
-    pub fn new() -> Self {
-        Self {
-            handle: None,
-            token: CancellationToken::new(),
-        }
-    }
-
-    pub fn start(
-        &mut self,
-        engine: Engine,
-        tick_period: Duration,
-        url: String,
-    ) {
-        if self.handle.is_some() {
-            error!("Claim fees task already started");
-            return;
-        }
-
-        let token = self.token.clone();
-        let handle =
-            tokio::spawn(run_claim_fees_loop(engine, token, tick_period, url));
-        self.handle = Some(handle);
-    }
-
-    pub async fn stop(&mut self) {
-        if let Some(handle) = self.handle.take() {
-            info!("Stopping claim fees task");
-            self.token.cancel();
-            // Give the task a grace period to shut down gracefully
-            if tokio::time::timeout(Duration::from_secs(2), handle)
-                .await
-                .is_err()
-            {
-                error!("Claim fees task did not stop within grace period");
-            }
-        }
-    }
-}
-
-impl Default for ClaimFeesTask {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-#[instrument(skip(engine, token), fields(tick_period_ms = tick_period.as_millis() as u64, url = %url))]
-async fn run_claim_fees_loop(
+#[instrument(skip(engine, shutdown), fields(tick_period_ms = tick_period.as_millis() as u64, url = %url))]
+pub async fn run_claim_fees_loop(
     engine: Engine,
-    token: CancellationToken,
+    mut shutdown: ShutdownHandle,
     tick_period: Duration,
     url: String,
 ) {
@@ -93,10 +42,11 @@ async fn run_claim_fees_loop(
                     error!(error = ?err, "Failed to claim fees");
                 }
             },
-            _ = token.cancelled() => break,
+            _ = shutdown.signalled() => break,
         }
     }
     info!("Claim fees task stopped");
+    shutdown.terminate(ShutdownReason::Signalled);
 }
 
 #[instrument(skip(engine), fields(validator = %engine.authority()))]

--- a/test-integration/Cargo.lock
+++ b/test-integration/Cargo.lock
@@ -119,7 +119,7 @@ dependencies = [
 [[package]]
 name = "agave-transaction-view"
 version = "4.1.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.1#cd021975429a9504f35d52dc9d5b0393a3c3e302"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.2#ea0a1581ee21670a0676f7c1f7583e0e49565523"
 dependencies = [
  "ahash 0.8.12",
  "solana-hash 4.4.0",
@@ -3519,8 +3519,8 @@ dependencies = [
 
 [[package]]
 name = "magic-root-interface"
-version = "0.3.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.1#cd021975429a9504f35d52dc9d5b0393a3c3e302"
+version = "0.3.2"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.2#ea0a1581ee21670a0676f7c1f7583e0e49565523"
 dependencies = [
  "solana-account 4.3.1",
  "solana-instruction 3.4.0",
@@ -3530,8 +3530,8 @@ dependencies = [
 
 [[package]]
 name = "magic-root-program"
-version = "0.3.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.1#cd021975429a9504f35d52dc9d5b0393a3c3e302"
+version = "0.3.2"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.2#ea0a1581ee21670a0676f7c1f7583e0e49565523"
 dependencies = [
  "magic-root-interface",
  "magicblock-engine-nucleus",
@@ -3546,8 +3546,8 @@ dependencies = [
 
 [[package]]
 name = "magicblock-accountsdb"
-version = "0.3.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.1#cd021975429a9504f35d52dc9d5b0393a3c3e302"
+version = "0.3.2"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.2#ea0a1581ee21670a0676f7c1f7583e0e49565523"
 dependencies = [
  "ahash 0.8.12",
  "bincode",
@@ -3665,6 +3665,7 @@ dependencies = [
  "magicblock-core",
  "magicblock-delegation-program-api 3.1.0 (git+https://github.com/magicblock-labs/delegation-program.git?rev=dcd46dc)",
  "magicblock-engine",
+ "magicblock-engine-nucleus",
  "magicblock-metrics",
  "magicblock-program",
  "magicblock-rpc-client",
@@ -3710,6 +3711,7 @@ dependencies = [
  "solana-keypair",
  "solana-pubkey 4.2.0",
  "solana-signer",
+ "thiserror 2.0.20",
  "url",
 ]
 
@@ -3803,8 +3805,8 @@ dependencies = [
 
 [[package]]
 name = "magicblock-engine"
-version = "0.3.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.1#cd021975429a9504f35d52dc9d5b0393a3c3e302"
+version = "0.3.2"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.2#ea0a1581ee21670a0676f7c1f7583e0e49565523"
 dependencies = [
  "agave-transaction-view",
  "derive_more",
@@ -3836,8 +3838,8 @@ dependencies = [
 
 [[package]]
 name = "magicblock-engine-nucleus"
-version = "0.3.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.1#cd021975429a9504f35d52dc9d5b0393a3c3e302"
+version = "0.3.2"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.2#ea0a1581ee21670a0676f7c1f7583e0e49565523"
 dependencies = [
  "agave-transaction-view",
  "derive_more",
@@ -3868,8 +3870,8 @@ dependencies = [
 
 [[package]]
 name = "magicblock-keeper"
-version = "0.3.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.1#cd021975429a9504f35d52dc9d5b0393a3c3e302"
+version = "0.3.2"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.2#ea0a1581ee21670a0676f7c1f7583e0e49565523"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.12",
@@ -3907,8 +3909,8 @@ dependencies = [
 
 [[package]]
 name = "magicblock-ledger"
-version = "0.3.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.1#cd021975429a9504f35d52dc9d5b0393a3c3e302"
+version = "0.3.2"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.2#ea0a1581ee21670a0676f7c1f7583e0e49565523"
 dependencies = [
  "agave-transaction-view",
  "bitcode",
@@ -3964,17 +3966,17 @@ dependencies = [
  "hyper",
  "hyper-util",
  "lazy_static",
+ "magicblock-engine-nucleus",
  "prometheus",
  "solana-signature",
  "tokio",
- "tokio-util",
  "tracing",
 ]
 
 [[package]]
 name = "magicblock-processor"
-version = "0.3.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.1#cd021975429a9504f35d52dc9d5b0393a3c3e302"
+version = "0.3.2"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.2#ea0a1581ee21670a0676f7c1f7583e0e49565523"
 dependencies = [
  "agave-feature-set",
  "agave-precompiles",
@@ -4101,6 +4103,7 @@ dependencies = [
  "futures-util",
  "magicblock-config",
  "magicblock-engine",
+ "magicblock-engine-nucleus",
  "magicblock-keeper",
  "magicblock-program",
  "rusqlite",
@@ -4124,6 +4127,7 @@ version = "0.14.11"
 dependencies = [
  "magicblock-delegation-program-api 3.1.0 (git+https://github.com/magicblock-labs/delegation-program.git?rev=dcd46dc)",
  "magicblock-engine",
+ "magicblock-engine-nucleus",
  "magicblock-rpc-client",
  "solana-commitment-config",
  "solana-pubkey 4.2.0",
@@ -4133,7 +4137,6 @@ dependencies = [
  "solana-transaction 4.1.5",
  "thiserror 2.0.20",
  "tokio",
- "tokio-util",
  "tracing",
 ]
 
@@ -6120,7 +6123,7 @@ dependencies = [
 [[package]]
 name = "solana-account"
 version = "4.3.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.1#cd021975429a9504f35d52dc9d5b0393a3c3e302"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.2#ea0a1581ee21670a0676f7c1f7583e0e49565523"
 dependencies = [
  "bincode",
  "bitflags 2.13.1",
@@ -7706,7 +7709,7 @@ dependencies = [
 [[package]]
 name = "solana-program-runtime"
 version = "4.1.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.1#cd021975429a9504f35d52dc9d5b0393a3c3e302"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.2#ea0a1581ee21670a0676f7c1f7583e0e49565523"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -8396,7 +8399,7 @@ dependencies = [
 [[package]]
 name = "solana-svm"
 version = "4.1.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.1#cd021975429a9504f35d52dc9d5b0393a3c3e302"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.2#ea0a1581ee21670a0676f7c1f7583e0e49565523"
 dependencies = [
  "ahash 0.8.12",
  "magic-root-interface",
@@ -8783,7 +8786,7 @@ dependencies = [
 [[package]]
 name = "solana-transaction-context"
 version = "4.1.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.1#cd021975429a9504f35d52dc9d5b0393a3c3e302"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.2#ea0a1581ee21670a0676f7c1f7583e0e49565523"
 dependencies = [
  "bincode",
  "serde",
@@ -9759,10 +9762,7 @@ checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
- "futures-io",
  "futures-sink",
- "futures-util",
- "hashbrown 0.15.5",
  "libc",
  "pin-project-lite",
  "slab",
@@ -10265,8 +10265,8 @@ dependencies = [
 
 [[package]]
 name = "v42-calculator-interface"
-version = "0.3.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.1#cd021975429a9504f35d52dc9d5b0393a3c3e302"
+version = "0.3.2"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.2#ea0a1581ee21670a0676f7c1f7583e0e49565523"
 dependencies = [
  "solana-instruction 3.4.0",
  "solana-pubkey 4.2.0",

--- a/test-integration/Cargo.toml
+++ b/test-integration/Cargo.toml
@@ -32,14 +32,14 @@ chrono = "0.4"
 cleanass = "0.0.1"
 color-backtrace = { version = "0.7" }
 ctrlc = "3.4.7"
-engine = { package = "magicblock-engine", git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.1", features = [
+engine = { package = "magicblock-engine", git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.2", features = [
     "testkit"
 ] }
 ephemeral-rollups-sdk = { version = "0.14", default-features = false, features = ["modular-sdk"] }
 futures = "0.3.31"
 integration-test-tools = { path = "test-tools" }
 isocountry = "0.3.2"
-keeper = { package = "magicblock-keeper", git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.1", features = [
+keeper = { package = "magicblock-keeper", git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.2", features = [
     "testkit"
 ] }
 lazy_static = "1.4.0"
@@ -71,7 +71,7 @@ schedulecommit-client = { path = "schedulecommit/client" }
 serde = "1.0.217"
 serial_test = "3.2.0"
 shlex = "1.3.0"
-solana-account = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.1" }
+solana-account = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.2" }
 solana-address = "=2.6.1"
 solana-address-lookup-table-interface = "3.0"
 solana-clock = "=3.1.1"
@@ -114,15 +114,15 @@ toml = "0.8.13"
 tracing = "0.1"
 ureq = "2.9.6"
 url = "2.5.0"
-v42-calculator-interface = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.1", features = [
+v42-calculator-interface = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.2", features = [
     "builder"
 ] }
 
 [patch.crates-io]
-agave-transaction-view = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.1" }
-solana-account = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.1" }
-solana-program-runtime = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.1" }
-solana-svm = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.1" }
-solana-transaction-context = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.1" }
+agave-transaction-view = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.2" }
+solana-account = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.2" }
+solana-program-runtime = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.2" }
+solana-svm = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.2" }
+solana-transaction-context = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.2" }
 # Fix libsodium for ARM builds - upstream crates.io version breaks Linux ARM binaries
 libsodium-rs = { git = "https://github.com/jedisct1/libsodium-rs.git", rev = "0397a6c5785233f9f2ac91f3eedc3cceb74e0060" }

--- a/test-integration/test-validator-services/tests/test_claim_fees.rs
+++ b/test-integration/test-validator-services/tests/test_claim_fees.rs
@@ -144,7 +144,7 @@ fn test_claim_fees_rpc_connection() {
 fn test_validator_claim_fees() {
     println!("Starting Validator Fee Claiming Integration Test\n");
 
-    // 3. Fund the validator for transaction fees
+    // Fund the validator for transaction fees
     let client = RpcClient::new_with_commitment(
         DEVNET_URL,
         CommitmentConfig::confirmed(),
@@ -157,7 +157,7 @@ fn test_validator_claim_fees() {
     )
     .expect("Failed to airdrop initial funds to validator");
 
-    // 4. Run test sequence
+    // Run test sequence
     println!("=== Test 1: Instruction Creation ===");
     test_claim_fees_instruction();
 

--- a/test-integration/test-validator-services/tests/test_claim_fees.rs
+++ b/test-integration/test-validator-services/tests/test_claim_fees.rs
@@ -4,7 +4,6 @@ use dlp_api::instruction_builder::validator_claim_fees;
 use integration_test_tools::{
     loaded_accounts::LoadedAccounts, IntegrationTestContext,
 };
-use magicblock_validator_admin::claim_fees::ClaimFeesTask;
 use solana_commitment_config::CommitmentConfig;
 use solana_rpc_client::rpc_client::RpcClient;
 use solana_sdk::{
@@ -85,26 +84,6 @@ fn test_add_fees_to_vault() {
     println!("✓ Added {} lamports test fees to vault", TEST_FEE_AMOUNT);
 }
 
-/// Test the ClaimFeesTask struct
-fn test_claim_fees_task() {
-    println!("Testing ClaimFeesTask struct...");
-
-    let task = ClaimFeesTask::new();
-
-    // Test that the task starts in the correct state
-    assert!(task.handle.is_none(), "Task should start with no handle");
-
-    println!("✓ ClaimFeesTask created successfully");
-
-    let default_task = ClaimFeesTask::default();
-    assert!(
-        default_task.handle.is_none(),
-        "Default task should have no handle"
-    );
-
-    println!("✓ ClaimFeesTask default implementation works");
-}
-
 /// Test the actual fee claiming transaction
 fn test_claim_fees_transaction() {
     println!("Testing actual claim fees transaction...");
@@ -182,16 +161,13 @@ fn test_validator_claim_fees() {
     println!("=== Test 1: Instruction Creation ===");
     test_claim_fees_instruction();
 
-    println!("\n=== Test 2: ClaimFeesTask Struct ===");
-    test_claim_fees_task();
-
-    println!("\n=== Test 3: Add Test Fees ===");
+    println!("\n=== Test 2: Add Test Fees ===");
     test_add_fees_to_vault();
 
-    println!("\n=== Test 4: Claim Fees Transaction ===");
+    println!("\n=== Test 3: Claim Fees Transaction ===");
     test_claim_fees_transaction();
 
-    println!("\n=== Test 5: RPC Connection ===");
+    println!("\n=== Test 4: RPC Connection ===");
     test_claim_fees_rpc_connection();
 
     println!("\nAll tests completed successfully!");


### PR DESCRIPTION
## What changed

Unified validator and verifier process lifecycle under Engine's `ShutdownManager`. Leader-owned RPC, on-chain setup, task scheduling, intent execution, undelegation observation, fee claiming, and metrics now retain service handles and report terminal outcomes directly. Both binaries use Engine's stable shutdown classification, while verifier snapshot restarts continue reopening the Engine in-process.

Service APIs now own and supervise their workers, bind ingress before spawning, and drain owned work before reporting termination. The supported root and integration workspaces now use Engine `0.3.2`.

Closes #1593

## Impact

Engine classifies clean shutdown, restart-required, unexpected completion, and service failure with stable exit codes. The verifier consumes restart-required outcomes internally; other terminal outcomes reach the process supervisor. Work-producing and ingress services stop before the pacemaker, while metrics remains available through the final shutdown tier.

This changes internal service startup APIs and removes the prior Leader cancellation, failure-channel, and join-handle lifecycle.

## Reviewer notes

The highest-risk boundary is worker ownership during tiered shutdown: every registered service retains its `ShutdownHandle` until all owned workers stop, and finite on-chain setup waits for shutdown after successful completion. Per-request failures remain recoverable within their owning service; only terminal failures reach the process coordinator.
