### PR TITLE
chore(deps): update engine to the account-store and prepare fix stack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,7 +126,7 @@ dependencies = [
 [[package]]
 name = "agave-transaction-view"
 version = "4.1.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.1#cd021975429a9504f35d52dc9d5b0393a3c3e302"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?rev=ec741da47eca2f43f5797dde2530640ecb12aa39#ec741da47eca2f43f5797dde2530640ecb12aa39"
 dependencies = [
  "ahash 0.8.12",
  "solana-hash 4.4.0",
@@ -3697,7 +3697,7 @@ dependencies = [
 [[package]]
 name = "magic-root-interface"
 version = "0.3.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.1#cd021975429a9504f35d52dc9d5b0393a3c3e302"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?rev=ec741da47eca2f43f5797dde2530640ecb12aa39#ec741da47eca2f43f5797dde2530640ecb12aa39"
 dependencies = [
  "solana-account 4.3.1",
  "solana-instruction 3.4.0",
@@ -3708,7 +3708,7 @@ dependencies = [
 [[package]]
 name = "magic-root-program"
 version = "0.3.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.1#cd021975429a9504f35d52dc9d5b0393a3c3e302"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?rev=ec741da47eca2f43f5797dde2530640ecb12aa39#ec741da47eca2f43f5797dde2530640ecb12aa39"
 dependencies = [
  "magic-root-interface",
  "magicblock-engine-nucleus",
@@ -3716,6 +3716,7 @@ dependencies = [
  "solana-instruction 3.4.0",
  "solana-instruction-error",
  "solana-program-runtime",
+ "solana-sdk-ids 3.1.0",
  "solana-svm-log-collector",
  "solana-transaction-context",
  "wincode",
@@ -3758,7 +3759,7 @@ dependencies = [
 [[package]]
 name = "magicblock-accountsdb"
 version = "0.3.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.1#cd021975429a9504f35d52dc9d5b0393a3c3e302"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?rev=ec741da47eca2f43f5797dde2530640ecb12aa39#ec741da47eca2f43f5797dde2530640ecb12aa39"
 dependencies = [
  "ahash 0.8.12",
  "bincode",
@@ -4047,7 +4048,7 @@ dependencies = [
 [[package]]
 name = "magicblock-engine"
 version = "0.3.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.1#cd021975429a9504f35d52dc9d5b0393a3c3e302"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?rev=ec741da47eca2f43f5797dde2530640ecb12aa39#ec741da47eca2f43f5797dde2530640ecb12aa39"
 dependencies = [
  "agave-transaction-view",
  "derive_more",
@@ -4080,7 +4081,7 @@ dependencies = [
 [[package]]
 name = "magicblock-engine-nucleus"
 version = "0.3.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.1#cd021975429a9504f35d52dc9d5b0393a3c3e302"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?rev=ec741da47eca2f43f5797dde2530640ecb12aa39#ec741da47eca2f43f5797dde2530640ecb12aa39"
 dependencies = [
  "agave-transaction-view",
  "derive_more",
@@ -4112,7 +4113,7 @@ dependencies = [
 [[package]]
 name = "magicblock-keeper"
 version = "0.3.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.1#cd021975429a9504f35d52dc9d5b0393a3c3e302"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?rev=ec741da47eca2f43f5797dde2530640ecb12aa39#ec741da47eca2f43f5797dde2530640ecb12aa39"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.12",
@@ -4151,7 +4152,7 @@ dependencies = [
 [[package]]
 name = "magicblock-ledger"
 version = "0.3.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.1#cd021975429a9504f35d52dc9d5b0393a3c3e302"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?rev=ec741da47eca2f43f5797dde2530640ecb12aa39#ec741da47eca2f43f5797dde2530640ecb12aa39"
 dependencies = [
  "agave-transaction-view",
  "bitcode",
@@ -4234,7 +4235,7 @@ dependencies = [
 [[package]]
 name = "magicblock-processor"
 version = "0.3.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.1#cd021975429a9504f35d52dc9d5b0393a3c3e302"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?rev=ec741da47eca2f43f5797dde2530640ecb12aa39#ec741da47eca2f43f5797dde2530640ecb12aa39"
 dependencies = [
  "agave-feature-set",
  "agave-precompiles",
@@ -4307,7 +4308,7 @@ dependencies = [
 [[package]]
 name = "magicblock-replicator"
 version = "0.3.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.1#cd021975429a9504f35d52dc9d5b0393a3c3e302"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?rev=ec741da47eca2f43f5797dde2530640ecb12aa39#ec741da47eca2f43f5797dde2530640ecb12aa39"
 dependencies = [
  "derive_more",
  "flume",
@@ -6740,7 +6741,7 @@ dependencies = [
 [[package]]
 name = "solana-account"
 version = "4.3.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.1#cd021975429a9504f35d52dc9d5b0393a3c3e302"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?rev=ec741da47eca2f43f5797dde2530640ecb12aa39#ec741da47eca2f43f5797dde2530640ecb12aa39"
 dependencies = [
  "bincode",
  "bitflags 2.13.0",
@@ -8353,7 +8354,7 @@ dependencies = [
 [[package]]
 name = "solana-program-runtime"
 version = "4.1.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.1#cd021975429a9504f35d52dc9d5b0393a3c3e302"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?rev=ec741da47eca2f43f5797dde2530640ecb12aa39#ec741da47eca2f43f5797dde2530640ecb12aa39"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -9078,7 +9079,7 @@ dependencies = [
 [[package]]
 name = "solana-svm"
 version = "4.1.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.1#cd021975429a9504f35d52dc9d5b0393a3c3e302"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?rev=ec741da47eca2f43f5797dde2530640ecb12aa39#ec741da47eca2f43f5797dde2530640ecb12aa39"
 dependencies = [
  "ahash 0.8.12",
  "magic-root-interface",
@@ -9465,7 +9466,7 @@ dependencies = [
 [[package]]
 name = "solana-transaction-context"
 version = "4.1.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.1#cd021975429a9504f35d52dc9d5b0393a3c3e302"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?rev=ec741da47eca2f43f5797dde2530640ecb12aa39#ec741da47eca2f43f5797dde2530640ecb12aa39"
 dependencies = [
  "bincode",
  "serde",
@@ -10906,7 +10907,7 @@ dependencies = [
 [[package]]
 name = "v42-calculator-interface"
 version = "0.3.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.1#cd021975429a9504f35d52dc9d5b0393a3c3e302"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?rev=ec741da47eca2f43f5797dde2530640ecb12aa39#ec741da47eca2f43f5797dde2530640ecb12aa39"
 dependencies = [
  "solana-instruction 3.4.0",
  "solana-pubkey 4.2.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
     "magicblock-validator-admin",
     "magicblock-version",
     "programs/magicblock",
-    "storage-proto"
+    "storage-proto",
 ]
 
 # This prevents a Travis CI error when building for Windows.
@@ -47,7 +47,7 @@ magicblock-aml = { path = "magicblock-aml" }
 magicblock-aperture = { path = "magicblock-aperture" }
 magicblock-chainlink = { path = "magicblock-chainlink" }
 magicblock-committor-program = { path = "magicblock-committor-program", features = [
-    "no-entrypoint"
+    "no-entrypoint",
 ] }
 magicblock-committor-service = { path = "magicblock-committor-service" }
 magicblock-config = { path = "magicblock-config" }
@@ -65,17 +65,22 @@ magicblock-task-scheduler = { path = "magicblock-task-scheduler" }
 magicblock-validator-admin = { path = "magicblock-validator-admin" }
 magicblock-version = { path = "magicblock-version" }
 
-engine = { package = "magicblock-engine", git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.1" }
-keeper = { package = "magicblock-keeper", git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.1" }
-ledger = { package = "magicblock-ledger", git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.1" }
-nucleus = { package = "magicblock-engine-nucleus", git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.1" }
-replicator = { package = "magicblock-replicator", git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.1" }
-v42-calculator-interface = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.1" }
+engine = { package = "magicblock-engine", git = "https://github.com/magicblock-labs/magicblock-engine.git", rev = "ec741da47eca2f43f5797dde2530640ecb12aa39" }
+keeper = { package = "magicblock-keeper", git = "https://github.com/magicblock-labs/magicblock-engine.git", rev = "ec741da47eca2f43f5797dde2530640ecb12aa39" }
+ledger = { package = "magicblock-ledger", git = "https://github.com/magicblock-labs/magicblock-engine.git", rev = "ec741da47eca2f43f5797dde2530640ecb12aa39" }
+magic-root-interface = { package = "magic-root-interface", git = "https://github.com/magicblock-labs/magicblock-engine.git", rev = "ec741da47eca2f43f5797dde2530640ecb12aa39" }
+nucleus = { package = "magicblock-engine-nucleus", git = "https://github.com/magicblock-labs/magicblock-engine.git", rev = "ec741da47eca2f43f5797dde2530640ecb12aa39" }
+replicator = { package = "magicblock-replicator", git = "https://github.com/magicblock-labs/magicblock-engine.git", rev = "ec741da47eca2f43f5797dde2530640ecb12aa39" }
+v42-calculator-interface = { git = "https://github.com/magicblock-labs/magicblock-engine.git", rev = "ec741da47eca2f43f5797dde2530640ecb12aa39" }
 
 agave-geyser-plugin-interface = { version = "4.1" }
 agave-precompiles = { version = "4.1", features = ["agave-unstable-api"] }
-agave-syscalls = { package = "solana-syscalls", version = "4.1", features = ["agave-unstable-api"] }
-agave-transaction-view = { version = "=4.1.1", features = ["agave-unstable-api"] }
+agave-syscalls = { package = "solana-syscalls", version = "4.1", features = [
+    "agave-unstable-api",
+] }
+agave-transaction-view = { version = "=4.1.1", features = [
+    "agave-unstable-api",
+] }
 anyhow = "1.0.86"
 arc-swap = { version = "1.7" }
 assert_matches = "1.5.0"
@@ -130,10 +135,13 @@ protobuf-src = "1.1"
 rand = "0.9"
 reqwest = "0.12"
 rocksdb = { version = "0.23", default-features = false, features = ["lz4"] }
-rusqlite = { version = "0.37.0", features = ["bundled"] }                                     # bundled sqlite 3.44
+rusqlite = { version = "0.37.0", features = ["bundled"] } # bundled sqlite 3.44
 rustc-hash = "2.1"
 rustc_version = "0.4"
-rustls = { version = "0.23", default-features = false, features = ["aws_lc_rs", "std"] }
+rustls = { version = "0.23", default-features = false, features = [
+    "aws_lc_rs",
+    "std",
+] }
 scc = "3.8"
 semver = "1.0.22"
 serde = "1.0.217"
@@ -153,7 +161,10 @@ tonic-prost-build = "0.14"
 tracing = "0.1"
 tracing-log = { version = "0.2", features = ["log-tracer"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
-twox-hash = { version = "2.1", default-features = false, features = ["alloc", "xxhash3_64"] }
+twox-hash = { version = "2.1", default-features = false, features = [
+    "alloc",
+    "xxhash3_64",
+] }
 url = "2.5.0"
 wincode = "0.5"
 
@@ -163,14 +174,20 @@ solana-account-decoder = { version = "4.1" }
 solana-account-decoder-client-types = { version = "4.1" }
 solana-account-info = { version = "3.1" }
 solana-address-lookup-table-interface = { version = "3.0" }
-solana-bpf-loader-program = { version = "4.1", features = ["agave-unstable-api"] }
+solana-bpf-loader-program = { version = "4.1", features = [
+    "agave-unstable-api",
+] }
 solana-clock = { version = "3.1" }
 solana-cluster-type = { version = "3.1" }
 solana-commitment-config = { version = "3.1" }
 solana-compute-budget = { version = "4.1", features = ["agave-unstable-api"] }
-solana-compute-budget-instruction = { version = "4.1", features = ["agave-unstable-api"] }
+solana-compute-budget-instruction = { version = "4.1", features = [
+    "agave-unstable-api",
+] }
 solana-compute-budget-interface = { version = "3.0" }
-solana-compute-budget-program = { version = "4.1", features = ["agave-unstable-api"] }
+solana-compute-budget-program = { version = "4.1", features = [
+    "agave-unstable-api",
+] }
 solana-cpi = { version = "3.1" }
 solana-feature-gate-interface = { version = "4.0" }
 solana-feature-set = { package = "agave-feature-set", version = "4.1" }
@@ -183,12 +200,14 @@ solana-instructions-sysvar = { version = "4.0" }
 solana-keypair = { version = "3.1" }
 solana-loader-v3-interface = { version = "7.0" }
 solana-loader-v4-interface = { version = "3.1" }
-solana-loader-v4-program = { version = "4.1", features = ["agave-unstable-api"] }
+solana-loader-v4-program = { version = "4.1", features = [
+    "agave-unstable-api",
+] }
 solana-log-collector = { package = "solana-svm-log-collector", version = "4.1", features = [
-    "agave-unstable-api"
+    "agave-unstable-api",
 ] }
 solana-measure = { package = "solana-svm-measure", version = "4.1", features = [
-    "agave-unstable-api"
+    "agave-unstable-api",
 ] }
 solana-message = { version = "4.1" }
 solana-metrics = { version = "4.1", features = ["agave-unstable-api"] }
@@ -223,7 +242,9 @@ solana-transaction-context = { version = "4.1" }
 solana-transaction-error = { version = "3.2" }
 solana-transaction-status = { version = "4.1" }
 solana-transaction-status-client-types = "4.1"
-solana-zk-elgamal-proof-program = { version = "4.1", features = ["agave-unstable-api"] }
+solana-zk-elgamal-proof-program = { version = "4.1", features = [
+    "agave-unstable-api",
+] }
 spl-token = { package = "spl-token-interface", version = "2.0" }
 spl-token-2022 = { package = "spl-token-2022-interface", version = "2.1" }
 
@@ -231,8 +252,8 @@ spl-token-2022 = { package = "spl-token-2022-interface", version = "2.1" }
 [patch.crates-io]
 libsodium-rs = { git = "https://github.com/jedisct1/libsodium-rs.git", rev = "0397a6c5785233f9f2ac91f3eedc3cceb74e0060" }
 
-agave-transaction-view = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.1" }
-solana-account = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.1" }
-solana-program-runtime = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.1" }
-solana-svm = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.1" }
-solana-transaction-context = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.1" }
+agave-transaction-view = { git = "https://github.com/magicblock-labs/magicblock-engine.git", rev = "ec741da47eca2f43f5797dde2530640ecb12aa39" }
+solana-account = { git = "https://github.com/magicblock-labs/magicblock-engine.git", rev = "ec741da47eca2f43f5797dde2530640ecb12aa39" }
+solana-program-runtime = { git = "https://github.com/magicblock-labs/magicblock-engine.git", rev = "ec741da47eca2f43f5797dde2530640ecb12aa39" }
+solana-svm = { git = "https://github.com/magicblock-labs/magicblock-engine.git", rev = "ec741da47eca2f43f5797dde2530640ecb12aa39" }
+solana-transaction-context = { git = "https://github.com/magicblock-labs/magicblock-engine.git", rev = "ec741da47eca2f43f5797dde2530640ecb12aa39" }


### PR DESCRIPTION
## What changed
Pins every `magicblock-engine` git dependency and `[patch.crates-io]` entry to rev `ec741da47eca2f43f5797dde2530640ecb12aa39`, the tip of the engine fix stack (magicblock-labs/magicblock-engine#103, magicblock-labs/magicblock-engine#104, magicblock-labs/magicblock-engine#105), instead of tag `0.3.1`. Adds `magic-root-interface` to the workspace dependency table (used later in this stack) and regenerates `Cargo.lock`. The dependency-table reformatting is from the workspace TOML formatter.

Closes #1598

## Impact
The validator picks up in-place account slot reuse, the `Prepare` instruction for missing writable action accounts, and the checksum-boundary index fsync. No validator code changes. The rev pin is a stopgap until the engine stack lands in a release tag.

## Reviewer notes
The rev must stay reachable on the engine remote (it is the head of the `dode/sync-on-checksum` PR branch). `cargo check --workspace` passes at this commit against the pinned rev.