### PR TITLE
fix: resolve user program owner and caller across MagicRoot frames

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4270,6 +4270,7 @@ version = "0.14.11"
 dependencies = [
  "assert_matches",
  "lazy_static",
+ "magic-root-interface",
  "magicblock-chainlink",
  "magicblock-core",
  "magicblock-delegation-program-api",

--- a/magicblock-core/src/intent/types.rs
+++ b/magicblock-core/src/intent/types.rs
@@ -5,6 +5,12 @@ use wincode::{SchemaRead, SchemaWrite};
 
 use crate::token_programs::try_remap_ata_to_eata;
 
+/// Engine-internal wrapper that runs post-delegation actions. It is never the
+/// owner program of a committed user account; treating it as one makes DLP
+/// finalize reject the validator (`InvalidAuthority`).
+const MAGIC_ROOT_PROGRAM_ID: Pubkey =
+    Pubkey::from_str_const("MagicRootDRJ5atQjSJUxFjXzjeZXMADHUDznbk22gy");
+
 pub type CommittedAccountRef = (Pubkey, AccountSharedData);
 
 #[derive(
@@ -54,12 +60,51 @@ impl CommittedAccount {
             executable: account_shared.executable(),
             rent_epoch: account_shared.rent_epoch(),
         };
-        account.owner = parent_program_id.unwrap_or(account.owner);
+        // Rescue undelegation is CPI'd from MagicRoot. Keep the ER owner
+        // (the user program) so L1 finalize restores the same owner.
+        if let Some(parent) = parent_program_id {
+            if parent != MAGIC_ROOT_PROGRAM_ID {
+                account.owner = parent;
+            }
+        }
 
         CommittedAccount {
             pubkey,
             account,
             remote_slot,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use solana_account::AccountSharedData;
+    use solana_pubkey::Pubkey as SolanaPubkey;
+
+    use super::*;
+
+    #[test]
+    fn rescue_undelegate_keeps_user_program_owner() {
+        let owner = SolanaPubkey::new_unique();
+        let account = AccountSharedData::new(1_000, 8, &owner);
+        let committed = CommittedAccount::from_account_shared(
+            SolanaPubkey::new_unique(),
+            &account,
+            Some(MAGIC_ROOT_PROGRAM_ID),
+        );
+        assert_eq!(committed.account.owner, owner);
+    }
+
+    #[test]
+    fn parent_program_still_overrides_owner_when_not_magic_root() {
+        let owner = SolanaPubkey::new_unique();
+        let parent = SolanaPubkey::new_unique();
+        let account = AccountSharedData::new(1_000, 8, &owner);
+        let committed = CommittedAccount::from_account_shared(
+            SolanaPubkey::new_unique(),
+            &account,
+            Some(parent),
+        );
+        assert_eq!(committed.account.owner, parent);
     }
 }

--- a/programs/magicblock/Cargo.toml
+++ b/programs/magicblock/Cargo.toml
@@ -12,6 +12,7 @@ lazy_static = { workspace = true }
 magicblock-core = { workspace = true }
 magicblock-delegation-program-api = { workspace = true }
 magicblock-magic-program-api = { workspace = true }
+magic-root-interface = { workspace = true }
 nucleus = { workspace = true, features = ["tls"] }
 num-derive = { workspace = true }
 num-traits = { workspace = true }

--- a/programs/magicblock/src/ephemeral_accounts/validation.rs
+++ b/programs/magicblock/src/ephemeral_accounts/validation.rs
@@ -8,10 +8,7 @@ use solana_sdk_ids::system_program;
 use solana_transaction_context::transaction::TransactionContext;
 
 use super::{EPHEMERAL_IDX, SPONSOR_IDX, VAULT_IDX};
-use crate::utils::{
-    accounts::{self, InstructionAccount},
-    instruction_context_frames::InstructionContextFrames,
-};
+use crate::utils::accounts::{self, InstructionAccount};
 
 /// Returns the program ID of the CPI caller.
 ///
@@ -20,11 +17,13 @@ use crate::utils::{
 fn get_caller_program_id(
     tc: &TransactionContext<'_>,
 ) -> Result<Pubkey, InstructionError> {
-    let frames = InstructionContextFrames::try_from(tc)?;
-    frames
-        .find_program_id_of_parent_of_current_instruction()
+    let height = tc.get_instruction_stack_height();
+    let parent_level = height
+        .checked_sub(2)
+        .ok_or(InstructionError::IncorrectProgramId)?;
+    tc.get_instruction_context_at_nesting_level(parent_level)?
+        .get_program_key()
         .copied()
-        .ok_or(InstructionError::IncorrectProgramId)
 }
 
 /// Validates that the sponsor account is a signer.

--- a/programs/magicblock/src/schedule_transactions/mod.rs
+++ b/programs/magicblock/src/schedule_transactions/mod.rs
@@ -55,6 +55,9 @@ fn get_parent_program_id(
     let frames = crate::utils::instruction_context_frames::InstructionContextFrames::try_from(transaction_context)?;
     let parent_program_id =
         frames.find_program_id_of_parent_of_current_instruction();
+    // MagicRoot wraps post-delegation actions; it is not a user owner program.
+    let parent_program_id =
+        parent_program_id.filter(|id| **id != magic_root_interface::ID);
 
     ic_msg!(
         invoke_context,


### PR DESCRIPTION
## What changed
Post-delegation actions execute CPI-wrapped by the engine's MagicRoot program; three paths misattributed those frames to MagicRoot:

- `CommittedAccount::from_account_shared` no longer overrides the committed account's owner when the parent program is MagicRoot, so rescue undelegation keeps the user program as owner and DLP finalize on the base layer stops rejecting the validator with `InvalidAuthority`.
- `get_parent_program_id` (schedule_transactions) filters MagicRoot out of the parent resolution, using `magic_root_interface::ID`.
- `get_caller_program_id` (ephemeral account validation) resolves the direct CPI caller from the live instruction stack (`stack height - 2`) instead of walking reconstructed frames, which failed under the extra MagicRoot nesting.

Closes #1599

## Impact
Tickets whose `record_bid` goes through the rescue path now undelegate instead of failing finalize forever. Caller validation for ephemeral account instructions works identically for regular CPIs and post-delegation action frames.

## Reviewer notes
`magicblock-core` cannot depend on `magic-root-interface` without a cycle, so `types.rs` re-declares the MagicRoot program id as a `from_str_const`; the unit tests `rescue_undelegate_keeps_user_program_owner` and `parent_program_still_overrides_owner_when_not_magic_root` pin the behavior. The `height - 2` resolution assumes this instruction always executes at CPI depth, which the top-level rejection path enforces.