### PR TITLE
fix: keep fetches and live transports usable when pubsub fails

### DIFF
--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -1583,7 +1583,8 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
 
     /// Gets the accounts for the given pubkeys by fetching from RPC.
     /// Always fetches fresh data. FetchCloner handles request deduplication.
-    /// Subscribes first to catch any updates that arrive during fetch.
+    /// Subscribe is best-effort so a pubsub outage cannot drop the snapshot
+    /// that post-delegation actions need.
     #[instrument(skip(self, pubkeys, mark_empty_if_not_found, fetch_context))]
     pub async fn try_get_multi(
         &self,
@@ -1895,7 +1896,9 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
         }
         // Send all subscription requests in parallel (non-fail-fast).
         // We use join_all instead of try_join_all to ensure ALL acquire
-        // attempts complete, even if some fail.
+        // attempts complete, even if some fail. A failed subscribe must
+        // not abort the RPC snapshot: pubsub is for staying current, and
+        // post-delegation actions (record_bid) only run after that fetch.
         let subscription_results = join_all(pubkeys.iter().map(|pubkey| {
             let fetch_context = fetch_context.clone();
             async move {
@@ -1909,58 +1912,14 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
         }))
         .await;
 
-        let mut errors = Vec::new();
-        let mut acquired = Vec::new();
         for (result, pubkey) in subscription_results.iter().zip(pubkeys.iter())
         {
-            match result {
-                Err(err) => {
-                    error!(
-                        pubkey = %pubkey, err = ?err,
-                        "Failed to subscribe to account"
-                    );
-                    errors.push(format!("{}: {}", pubkey, err));
-                }
-                Ok(()) => acquired.push(*pubkey),
+            if let Err(err) = result {
+                warn!(
+                    pubkey = %pubkey, err = ?err,
+                    "Failed to subscribe to account; continuing with RPC fetch"
+                );
             }
-        }
-
-        if !errors.is_empty() {
-            for pubkey in &acquired {
-                if let Err(unsub_err) = self
-                    .release_single_subscription(
-                        pubkey,
-                        SubscriptionReason::DirectAccount,
-                    )
-                    .await
-                {
-                    if matches!(
-                        unsub_err,
-                        RemoteAccountProviderError::AccountSubscriptionDoesNotExist(_)
-                    ) {
-                        debug!(
-                            pubkey = %pubkey, err = ?unsub_err,
-                            "Failed to unsubscribe after partial \
-                             subscription failure"
-                        );
-                    } else {
-                        warn!(
-                            pubkey = %pubkey, err = ?unsub_err,
-                            "Failed to unsubscribe after partial \
-                             subscription failure"
-                        );
-                    }
-                }
-            }
-            return Err(
-                RemoteAccountProviderError::AccountSubscriptionsTaskFailed(
-                    format!(
-                        "{} subscription(s) failed: [{}]",
-                        errors.len(),
-                        errors.join(", ")
-                    ),
-                ),
-            );
         }
 
         Ok(())

--- a/magicblock-chainlink/src/remote_account_provider/tests.rs
+++ b/magicblock-chainlink/src/remote_account_provider/tests.rs
@@ -334,8 +334,7 @@ async fn setup_matching_slots(
 }
 
 #[tokio::test]
-async fn test_try_get_multi_setup_subscriptions_failure_cleans_up_pending_entry()
- {
+async fn test_try_get_multi_fetches_when_subscribe_fails() {
     let _metrics_guard =
         crate::testing::pending_metric_test_lock().lock().await;
     let pubkey = solana_pubkey::Pubkey::new_unique();
@@ -381,25 +380,15 @@ async fn test_try_get_multi_setup_subscriptions_failure_cleans_up_pending_entry(
         .await
         .expect("owner task should complete")
         .expect("owner task should not panic");
-    let err = result.expect_err("setup_subscriptions should fail");
-    assert!(err.to_string().contains("subscription(s) failed"));
+    let remote_accounts = result
+        .expect("RPC fetch must proceed when pubsub subscribe fails");
+    assert_eq!(remote_accounts.len(), 1);
+    assert_eq!(remote_accounts[0].fresh_lamports(), Some(1_000_000));
     assert!(!provider.is_pending(&pubkey));
-
-    pubsub_client.try_reconnect().await.unwrap();
-    let retry = provider
-        .try_get_multi(
-            &[pubkey],
-            None,
-            AccountFetchContext::rpc_get_account(),
-            None,
-        )
-        .await
-        .expect("retry after cleanup should succeed");
-    assert_eq!(retry.len(), 1);
 }
 
 #[tokio::test]
-async fn test_try_get_multi_waiter_receives_setup_subscriptions_failure() {
+async fn test_try_get_multi_waiter_receives_account_when_subscribe_fails() {
     let _metrics_guard =
         crate::testing::pending_metric_test_lock().lock().await;
     let pubkey = solana_pubkey::Pubkey::new_unique();
@@ -484,10 +473,14 @@ async fn test_try_get_multi_waiter_receives_setup_subscriptions_failure() {
             .expect("waiter task should complete")
             .expect("waiter task should not panic");
 
-    let first_err = first_result.expect_err("owner should fail");
-    let second_err = second_result.expect_err("waiter should fail");
-    assert!(first_err.to_string().contains("subscription(s) failed"));
-    assert!(second_err.to_string().contains("subscription(s) failed"));
+    let first_accounts = first_result
+        .expect("owner must receive the RPC snapshot when subscribe fails");
+    let second_accounts = second_result
+        .expect("waiter must receive the RPC snapshot when subscribe fails");
+    assert_eq!(first_accounts.len(), 1);
+    assert_eq!(second_accounts.len(), 1);
+    assert_eq!(first_accounts[0].fresh_lamports(), Some(1_000_000));
+    assert_eq!(second_accounts[0].fresh_lamports(), Some(1_000_000));
     assert!(!provider.is_pending(&pubkey));
 }
 

--- a/magicblock-chainlink/src/submux/mod.rs
+++ b/magicblock-chainlink/src/submux/mod.rs
@@ -731,13 +731,17 @@ where
         let account_subs = accounts_tracker.subscribed_accounts();
 
         if let Err(err) = client.resub_multiple(account_subs).await {
-            debug!(
+            warn!(
                 client_id = %client.id(),
                 resub_delay_ms = ?client.current_resub_delay_ms(),
                 error = ?err,
-                "Failed to resubscribe accounts after reconnect"
+                "Failed to resubscribe accounts after reconnect; keeping client visible so new subscriptions can use the live transport"
             );
-            rollback_visibility();
+            // Do not rollback visibility. Rolling back empties
+            // connected_clients_snapshot() and makes every subscribe() fail
+            // with "No clients provided" until the next backoff retry.
+            // The reconnector still retries the resub; the reconciler
+            // repairs stragglers.
             return Err(err);
         }
 
@@ -2178,6 +2182,54 @@ mod tests {
         let up = got.expect("should receive update after retry reconnect");
         assert_eq!(up.pubkey, pk);
         assert!(up.slot >= 100);
+
+        mux.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_reconnect_keeps_client_visible_when_account_resub_fails() {
+        init_logger();
+
+        let (tx, rx) = mpsc::channel(10_000);
+        let client = Arc::new(ChainPubsubClientMock::new(tx, rx));
+
+        let pk = Pubkey::new_unique();
+        let (mux, aborts) =
+            new_submux_with_abort(vec![client.clone()], vec![pk], Some(100));
+
+        mux.subscribe(pk, None).await.unwrap();
+        assert_eq!(mux.connected_clients_snapshot().len(), 1);
+
+        client.fail_next_resubscriptions(1);
+        client.simulate_disconnect();
+        aborts[0].send(()).await.expect("abort send");
+
+        let deadline = Instant::now() + Duration::from_millis(500);
+        while Instant::now() < deadline {
+            if client.reconnect_calls() >= 1 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(
+            client.reconnect_calls() >= 1,
+            "reconnect should have attempted account resubscribe"
+        );
+        // Let the forced resub failure finish and apply rollback (today)
+        // or keep the client visible (desired).
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        assert_eq!(
+            mux.connected_clients_snapshot().len(),
+            1,
+            "a live transport must stay usable for new subscriptions after account resub fails"
+        );
+
+        let pk2 = Pubkey::new_unique();
+        mux.subscribe(pk2, None)
+            .await
+            .expect("subscribe must not see an empty connected-client set");
+        assert!(client.subscriptions_union().contains(&pk2));
 
         mux.shutdown().await.unwrap();
     }


### PR DESCRIPTION
## What changed
Two pubsub failure modes no longer take down account materialization:

- `try_get_multi` treats subscriptions as best-effort: a failed subscribe logs a warning and the RPC snapshot proceeds, instead of aborting with `AccountSubscriptionsTaskFailed` and unwinding the already-acquired subscriptions.
- After a reconnect, a failed account resubscription no longer rolls back the client's visibility in submux. Rolling back emptied `connected_clients_snapshot()` and made every new `subscribe()` fail with "No clients provided" until the next backoff round; the reconnector still retries the resub and the reconciler repairs stragglers.

Closes #1602

## Impact
Accounts (and their post-delegation actions, which only run after the RPC fetch) keep materializing through pubsub outages; a transient resub failure no longer becomes a subscription blackout. Trade-off: an account fetched during an outage may miss updates until the reconciler repairs its subscription — previously the fetch failed outright.

## Reviewer notes
Tests updated/added: `test_try_get_multi_fetches_when_subscribe_fails`, `test_try_get_multi_waiter_receives_account_when_subscribe_fails`, and `test_reconnect_keeps_client_visible_when_account_resub_fails`. The removed cleanup block in `setup_subscriptions` was only reachable on the now-removed error path.