### PR TITLE
fix: stop re-signing already-submitted transactions on confirmation timeouts

### DIFF
--- a/magicblock-committor-service/Cargo.toml
+++ b/magicblock-committor-service/Cargo.toml
@@ -52,6 +52,7 @@ wincode = { workspace = true }
 
 [dev-dependencies]
 rand = { workspace = true }
+solana-commitment-config = { workspace = true }
 solana-signature = { workspace = true, features = ["rand"] }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }

--- a/magicblock-committor-service/src/intent_executor/error.rs
+++ b/magicblock-committor-service/src/intent_executor/error.rs
@@ -144,7 +144,7 @@ impl IntentExecutorError {
             Self::FailedToFinalizeError {
                 err,
                 commit_signature: None,
-                ..
+                finalize_signature: None,
             } => err.is_transient(),
             Self::FailedToFinalizeError { .. }
             | Self::FailedFinalizePreparationError(_) => false,
@@ -653,6 +653,27 @@ mod tests {
             finalize_signature: None,
         };
         assert!(!err.is_transient());
+    }
+
+    #[test]
+    fn sent_finalize_signature_is_not_retried_as_a_fresh_send() {
+        let confirm_timeout = TransactionStrategyExecutionError::InternalError(
+            InternalError::MagicBlockRpcClientError(Box::new(
+                MagicBlockRpcClientError::CannotConfirmTransactionSignatureStatus(
+                    solana_signature::Signature::default(),
+                    solana_commitment_config::CommitmentLevel::Confirmed,
+                ),
+            )),
+        );
+        let err = super::IntentExecutorError::FailedToFinalizeError {
+            err: confirm_timeout,
+            commit_signature: None,
+            finalize_signature: Some(solana_signature::Signature::default()),
+        };
+        assert!(
+            !err.is_transient(),
+            "single-stage CAU already submitted a signature; re-executing would send again"
+        );
     }
 
     #[test]

--- a/magicblock-rpc-client/src/lib.rs
+++ b/magicblock-rpc-client/src/lib.rs
@@ -205,8 +205,10 @@ impl MagicBlockSendTransactionConfig {
             check_for_processed_interval: None,
             // NOTE: we skip the processed check here and wait directly for
             //       the commitment level, trusting the confirmed result
-            //       even if an earlier processed check would have failed
-            wait_for_commitment_level: Some(Duration::from_millis(8_000)),
+            //       even if an earlier processed check would have failed.
+            //       Use the processed window so a single send can confirm
+            //       under a large parallel CAU queue instead of re-signing.
+            wait_for_commitment_level: Some(DEFAULT_MAX_TIME_TO_PROCESSED),
             check_for_commitment_interval: Some(Duration::from_millis(400)),
         }
     }

--- a/magicblock-rpc-client/src/utils.rs
+++ b/magicblock-rpc-client/src/utils.rs
@@ -199,9 +199,10 @@ pub fn decide_rpc_error_flow(
         | MagicBlockRpcClientError::CannotConfirmTransactionSignatureStatus(
             ..,
         ) => {
-            // if there's still time left we can retry sending tx
-            // Since [`DEFAULT_MAX_TIME_TO_PROCESSED`] is large we skip sleep as well
-            ControlFlow::Continue(Duration::ZERO)
+            // The transaction was already submitted. Re-signing with a fresh
+            // blockhash can land a second CAU (AlreadyProcessed / NotUndelegatable)
+            // and occupies an executor for minutes under a large ticket queue.
+            ControlFlow::Break(())
         }
         MagicBlockRpcClientError::GetLatestBlockhash(err) => {
             trace!(error = ?err, "Failed to get latest blockhash during sending tx");
@@ -248,6 +249,7 @@ fn decide_reqwest_flow(status: Option<u16>) -> ControlFlow<(), Duration> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::MagicBlockRpcClientError;
 
     #[test]
     fn test_reqwest_transport_and_transient_statuses_retried() {
@@ -290,5 +292,31 @@ mod tests {
             })),
         };
         assert!(decide_rpc_native_flow(&err).is_break());
+    }
+
+    #[test]
+    fn test_confirm_timeout_does_not_resend() {
+        let err =
+            MagicBlockRpcClientError::CannotConfirmTransactionSignatureStatus(
+                solana_signature::Signature::default(),
+                solana_commitment_config::CommitmentLevel::Confirmed,
+            );
+        assert!(
+            decide_rpc_error_flow(&err).is_break(),
+            "a sent transaction that timed out on confirm must be re-polled, not re-signed"
+        );
+    }
+
+    #[test]
+    fn test_processed_status_timeout_does_not_resend() {
+        let err =
+            MagicBlockRpcClientError::CannotGetTransactionSignatureStatus(
+                solana_signature::Signature::default(),
+                "timed out waiting for processed signature status".to_string(),
+            );
+        assert!(
+            decide_rpc_error_flow(&err).is_break(),
+            "a sent transaction that timed out on processed must be re-polled, not re-signed"
+        );
     }
 }


### PR DESCRIPTION
## What changed
Timeouts on transactions that were already submitted stop triggering re-sends:

- `decide_rpc_error_flow` breaks the send-retry loop on `CannotConfirmTransactionSignatureStatus` and processed-status timeouts instead of re-signing with a fresh blockhash and sending again.
- `IntentExecutorError::FailedToFinalizeError` with a sent finalize signature is no longer classified as transient, so the intent executor does not re-execute an already-submitted finalize as a fresh send.
- The ensure-committed confirmation window uses `DEFAULT_MAX_TIME_TO_PROCESSED` instead of a hardcoded 8s, which was far below realistic confirmation latency under a large parallel CAU queue.

Closes #1605

## Impact
Under load the original transaction usually landed and only the confirmation outran the RPC node; re-sending produced duplicate CAUs failing `AlreadyProcessed` — and for undelegations DLP `Custom(1)` (`NotUndelegatable`), since the first undelegation consumed the request — while occupying an intent executor for minutes per retry. Failure surfacing is unchanged: a genuinely dropped transaction now surfaces as a confirmation failure instead of being silently re-signed.

## Reviewer notes
Tests pin all three behaviors: `test_confirm_timeout_does_not_resend`, `test_processed_status_timeout_does_not_resend` (rpc-client), and `sent_finalize_signature_is_not_retried_as_a_fresh_send` (committor). `solana-commitment-config` is added as a committor dev-dependency for the latter.