### PR TITLE
fix: keep independent intents flowing while a backlog drains

### DIFF
--- a/magicblock-committor-service/src/intent_execution_manager.rs
+++ b/magicblock-committor-service/src/intent_execution_manager.rs
@@ -80,32 +80,8 @@ impl<D: DB> IntentExecutionManager<D> {
         &self,
         intent_bundles: Vec<ScheduledIntentBundle>,
     ) -> Result<(), IntentExecutionManagerError> {
-        // If db not empty push el-t there
-        // This means that at some point channel got full
-        // Worker first will clean-up channel, and then DB.
-        // Pushing into channel would break order of commits
-        if !self.db.is_empty() {
-            self.db.store_intent_bundles(intent_bundles).await?;
-            return Ok(());
-        }
-
-        let mut iter = intent_bundles.into_iter();
-        // Treated as regular value not propagated lower
-        #[allow(clippy::result_large_err)]
-        let res = iter.try_for_each(|el| self.intent_sender.try_send(el));
-        match res {
-            Ok(_) => Ok(()),
-            Err(TrySendError::Closed(_)) => {
-                Err(IntentExecutionManagerError::ChannelClosed)
-            }
-            Err(TrySendError::Full(el)) => {
-                let leftovers = std::iter::once(el).chain(iter).collect();
-                self.db
-                    .store_intent_bundles(leftovers)
-                    .await
-                    .map_err(IntentExecutionManagerError::from)
-            }
-        }
+        enqueue_intent_bundles(&self.intent_sender, self.db.as_ref(), intent_bundles)
+            .await
     }
 
     /// Creates a subscription for results of BaseIntent execution
@@ -113,6 +89,32 @@ impl<D: DB> IntentExecutionManager<D> {
         &self,
     ) -> broadcast::Receiver<BroadcastedIntentExecutionResult> {
         self.result_subscriber.subscribe()
+    }
+}
+
+/// Try the live channel first so a later independent CAU can run while a
+/// DummyDB ticket backlog drains. Overflow still goes to DummyDB. Same-account
+/// order is preserved by [`IntentExecutionEngine::get_new_intent`].
+pub(crate) async fn enqueue_intent_bundles<D: DB>(
+    sender: &mpsc::Sender<ScheduledIntentBundle>,
+    db: &D,
+    intent_bundles: Vec<ScheduledIntentBundle>,
+) -> Result<(), IntentExecutionManagerError> {
+    let mut iter = intent_bundles.into_iter();
+    // Treated as regular value not propagated lower
+    #[allow(clippy::result_large_err)]
+    let res = iter.try_for_each(|el| sender.try_send(el));
+    match res {
+        Ok(_) => Ok(()),
+        Err(TrySendError::Closed(_)) => {
+            Err(IntentExecutionManagerError::ChannelClosed)
+        }
+        Err(TrySendError::Full(el)) => {
+            let leftovers = std::iter::once(el).chain(iter).collect();
+            db.store_intent_bundles(leftovers)
+                .await
+                .map_err(IntentExecutionManagerError::from)
+        }
     }
 }
 

--- a/magicblock-committor-service/src/intent_execution_manager/db.rs
+++ b/magicblock-committor-service/src/intent_execution_manager/db.rs
@@ -1,9 +1,13 @@
-use std::{collections::VecDeque, sync::Mutex};
+use std::{
+    collections::{HashMap, VecDeque},
+    sync::Mutex,
+};
 
 /// DB for storing intents that overflow committor channel
 use async_trait::async_trait;
 use magicblock_metrics::metrics;
 use magicblock_program::magic_scheduled_base_intent::ScheduledIntentBundle;
+use solana_pubkey::Pubkey;
 
 const POISONED_MUTEX_MSG: &str = "Dummy db mutex poisoned";
 
@@ -23,16 +27,46 @@ pub trait DB: Send + Sync + 'static {
         &self,
     ) -> DBResult<Option<ScheduledIntentBundle>>;
     fn is_empty(&self) -> bool;
+
+    /// True when `intent` shares a committed pubkey with anything still queued.
+    fn conflicts_with(&self, intent: &ScheduledIntentBundle) -> bool;
+}
+
+struct DummyDbInner {
+    queue: VecDeque<ScheduledIntentBundle>,
+    queued_pubkeys: HashMap<Pubkey, usize>,
+}
+
+impl DummyDbInner {
+    fn track(&mut self, intent: &ScheduledIntentBundle) {
+        for pubkey in intent.get_all_committed_pubkeys() {
+            *self.queued_pubkeys.entry(pubkey).or_default() += 1;
+        }
+    }
+
+    fn untrack(&mut self, intent: &ScheduledIntentBundle) {
+        for pubkey in intent.get_all_committed_pubkeys() {
+            if let Some(count) = self.queued_pubkeys.get_mut(&pubkey) {
+                *count -= 1;
+                if *count == 0 {
+                    self.queued_pubkeys.remove(&pubkey);
+                }
+            }
+        }
+    }
 }
 
 pub(crate) struct DummyDB {
-    db: Mutex<VecDeque<ScheduledIntentBundle>>,
+    db: Mutex<DummyDbInner>,
 }
 
 impl DummyDB {
     pub fn new() -> Self {
         Self {
-            db: Mutex::new(VecDeque::new()),
+            db: Mutex::new(DummyDbInner {
+                queue: VecDeque::new(),
+                queued_pubkeys: HashMap::new(),
+            }),
         }
     }
 }
@@ -44,9 +78,10 @@ impl DB for DummyDB {
         intent_bundle: ScheduledIntentBundle,
     ) -> DBResult<()> {
         let mut db = self.db.lock().expect(POISONED_MUTEX_MSG);
-        db.push_back(intent_bundle);
+        db.track(&intent_bundle);
+        db.queue.push_back(intent_bundle);
 
-        metrics::set_committor_intents_backlog_count(db.len() as i64);
+        metrics::set_committor_intents_backlog_count(db.queue.len() as i64);
         Ok(())
     }
 
@@ -55,9 +90,12 @@ impl DB for DummyDB {
         intent_bundles: Vec<ScheduledIntentBundle>,
     ) -> DBResult<()> {
         let mut db = self.db.lock().expect(POISONED_MUTEX_MSG);
-        db.extend(intent_bundles);
+        for intent in &intent_bundles {
+            db.track(intent);
+        }
+        db.queue.extend(intent_bundles);
 
-        metrics::set_committor_intents_backlog_count(db.len() as i64);
+        metrics::set_committor_intents_backlog_count(db.queue.len() as i64);
         Ok(())
     }
 
@@ -65,14 +103,25 @@ impl DB for DummyDB {
         &self,
     ) -> DBResult<Option<ScheduledIntentBundle>> {
         let mut db = self.db.lock().expect(POISONED_MUTEX_MSG);
-        let res = db.pop_front();
+        let res = db.queue.pop_front();
+        if let Some(intent) = res.as_ref() {
+            db.untrack(intent);
+        }
 
-        metrics::set_committor_intents_backlog_count(db.len() as i64);
+        metrics::set_committor_intents_backlog_count(db.queue.len() as i64);
         Ok(res)
     }
 
     fn is_empty(&self) -> bool {
-        self.db.lock().expect(POISONED_MUTEX_MSG).is_empty()
+        self.db.lock().expect(POISONED_MUTEX_MSG).queue.is_empty()
+    }
+
+    fn conflicts_with(&self, intent: &ScheduledIntentBundle) -> bool {
+        let db = self.db.lock().expect(POISONED_MUTEX_MSG);
+        intent
+            .get_all_committed_pubkeys()
+            .iter()
+            .any(|pubkey| db.queued_pubkeys.contains_key(pubkey))
     }
 }
 

--- a/magicblock-committor-service/src/intent_execution_manager/intent_execution_engine.rs
+++ b/magicblock-committor-service/src/intent_execution_manager/intent_execution_engine.rs
@@ -145,7 +145,7 @@ where
 
     /// Spawns `main_loop` and return `Receiver` listening to results
     pub fn spawn(self) -> ResultSubscriber {
-        let (result_sender, _) = broadcast::channel(100);
+        let (result_sender, _) = broadcast::channel(4096);
         tokio::spawn(self.main_loop(result_sender.clone()));
 
         ResultSubscriber(result_sender)
@@ -273,7 +273,18 @@ where
         db: &Arc<D>,
     ) -> Result<ScheduledIntentBundle, IntentExecutionManagerError> {
         match receiver.try_recv() {
-            Ok(val) => Ok(val),
+            Ok(val) => {
+                // Independent later CAUs may jump a DummyDB backlog. A later
+                // CAU for an account already queued must wait its turn.
+                if db.conflicts_with(&val) {
+                    db.store_intent_bundle(val).await?;
+                    Ok(db.pop_intent_bundle().await?.expect(
+                        "DummyDB cannot be empty after storing a conflicting intent",
+                    ))
+                } else {
+                    Ok(val)
+                }
+            }
             Err(TryRecvError::Empty) => {
                 // Worker either cleaned-up congested channel and now need to clean-up DB
                 // or we're just waiting on empty channel
@@ -629,6 +640,77 @@ mod tests {
             result.inner.unwrap_err().to_string(),
             "FailedToCommitError: InternalError: SignerError: custom error: oops"
         );
+    }
+
+    #[tokio::test]
+    async fn test_get_new_intent_does_not_reorder_same_account_behind_db() {
+        let (sender, worker) = setup_engine(false);
+        let shared = pubkey!("1111111111111111111111111111111111111111111");
+        let earlier = create_test_intent(1, &[shared], true);
+        let later = create_test_intent(2, &[shared], true);
+        worker.db.store_intent_bundle(earlier.clone()).await.unwrap();
+        sender.send(later).await.unwrap();
+
+        let mut receiver = worker.receiver;
+        let next = MockIntentExecutionEngine::get_new_intent(
+            &mut receiver,
+            &worker.db,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            next.id, 1,
+            "later CAU for the same account must not jump an earlier one still in DummyDB"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_new_intent_runs_nonconflicting_channel_intent_ahead_of_db()
+    {
+        let (sender, worker) = setup_engine(false);
+        let queued = create_test_intent(1, &[Pubkey::new_unique()], true);
+        let incoming = create_test_intent(2, &[Pubkey::new_unique()], true);
+        worker.db.store_intent_bundle(queued).await.unwrap();
+        sender.send(incoming.clone()).await.unwrap();
+
+        let mut receiver = worker.receiver;
+        let next = MockIntentExecutionEngine::get_new_intent(
+            &mut receiver,
+            &worker.db,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            next.id, 2,
+            "independent later CAUs must not wait behind a DummyDB ticket backlog"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_enqueue_keeps_channel_usable_when_db_has_backlog() {
+        let (sender, receiver) = mpsc::channel(4);
+        let db = DummyDB::new();
+        let queued = create_test_intent(1, &[Pubkey::new_unique()], true);
+        db.store_intent_bundle(queued).await.unwrap();
+
+        let incoming = create_test_intent(2, &[Pubkey::new_unique()], true);
+        crate::intent_execution_manager::enqueue_intent_bundles(
+            &sender,
+            &db,
+            vec![incoming.clone()],
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            !db.is_empty(),
+            "backlog stays in DummyDB until the worker drains it"
+        );
+        let mut receiver = receiver;
+        let from_channel = receiver.try_recv().expect(
+            "non-conflicting later CAU must enter the live channel, not the DummyDB tail",
+        );
+        assert_eq!(from_channel.id, 2);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What changed
The committor no longer serializes everything behind a backlog:

- `enqueue_intent_bundles` tries the live channel first even when the backlog DB is non-empty; only overflow goes to the DB.
- Same-account ordering is preserved at dequeue instead: `DummyDB` tracks the committed pubkeys of queued intents, and `get_new_intent` re-routes a channel intent to the back of the DB when it conflicts with anything still queued.
- The result broadcast channel grows from 100 to 4096 slots so burst-sized fan-out does not drop execution results.

Closes #1606

## Impact
An independent intent (e.g. the auction result commit scheduled during the 41k-ticket drain) executes immediately instead of waiting behind every queued ticket, while a later CAU for an account with queued work still waits its turn. Result subscribers stop losing outcomes under bursts.

## Reviewer notes
The ordering invariant lives entirely in `conflicts_with` + the re-route in `get_new_intent`; tests `test_get_new_intent_does_not_reorder_same_account_behind_db`, `test_get_new_intent_runs_nonconflicting_channel_intent_ahead_of_db`, and `test_enqueue_keeps_channel_usable_when_db_has_backlog` cover both sides. The pubkey refcounts in `DummyDbInner` must stay balanced across `track`/`untrack`; `pop_intent_bundle` is the only dequeue path.