### PR TITLE
ci: use shared Magic Lab project automation

### DIFF
--- a/.github/workflows/auto_add_to_board.yml
+++ b/.github/workflows/auto_add_to_board.yml
@@ -1,0 +1,19 @@
+name: Magic Lab Project Automation
+
+on:
+  issues:
+    types: [opened, reopened, transferred, labeled, unlabeled]
+  pull_request:
+    types: [opened, reopened, labeled, closed]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  magic-lab:
+    name: Update Magic Lab
+    uses: magicblock-labs/.github/.github/workflows/magic_lab_automation.yml@21cae0c2ecb071828423f673076e887f8a5fe63d
+    secrets:
+      ADD_TO_PROJECT_PAT: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
## What changed

Add the caller for the shared Magic Lab issue and pull-request automation workflow.

## Impact

Issues and pull requests will be added to Magic Lab consistently, unassigned items will be assigned to their authors, P0-P3 labels will update project priority, and merging a pull request will close linked issues. Runtime behavior, APIs, storage, security, and performance are unchanged.

The repository must be granted access to the ADD_TO_PROJECT_PAT organization secret and its fine-grained token.

## Reviewer notes

The reusable workflow is pinned to immutable commit 21cae0c2ecb071828423f673076e887f8a5fe63d. The invariant review found no applicable violation because the diff only adds GitHub Actions orchestration. Disable the repository-specific native Magic Lab project workflow after this PR is ready.