### PR TITLE
fix(deps): bump h2 to 0.4.16 to resolve RUSTSEC-2026-0258

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2592,9 +2592,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
## What changed
Bump `h2` from 0.4.15 to 0.4.16 in Cargo.lock.

## Why
h2 <0.4.16 accepts and queues unbounded empty DATA frames without limit, which can lead to unbounded memory usage or a panic (DoS) if streams are not actively drained (GHSA-q83h-524g-xf6h). h2 is pulled in via tonic/reqwest for client-side HTTP/2 usage (remote RPC/geyser connections).

## Compatibility
None — patch-level bump only. Dependency spec is identical between 0.4.15 and 0.4.16 per the crates.io index, so no API surface changed.

## Validation
- `cargo build --release` succeeds cleanly for the full workspace
- Full test suite could not be run due to a pre-existing, unrelated `cargo build-sbf`/edition2024 toolchain mismatch in this environment (reproduced identically on unpatched Cargo.lock via git stash, confirming it's unrelated to this change)

Advisory: https://github.com/hyperium/hyper/security/advisories/GHSA-q83h-524g-xf6h