### PR TITLE
fix: stop chainlink subscriptions before cancelling the scheduler

### DIFF
--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -113,6 +113,7 @@ pub struct MagicValidator {
     exit: Arc<AtomicBool>,
     token: CancellationToken,
     accountsdb: Arc<AccountsDb>,
+    chainlink: Arc<ChainlinkImpl>,
     ledger: Arc<Ledger>,
     ledger_truncator: LedgerTruncator,
     intent_execution_service: IntentExecutionServiceImpl,
@@ -460,6 +461,7 @@ impl MagicValidator {
 
         Ok(Self {
             accountsdb,
+            chainlink,
             config,
             exit,
             _metrics: (metrics_service, system_metrics_ticker),
@@ -1259,6 +1261,15 @@ impl MagicValidator {
         // replication drain treats a closed channel as "producer finished"
         // and otherwise waits out its full timeout.
         self.replication_tx = None;
+
+        // Stop chain subscriptions before the token is cancelled: the cloner
+        // turns subscription updates into scheduled transactions, and once
+        // the scheduler is gone each one fails with `ClusterMaintenance` and
+        // is retried until the process is killed, which keeps the RPC
+        // runtime alive past its shutdown timeout.
+        let step_start = Instant::now();
+        self.chainlink.shutdown().await;
+        log_timing("shutdown", "chainlink_stop", step_start);
 
         // Stop request ingress before stopping intent execution so shutdown
         // does not admit new local undelegation scheduling work.

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -800,6 +800,19 @@ where
             .scan(|_pubkey, pending| pending.cancel.notify_one());
     }
 
+    /// Stops chain subscriptions and cancels in-flight fetch+clone work.
+    ///
+    /// Cloning runs through the transaction scheduler, so every update that
+    /// still arrives once the scheduler is gone fails with
+    /// `ClusterMaintenance` and is retried. Shutdown calls this before the
+    /// scheduler is cancelled so the pipeline is already dry by then.
+    pub async fn shutdown(&self) {
+        if let Err(err) = self.remote_account_provider.shutdown().await {
+            warn!(error = ?err, "Failed to shut down chain subscriptions");
+        }
+        self.cancel_all_pending();
+    }
+
     /// Check if a program is allowed to be cloned.
     /// Returns true if:
     /// - No allowed_programs restriction is set (None), OR

--- a/magicblock-chainlink/src/chainlink/mod.rs
+++ b/magicblock-chainlink/src/chainlink/mod.rs
@@ -313,6 +313,16 @@ impl<T: ChainRpcClient, U: ChainPubsubClient, V: AccountsBank, C: Cloner>
         }
     }
 
+    /// Stops chain subscriptions and in-flight clones. Must run before the
+    /// transaction scheduler is cancelled: clones are scheduled
+    /// transactions, and updates arriving after the scheduler is gone fail
+    /// with `ClusterMaintenance` and retry for the rest of the shutdown.
+    pub async fn shutdown(&self) {
+        if let Some(fetch_cloner) = self.fetch_cloner() {
+            fetch_cloner.shutdown().await;
+        }
+    }
+
     pub fn is_watching(&self, pubkey: &Pubkey) -> bool {
         match self {
             Self::Enabled(chainlink) => chainlink.is_watching(pubkey),

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -2076,6 +2076,12 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
         self.received_updates_count.load(Ordering::Relaxed)
     }
 
+    /// Shuts down the chain subscriptions feeding this provider, so no
+    /// further account updates are delivered.
+    pub async fn shutdown(&self) -> RemoteAccountProviderResult<()> {
+        self.pubsub_client.shutdown().await
+    }
+
     fn listen_for_account_updates(
         &self,
         mut updates: mpsc::Receiver<SubscriptionUpdate>,


### PR DESCRIPTION
## Summary
`MagicValidator::stop` cancelled the shutdown token — and with it the transaction scheduler — before stopping the chain subscriptions, so the cloner kept turning subscription updates into transactions that could only fail, hanging shutdown until the service manager SIGKILLed the process.

Cloning goes through the scheduler (`ChainlinkCloner::clone_account` → `tx_scheduler.execute`), and a closed scheduler channel maps to `TransactionError::ClusterMaintenance` (`magicblock-core/src/link/transactions.rs:285`). Once the token is cancelled, every update chainlink is still subscribed to produces one of those, is logged, and is retried for the remainder of the shutdown window.

The fix stops the chain subscriptions and cancels in-flight fetch+clone work first, so the clone pipeline is dry before the scheduler goes away:

- `RemoteAccountProvider::shutdown` — shuts down the pubsub client (the test/dev-only `pubsub_client()` accessor is not available in release builds).
- `FetchCloner::shutdown` — the above plus `cancel_all_pending()`.
- `Chainlink::shutdown` — no-op when chainlink is disabled (replica mode).
- `MagicValidator::stop` — calls it before `token.cancel()`, timed as the `chainlink_stop` shutdown step.

## Breaking Changes
- [x] None
- [ ] Yes — migration path described below

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved shutdown handling by stopping chain subscriptions before the transaction scheduler exits.
  - Cancelled in-progress synchronization and replication work during shutdown.
  - Prevented shutdown-time updates from creating failed transactions and repeated retries during cluster maintenance.
  - Improved reliability and ensured services stop cleanly without lingering background activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->