### PR TITLE
fix(committor): retry account not-found fetches instead of failing the intent

### DIFF
--- a/magicblock-api/src/magic_sys_adapter.rs
+++ b/magicblock-api/src/magic_sys_adapter.rs
@@ -2,7 +2,9 @@ use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use magicblock_committor_service::{
     committor_processor::CommittorProcessor,
-    intent_executor::task_info_fetcher::TaskInfoFetcherResult,
+    intent_executor::task_info_fetcher::{
+        AccountSnapshot, TaskInfoFetcherResult,
+    },
     tasks::intent_size_validator::IntentSizeValidator,
 };
 use magicblock_core::{
@@ -43,19 +45,19 @@ impl MagicSysAdapter {
 
     fn fetch_current_commit_nonces_sync(
         &self,
-        pubkeys: &[Pubkey],
+        accounts: &[AccountSnapshot],
         min_context_slot: u64,
     ) -> std::sync::mpsc::Receiver<TaskInfoFetcherResult<HashMap<Pubkey, u64>>>
     {
         let (sender, receiver) = std::sync::mpsc::channel();
         let committor_processor = self.committor_processor.clone();
-        let pubkeys = pubkeys.to_owned();
+        let accounts = accounts.to_owned();
 
         // This is required to switch from TransactionExecutor runtime
         // blocking on it would cause a panic
         self.handle.spawn(async move {
             let result = committor_processor
-                .fetch_current_commit_nonces(&pubkeys, min_context_slot)
+                .fetch_current_commit_nonces(&accounts, min_context_slot)
                 .await;
             if let Err(err) = sender.send(result) {
                 error!(error = ?err, "Failed to send result back");
@@ -80,12 +82,14 @@ impl MagicSys for MagicSysAdapter {
             .map(|account| account.remote_slot)
             .max()
             .unwrap_or(0);
-        let pubkeys: Vec<_> =
-            commits.iter().map(|account| account.pubkey).collect();
+        let accounts: Vec<_> = commits
+            .iter()
+            .map(|account| (account.pubkey, account.remote_slot))
+            .collect();
 
         let _timer = metrics::start_fetch_commit_nonces_wait_timer();
         let receiver =
-            self.fetch_current_commit_nonces_sync(&pubkeys, min_context_slot);
+            self.fetch_current_commit_nonces_sync(&accounts, min_context_slot);
         receiver
             .recv_timeout(Self::FETCH_TIMEOUT)
             .map_err(|err| match err {

--- a/magicblock-committor-service/src/committor_processor.rs
+++ b/magicblock-committor-service/src/committor_processor.rs
@@ -26,8 +26,8 @@ use crate::{
     intent_executor::{
         intent_executor_factory::ExecutorConfig,
         task_info_fetcher::{
-            CacheTaskInfoFetcher, RpcTaskInfoFetcher, TaskInfoFetcher,
-            TaskInfoFetcherResult,
+            AccountSnapshot, CacheTaskInfoFetcher, RpcTaskInfoFetcher,
+            TaskInfoFetcher, TaskInfoFetcherResult,
         },
     },
     persist::{
@@ -349,11 +349,11 @@ impl CommittorProcessor {
     /// Fetches current commit nonces
     pub async fn fetch_current_commit_nonces(
         &self,
-        pubkeys: &[Pubkey],
+        accounts: &[AccountSnapshot],
         min_context_slot: u64,
     ) -> TaskInfoFetcherResult<HashMap<Pubkey, u64>> {
         self.task_info_fetcher
-            .fetch_current_commit_nonces(pubkeys, min_context_slot)
+            .fetch_current_commit_nonces(accounts, min_context_slot)
             .await
     }
 

--- a/magicblock-committor-service/src/intent_executor/error.rs
+++ b/magicblock-committor-service/src/intent_executor/error.rs
@@ -614,6 +614,18 @@ mod tests {
         );
         assert!(err.is_transient());
 
+        // A delegation created after the committed snapshot is terminal
+        let err = super::IntentExecutorError::TaskBuilderError(
+            TaskBuilderError::FinalizedTasksBuildError(
+                TaskInfoFetcherError::DelegationSessionChangedError {
+                    delegated_account: solana_pubkey::Pubkey::new_unique(),
+                    delegation_slot: 2,
+                    min_context_slot: 1,
+                },
+            ),
+        );
+        assert!(!err.is_transient());
+
         // Missing delegation metadata is deterministic
         let err = super::IntentExecutorError::TaskBuilderError(
             TaskBuilderError::MissingDelegationMetadata(

--- a/magicblock-committor-service/src/intent_executor/error.rs
+++ b/magicblock-committor-service/src/intent_executor/error.rs
@@ -604,6 +604,16 @@ mod tests {
         );
         assert!(err.is_transient());
 
+        // Not-found on fetch is transient (may be a stale RPC read)
+        let err = super::IntentExecutorError::TaskBuilderError(
+            TaskBuilderError::FinalizedTasksBuildError(
+                TaskInfoFetcherError::AccountNotFoundError(
+                    solana_pubkey::Pubkey::new_unique(),
+                ),
+            ),
+        );
+        assert!(err.is_transient());
+
         // Missing delegation metadata is deterministic
         let err = super::IntentExecutorError::TaskBuilderError(
             TaskBuilderError::MissingDelegationMetadata(

--- a/magicblock-committor-service/src/intent_executor/error.rs
+++ b/magicblock-committor-service/src/intent_executor/error.rs
@@ -620,7 +620,7 @@ mod tests {
                 TaskInfoFetcherError::DelegationSessionChangedError {
                     delegated_account: solana_pubkey::Pubkey::new_unique(),
                     delegation_slot: 2,
-                    min_context_slot: 1,
+                    snapshot_slot: 1,
                 },
             ),
         );

--- a/magicblock-committor-service/src/intent_executor/task_info_fetcher.rs
+++ b/magicblock-committor-service/src/intent_executor/task_info_fetcher.rs
@@ -30,28 +30,34 @@ use tracing::{error, info, warn};
 const NUM_FETCH_RETRIES: NonZeroUsize = NonZeroUsize::new(5).unwrap();
 const MUTEX_POISONED_MSG: &str = "CacheTaskInfoFetcher mutex poisoned!";
 
+/// A delegated account paired with the base-layer slot of the state
+/// snapshot being committed for it (`CommittedAccount::remote_slot`).
+/// The slot pins the delegation session: a delegation record created
+/// after it belongs to a newer delegation of the same account.
+pub type AccountSnapshot = (Pubkey, u64);
+
 #[async_trait]
 pub trait TaskInfoFetcher: Send + Sync + 'static {
-    /// Fetches correct commit nonces for pubkeys
+    /// Fetches correct commit nonces for accounts
     /// Those nonces can be used as correct commit_nonce during Commit
     async fn fetch_next_commit_nonces(
         &self,
-        pubkeys: &[Pubkey],
+        accounts: &[AccountSnapshot],
         min_context_slot: u64,
     ) -> TaskInfoFetcherResult<HashMap<Pubkey, u64>>;
 
-    /// Fetches current commit nonces for pubkeys
+    /// Fetches current commit nonces for accounts
     /// Missing nonces will be fetched from chain
     async fn fetch_current_commit_nonces(
         &self,
-        pubkeys: &[Pubkey],
+        accounts: &[AccountSnapshot],
         min_context_slot: u64,
     ) -> TaskInfoFetcherResult<HashMap<Pubkey, u64>>;
 
     /// Fetches delegation metadata keyed by delegated account pubkey.
     async fn fetch_delegation_metadata(
         &self,
-        pubkeys: &[Pubkey],
+        accounts: &[AccountSnapshot],
         min_context_slot: u64,
     ) -> TaskInfoFetcherResult<HashMap<Pubkey, DelegationMetadata>>;
 
@@ -79,22 +85,22 @@ impl RpcTaskInfoFetcher {
     /// Fetches [`DelegationMetadata`]s with some num of retries
     pub async fn fetch_metadata_with_retries(
         rpc_client: &MagicblockRpcClient,
-        pubkeys: &[Pubkey],
+        accounts: &[AccountSnapshot],
         min_context_slot: u64,
         max_retries: NonZeroUsize,
     ) -> TaskInfoFetcherResult<Vec<DelegationMetadata>> {
-        if pubkeys.is_empty() {
+        if accounts.is_empty() {
             return Ok(Vec::new());
         }
 
         // Fetch the delegation record alongside the metadata to pin the
-        // delegation session: a record created after `min_context_slot`
-        // (the slot of the state snapshot being committed) belongs to a
-        // newer delegation of the same account, and committing the old
-        // snapshot into it must fail terminally.
-        let pda_accounts: Vec<Pubkey> = pubkeys
+        // delegation session: a record created after the account's
+        // snapshot slot belongs to a newer delegation of the same
+        // account, and committing the old snapshot into it must fail
+        // terminally.
+        let pda_accounts: Vec<Pubkey> = accounts
             .iter()
-            .flat_map(|delegated_account| {
+            .flat_map(|(delegated_account, _)| {
                 [
                     Pubkey::find_program_address(
                         delegation_record_seeds_from_delegated_account!(
@@ -114,7 +120,7 @@ impl RpcTaskInfoFetcher {
             })
             .collect();
 
-        let accounts = Self::fetch_accounts_with_retries(
+        let fetched = Self::fetch_accounts_with_retries(
             rpc_client,
             &pda_accounts,
             min_context_slot,
@@ -122,11 +128,11 @@ impl RpcTaskInfoFetcher {
         )
         .await?;
 
-        accounts
+        fetched
             .chunks_exact(2)
             .zip(pda_accounts.chunks_exact(2))
-            .zip(pubkeys)
-            .map(|((pair, pdas), delegated_account)| {
+            .zip(accounts)
+            .map(|((pair, pdas), (delegated_account, snapshot_slot))| {
                 let record =
                     DelegationRecord::try_from_bytes_with_discriminator(
                         &pair[0].data,
@@ -134,12 +140,12 @@ impl RpcTaskInfoFetcher {
                     .map_err(|_| {
                         TaskInfoFetcherError::InvalidAccountDataError(pdas[0])
                     })?;
-                if record.delegation_slot > min_context_slot {
+                if record.delegation_slot > *snapshot_slot {
                     return Err(
                         TaskInfoFetcherError::DelegationSessionChangedError {
                             delegated_account: *delegated_account,
                             delegation_slot: record.delegation_slot,
-                            min_context_slot,
+                            snapshot_slot: *snapshot_slot,
                         },
                     );
                 }
@@ -272,56 +278,56 @@ impl RpcTaskInfoFetcher {
 impl TaskInfoFetcher for RpcTaskInfoFetcher {
     async fn fetch_next_commit_nonces(
         &self,
-        pubkeys: &[Pubkey],
+        accounts: &[AccountSnapshot],
         min_context_slot: u64,
     ) -> TaskInfoFetcherResult<HashMap<Pubkey, u64>> {
-        if pubkeys.is_empty() {
+        if accounts.is_empty() {
             return Ok(HashMap::new());
         }
         let nonces = Self::fetch_metadata_with_retries(
             &self.rpc_client,
-            pubkeys,
+            accounts,
             min_context_slot,
             NUM_FETCH_RETRIES,
         )
         .await?
         .into_iter()
         .map(|m| m.last_commit_id + 1);
-        Ok(pubkeys.iter().copied().zip(nonces).collect())
+        Ok(accounts.iter().map(|(pk, _)| *pk).zip(nonces).collect())
     }
 
     async fn fetch_current_commit_nonces(
         &self,
-        pubkeys: &[Pubkey],
+        accounts: &[AccountSnapshot],
         min_context_slot: u64,
     ) -> TaskInfoFetcherResult<HashMap<Pubkey, u64>> {
-        if pubkeys.is_empty() {
+        if accounts.is_empty() {
             return Ok(HashMap::new());
         }
         let nonces = Self::fetch_metadata_with_retries(
             &self.rpc_client,
-            pubkeys,
+            accounts,
             min_context_slot,
             NUM_FETCH_RETRIES,
         )
         .await?
         .into_iter()
         .map(|m| m.last_commit_id);
-        Ok(pubkeys.iter().copied().zip(nonces).collect())
+        Ok(accounts.iter().map(|(pk, _)| *pk).zip(nonces).collect())
     }
 
     async fn fetch_delegation_metadata(
         &self,
-        pubkeys: &[Pubkey],
+        accounts: &[AccountSnapshot],
         min_context_slot: u64,
     ) -> TaskInfoFetcherResult<HashMap<Pubkey, DelegationMetadata>> {
-        Ok(pubkeys
+        Ok(accounts
             .iter()
-            .copied()
+            .map(|(pk, _)| *pk)
             .zip(
                 Self::fetch_metadata_with_retries(
                     &self.rpc_client,
-                    pubkeys,
+                    accounts,
                     min_context_slot,
                     NUM_FETCH_RETRIES,
                 )
@@ -543,19 +549,21 @@ impl<T: TaskInfoFetcher> CacheTaskInfoFetcher<T> {
 /// TaskInfoFetcher implementation that caches the most used 1000 nonces
 #[async_trait]
 impl<T: TaskInfoFetcher> TaskInfoFetcher for CacheTaskInfoFetcher<T> {
-    /// Returns next ids for requested pubkeys
+    /// Returns next ids for requested accounts
     /// If key isn't in cache, it will be requested
     async fn fetch_next_commit_nonces(
         &self,
-        pubkeys: &[Pubkey],
+        accounts: &[AccountSnapshot],
         min_context_slot: u64,
     ) -> TaskInfoFetcherResult<HashMap<Pubkey, u64>> {
-        if pubkeys.is_empty() {
+        if accounts.is_empty() {
             return Ok(HashMap::new());
         }
+        let snapshot_slots = snapshot_slots_by_pubkey(accounts);
 
         // Acquire locks on requested nonces
-        let locks_guard = self.acquire_nonce_locks(pubkeys);
+        let pubkeys: Vec<Pubkey> = accounts.iter().map(|(pk, _)| *pk).collect();
+        let locks_guard = self.acquire_nonce_locks(&pubkeys);
 
         // Acquire per-account locks sequentially in sorted order (see sort above).
         // join_all would poll all futures concurrently, allowing partial acquisition
@@ -582,10 +590,15 @@ impl<T: TaskInfoFetcher> TaskInfoFetcher for CacheTaskInfoFetcher<T> {
 
         // Fetch missing nonces in cache
         let fetched_nonces = {
-            let missing_pubkeys: Vec<_> =
-                missing.iter().map(|(pubkey, _)| **pubkey).collect();
+            let missing_accounts: Vec<AccountSnapshot> = missing
+                .iter()
+                .map(|(pubkey, _)| (**pubkey, snapshot_slots[*pubkey]))
+                .collect();
             self.inner
-                .fetch_current_commit_nonces(&missing_pubkeys, min_context_slot)
+                .fetch_current_commit_nonces(
+                    &missing_accounts,
+                    min_context_slot,
+                )
                 .await?
         };
 
@@ -610,15 +623,17 @@ impl<T: TaskInfoFetcher> TaskInfoFetcher for CacheTaskInfoFetcher<T> {
 
     async fn fetch_current_commit_nonces(
         &self,
-        pubkeys: &[Pubkey],
+        accounts: &[AccountSnapshot],
         min_context_slot: u64,
     ) -> TaskInfoFetcherResult<HashMap<Pubkey, u64>> {
-        if pubkeys.is_empty() {
+        if accounts.is_empty() {
             return Ok(HashMap::new());
         }
+        let snapshot_slots = snapshot_slots_by_pubkey(accounts);
 
         // Acquire locks on requested nonces
-        let locks_guard = self.acquire_nonce_locks(pubkeys);
+        let pubkeys: Vec<Pubkey> = accounts.iter().map(|(pk, _)| *pk).collect();
+        let locks_guard = self.acquire_nonce_locks(&pubkeys);
 
         // Acquire per-account locks sequentially in sorted order (see sort above).
         let nonce_guards = locks_guard.lock().await;
@@ -638,10 +653,15 @@ impl<T: TaskInfoFetcher> TaskInfoFetcher for CacheTaskInfoFetcher<T> {
 
         // Fetch missing nonces in cache
         let fetched_nonces = {
-            let missing_pubkeys: Vec<_> =
-                missing.iter().map(|(pubkey, _)| **pubkey).collect();
+            let missing_accounts: Vec<AccountSnapshot> = missing
+                .iter()
+                .map(|(pubkey, _)| (**pubkey, snapshot_slots[*pubkey]))
+                .collect();
             self.inner
-                .fetch_current_commit_nonces(&missing_pubkeys, min_context_slot)
+                .fetch_current_commit_nonces(
+                    &missing_accounts,
+                    min_context_slot,
+                )
                 .await?
         };
 
@@ -663,11 +683,11 @@ impl<T: TaskInfoFetcher> TaskInfoFetcher for CacheTaskInfoFetcher<T> {
 
     async fn fetch_delegation_metadata(
         &self,
-        pubkeys: &[Pubkey],
+        accounts: &[AccountSnapshot],
         min_context_slot: u64,
     ) -> TaskInfoFetcherResult<HashMap<Pubkey, DelegationMetadata>> {
         self.inner
-            .fetch_delegation_metadata(pubkeys, min_context_slot)
+            .fetch_delegation_metadata(accounts, min_context_slot)
             .await
     }
 
@@ -687,17 +707,30 @@ pub enum ResetType<'a> {
     Specific(&'a [Pubkey]),
 }
 
+/// Deduplicates snapshots by pubkey, keeping the newest snapshot slot.
+fn snapshot_slots_by_pubkey(
+    accounts: &[AccountSnapshot],
+) -> HashMap<Pubkey, u64> {
+    let mut slots: HashMap<Pubkey, u64> =
+        HashMap::with_capacity(accounts.len());
+    for (pubkey, slot) in accounts {
+        let entry = slots.entry(*pubkey).or_insert(*slot);
+        *entry = (*entry).max(*slot);
+    }
+    slots
+}
+
 #[derive(thiserror::Error, Debug)]
 pub enum TaskInfoFetcherError {
     #[error("Metadata not found for: {0}")]
     AccountNotFoundError(Pubkey),
     #[error("InvalidAccountDataError for: {0}")]
     InvalidAccountDataError(Pubkey),
-    #[error("Delegation session changed for {delegated_account}: delegated at slot {delegation_slot}, committed state is from slot {min_context_slot}")]
+    #[error("Delegation session changed for {delegated_account}: delegated at slot {delegation_slot}, committed state is from slot {snapshot_slot}")]
     DelegationSessionChangedError {
         delegated_account: Pubkey,
         delegation_slot: u64,
-        min_context_slot: u64,
+        snapshot_slot: u64,
     },
     #[error("Minimum context slot {0} not reached: {1}")]
     MinContextSlotNotReachedError(u64, Box<MagicBlockRpcClientError>),
@@ -805,16 +838,29 @@ mod tests {
 
     use super::*;
 
+    #[test]
+    fn snapshot_slots_keep_newest_on_duplicates() {
+        let pk = Pubkey::new_unique();
+        let slots = snapshot_slots_by_pubkey(&[(pk, 5), (pk, 9), (pk, 7)]);
+        assert_eq!(slots[&pk], 9);
+    }
+
     #[tokio::test]
     async fn cache_miss_then_hit() {
         let pk = Pubkey::new_unique();
         let fetcher = FetcherBuilder::new(vec![10]).build();
 
-        let r1 = fetcher.fetch_next_commit_nonces(&[pk], 0).await.unwrap();
+        let r1 = fetcher
+            .fetch_next_commit_nonces(&[(pk, 0)], 0)
+            .await
+            .unwrap();
         assert_eq!(r1[&pk], 11);
 
         // Cache hit: no RPC (only 1 response queued), increments
-        let r2 = fetcher.fetch_next_commit_nonces(&[pk], 0).await.unwrap();
+        let r2 = fetcher
+            .fetch_next_commit_nonces(&[(pk, 0)], 0)
+            .await
+            .unwrap();
         assert_eq!(r2[&pk], 12);
     }
 
@@ -825,9 +871,12 @@ mod tests {
         // prime pk1 (nonce 5), then mixed call fetches only cold pk2 (nonce 20)
         let fetcher = FetcherBuilder::new(vec![5, 20]).build();
 
-        fetcher.fetch_next_commit_nonces(&[pk1], 0).await.unwrap(); // pk1 = 6
+        fetcher
+            .fetch_next_commit_nonces(&[(pk1, 0)], 0)
+            .await
+            .unwrap(); // pk1 = 6
         let r = fetcher
-            .fetch_next_commit_nonces(&[pk1, pk2], 0)
+            .fetch_next_commit_nonces(&[(pk1, 0), (pk2, 0)], 0)
             .await
             .unwrap();
         assert_eq!(r[&pk1], 7); // cached, incremented
@@ -841,12 +890,21 @@ mod tests {
         // pk1 initial, pk2 evicts pk1, pk1 re-fetch after eviction
         let fetcher = FetcherBuilder::new(vec![1, 2, 10]).capacity(1).build();
 
-        fetcher.fetch_next_commit_nonces(&[pk1], 0).await.unwrap(); // pk1 cached = 2
-        fetcher.fetch_next_commit_nonces(&[pk2], 0).await.unwrap(); // pk2 cached = 3, pk1 evicted
+        fetcher
+            .fetch_next_commit_nonces(&[(pk1, 0)], 0)
+            .await
+            .unwrap(); // pk1 cached = 2
+        fetcher
+            .fetch_next_commit_nonces(&[(pk2, 0)], 0)
+            .await
+            .unwrap(); // pk2 cached = 3, pk1 evicted
 
         assert!(fetcher.peek_commit_nonce(&pk1).await.is_none()); // evicted
 
-        let r = fetcher.fetch_next_commit_nonces(&[pk1], 0).await.unwrap();
+        let r = fetcher
+            .fetch_next_commit_nonces(&[(pk1, 0)], 0)
+            .await
+            .unwrap();
         assert_eq!(r[&pk1], 11); // re-fetched (10 + 1)
 
         // Sequential eviction: pk1's guard was dropped before pk2 evicted it,
@@ -866,17 +924,24 @@ mod tests {
         iters: usize,
     ) {
         for pk in &phase1_keys {
-            fetcher.fetch_next_commit_nonces(&[*pk], 0).await.unwrap();
+            fetcher
+                .fetch_next_commit_nonces(&[(*pk, 0)], 0)
+                .await
+                .unwrap();
         }
         barrier.wait().await; // signal phase 1 done
         barrier.wait().await; // wait for outer verification
         for _ in 0..iters {
             for pk in &phase2_keys {
-                fetcher.fetch_next_commit_nonces(&[*pk], 0).await.unwrap();
+                fetcher
+                    .fetch_next_commit_nonces(&[(*pk, 0)], 0)
+                    .await
+                    .unwrap();
             }
         }
         for chunk in shared_b.chunks(2) {
-            fetcher.fetch_next_commit_nonces(chunk, 0).await.unwrap();
+            let chunk: Vec<_> = chunk.iter().map(|pk| (*pk, 0)).collect();
+            fetcher.fetch_next_commit_nonces(&chunk, 0).await.unwrap();
         }
     }
 
@@ -975,11 +1040,17 @@ mod tests {
         let pk = Pubkey::new_unique();
         let fetcher = FetcherBuilder::new(vec![10]).build();
 
-        let r1 = fetcher.fetch_current_commit_nonces(&[pk], 0).await.unwrap();
+        let r1 = fetcher
+            .fetch_current_commit_nonces(&[(pk, 0)], 0)
+            .await
+            .unwrap();
         assert_eq!(r1[&pk], 10); // stored as-is
 
         // Cache hit: still 10, fetch_current never increments
-        let r2 = fetcher.fetch_current_commit_nonces(&[pk], 0).await.unwrap();
+        let r2 = fetcher
+            .fetch_current_commit_nonces(&[(pk, 0)], 0)
+            .await
+            .unwrap();
         assert_eq!(r2[&pk], 10);
     }
 
@@ -990,14 +1061,23 @@ mod tests {
         // pk1 initial, pk2 initial, pk1 after reset
         let fetcher = FetcherBuilder::new(vec![1, 2, 50]).build();
 
-        fetcher.fetch_next_commit_nonces(&[pk1], 0).await.unwrap(); // pk1 cached = 2
-        fetcher.fetch_next_commit_nonces(&[pk2], 0).await.unwrap(); // pk2 cached = 3
+        fetcher
+            .fetch_next_commit_nonces(&[(pk1, 0)], 0)
+            .await
+            .unwrap(); // pk1 cached = 2
+        fetcher
+            .fetch_next_commit_nonces(&[(pk2, 0)], 0)
+            .await
+            .unwrap(); // pk2 cached = 3
         fetcher.reset(ResetType::Specific(&[pk1]));
 
         assert!(fetcher.peek_commit_nonce(&pk1).await.is_none()); // cleared
         assert_eq!(fetcher.peek_commit_nonce(&pk2).await, Some(3)); // still cached
 
-        let r1 = fetcher.fetch_next_commit_nonces(&[pk1], 0).await.unwrap();
+        let r1 = fetcher
+            .fetch_next_commit_nonces(&[(pk1, 0)], 0)
+            .await
+            .unwrap();
         assert_eq!(r1[&pk1], 51); // re-fetched (50 + 1)
     }
 
@@ -1017,7 +1097,10 @@ mod tests {
         // Spawn Task A: slow fetch for pk1 acquires its nonce lock and sleeps.
         let fetcher2 = fetcher.clone();
         let task_a = tokio::spawn(async move {
-            fetcher2.fetch_next_commit_nonces(&[pk1], 0).await.unwrap();
+            fetcher2
+                .fetch_next_commit_nonces(&[(pk1, 0)], 0)
+                .await
+                .unwrap();
         });
 
         // Let Task A acquire pk1's nonce lock and start the slow fetch.
@@ -1027,7 +1110,10 @@ mod tests {
         // because Task A's guard still holds a clone of pk1's Arc.
         let fetcher3 = fetcher.clone();
         let task_b = tokio::spawn(async move {
-            fetcher3.fetch_next_commit_nonces(&[pk2], 0).await.unwrap();
+            fetcher3
+                .fetch_next_commit_nonces(&[(pk2, 0)], 0)
+                .await
+                .unwrap();
         });
 
         // Let Task B run through acquire_nonce_locks (eviction happens here).
@@ -1071,25 +1157,25 @@ mod tests {
     impl TaskInfoFetcher for MockInfoFetcher {
         async fn fetch_next_commit_nonces(
             &self,
-            pubkeys: &[Pubkey],
+            accounts: &[AccountSnapshot],
             min_context_slot: u64,
         ) -> TaskInfoFetcherResult<HashMap<Pubkey, u64>> {
-            self.fetch_current_commit_nonces(pubkeys, min_context_slot)
+            self.fetch_current_commit_nonces(accounts, min_context_slot)
                 .await
         }
 
         async fn fetch_current_commit_nonces(
             &self,
-            pubkeys: &[Pubkey],
+            accounts: &[AccountSnapshot],
             _: u64,
         ) -> TaskInfoFetcherResult<HashMap<Pubkey, u64>> {
             if let Some(delay) = self.delay {
                 tokio::time::sleep(delay).await;
             }
             let mut q = self.nonces.lock().unwrap();
-            Ok(pubkeys
+            Ok(accounts
                 .iter()
-                .map(|pk| {
+                .map(|(pk, _)| {
                     let nonce =
                         q.pop_front().expect("mock nonce queue exhausted");
                     (*pk, nonce)
@@ -1099,13 +1185,13 @@ mod tests {
 
         async fn fetch_delegation_metadata(
             &self,
-            pubkeys: &[Pubkey],
+            accounts: &[AccountSnapshot],
             _: u64,
         ) -> TaskInfoFetcherResult<HashMap<Pubkey, DelegationMetadata>>
         {
-            Ok(pubkeys
+            Ok(accounts
                 .iter()
-                .map(|pubkey| {
+                .map(|(pubkey, _)| {
                     (
                         *pubkey,
                         DelegationMetadata {

--- a/magicblock-committor-service/src/intent_executor/task_info_fetcher.rs
+++ b/magicblock-committor-service/src/intent_executor/task_info_fetcher.rs
@@ -8,7 +8,9 @@ use std::{
 
 use async_trait::async_trait;
 use dlp_api::{
-    delegation_metadata_seeds_from_delegated_account, state::DelegationMetadata,
+    delegation_metadata_seeds_from_delegated_account,
+    delegation_record_seeds_from_delegated_account,
+    state::{DelegationMetadata, DelegationRecord},
 };
 use lru::LruCache;
 use magicblock_metrics::metrics;
@@ -85,16 +87,30 @@ impl RpcTaskInfoFetcher {
             return Ok(Vec::new());
         }
 
+        // Fetch the delegation record alongside the metadata to pin the
+        // delegation session: a record created after `min_context_slot`
+        // (the slot of the state snapshot being committed) belongs to a
+        // newer delegation of the same account, and committing the old
+        // snapshot into it must fail terminally.
         let pda_accounts: Vec<Pubkey> = pubkeys
             .iter()
-            .map(|delegated_account| {
-                Pubkey::find_program_address(
-                    delegation_metadata_seeds_from_delegated_account!(
-                        delegated_account
-                    ),
-                    &dlp_api::id(),
-                )
-                .0
+            .flat_map(|delegated_account| {
+                [
+                    Pubkey::find_program_address(
+                        delegation_record_seeds_from_delegated_account!(
+                            delegated_account
+                        ),
+                        &dlp_api::id(),
+                    )
+                    .0,
+                    Pubkey::find_program_address(
+                        delegation_metadata_seeds_from_delegated_account!(
+                            delegated_account
+                        ),
+                        &dlp_api::id(),
+                    )
+                    .0,
+                ]
             })
             .collect();
 
@@ -107,13 +123,32 @@ impl RpcTaskInfoFetcher {
         .await?;
 
         accounts
-            .into_iter()
-            .zip(pda_accounts)
-            .map(|(account, pda)| {
+            .chunks_exact(2)
+            .zip(pda_accounts.chunks_exact(2))
+            .zip(pubkeys)
+            .map(|((pair, pdas), delegated_account)| {
+                let record =
+                    DelegationRecord::try_from_bytes_with_discriminator(
+                        &pair[0].data,
+                    )
+                    .map_err(|_| {
+                        TaskInfoFetcherError::InvalidAccountDataError(pdas[0])
+                    })?;
+                if record.delegation_slot > min_context_slot {
+                    return Err(
+                        TaskInfoFetcherError::DelegationSessionChangedError {
+                            delegated_account: *delegated_account,
+                            delegation_slot: record.delegation_slot,
+                            min_context_slot,
+                        },
+                    );
+                }
                 DelegationMetadata::try_from_bytes_with_discriminator(
-                    &account.data,
+                    &pair[1].data,
                 )
-                .map_err(|_| TaskInfoFetcherError::InvalidAccountDataError(pda))
+                .map_err(|_| {
+                    TaskInfoFetcherError::InvalidAccountDataError(pdas[1])
+                })
             })
             .collect()
     }
@@ -154,7 +189,10 @@ impl RpcTaskInfoFetcher {
                         "Account not found, possibly stale RPC read"
                     );
                 }
-                err @ TaskInfoFetcherError::InvalidAccountDataError(_) => {
+                err @ (TaskInfoFetcherError::InvalidAccountDataError(_)
+                | TaskInfoFetcherError::DelegationSessionChangedError {
+                    ..
+                }) => {
                     error!(error = ?err, "Unexpected error");
                     break Err(err);
                 }
@@ -655,6 +693,12 @@ pub enum TaskInfoFetcherError {
     AccountNotFoundError(Pubkey),
     #[error("InvalidAccountDataError for: {0}")]
     InvalidAccountDataError(Pubkey),
+    #[error("Delegation session changed for {delegated_account}: delegated at slot {delegation_slot}, committed state is from slot {min_context_slot}")]
+    DelegationSessionChangedError {
+        delegated_account: Pubkey,
+        delegation_slot: u64,
+        min_context_slot: u64,
+    },
     #[error("Minimum context slot {0} not reached: {1}")]
     MinContextSlotNotReachedError(u64, Box<MagicBlockRpcClientError>),
     #[error("MagicBlockRpcClientError: {0}")]
@@ -665,14 +709,17 @@ impl TaskInfoFetcherError {
     /// RPC-side fetch failures are transient; malformed delegation
     /// accounts are deterministic. Not-found is transient too: the
     /// accounts fetched here exist from the ER's perspective, so it is
-    /// most likely a lagging RPC node. The bounded intent-level retry
-    /// makes a genuinely absent account fail terminally.
+    /// most likely a lagging RPC node. Retries are session-guarded — a
+    /// delegation created after the committed snapshot fails terminally
+    /// via `DelegationSessionChangedError`, as does a genuinely absent
+    /// account once the bounded intent-level retries are exhausted.
     pub fn is_transient(&self) -> bool {
         match self {
             Self::AccountNotFoundError(_) => true,
             Self::MinContextSlotNotReachedError(_, _) => true,
             Self::MagicBlockRpcClientError(err) => err.is_transient(),
             Self::InvalidAccountDataError(_) => false,
+            Self::DelegationSessionChangedError { .. } => false,
         }
     }
 
@@ -739,6 +786,7 @@ impl TaskInfoFetcherError {
         match self {
             Self::AccountNotFoundError(_) => None,
             Self::InvalidAccountDataError(_) => None,
+            Self::DelegationSessionChangedError { .. } => None,
             Self::MinContextSlotNotReachedError(_, err) => err.signature(),
             Self::MagicBlockRpcClientError(err) => err.signature(),
         }

--- a/magicblock-committor-service/src/intent_executor/task_info_fetcher.rs
+++ b/magicblock-committor-service/src/intent_executor/task_info_fetcher.rs
@@ -140,7 +140,11 @@ impl RpcTaskInfoFetcher {
                     .map_err(|_| {
                         TaskInfoFetcherError::InvalidAccountDataError(pdas[0])
                     })?;
-                if record.delegation_slot > *snapshot_slot {
+                // Snapshot slot 0 means the intent carries no snapshot
+                // provenance (synthetic/test intents); skip the session
+                // comparison since there is nothing to compare against.
+                if *snapshot_slot > 0 && record.delegation_slot > *snapshot_slot
+                {
                     return Err(
                         TaskInfoFetcherError::DelegationSessionChangedError {
                             delegated_account: *delegated_account,

--- a/magicblock-committor-service/src/intent_executor/task_info_fetcher.rs
+++ b/magicblock-committor-service/src/intent_executor/task_info_fetcher.rs
@@ -144,8 +144,15 @@ impl RpcTaskInfoFetcher {
             };
 
             match err {
-                TaskInfoFetcherError::AccountNotFoundError(_) => {
-                    break Err(err)
+                // Not-found can be a stale read from a load-balanced RPC
+                // pool right after the account was created, so retry
+                TaskInfoFetcherError::AccountNotFoundError(ref pubkey) => {
+                    warn!(
+                        %pubkey,
+                        min_context_slot,
+                        attempt = i,
+                        "Account not found, possibly stale RPC read"
+                    );
                 }
                 err @ TaskInfoFetcherError::InvalidAccountDataError(_) => {
                     error!(error = ?err, "Unexpected error");
@@ -655,13 +662,17 @@ pub enum TaskInfoFetcherError {
 }
 
 impl TaskInfoFetcherError {
-    /// RPC-side fetch failures are transient; malformed or absent
-    /// delegation accounts are deterministic.
+    /// RPC-side fetch failures are transient; malformed delegation
+    /// accounts are deterministic. Not-found is transient too: the
+    /// accounts fetched here exist from the ER's perspective, so it is
+    /// most likely a lagging RPC node. The bounded intent-level retry
+    /// makes a genuinely absent account fail terminally.
     pub fn is_transient(&self) -> bool {
         match self {
+            Self::AccountNotFoundError(_) => true,
             Self::MinContextSlotNotReachedError(_, _) => true,
             Self::MagicBlockRpcClientError(err) => err.is_transient(),
-            _ => false,
+            Self::InvalidAccountDataError(_) => false,
         }
     }
 

--- a/magicblock-committor-service/src/intent_executor/utils.rs
+++ b/magicblock-committor-service/src/intent_executor/utils.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{collections::HashMap, time::Duration};
 
 use async_trait::async_trait;
 use magicblock_core::traits::{
@@ -71,26 +71,39 @@ pub(in crate::intent_executor) async fn handle_commit_id_error<
     strategy: &mut TransactionStrategy,
     intent_id: u64,
 ) -> Result<TransactionStrategy, TaskBuilderError> {
-    let min_context_slot = strategy
+    let snapshot_slots: HashMap<Pubkey, u64> = strategy
         .optimized_tasks
         .iter()
         .filter_map(|task| match task {
-            BaseTaskImpl::Commit(task) => {
-                Some(task.committed_account.remote_slot)
-            }
-            BaseTaskImpl::CommitFinalize(task) => {
-                Some(task.committed_account.remote_slot)
-            }
+            BaseTaskImpl::Commit(task) => Some((
+                task.committed_account.pubkey,
+                task.committed_account.remote_slot,
+            )),
+            BaseTaskImpl::CommitFinalize(task) => Some((
+                task.committed_account.pubkey,
+                task.committed_account.remote_slot,
+            )),
             _ => None,
         })
-        .max()
-        .unwrap_or_default();
+        .collect();
+    let min_context_slot =
+        snapshot_slots.values().copied().max().unwrap_or_default();
+    let committed_accounts: Vec<_> = committed_pubkeys
+        .iter()
+        .map(|pubkey| {
+            let slot = snapshot_slots
+                .get(pubkey)
+                .copied()
+                .unwrap_or(min_context_slot);
+            (*pubkey, slot)
+        })
+        .collect();
 
     // We reset TaskInfoFetcher for all committed accounts
     // We re-fetch them to fix out of sync tasks
     task_info_fetcher.reset(ResetType::Specific(committed_pubkeys));
     let commit_ids = task_info_fetcher
-        .fetch_next_commit_nonces(committed_pubkeys, min_context_slot)
+        .fetch_next_commit_nonces(&committed_accounts, min_context_slot)
         .await
         .map_err(TaskBuilderError::CommitTasksBuildError)?;
 
@@ -444,7 +457,9 @@ mod tests {
 
     use super::*;
     use crate::{
-        intent_executor::task_info_fetcher::TaskInfoFetcherResult,
+        intent_executor::task_info_fetcher::{
+            AccountSnapshot, TaskInfoFetcherResult,
+        },
         tasks::utils::create_commit_task,
     };
 
@@ -455,12 +470,12 @@ mod tests {
     impl TaskInfoFetcher for FreshDelegationFetcher {
         async fn fetch_next_commit_nonces(
             &self,
-            pubkeys: &[Pubkey],
+            accounts: &[AccountSnapshot],
             _: u64,
         ) -> TaskInfoFetcherResult<HashMap<Pubkey, u64>> {
-            Ok(pubkeys
+            Ok(accounts
                 .iter()
-                .map(|pubkey| {
+                .map(|(pubkey, _)| {
                     (*pubkey, if self.0 == Some(*pubkey) { 5 } else { 1 })
                 })
                 .collect())
@@ -468,12 +483,12 @@ mod tests {
 
         async fn fetch_current_commit_nonces(
             &self,
-            pubkeys: &[Pubkey],
+            accounts: &[AccountSnapshot],
             _: u64,
         ) -> TaskInfoFetcherResult<HashMap<Pubkey, u64>> {
-            Ok(pubkeys
+            Ok(accounts
                 .iter()
-                .map(|pubkey| {
+                .map(|(pubkey, _)| {
                     (*pubkey, if self.0 == Some(*pubkey) { 4 } else { 0 })
                 })
                 .collect())
@@ -481,13 +496,13 @@ mod tests {
 
         async fn fetch_delegation_metadata(
             &self,
-            pubkeys: &[Pubkey],
+            accounts: &[AccountSnapshot],
             _: u64,
         ) -> TaskInfoFetcherResult<HashMap<Pubkey, DelegationMetadata>>
         {
-            Ok(pubkeys
+            Ok(accounts
                 .iter()
-                .map(|pubkey| {
+                .map(|(pubkey, _)| {
                     (
                         *pubkey,
                         DelegationMetadata {

--- a/magicblock-committor-service/src/service.rs
+++ b/magicblock-committor-service/src/service.rs
@@ -444,7 +444,7 @@ where
         if !result {
             false
         } else {
-            self.is_valid_nonce(&pubkeys, recovered, min_context_slot)
+            self.is_valid_nonce(recovered, min_context_slot)
                 .await
                 .inspect_err(|err| {
                     error!(intent_id = recovered.bundle.id, error = ?err, "Failed to check commit nonce for recovery");
@@ -501,13 +501,18 @@ where
     /// been consumed on chain, or couldn't be verified.
     async fn is_valid_nonce(
         &self,
-        pubkeys: &[Pubkey],
         recovered: &RecoveredIntent,
         min_context_slot: u64,
     ) -> TaskInfoFetcherResult<bool> {
+        let accounts: Vec<_> = recovered
+            .bundle
+            .get_all_committed_accounts()
+            .iter()
+            .map(|account| (account.pubkey, account.remote_slot))
+            .collect();
         let current_nonces = self
             .processor
-            .fetch_current_commit_nonces(pubkeys, min_context_slot)
+            .fetch_current_commit_nonces(&accounts, min_context_slot)
             .await?;
 
         let valid = recovered.commit_ids.iter().all(|(pubkey, commit_id)| {

--- a/magicblock-committor-service/src/tasks/task_builder.rs
+++ b/magicblock-committor-service/src/tasks/task_builder.rs
@@ -58,13 +58,13 @@ impl TaskBuilderImpl {
         accounts: &[CommittedAccount],
         min_context_slot: u64,
     ) -> TaskInfoFetcherResult<HashMap<Pubkey, u64>> {
-        let committed_pubkeys = accounts
+        let committed_accounts = accounts
             .iter()
-            .map(|account| account.pubkey)
+            .map(|account| (account.pubkey, account.remote_slot))
             .collect::<Vec<_>>();
 
         task_info_fetcher
-            .fetch_next_commit_nonces(&committed_pubkeys, min_context_slot)
+            .fetch_next_commit_nonces(&committed_accounts, min_context_slot)
             .await
     }
 
@@ -86,18 +86,19 @@ impl TaskBuilderImpl {
             .await
     }
 
-    fn get_finalize_stage_metadata_pubkeys(
+    fn get_finalize_stage_metadata_accounts(
         intent_bundle: &ScheduledIntentBundle,
-    ) -> Vec<Pubkey> {
+    ) -> Vec<(Pubkey, u64)> {
         [
-            intent_bundle.get_undelegate_intent_pubkeys(),
+            intent_bundle.get_undelegate_intent_accounts(),
             intent_bundle
                 .intent_bundle
-                .get_commit_finalize_and_undelegate_intent_pubkeys(),
+                .get_commit_finalize_and_undelegate_intent_accounts(),
         ]
         .into_iter()
         .flatten()
         .flatten()
+        .map(|account| (account.pubkey, account.remote_slot))
         .collect()
     }
 
@@ -298,8 +299,8 @@ impl TasksBuilder for TaskBuilderImpl {
         }
 
         let mut tasks = Vec::new();
-        let finalize_metadata_pubkeys =
-            Self::get_finalize_stage_metadata_pubkeys(intent_bundle);
+        let finalize_metadata_accounts =
+            Self::get_finalize_stage_metadata_accounts(intent_bundle);
         let min_context_slot = intent_bundle
             .get_all_committed_accounts()
             .iter()
@@ -308,7 +309,7 @@ impl TasksBuilder for TaskBuilderImpl {
             .unwrap_or(0);
         let delegation_metadata = info_fetcher
             .fetch_delegation_metadata(
-                &finalize_metadata_pubkeys,
+                &finalize_metadata_accounts,
                 min_context_slot,
             )
             .await

--- a/magicblock-committor-service/src/tasks/task_strategist.rs
+++ b/magicblock-committor-service/src/tasks/task_strategist.rs
@@ -506,7 +506,7 @@ mod tests {
     use crate::{
         intent_execution_manager::intent_scheduler::create_test_intent,
         intent_executor::task_info_fetcher::{
-            TaskInfoFetcher, TaskInfoFetcherResult,
+            AccountSnapshot, TaskInfoFetcher, TaskInfoFetcherResult,
         },
         persist::IntentPersisterImpl,
         tasks::{
@@ -528,29 +528,29 @@ mod tests {
     impl TaskInfoFetcher for MockInfoFetcher {
         async fn fetch_next_commit_nonces(
             &self,
-            pubkeys: &[Pubkey],
+            accounts: &[AccountSnapshot],
             _: u64,
         ) -> TaskInfoFetcherResult<HashMap<Pubkey, u64>> {
-            Ok(pubkeys.iter().map(|pubkey| (*pubkey, 0)).collect())
+            Ok(accounts.iter().map(|(pubkey, _)| (*pubkey, 0)).collect())
         }
 
         async fn fetch_current_commit_nonces(
             &self,
-            pubkeys: &[Pubkey],
+            accounts: &[AccountSnapshot],
             _: u64,
         ) -> TaskInfoFetcherResult<HashMap<Pubkey, u64>> {
-            Ok(pubkeys.iter().map(|pubkey| (*pubkey, 0)).collect())
+            Ok(accounts.iter().map(|(pubkey, _)| (*pubkey, 0)).collect())
         }
 
         async fn fetch_delegation_metadata(
             &self,
-            pubkeys: &[Pubkey],
+            accounts: &[AccountSnapshot],
             _: u64,
         ) -> TaskInfoFetcherResult<HashMap<Pubkey, DelegationMetadata>>
         {
-            Ok(pubkeys
+            Ok(accounts
                 .iter()
-                .map(|pubkey| {
+                .map(|(pubkey, _)| {
                     let (undelegation_requester, rent_payer) = self
                         .delegation_metadata
                         .get(pubkey)

--- a/test-integration/test-committor-service/tests/common.rs
+++ b/test-integration/test-committor-service/tests/common.rs
@@ -11,8 +11,8 @@ use dlp_api::state::{DelegationMetadata, UndelegationRequester};
 use magicblock_committor_service::{
     intent_executor::{
         task_info_fetcher::{
-            CacheTaskInfoFetcher, TaskInfoFetcher, TaskInfoFetcherError,
-            TaskInfoFetcherResult,
+            AccountSnapshot, CacheTaskInfoFetcher, TaskInfoFetcher,
+            TaskInfoFetcherError, TaskInfoFetcherResult,
         },
         IntentExecutorImpl,
     },
@@ -197,28 +197,28 @@ pub struct MockTaskInfoFetcher(MagicblockRpcClient);
 impl TaskInfoFetcher for MockTaskInfoFetcher {
     async fn fetch_next_commit_nonces(
         &self,
-        pubkeys: &[Pubkey],
+        accounts: &[AccountSnapshot],
         _: u64,
     ) -> TaskInfoFetcherResult<HashMap<Pubkey, u64>> {
-        Ok(pubkeys.iter().map(|pubkey| (*pubkey, 0)).collect())
+        Ok(accounts.iter().map(|(pubkey, _)| (*pubkey, 0)).collect())
     }
 
     async fn fetch_current_commit_nonces(
         &self,
-        pubkeys: &[Pubkey],
+        accounts: &[AccountSnapshot],
         _: u64,
     ) -> TaskInfoFetcherResult<HashMap<Pubkey, u64>> {
-        Ok(pubkeys.iter().map(|pubkey| (*pubkey, 0)).collect())
+        Ok(accounts.iter().map(|(pubkey, _)| (*pubkey, 0)).collect())
     }
 
     async fn fetch_delegation_metadata(
         &self,
-        pubkeys: &[Pubkey],
+        accounts: &[AccountSnapshot],
         _: u64,
     ) -> TaskInfoFetcherResult<HashMap<Pubkey, DelegationMetadata>> {
-        Ok(pubkeys
+        Ok(accounts
             .iter()
-            .map(|pubkey| {
+            .map(|(pubkey, _)| {
                 (
                     *pubkey,
                     DelegationMetadata {

--- a/test-integration/test-committor-service/tests/test_intent_executor.rs
+++ b/test-integration/test-committor-service/tests/test_intent_executor.rs
@@ -157,7 +157,12 @@ async fn test_commit_id_error_parsing() {
     // Invalidate ids before execution
     task_info_fetcher
         .fetch_next_commit_nonces(
-            &intent.get_undelegate_intent_pubkeys().unwrap(),
+            &intent
+                .get_undelegate_intent_pubkeys()
+                .unwrap()
+                .into_iter()
+                .map(|pubkey| (pubkey, remote_slot))
+                .collect::<Vec<_>>(),
             remote_slot,
         )
         .await
@@ -484,7 +489,10 @@ async fn test_commit_id_error_recovery() {
 
     // Invalidate commit nonce cache
     let res = task_info_fetcher
-        .fetch_next_commit_nonces(&[committed_account.pubkey], remote_slot)
+        .fetch_next_commit_nonces(
+            &[(committed_account.pubkey, remote_slot)],
+            remote_slot,
+        )
         .await;
     assert!(res.is_ok());
     assert!(res.unwrap().contains_key(&committed_account.pubkey));
@@ -694,7 +702,10 @@ async fn test_commit_id_and_action_errors_recovery() {
 
     // Invalidate commit nonce cache
     let res = task_info_fetcher
-        .fetch_next_commit_nonces(&[committed_account.pubkey], remote_slot)
+        .fetch_next_commit_nonces(
+            &[(committed_account.pubkey, remote_slot)],
+            remote_slot,
+        )
         .await;
     assert!(res.is_ok());
     assert!(res.unwrap().contains_key(&committed_account.pubkey));
@@ -913,9 +924,12 @@ async fn test_commit_id_actions_cpi_limit_errors_recovery() {
     let scheduled_intent = create_scheduled_intent(base_intent);
 
     // Force CommitIDError by invalidating the commit-nonce cache before running
-    let pubkeys: Vec<_> = committed_accounts.iter().map(|c| c.pubkey).collect();
+    let accounts: Vec<_> = committed_accounts
+        .iter()
+        .map(|c| (c.pubkey, c.remote_slot))
+        .collect();
     let mut invalidated_keys = task_info_fetcher
-        .fetch_next_commit_nonces(&pubkeys, Default::default())
+        .fetch_next_commit_nonces(&accounts, Default::default())
         .await
         .unwrap();
 


### PR DESCRIPTION
## Summary

Retry `AccountNotFoundError` in the committor's account fetches instead of failing the intent on the first attempt: a not-found from a load-balanced RPC pool can be a stale read for a just-created account (e.g. delegation PDAs right after delegation), even with `min_context_slot` set.

Seen in production: an account was delegated on the base layer and its commit intent failed seconds later with `FinalizedTasksBuildError(AccountNotFoundError(<delegation-metadata PDA>))`, marking the account stuck, right after an RPC pool connection drop. The PDA existed on chain the whole time.

Three coordinated changes:
- `fetch_accounts_with_retries` now retries not-found (bounded by the existing `NUM_FETCH_RETRIES`) instead of breaking immediately, covering brief stale reads.
- `TaskInfoFetcherError::AccountNotFoundError` is now `is_transient()`, so the bounded intent-level retry loop (`MAX_INTENT_ATTEMPTS`, backoff + jitter, commit-nonce dedup) re-executes the intent, covering multi-second pool lag. A genuinely absent account still fails terminally after the last attempt.
- Retries are session-guarded: `fetch_metadata_with_retries` now fetches the `DelegationRecord` alongside the metadata (same `getMultipleAccounts` call) and fails terminally with the new non-transient `DelegationSessionChangedError` when `delegation_slot` is newer than the account's **own** snapshot slot — i.e. the account was re-delegated after the state being committed. To make the check per-account rather than bundle-wide, the `TaskInfoFetcher` metadata methods now take `(Pubkey, remote_slot)` pairs (`AccountSnapshot`) instead of bare pubkeys; the RPC `min_context_slot` semantics are unchanged. This prevents a retried intent from committing an old snapshot into a new delegation session (complementing the existing `is_same_delegation_session` check on restart recovery).

## Breaking Changes
- [x] None
- [ ] Yes — migration path described below

## Test Plan

- Extended `builder_and_preparation_error_transience`: `AccountNotFoundError` is transient, `DelegationSessionChangedError` is terminal; added `snapshot_slots_keep_newest_on_duplicates`.
- Targeted nextest run (transience, cache fetcher, commit-id recovery tests) passes; clippy clean on `magicblock-committor-service` and `magicblock-api`; nightly rustfmt applied.
