### PR TITLE
fix(chainlink): serialize account materialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,7 +126,7 @@ dependencies = [
 [[package]]
 name = "agave-transaction-view"
 version = "4.1.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.3#a5a284482fee558b77d896da0de51cb27a90c1b4"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.4.0#2dc279bd2f6fd1878ea647c27756c93263634e6b"
 dependencies = [
  "ahash 0.8.12",
  "solana-hash 4.4.0",
@@ -3696,8 +3696,8 @@ dependencies = [
 
 [[package]]
 name = "magic-root-interface"
-version = "0.3.3"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.3#a5a284482fee558b77d896da0de51cb27a90c1b4"
+version = "0.4.0"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.4.0#2dc279bd2f6fd1878ea647c27756c93263634e6b"
 dependencies = [
  "solana-account 4.3.1",
  "solana-instruction 3.4.0",
@@ -3707,8 +3707,8 @@ dependencies = [
 
 [[package]]
 name = "magic-root-program"
-version = "0.3.3"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.3#a5a284482fee558b77d896da0de51cb27a90c1b4"
+version = "0.4.0"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.4.0#2dc279bd2f6fd1878ea647c27756c93263634e6b"
 dependencies = [
  "magic-root-interface",
  "magicblock-engine-nucleus",
@@ -3757,8 +3757,8 @@ dependencies = [
 
 [[package]]
 name = "magicblock-accountsdb"
-version = "0.3.3"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.3#a5a284482fee558b77d896da0de51cb27a90c1b4"
+version = "0.4.0"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.4.0#2dc279bd2f6fd1878ea647c27756c93263634e6b"
 dependencies = [
  "ahash 0.8.12",
  "bincode",
@@ -4048,8 +4048,8 @@ dependencies = [
 
 [[package]]
 name = "magicblock-engine"
-version = "0.3.3"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.3#a5a284482fee558b77d896da0de51cb27a90c1b4"
+version = "0.4.0"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.4.0#2dc279bd2f6fd1878ea647c27756c93263634e6b"
 dependencies = [
  "agave-transaction-view",
  "derive_more",
@@ -4081,8 +4081,8 @@ dependencies = [
 
 [[package]]
 name = "magicblock-engine-nucleus"
-version = "0.3.3"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.3#a5a284482fee558b77d896da0de51cb27a90c1b4"
+version = "0.4.0"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.4.0#2dc279bd2f6fd1878ea647c27756c93263634e6b"
 dependencies = [
  "agave-transaction-view",
  "derive_more",
@@ -4113,8 +4113,8 @@ dependencies = [
 
 [[package]]
 name = "magicblock-keeper"
-version = "0.3.3"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.3#a5a284482fee558b77d896da0de51cb27a90c1b4"
+version = "0.4.0"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.4.0#2dc279bd2f6fd1878ea647c27756c93263634e6b"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.12",
@@ -4152,8 +4152,8 @@ dependencies = [
 
 [[package]]
 name = "magicblock-ledger"
-version = "0.3.3"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.3#a5a284482fee558b77d896da0de51cb27a90c1b4"
+version = "0.4.0"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.4.0#2dc279bd2f6fd1878ea647c27756c93263634e6b"
 dependencies = [
  "agave-transaction-view",
  "bitcode",
@@ -4235,8 +4235,8 @@ dependencies = [
 
 [[package]]
 name = "magicblock-processor"
-version = "0.3.3"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.3#a5a284482fee558b77d896da0de51cb27a90c1b4"
+version = "0.4.0"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.4.0#2dc279bd2f6fd1878ea647c27756c93263634e6b"
 dependencies = [
  "agave-feature-set",
  "agave-precompiles",
@@ -4308,8 +4308,8 @@ dependencies = [
 
 [[package]]
 name = "magicblock-replicator"
-version = "0.3.3"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.3#a5a284482fee558b77d896da0de51cb27a90c1b4"
+version = "0.4.0"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.4.0#2dc279bd2f6fd1878ea647c27756c93263634e6b"
 dependencies = [
  "derive_more",
  "flume",
@@ -6744,7 +6744,7 @@ dependencies = [
 [[package]]
 name = "solana-account"
 version = "4.3.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.3#a5a284482fee558b77d896da0de51cb27a90c1b4"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.4.0#2dc279bd2f6fd1878ea647c27756c93263634e6b"
 dependencies = [
  "bincode",
  "bitflags 2.13.0",
@@ -8357,7 +8357,7 @@ dependencies = [
 [[package]]
 name = "solana-program-runtime"
 version = "4.1.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.3#a5a284482fee558b77d896da0de51cb27a90c1b4"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.4.0#2dc279bd2f6fd1878ea647c27756c93263634e6b"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -9082,7 +9082,7 @@ dependencies = [
 [[package]]
 name = "solana-svm"
 version = "4.1.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.3#a5a284482fee558b77d896da0de51cb27a90c1b4"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.4.0#2dc279bd2f6fd1878ea647c27756c93263634e6b"
 dependencies = [
  "ahash 0.8.12",
  "magic-root-interface",
@@ -9469,7 +9469,7 @@ dependencies = [
 [[package]]
 name = "solana-transaction-context"
 version = "4.1.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.3#a5a284482fee558b77d896da0de51cb27a90c1b4"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.4.0#2dc279bd2f6fd1878ea647c27756c93263634e6b"
 dependencies = [
  "bincode",
  "serde",
@@ -10906,8 +10906,8 @@ dependencies = [
 
 [[package]]
 name = "v42-calculator-interface"
-version = "0.3.3"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.3#a5a284482fee558b77d896da0de51cb27a90c1b4"
+version = "0.4.0"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.4.0#2dc279bd2f6fd1878ea647c27756c93263634e6b"
 dependencies = [
  "solana-instruction 3.4.0",
  "solana-pubkey 4.2.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,12 +65,12 @@ magicblock-task-scheduler = { path = "magicblock-task-scheduler" }
 magicblock-validator-admin = { path = "magicblock-validator-admin" }
 magicblock-version = { path = "magicblock-version" }
 
-engine = { package = "magicblock-engine", git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.3" }
-keeper = { package = "magicblock-keeper", git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.3" }
-ledger = { package = "magicblock-ledger", git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.3" }
-nucleus = { package = "magicblock-engine-nucleus", git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.3" }
-replicator = { package = "magicblock-replicator", git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.3" }
-v42-calculator-interface = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.3" }
+engine = { package = "magicblock-engine", git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.4.0" }
+keeper = { package = "magicblock-keeper", git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.4.0" }
+ledger = { package = "magicblock-ledger", git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.4.0" }
+nucleus = { package = "magicblock-engine-nucleus", git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.4.0" }
+replicator = { package = "magicblock-replicator", git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.4.0" }
+v42-calculator-interface = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.4.0" }
 
 agave-geyser-plugin-interface = { version = "4.1" }
 agave-precompiles = { version = "4.1", features = ["agave-unstable-api"] }
@@ -231,8 +231,8 @@ spl-token-2022 = { package = "spl-token-2022-interface", version = "2.1" }
 [patch.crates-io]
 libsodium-rs = { git = "https://github.com/jedisct1/libsodium-rs.git", rev = "0397a6c5785233f9f2ac91f3eedc3cceb74e0060" }
 
-agave-transaction-view = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.3" }
-solana-account = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.3" }
-solana-program-runtime = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.3" }
-solana-svm = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.3" }
-solana-transaction-context = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.3" }
+agave-transaction-view = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.4.0" }
+solana-account = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.4.0" }
+solana-program-runtime = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.4.0" }
+solana-svm = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.4.0" }
+solana-transaction-context = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.4.0" }

--- a/magicblock-chainlink/src/chainlink/errors.rs
+++ b/magicblock-chainlink/src/chainlink/errors.rs
@@ -64,9 +64,6 @@ pub enum ChainlinkError {
     #[error("Missing accounts required by delegation actions: {0:?}")]
     MissingDelegationActionAccounts(Vec<Pubkey>),
 
-    #[error("account load failed for {0}")]
-    AccountLoadFailed(Pubkey),
-
     #[error("Failed to perform risk check: {0}")]
     RiskCheckFailed(#[from] RiskError),
 }

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -1,11 +1,11 @@
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashSet,
     future::Future,
     mem,
     num::NonZeroUsize,
     pin::Pin,
     sync::{
-        Arc, Mutex,
+        Arc,
         atomic::{AtomicU64, Ordering},
     },
     time::Duration,
@@ -19,7 +19,7 @@ use dlp_api::{
     },
 };
 use engine::Engine;
-use keeper::MissingAccount;
+use keeper::error::KeeperError;
 use lru::LruCache;
 use magicblock_aml::RiskService;
 use magicblock_config::config::{AllowedProgram, AmlCheckStrategy};
@@ -74,8 +74,8 @@ use self::{
     subscription::{SubscriptionRelease, release_subs},
     types::{
         AccountWithCompanion, ClassifiedAccounts, FetchAndCloneBatchResult,
-        MaterializedAccount, PartitionedNotFound, RefreshDecision,
-        ResolvedDelegatedAccounts, ResolvedPrograms,
+        PartitionedNotFound, RefreshDecision, ResolvedDelegatedAccounts,
+        ResolvedPrograms,
     },
 };
 use super::errors::{ChainlinkError, ChainlinkResult};
@@ -85,8 +85,8 @@ use crate::{
         account_still_undelegating_on_chain::account_still_undelegating_on_chain,
     },
     cloner::{
-        self, AccountCloneRequest, AccountMaterialization,
-        ClonePostDelegationMode, DelegationActions, errors::ClonerResult,
+        self, AccountCloneRequest, ClonePostDelegationMode, DelegationActions,
+        errors::ClonerResult,
     },
     remote_account_provider::{
         ChainPubsubClient, ChainRpcClient, ForwardedSubscriptionUpdate,
@@ -145,26 +145,10 @@ where
     /// internal DLP discriminator via delegation-record sightings.
     dlp_collision_tracker: Arc<PlMutex<DlpCollisionTracker>>,
 
-    pending_undelegations: Arc<Mutex<HashSet<Pubkey>>>,
-
     /// Risk checker for post-delegation action addresses.
     risk_service: Option<Arc<RiskService>>,
 
     undelegation_request_sender: broadcast::Sender<ObservedUndelegationRequest>,
-}
-
-struct PendingUndelegationGuard {
-    pending_undelegations: Arc<Mutex<HashSet<Pubkey>>>,
-    pubkey: Pubkey,
-}
-
-impl Drop for PendingUndelegationGuard {
-    fn drop(&mut self) {
-        if let Ok(mut pending_undelegations) = self.pending_undelegations.lock()
-        {
-            pending_undelegations.remove(&self.pubkey);
-        }
-    }
 }
 
 /// Negative-cache capacity for known-empty eATAs.
@@ -328,7 +312,6 @@ where
             programdata_index: self.programdata_index.clone(),
             programdata_sweep_cursor: self.programdata_sweep_cursor.clone(),
             dlp_collision_tracker: self.dlp_collision_tracker.clone(),
-            pending_undelegations: self.pending_undelegations.clone(),
             risk_service: self.risk_service.clone(),
             undelegation_request_sender: self
                 .undelegation_request_sender
@@ -482,7 +465,6 @@ where
             dlp_collision_tracker: Arc::new(PlMutex::new(
                 DlpCollisionTracker::new(),
             )),
-            pending_undelegations: Arc::new(Mutex::new(HashSet::new())),
             risk_service,
             undelegation_request_sender,
         });
@@ -760,13 +742,12 @@ where
         }
     }
 
-    async fn clone_account(
+    async fn submit_account(
         &self,
+        accessor: &mut engine::AccountAccessor<'_>,
         request: AccountCloneRequest,
         fetch_context: AccountFetchContext,
-        materialization: AccountMaterialization,
-    ) -> ClonerResult<MaterializedAccount> {
-        let pubkey = request.pubkey;
+    ) -> ClonerResult<()> {
         let remote_result = Self::clone_remote_result_for_request(&request);
         let clone_intent = Self::clone_intent_for_request(&request);
         let is_empty_placeholder =
@@ -784,7 +765,7 @@ where
             Outcome::Success,
         );
         let result =
-            cloner::clone_account(&self.engine, request, materialization).await;
+            cloner::clone_account(&self.engine, accessor, request).await;
         if result.is_ok() {
             metrics::inc_chainlink_clone_accounts_total_with_context(
                 fetch_context.clone(),
@@ -812,7 +793,7 @@ where
                 Outcome::Error,
             );
         }
-        result.map(|mode| MaterializedAccount { pubkey, mode })
+        result
     }
 
     async fn watch_programdata(
@@ -1027,29 +1008,37 @@ where
         &self,
         program: LoadedProgram,
         fetch_context: AccountFetchContext,
-        materialization: AccountMaterialization,
-    ) -> ClonerResult<Option<MaterializedAccount>> {
+    ) -> ChainlinkResult<()> {
         let program_id = program.program_id;
-        let remote_slot = program.remote_slot;
         let is_loaderv3 = matches!(program.loader, RemoteProgramLoader::V3);
         let remote_result = ChainlinkCloneRemoteResult::Found;
         let clone_intent = ChainlinkCloneIntent::ProgramData;
-
-        if self
-            .read_account(&program_id, |account| account.slot() >= remote_slot)
-            .unwrap_or(false)
-        {
+        let Some(mut request) = cloner::resolve_program(program) else {
             metrics::inc_chainlink_clone_accounts_total_with_context(
                 fetch_context,
                 remote_result,
                 clone_intent,
                 ChainlinkCloneOutcome::Skipped,
             );
-            if is_loaderv3 {
-                let _ = self.watch_programdata(program_id).await;
-            }
-            return Ok(None);
-        }
+            return Ok(());
+        };
+        let installed_watch = is_loaderv3
+            && matches!(
+                self.watch_programdata(program_id).await,
+                Ok(ProgramDataWatch::Installed)
+            );
+
+        let Some(mut accessor) =
+            cloner::claim_materialization(&self.engine, &mut request).await?
+        else {
+            metrics::inc_chainlink_clone_accounts_total_with_context(
+                fetch_context,
+                remote_result,
+                clone_intent,
+                ChainlinkCloneOutcome::Skipped,
+            );
+            return Ok(());
+        };
 
         metrics::inc_chainlink_clone_accounts_total_with_context(
             fetch_context.clone(),
@@ -1057,13 +1046,10 @@ where
             clone_intent,
             ChainlinkCloneOutcome::Submitted,
         );
-        let installed_watch = is_loaderv3
-            && matches!(
-                self.watch_programdata(program_id).await,
-                Ok(ProgramDataWatch::Installed)
-            );
-        let result =
-            cloner::clone_program(&self.engine, program, materialization).await;
+        let result = cloner::clone_program(&mut accessor, request)
+            .await
+            .map_err(ChainlinkError::from);
+        drop(accessor);
         if result.is_ok() {
             if is_loaderv3 {
                 let _ = self.watch_programdata(program_id).await;
@@ -1091,30 +1077,14 @@ where
                 ChainlinkCloneOutcome::SubmitFailed,
             );
         }
-        result.map(|mode| {
-            mode.map(|mode| MaterializedAccount {
-                pubkey: program_id,
-                mode,
-            })
-        })
+        result
     }
 
     async fn clone_account_with_post_delegation_action_invariants(
         &self,
         mut request: AccountCloneRequest,
         fetch_context: AccountFetchContext,
-        materialization: AccountMaterialization,
-    ) -> ChainlinkResult<Option<MaterializedAccount>> {
-        if materialization == AccountMaterialization::Update
-            && !self.contains_account(&request.pubkey)
-        {
-            trace!(
-                pubkey = %request.pubkey,
-                "Ignoring account update for account absent from bank"
-            );
-            return Ok(None);
-        }
-
+    ) -> ChainlinkResult<()> {
         if request.account.read().is(AccountMode::Delegated)
             && is_ata(
                 &request.pubkey,
@@ -1133,30 +1103,21 @@ where
                     })?;
         }
         self.normalize_unresolved_dlp_clone_request(&mut request)?;
-        self.normalize_immutable_account(&mut request);
+        Self::normalize_immutable_account(&mut request);
 
-        if materialization == AccountMaterialization::Update
-            && request.post_delegation_mode.has_actions()
-        {
-            return Err(ChainlinkError::InvalidDelegationActions(
-                request.pubkey,
-                "account update unexpectedly contains post-delegation actions"
-                    .to_string(),
-            ));
-        }
-
-        if request.account.read().is(AccountMode::Delegated)
-            && self.local_delegated_clone_target_active(request.pubkey)
-        {
-            return Ok(None);
-        }
-
-        let Some(delegation_actions) = request.post_delegation_mode.actions()
+        let ClonePostDelegationMode::ExecuteActions(delegation) =
+            &request.post_delegation_mode
         else {
-            return Ok(Some(
-                self.clone_account(request, fetch_context, materialization)
-                    .await?,
-            ));
+            let Some(mut accessor) =
+                cloner::claim_materialization(&self.engine, &mut request)
+                    .await?
+            else {
+                return Ok(());
+            };
+            return self
+                .submit_account(&mut accessor, request, fetch_context)
+                .await
+                .map_err(Into::into);
         };
 
         if !request.account.read().is(AccountMode::Delegated) {
@@ -1166,127 +1127,88 @@ where
                     .to_string(),
             ));
         }
+        let source_program = delegation.source_program();
 
-        let result = async {
-            self.ensure_delegation_action_dependencies(
+        let dependency_error = self
+            .ensure_delegation_action_dependencies(
                 request.pubkey,
                 request.account.read().slot(),
-                delegation_actions,
+                delegation,
                 fetch_context.clone(),
             )
-            .await?;
+            .await
+            .err();
 
-            Ok(Some(
-                self.clone_account(
-                    request.clone(),
-                    fetch_context.clone(),
-                    AccountMaterialization::Create,
+        let Some(mut accessor) =
+            cloner::claim_materialization(&self.engine, &mut request).await?
+        else {
+            return Ok(());
+        };
+        if let Some(err) = dependency_error {
+            request.post_delegation_mode =
+                ClonePostDelegationMode::RescueUndelegate(source_program);
+            return self
+                .rescue_failed_activation(
+                    &mut accessor,
+                    request,
+                    fetch_context,
+                    err,
                 )
-                .await?,
-            ))
+                .await;
         }
-        .await;
-
-        match result {
-            Ok(materialized) => Ok(materialized),
+        // Keep the shared account buffer for fallback without cloning the
+        // action instructions that move into the activation attempt.
+        let rescue = AccountCloneRequest {
+            pubkey: request.pubkey,
+            account: request.account.clone(),
+            commit_frequency_ms: request.commit_frequency_ms,
+            post_delegation_mode: ClonePostDelegationMode::RescueUndelegate(
+                source_program,
+            ),
+            delegated_to_other: request.delegated_to_other,
+        };
+        match self
+            .submit_account(&mut accessor, request, fetch_context.clone())
+            .await
+        {
+            Ok(()) => Ok(()),
             Err(err) => {
-                let pubkey = request.pubkey;
-                warn!(
-                    pubkey = %pubkey,
-                    error = ?err,
-                    "Post-delegation actions could not be satisfied; undelegating"
-                );
-                if self
-                    .read_account(&pubkey, |account| {
-                        account.is(AccountMode::Transient)
-                    })
-                    .unwrap_or(false)
-                {
-                    return Err(err);
-                }
-
-                let Some(_guard) = self.claim_undelegation(pubkey) else {
-                    return Err(err);
-                };
-
-                // The post-delegation actions could not be satisfied (e.g. a
-                // high-risk signer or a missing dependency): the account is
-                // still cloned, but flagged so it gets automatically
-                // undelegated back to chain.
-                match self
-                    .clone_account_and_schedule_undelegation(
-                        request,
-                        fetch_context,
-                    )
-                    .await
-                {
-                    Ok(materialized) => Ok(materialized),
-                    Err(undelegation_err) => {
-                        warn!(
-                            pubkey = %pubkey,
-                            error = ?err,
-                            undelegation_error = ?undelegation_err,
-                            "Failed to schedule undelegation after post-delegation action clone failure"
-                        );
-                        Err(err)
-                    }
-                }
+                self.rescue_failed_activation(
+                    &mut accessor,
+                    rescue,
+                    fetch_context,
+                    err.into(),
+                )
+                .await
             }
         }
     }
 
-    async fn clone_account_and_schedule_undelegation(
+    async fn rescue_failed_activation(
         &self,
-        mut request: AccountCloneRequest,
+        accessor: &mut engine::AccountAccessor<'_>,
+        request: AccountCloneRequest,
         fetch_context: AccountFetchContext,
-    ) -> ClonerResult<Option<MaterializedAccount>> {
+        err: ChainlinkError,
+    ) -> ChainlinkResult<()> {
         let pubkey = request.pubkey;
-        request.post_delegation_mode = request
-            .post_delegation_mode
-            .rescue_undelegate()
-            .ok_or_else(|| {
-                cloner::errors::ClonerError::UndelegationSchedulingUnavailable(
-                    pubkey,
-                )
-            })?;
-        let remote_result = Self::clone_remote_result_for_request(&request);
-        let clone_intent = Self::clone_intent_for_request(&request);
-
-        if self
-            .read_account(&pubkey, |account| account.is(AccountMode::Transient))
-            .unwrap_or(false)
-        {
-            metrics::inc_chainlink_clone_accounts_total_with_context(
-                fetch_context,
-                remote_result,
-                clone_intent,
-                ChainlinkCloneOutcome::Skipped,
-            );
-            return Ok(None);
+        warn!(
+            pubkey = %pubkey,
+            error = ?err,
+            "Post-delegation actions could not be satisfied; undelegating"
+        );
+        match self.submit_account(accessor, request, fetch_context).await {
+            Ok(()) => Ok(()),
+            Err(undelegation_err) => {
+                warn!(
+                    pubkey = %pubkey,
+                    error = ?err,
+                    undelegation_error = ?undelegation_err,
+                    "Failed to schedule undelegation after post-delegation action clone failure"
+                );
+                Err(err)
+            }
         }
-
-        self.clone_account(
-            request,
-            fetch_context,
-            AccountMaterialization::Create,
-        )
-        .await
-        .map(Some)
-    }
-
-    fn claim_undelegation(
-        &self,
-        pubkey: Pubkey,
-    ) -> Option<PendingUndelegationGuard> {
-        let mut pending_undelegations =
-            self.pending_undelegations.lock().ok()?;
-        if !pending_undelegations.insert(pubkey) {
-            return None;
-        }
-        Some(PendingUndelegationGuard {
-            pending_undelegations: Arc::clone(&self.pending_undelegations),
-            pubkey,
-        })
     }
 
     fn normalize_unresolved_dlp_clone_request(
@@ -1326,34 +1248,21 @@ where
         Ok(())
     }
 
-    fn normalize_immutable_account(&self, request: &mut AccountCloneRequest) {
-        if !request.account.read().is(AccountMode::ReadOnly)
-            && !request.account.read().is(AccountMode::Placeholder)
-        {
+    fn normalize_immutable_account(request: &mut AccountCloneRequest) {
+        let account = request.account.read();
+        if !matches!(
+            account.mode(),
+            AccountMode::ReadOnly | AccountMode::Placeholder
+        ) {
             return;
         }
 
-        let mode = immutable_account_mode(request.account.read().lamports());
-        // Engine create composition can also refresh an existing target.
-        // Placeholder is reserved for a zero-lamport account absent locally;
-        // existing lifecycle transitions resolve through ReadOnly.
-        let mode = if mode == AccountMode::Placeholder
-            && !self.contains_account(&request.pubkey)
-        {
-            AccountMode::Placeholder
-        } else {
-            AccountMode::ReadOnly
-        };
-        if mode == request.account.read().mode() {
+        let mode = immutable_account_mode(account.lamports());
+        if mode == account.mode() {
             return;
         }
 
         request.account = mem::take(&mut request.account).mode(mode);
-    }
-
-    fn local_delegated_clone_target_active(&self, pubkey: Pubkey) -> bool {
-        self.read_account(&pubkey, |account| account.is(AccountMode::Delegated))
-            .unwrap_or(false)
     }
 
     pub fn start_subscription_listener(
@@ -1637,7 +1546,6 @@ where
                     .clone_projected_ata_request(
                         projected_ata_clone_request,
                         subscription_clone_context,
-                        AccountMaterialization::Update,
                     )
                     .await
             {
@@ -1778,11 +1686,12 @@ where
                         pubkey,
                         account,
                         commit_frequency_ms,
-                        post_delegation_mode: ClonePostDelegationMode::None,
+                        post_delegation_mode: ClonePostDelegationMode::from(
+                            delegation_actions,
+                        ),
                         delegated_to_other,
                     },
                     subscription_clone_context.clone(),
-                    AccountMaterialization::Update,
                 )
                 .await
             {
@@ -1797,7 +1706,6 @@ where
                     .clone_projected_ata_request(
                         projected_ata_clone_request,
                         subscription_clone_context,
-                        AccountMaterialization::Update,
                     )
                     .await
             {
@@ -1814,51 +1722,43 @@ where
         &'a self,
         pubkey: Pubkey,
         remote_slot: u64,
-        delegation_actions: &'a [solana_instruction::Instruction],
+        delegation: &'a DelegationActions,
         fetch_context: AccountFetchContext,
     ) -> Pin<Box<dyn Future<Output = ChainlinkResult<()>> + Send + 'a>> {
         Box::pin(async move {
-            if delegation_actions.is_empty() {
-                return Ok(());
-            }
-
-            self.validate_post_delegation_action_signers(delegation_actions)
+            self.validate_post_delegation_action_signers(delegation.actions())
                 .await?;
 
-            let (dependencies, writable_dependencies) =
-                Self::collect_post_delegation_action_dependencies(
-                    pubkey,
-                    delegation_actions,
-                );
+            let mut dependencies = HashSet::new();
+            let mut writable_dependencies = HashSet::new();
+            for (dependency, writable) in delegation.dependencies(pubkey) {
+                dependencies.insert(dependency);
+                if writable {
+                    writable_dependencies.insert(dependency);
+                }
+            }
 
             let dependencies_to_fetch = {
                 let accessor = self.engine.accounts();
                 let loader = accessor.loader();
                 dependencies
                     .into_iter()
-                    .filter(|dependency| {
-                        let reader = |account: &AccountSharedData| {
-                            // A copy that already sits at `remote_slot` is as
-                            // fresh as the update we are resolving. Refreshing
-                            // it anyway re-clones it at its current slot, and
-                            // the engine rejects that slot patch as a
-                            // non-advancing transition, which fails the whole
-                            // action path and undelegates the account.
-                            account.slot() < remote_slot
-                                && writable_dependencies.contains(dependency)
-                                && (!account.is(AccountMode::Delegated)
-                                    || account.is(AccountMode::Transient))
-                        };
-                        let Some(needs_refresh) =
-                            loader.read(dependency, reader).ok().flatten()
-                        else {
-                            return true;
-                        };
-                        needs_refresh
+                    .try_fold(Vec::new(), |mut pending, dependency| {
+                        let local = loader
+                            .read(&dependency, |account| {
+                                (account.slot(), account.mode())
+                            })
+                            .map_err(KeeperError::from)?;
+                        if Self::action_dependency_needs_fetch(
+                            local,
+                            remote_slot,
+                            writable_dependencies.contains(&dependency),
+                        ) {
+                            pending.push(dependency);
+                        }
+                        Ok::<_, KeeperError>(pending)
                     })
-                    .collect::<HashSet<_>>()
-                    .into_iter()
-                    .collect::<Vec<_>>()
+                    .map_err(ChainlinkError::from)?
             };
 
             if dependencies_to_fetch.is_empty() {
@@ -1881,13 +1781,8 @@ where
                 return Ok(());
             }
 
-            let missing_accounts = result
-                .pubkeys_missing_delegation_record()
-                .into_iter()
-                .collect::<HashSet<_>>()
-                .into_iter()
-                .collect::<Vec<_>>();
-            let mut missing_accounts = missing_accounts;
+            let mut missing_accounts =
+                result.pubkeys_missing_delegation_record();
             missing_accounts.sort_unstable();
             Err(ChainlinkError::MissingDelegationActionAccounts(
                 missing_accounts,
@@ -1895,27 +1790,17 @@ where
         })
     }
 
-    fn collect_post_delegation_action_dependencies(
-        target: Pubkey,
-        delegation_actions: &[solana_instruction::Instruction],
-    ) -> (HashSet<Pubkey>, HashSet<Pubkey>) {
-        let mut dependencies = HashSet::new();
-        let mut writable_dependencies = HashSet::new();
-        for instruction in delegation_actions.iter() {
-            if instruction.program_id != target {
-                dependencies.insert(instruction.program_id);
-            }
-            for meta in &instruction.accounts {
-                if meta.pubkey == target {
-                    continue;
-                }
-                dependencies.insert(meta.pubkey);
-                if meta.is_writable {
-                    writable_dependencies.insert(meta.pubkey);
-                }
+    fn action_dependency_needs_fetch(
+        local: Option<(u64, AccountMode)>,
+        remote_slot: u64,
+        writable: bool,
+    ) -> bool {
+        match local {
+            None => !writable,
+            Some((slot, mode)) => {
+                slot < remote_slot && writable && mode != AccountMode::Delegated
             }
         }
-        (dependencies, writable_dependencies)
     }
 
     async fn validate_post_delegation_action_signers(
@@ -1967,31 +1852,18 @@ where
         &self,
         request: AccountCloneRequest,
         fetch_context: AccountFetchContext,
-        materialization: AccountMaterialization,
     ) -> ChainlinkResult<()> {
-        match self.read_account(&request.pubkey, |account| {
+        if let Some(true) = self.read_account(&request.pubkey, |account| {
             account.is(AccountMode::Transient)
         }) {
-            Some(true) => {
-                return Ok(());
-            }
-            None if materialization == AccountMaterialization::Update => {
-                trace!(
-                    pubkey = %request.pubkey,
-                    "Ignoring projected ATA update for account absent from bank"
-                );
-                return Ok(());
-            }
-            _ => {}
+            return Ok(());
         }
 
         self.clone_account_with_post_delegation_action_invariants(
             request,
             fetch_context.with_reason(AccountFetchReason::AtaProjection),
-            materialization,
         )
         .await
-        .map(drop)
     }
 
     async fn clone_released_collision_candidate(
@@ -2282,7 +2154,6 @@ where
                         .clone_projected_ata_request(
                             projected_ata_clone_request,
                             discovery_context.clone(),
-                            AccountMaterialization::Create,
                         )
                         .await
                     {
@@ -3043,8 +2914,8 @@ where
         .await;
         accounts_to_clone.extend(ata_accounts);
 
-        // Ensure all accounts referenced by delegation actions exist and are
-        // cloned before we execute those actions as part of account cloning.
+        // Prefetch absent read-only action dependencies. Absent writable
+        // accounts remain available for explicit creation by PostFinalize.
         let action_dependencies =
             pipeline::collect_delegation_action_dependencies(
                 &accounts_to_clone,
@@ -3054,16 +2925,23 @@ where
             let loader = accessor.loader();
             action_dependencies
                 .into_iter()
-                .filter(|dependency| {
-                    !loader.contains(dependency).unwrap_or(false)
+                .try_fold(Vec::new(), |mut pending, (dependency, writable)| {
+                    if !writable
                         && !accounts_to_clone
                             .iter()
-                            .any(|request| request.pubkey.eq(dependency))
+                            .any(|request| request.pubkey == dependency)
                         && !loaded_programs
                             .iter()
-                            .any(|program| program.program_id.eq(dependency))
+                            .any(|program| program.program_id == dependency)
+                        && !loader
+                            .contains(&dependency)
+                            .map_err(KeeperError::from)?
+                    {
+                        pending.push(dependency);
+                    }
+                    Ok::<_, KeeperError>(pending)
                 })
-                .collect::<Vec<_>>()
+                .map_err(ChainlinkError::from)?
         };
 
         if !action_dependencies_to_fetch.is_empty() {
@@ -3129,10 +3007,10 @@ where
                 Err(err) => {
                     let releases = pipeline::compute_subscription_releases(
                         &all_requested_pubkeys,
-                        &accounts_to_clone,
+                        accounts_to_clone.iter(),
                         &loaded_programs,
-                        record_subs.clone(),
-                        program_data_subs.clone(),
+                        record_subs.iter().copied(),
+                        &program_data_subs,
                     );
                     release_subs(&self.remote_account_provider, releases).await;
                     return Err(err);
@@ -3142,14 +3020,13 @@ where
             if !action_dep_missing_delegation_record.is_empty() {
                 let releases = pipeline::compute_subscription_releases(
                     &all_requested_pubkeys,
-                    &accounts_to_clone,
+                    accounts_to_clone.iter(),
                     &loaded_programs,
                     record_subs
                         .iter()
                         .copied()
-                        .chain(action_dep_record_subs.iter().copied())
-                        .collect(),
-                    program_data_subs.clone(),
+                        .chain(action_dep_record_subs.iter().copied()),
+                    &program_data_subs,
                 );
                 release_subs(&self.remote_account_provider, releases).await;
                 return Err(ChainlinkError::MissingDelegationActionAccounts(
@@ -3177,16 +3054,14 @@ where
             {
                 Ok(resolved) => resolved,
                 Err(err) => {
-                    let mut cleanup_accounts_to_clone =
-                        accounts_to_clone.clone();
-                    cleanup_accounts_to_clone
-                        .extend(action_dep_accounts_to_clone.clone());
                     let releases = pipeline::compute_subscription_releases(
                         &all_requested_pubkeys,
-                        &cleanup_accounts_to_clone,
+                        accounts_to_clone
+                            .iter()
+                            .chain(&action_dep_accounts_to_clone),
                         &loaded_programs,
-                        record_subs.clone(),
-                        program_data_subs.clone(),
+                        record_subs.iter().copied(),
+                        &program_data_subs,
                     );
                     release_subs(&self.remote_account_provider, releases).await;
                     return Err(err);
@@ -3213,13 +3088,13 @@ where
 
         let releases = pipeline::compute_subscription_releases(
             &all_requested_pubkeys,
-            &accounts_to_clone,
+            accounts_to_clone.iter(),
             &loaded_programs,
             record_subs,
-            program_data_subs,
+            &program_data_subs,
         );
 
-        let materialized = pipeline::clone_accounts_and_programs(
+        pipeline::clone_accounts_and_programs(
             self,
             accounts_to_clone,
             loaded_programs,
@@ -3234,7 +3109,6 @@ where
                 not_found_on_chain: not_found,
                 missing_delegation_record,
             },
-            materialized,
         })
     }
 
@@ -3336,8 +3210,8 @@ where
         RefreshDecision::No
     }
 
-    /// Fetches and clones accounts while the engine coordinates concurrent
-    /// requests for the same missing account.
+    /// Fetches and clones accounts while the engine serializes mutations for
+    /// each target account.
     #[instrument(skip(self, pubkeys))]
     pub async fn fetch_and_clone_accounts_with_dedup(
         &self,
@@ -3371,23 +3245,7 @@ where
             trace!(count, "Fetching and cloning accounts with dedup");
         }
 
-        let requested_pubkeys =
-            pubkeys.iter().map(|pubkey| **pubkey).collect::<Vec<_>>();
-        let mut loads = Vec::new();
-        let mut load_pubkeys = HashSet::new();
-        let mut waiters = Vec::new();
-        for missing in self.engine.accounts().ensure(&requested_pubkeys) {
-            match missing {
-                MissingAccount::Load(load) => {
-                    load_pubkeys.insert(load.pubkey);
-                    loads.push(load);
-                }
-                MissingAccount::Wait(wait) => waiters.push(wait),
-            }
-        }
-
         let mut in_bank = HashSet::new();
-        let mut refresh = HashSet::new();
         let mut extra_mark_empty = Vec::new();
         let mut bank_hit_no_fetch_non_undelegating_count = 0_u64;
         let mut bank_hit_no_fetch_undelegating_still_valid_count = 0_u64;
@@ -3429,7 +3287,6 @@ where
                         }
                     }
                     forced_refresh_remote_required_count += 1;
-                    refresh.insert(**pubkey);
                     continue;
                 }
                 let reader = |account: &AccountSharedData| {
@@ -3528,7 +3385,6 @@ where
                             "Account completed undelegation which was missed and is fetched again"
                         );
                         bank_hit_undelegating_refresh_required_count += 1;
-                        refresh.insert(pubkey);
                         metrics::inc_unstuck_undelegation_count();
                         if let RefreshDecision::YesAndMarkEmptyIfNotFound =
                             decision
@@ -3603,16 +3459,7 @@ where
         let mark_empty =
             (!mark_empty.is_empty()).then_some(mark_empty.as_slice());
 
-        // Existing accounts that require a forced lifecycle refresh are not
-        // returned by `ensure`; missing accounts are fetched only by the caller
-        // holding the engine load reservation.
-        let fetch_pubkeys = pubkeys
-            .into_iter()
-            .copied()
-            .filter(|pubkey| {
-                refresh.contains(pubkey) || load_pubkeys.contains(pubkey)
-            })
-            .collect::<Vec<_>>();
+        let fetch_pubkeys = pubkeys.into_iter().copied().collect::<Vec<_>>();
         let batch = if fetch_pubkeys.is_empty() {
             FetchAndCloneBatchResult::default()
         } else {
@@ -3625,29 +3472,7 @@ where
             .await?
         };
 
-        let FetchAndCloneBatchResult {
-            result,
-            materialized,
-        } = batch;
-        let mut materialized = materialized
-            .into_iter()
-            .map(|account| (account.pubkey, account.mode))
-            .collect::<HashMap<_, _>>();
-        for load in loads {
-            let Some(mode) = materialized.remove(&load.pubkey) else {
-                continue;
-            };
-            load.complete(mode).await;
-        }
-
-        for waiter in waiters {
-            let (pubkey, completed) = waiter.wait().await;
-            if !completed {
-                return Err(ChainlinkError::AccountLoadFailed(pubkey));
-            }
-        }
-
-        Ok(result)
+        Ok(batch.result)
     }
 
     fn task_to_fetch_with_delegation_record(

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/pipeline.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/pipeline.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashSet, sync::atomic::Ordering};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::atomic::Ordering,
+};
 
 use dlp_api::pda::delegation_record_pda_from_delegated_account;
 use magicblock_core::token_programs::is_ata;
@@ -18,16 +21,13 @@ use super::{
     FetchCloner,
     subscription::{SubscriptionRelease, acquire_subs, release_subs},
     types::{
-        AccountWithCompanion, ClassifiedAccounts, MaterializedAccount,
-        PartitionedNotFound, ResolvedDelegatedAccounts, ResolvedPrograms,
+        AccountWithCompanion, ClassifiedAccounts, PartitionedNotFound,
+        ResolvedDelegatedAccounts, ResolvedPrograms,
     },
 };
 use crate::{
     chainlink::errors::{ChainlinkError, ChainlinkResult},
-    cloner::{
-        AccountCloneRequest, AccountMaterialization, ClonePostDelegationMode,
-        errors::ClonerResult,
-    },
+    cloner::{AccountCloneRequest, ClonePostDelegationMode},
     remote_account_provider::{
         ChainPubsubClient, ChainRpcClient, MatchSlotsConfig, RemoteAccount,
         ResolvedAccount, SubscriptionReason,
@@ -41,15 +41,12 @@ use crate::{
 
 pub(crate) fn collect_delegation_action_dependencies(
     accounts_to_clone: &[AccountCloneRequest],
-) -> HashSet<Pubkey> {
-    let mut dependencies = HashSet::new();
+) -> HashMap<Pubkey, bool> {
+    let mut dependencies = HashMap::new();
     for request in accounts_to_clone {
-        if let Some(actions) = request.post_delegation_mode.actions() {
-            for instruction in actions.iter() {
-                dependencies.insert(instruction.program_id);
-                for account_meta in &instruction.accounts {
-                    dependencies.insert(account_meta.pubkey);
-                }
+        if let Some(delegation) = request.post_delegation_mode.delegation() {
+            for (pubkey, writable) in delegation.dependencies(request.pubkey) {
+                *dependencies.entry(pubkey).or_default() |= writable;
             }
         }
     }
@@ -625,36 +622,41 @@ where
     })
 }
 
-pub(crate) fn compute_subscription_releases(
+pub(crate) fn compute_subscription_releases<'a>(
     all_requested_pubkeys: &[Pubkey],
-    accounts_to_clone: &[AccountCloneRequest],
+    accounts_to_clone: impl IntoIterator<Item = &'a AccountCloneRequest>,
     loaded_programs: &[crate::remote_account_provider::program_account::LoadedProgram],
-    record_subs: Vec<Pubkey>,
-    program_data_subs: HashSet<Pubkey>,
+    record_subs: impl IntoIterator<Item = Pubkey>,
+    program_data_subs: &HashSet<Pubkey>,
 ) -> Vec<SubscriptionRelease> {
+    let record_subs = record_subs.into_iter().collect::<Vec<_>>();
     let cloned_accounts = accounts_to_clone
-        .iter()
-        .map(|request| request.pubkey)
-        .collect::<HashSet<_>>();
+        .into_iter()
+        .map(|request| {
+            (
+                request.pubkey,
+                request.account.read().is(AccountMode::Delegated),
+            )
+        })
+        .collect::<HashMap<_, _>>();
     let loaded_program_ids = loaded_programs
         .iter()
         .map(|program| program.program_id)
-        .collect::<HashSet<_>>();
-    let delegated_cloned_accounts = accounts_to_clone
-        .iter()
-        .filter(|request| request.account.read().is(AccountMode::Delegated))
-        .map(|request| request.pubkey)
         .collect::<HashSet<_>>();
 
     let mut direct_releases = all_requested_pubkeys
         .iter()
         .copied()
         .filter(|pubkey| {
-            !cloned_accounts.contains(pubkey)
+            !cloned_accounts.contains_key(pubkey)
                 && !loaded_program_ids.contains(pubkey)
         })
         .collect::<HashSet<_>>();
-    direct_releases.extend(delegated_cloned_accounts);
+    direct_releases.extend(
+        cloned_accounts
+            .into_iter()
+            .filter_map(|(pubkey, delegated)| delegated.then_some(pubkey)),
+    );
     direct_releases.extend(record_subs.iter().copied());
     direct_releases.extend(program_data_subs.iter().copied());
 
@@ -671,13 +673,52 @@ pub(crate) fn compute_subscription_releases(
             reason: SubscriptionReason::DelegationRecord,
         }
     }));
-    releases.extend(program_data_subs.into_iter().map(|pubkey| {
+    releases.extend(program_data_subs.iter().copied().map(|pubkey| {
         SubscriptionRelease::Pubkey {
             pubkey,
             reason: SubscriptionReason::ProgramData,
         }
     }));
     releases
+}
+
+async fn materialize_accounts<T, U>(
+    this: &FetchCloner<T, U>,
+    requests: Vec<AccountCloneRequest>,
+    fetch_context: &AccountFetchContext,
+) -> ChainlinkResult<()>
+where
+    T: ChainRpcClient,
+    U: ChainPubsubClient,
+{
+    let mut pending = JoinSet::new();
+    for request in requests {
+        if tracing::enabled!(tracing::Level::TRACE) {
+            let account = request.account.read();
+            trace!(
+                pubkey = %request.pubkey,
+                slot = account.slot(),
+                owner = %account.owner(),
+                actions = request.post_delegation_mode.has_actions(),
+                "Cloning account"
+            );
+        }
+        let this = this.clone();
+        let fetch_context = fetch_context.clone();
+        pending.spawn(async move {
+            this.clone_account_with_post_delegation_action_invariants(
+                request,
+                fetch_context,
+            )
+            .await
+        });
+    }
+    pending
+        .join_all()
+        .await
+        .into_iter()
+        .collect::<ChainlinkResult<Vec<_>>>()?;
+    Ok(())
 }
 
 /// Clones accounts and programs into the bank
@@ -689,7 +730,7 @@ pub(crate) async fn clone_accounts_and_programs<T, U>(
         crate::remote_account_provider::program_account::LoadedProgram,
     >,
     fetch_context: AccountFetchContext,
-) -> ChainlinkResult<Vec<MaterializedAccount>>
+) -> ChainlinkResult<()>
 where
     T: ChainRpcClient,
     U: ChainPubsubClient,
@@ -711,23 +752,14 @@ where
         let this_clone = this.clone();
         let fetch_context = fetch_context.clone();
         program_join_set.spawn(async move {
-            this_clone
-                .clone_program(
-                    acc,
-                    fetch_context,
-                    AccountMaterialization::Create,
-                )
-                .await
+            this_clone.clone_program(acc, fetch_context).await
         });
     }
-    let mut materialized = program_join_set
+    program_join_set
         .join_all()
         .await
         .into_iter()
-        .collect::<ClonerResult<Vec<_>>>()?
-        .into_iter()
-        .flatten()
-        .collect::<Vec<_>>();
+        .collect::<ChainlinkResult<Vec<_>>>()?;
 
     // 2) Clone accounts without post-delegation actions first so common action
     // dependencies are materialized before action-bearing clone instructions.
@@ -736,74 +768,11 @@ where
             .into_iter()
             .partition(|request| request.post_delegation_mode.has_actions());
 
-    let mut accounts_join_set = JoinSet::new();
-    for request in accounts_without_actions {
-        if tracing::enabled!(tracing::Level::TRACE) {
-            let account = request.account.read();
-            trace!(
-                pubkey = %request.pubkey,
-                slot = account.slot(),
-                owner = %account.owner(),
-                "Cloning account"
-            );
-        };
-
-        let this_clone = this.clone();
-        let fetch_context = fetch_context.clone();
-        accounts_join_set.spawn(async move {
-            this_clone
-                .clone_account_with_post_delegation_action_invariants(
-                    request,
-                    fetch_context,
-                    AccountMaterialization::Create,
-                )
-                .await
-        });
-    }
-    materialized.extend(
-        accounts_join_set
-            .join_all()
-            .await
-            .into_iter()
-            .collect::<ChainlinkResult<Vec<_>>>()?
-            .into_iter()
-            .flatten(),
-    );
+    materialize_accounts(this, accounts_without_actions, &fetch_context)
+        .await?;
 
     // 3) Finally clone accounts that carry embedded post-delegation actions.
-    let mut action_accounts_join_set = JoinSet::new();
-    for request in accounts_with_actions {
-        if tracing::enabled!(tracing::Level::TRACE) {
-            let account = request.account.read();
-            trace!(
-                pubkey = %request.pubkey,
-                slot = account.slot(),
-                owner = %account.owner(),
-                "Cloning account with delegation actions"
-            );
-        };
+    materialize_accounts(this, accounts_with_actions, &fetch_context).await?;
 
-        let this_clone = this.clone();
-        let fetch_context = fetch_context.clone();
-        action_accounts_join_set.spawn(async move {
-            this_clone
-                .clone_account_with_post_delegation_action_invariants(
-                    request,
-                    fetch_context,
-                    AccountMaterialization::Create,
-                )
-                .await
-        });
-    }
-    materialized.extend(
-        action_accounts_join_set
-            .join_all()
-            .await
-            .into_iter()
-            .collect::<ChainlinkResult<Vec<_>>>()?
-            .into_iter()
-            .flatten(),
-    );
-
-    Ok(materialized)
+    Ok(())
 }

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/program_loader.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/program_loader.rs
@@ -12,14 +12,11 @@ use super::{
     CompanionFetchLogContext, FetchCloner, ProgramVerifyState,
     log_companion_fetch_failure, subscription::release_program_data_subs,
 };
-use crate::{
-    cloner::AccountMaterialization,
-    remote_account_provider::{
-        ChainPubsubClient, ChainRpcClient, SubscriptionReason,
-        program_account::{
-            LOADER_V1, LOADER_V2, LOADER_V3, ProgramAccountResolver,
-            get_loaderv3_get_program_data_address,
-        },
+use crate::remote_account_provider::{
+    ChainPubsubClient, ChainRpcClient, SubscriptionReason,
+    program_account::{
+        LOADER_V1, LOADER_V2, LOADER_V3, ProgramAccountResolver,
+        get_loaderv3_get_program_data_address,
     },
 };
 
@@ -345,11 +342,7 @@ pub(crate) async fn handle_executable_sub_update_with_context<T, U>(
         }
     };
     match this
-        .clone_program(
-            loaded_program,
-            program_load_context,
-            AccountMaterialization::Update,
-        )
+        .clone_program(loaded_program, program_load_context)
         .await
     {
         // Only successful loads are remembered: a failure leaves the next

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/tests.rs
@@ -1,4 +1,4 @@
-use solana_account::{Account, AccountBuilder, AccountMode};
+use solana_account::{Account, AccountBuilder, AccountMode, ReadableAccount};
 use solana_instruction::Instruction;
 use solana_pubkey::Pubkey;
 use solana_sdk_ids::system_program;
@@ -10,7 +10,7 @@ type TestFetchCloner = FetchCloner<ChainRpcClientMock, ChainPubsubClientMock>;
 use crate::{
     cloner::{AccountCloneRequest, ClonePostDelegationMode, DelegationActions},
     remote_account_provider::chain_pubsub_client::mock::ChainPubsubClientMock,
-    testing::rpc_client_mock::ChainRpcClientMock,
+    testing::{context::TestContext, rpc_client_mock::ChainRpcClientMock},
 };
 
 fn request(account: AccountBuilder) -> AccountCloneRequest {
@@ -83,6 +83,87 @@ fn clone_request_classification() {
         TestFetchCloner::clone_intent_for_request(&dependency),
         ChainlinkCloneIntent::ActionDependency
     );
+}
+
+/// Proves absent writable dependencies remain available for ER-only creation,
+/// while missing read-only and stale local writable dependencies are fetched.
+#[test]
+fn post_delegation_dependency_fetch_policy() {
+    assert!(!TestFetchCloner::action_dependency_needs_fetch(
+        None, 10, true,
+    ));
+    assert!(TestFetchCloner::action_dependency_needs_fetch(
+        None, 10, false,
+    ));
+    assert!(TestFetchCloner::action_dependency_needs_fetch(
+        Some((9, AccountMode::ReadOnly)),
+        10,
+        true,
+    ));
+    assert!(!TestFetchCloner::action_dependency_needs_fetch(
+        Some((10, AccountMode::ReadOnly)),
+        10,
+        true,
+    ));
+    assert!(!TestFetchCloner::action_dependency_needs_fetch(
+        Some((9, AccountMode::Delegated)),
+        10,
+        true,
+    ));
+}
+
+/// Proves a newer request waiting behind an older materialization re-reads the
+/// bank and applies its own image instead of inheriting the older result.
+#[tokio::test]
+async fn waiter_applies_newer_account_image() {
+    let ctx = TestContext::init(11).await;
+    let fetch = ctx
+        .chainlink
+        .fetch_cloner()
+        .expect("test Chainlink has a fetch cloner");
+    let pubkey = Pubkey::new_unique();
+    let build = |slot, byte| AccountCloneRequest {
+        pubkey,
+        account: AccountBuilder::default()
+            .lamports(1_000_000)
+            .data(vec![byte])
+            .owner(system_program::id())
+            .mode(AccountMode::ReadOnly)
+            .slot(slot),
+        commit_frequency_ms: None,
+        post_delegation_mode: ClonePostDelegationMode::None,
+        delegated_to_other: None,
+    };
+    let older = build(11, 1);
+    let newer = build(12, 2);
+    let mut accessor = ctx.bank.account(pubkey).await;
+    let older = async {
+        let result = fetch
+            .submit_account(
+                &mut accessor,
+                older,
+                AccountFetchContext::rpc_get_multiple_accounts(),
+            )
+            .await;
+        drop(accessor);
+        result
+    };
+    let newer = fetch.clone_account_with_post_delegation_action_invariants(
+        newer,
+        AccountFetchContext::rpc_get_multiple_accounts(),
+    );
+    let (older, newer) = tokio::join!(older, newer);
+    older.expect("older materialization succeeds");
+    newer.expect("newer waiter materializes its own image");
+
+    let state = ctx
+        .bank
+        .accounts()
+        .loader()
+        .read(&pubkey, |account| (account.slot(), account.data().to_vec()))
+        .unwrap()
+        .unwrap();
+    assert_eq!(state, (12, vec![2]));
 }
 
 mod aml_check_strategy {

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/types.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/types.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashSet, fmt};
 
-use solana_account::{AccountBuilder, AccountMode};
+use solana_account::AccountBuilder;
 use solana_pubkey::Pubkey;
 
 use crate::{
@@ -50,15 +50,9 @@ pub(crate) struct PartitionedNotFound {
     pub(crate) not_found: Vec<(Pubkey, u64)>,
 }
 
-pub(crate) struct MaterializedAccount {
-    pub(crate) pubkey: Pubkey,
-    pub(crate) mode: AccountMode,
-}
-
 #[derive(Default)]
 pub(crate) struct FetchAndCloneBatchResult {
     pub(crate) result: FetchAndCloneResult,
-    pub(crate) materialized: Vec<MaterializedAccount>,
 }
 
 #[derive(Debug, Default, Clone)]

--- a/magicblock-chainlink/src/chainlink/mod.rs
+++ b/magicblock-chainlink/src/chainlink/mod.rs
@@ -261,35 +261,49 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> InnerChainlink<T, U> {
 
         task::spawn(async move {
             while let Some(pubkey) = stale_accounts_rx.recv().await {
-                // Removal notifications can race with a new acquire_subscription for the same
-                // pubkey. The provider helper holds the same per-pubkey subscription lock used
-                // by acquire/release while it re-checks is_watching and submits eviction. This
-                // prevents an EvictAccount transaction from being submitted after a fresh
-                // subscription has made the account watched again, without blocking unrelated
-                // pubkeys on the defensive-eviction slow path.
-                let engine = engine.clone();
-                let evicted = remote_account_provider
-                    .evict_unwatched_with_subscription_lock(&pubkey, || async move {
-                        // MagicRoot is the authoritative deletion boundary and
-                        // rejects the request if the account became mutable.
-                        trace!(
-                            pubkey = %pubkey,
-                            "Submitting eviction transaction for unwatched account"
-                        );
-                        if let Err(err) = cloner::evict_account(&engine, pubkey).await {
-                            warn!(
-                                pubkey = %pubkey,
-                                error = ?err,
-                                "Failed to submit eviction transaction"
-                            );
-                        }
-                    })
+                let subscription = remote_account_provider
+                    .lock_account_eviction(&pubkey)
                     .await;
-
-                if !evicted {
+                if subscription.is_watching() {
                     trace!(
                         pubkey = %pubkey,
                         "Skipping removal notification because account is watched again"
+                    );
+                    continue;
+                }
+                let mut accessor =
+                    match cloner::claim_account_eviction(&engine, pubkey).await
+                    {
+                        Ok(Some(accessor)) => accessor,
+                        Ok(None) => continue,
+                        Err(err) => {
+                            warn!(
+                                pubkey = %pubkey,
+                                error = ?err,
+                                "Failed to claim unwatched account eviction"
+                            );
+                            continue;
+                        }
+                    };
+                trace!(
+                    pubkey = %pubkey,
+                    "Submitting eviction transaction for unwatched account"
+                );
+                if let Err(err) = subscription.unsubscribe().await {
+                    warn!(
+                        pubkey = %pubkey,
+                        error = ?err,
+                        "Failed to unsubscribe unwatched account"
+                    );
+                    continue;
+                }
+                if let Err(err) =
+                    cloner::delete_claimed_account(&mut accessor, pubkey).await
+                {
+                    warn!(
+                        pubkey = %pubkey,
+                        error = ?err,
+                        "Failed to submit eviction transaction"
                     );
                 }
             }
@@ -317,24 +331,32 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> InnerChainlink<T, U> {
                         let engine = engine.clone();
                         let remote_account_provider = remote_account_provider.clone();
                         pending.spawn(async move {
-                            let ata_info = {
-                                let accessor = engine.accounts();
-                                let loader = accessor.loader();
-                                loader
-                                    .read(&pubkey, |account| {
-                                        is_ata(
-                                            &pubkey,
-                                            *account.owner(),
-                                            account.data(),
-                                        )
-                                    })
-                                    .ok()
-                                    .flatten()
-                                    .flatten()
+                            let subscription = remote_account_provider
+                                .lock_account_eviction(&pubkey)
+                                .await;
+                            let (mut accessor, ata_info) = match cloner::claim_cached_account_eviction(
+                                &engine,
+                                pubkey,
+                                |account| {
+                                    is_ata(
+                                        &pubkey,
+                                        *account.owner(),
+                                        account.data(),
+                                    )
+                                },
+                            ).await {
+                                Ok(Some(claim)) => claim,
+                                Ok(None) => return,
+                                Err(err) => {
+                                    warn!(
+                                        pubkey = %pubkey,
+                                        error = ?err,
+                                        "Failed to claim engine-evicted account"
+                                    );
+                                    return;
+                                }
                             };
-                            // Engine emits only cache-tracked readonly accounts;
-                            // MagicRoot still rejects a later mutable transition.
-                            if let Err(err) = remote_account_provider.unsubscribe(&pubkey).await {
+                            if let Err(err) = subscription.unsubscribe().await {
                                 warn!(
                                     pubkey = %pubkey,
                                     error = ?err,
@@ -342,7 +364,12 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> InnerChainlink<T, U> {
                                 );
                                 return;
                             }
-                            if let Err(err) = cloner::evict_account(&engine, pubkey).await {
+                            if let Err(err) = cloner::delete_claimed_account(
+                                &mut accessor,
+                                pubkey,
+                            )
+                            .await
+                            {
                                 warn!(
                                     pubkey = %pubkey,
                                     error = ?err,
@@ -350,6 +377,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> InnerChainlink<T, U> {
                                 );
                                 return;
                             }
+                            drop(subscription);
                             let Some(ata_info) = ata_info else {
                                 return;
                             };
@@ -730,8 +758,10 @@ mod tests {
         )
     }
 
+    /// Proves the subscription boundary remains held until same-pubkey account
+    /// eviction work finishes.
     #[tokio::test]
-    async fn test_defensive_eviction_blocks_same_pubkey_subscription_until_eviction_finishes()
+    async fn test_account_eviction_blocks_same_pubkey_subscription_until_eviction_finishes()
      {
         init_logger();
 
@@ -747,15 +777,11 @@ mod tests {
         let eviction_started_for_task = eviction_started.clone();
         let release_eviction_for_task = release_eviction.clone();
         let eviction_task = tokio::spawn(async move {
-            eviction_provider
-                .evict_unwatched_with_subscription_lock(
-                    &eviction_pubkey,
-                    || async move {
-                        eviction_started_for_task.notify_one();
-                        release_eviction_for_task.notified().await;
-                    },
-                )
-                .await
+            let _eviction = eviction_provider
+                .lock_account_eviction(&eviction_pubkey)
+                .await;
+            eviction_started_for_task.notify_one();
+            release_eviction_for_task.notified().await;
         });
 
         eviction_started.notified().await;
@@ -777,11 +803,11 @@ mod tests {
             tokio::time::timeout(Duration::from_millis(50), &mut result_rx,)
                 .await
                 .is_err(),
-            "same-pubkey subscribe must wait while defensive eviction holds the per-pubkey subscription lock"
+            "same-pubkey subscribe must wait while account eviction holds the subscription lock"
         );
 
         release_eviction.notify_one();
-        assert!(eviction_task.await.unwrap());
+        eviction_task.await.unwrap();
         let subscribe_result = tokio::time::timeout(
             Duration::from_secs(1),
             &mut result_rx,

--- a/magicblock-chainlink/src/cloner/errors.rs
+++ b/magicblock-chainlink/src/cloner/errors.rs
@@ -21,17 +21,10 @@ pub enum ClonerError {
     CommittorServiceError(String),
 
     #[error("engine error: {0}")]
-    Engine(String),
+    Engine(#[from] engine::EngineError),
 
-    #[error("account update for {0} unexpectedly contains delegation actions")]
-    UnexpectedDelegationActionsOnUpdate(Pubkey),
-
-    /// Rescue undelegation is a post-finalize creation action. Updates cannot
-    /// attach it and must refuse rather than silently skip undelegation.
-    #[error(
-        "account {0} cannot schedule rescue undelegation during update materialization"
-    )]
-    UndelegationSchedulingUnavailable(Pubkey),
+    #[error("account materialization rejected for {0}: {1}")]
+    InvalidAccountMaterialization(Pubkey, String),
 
     #[error(
         "Clone transaction for account {pubkey} is too large: {size} bytes (max {max_size} bytes)"

--- a/magicblock-chainlink/src/cloner/mod.rs
+++ b/magicblock-chainlink/src/cloner/mod.rs
@@ -1,4 +1,6 @@
-use engine::{Engine, PostFinalize};
+use std::{iter, mem};
+
+use engine::{AccountAccessor, Engine, PostFinalize};
 use errors::ClonerResult;
 use magicblock_magic_program_api::{
     MAGIC_CONTEXT_PUBKEY,
@@ -8,7 +10,9 @@ use magicblock_magic_program_api::{
     },
     instruction::MagicBlockInstruction,
 };
-use solana_account::{AccountBuilder, AccountMode};
+use solana_account::{
+    AccountBuilder, AccountMode, AccountSharedData, OwnedAccount,
+};
 use solana_instruction::{AccountMeta, Instruction};
 use solana_loader_v4_interface::state::LoaderV4Status;
 use solana_pubkey::Pubkey;
@@ -19,12 +23,6 @@ use crate::remote_account_provider::program_account::{
 };
 
 pub mod errors;
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum AccountMaterialization {
-    Create,
-    Update,
-}
 
 /// Non-empty post-delegation actions paired with their slot-matched owner.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -55,6 +53,23 @@ impl DelegationActions {
         &self.actions
     }
 
+    /// Yields non-target program and account dependencies with their writability.
+    pub(crate) fn dependencies(
+        &self,
+        target: Pubkey,
+    ) -> impl Iterator<Item = (Pubkey, bool)> + '_ {
+        self.actions
+            .iter()
+            .flat_map(|ix| {
+                iter::once((ix.program_id, false)).chain(
+                    ix.accounts
+                        .iter()
+                        .map(|meta| (meta.pubkey, meta.is_writable)),
+                )
+            })
+            .filter(move |(pubkey, _)| *pubkey != target)
+    }
+
     fn into_post_finalize(self) -> PostFinalize {
         PostFinalize {
             source_program: self.source_program,
@@ -79,53 +94,16 @@ pub(crate) enum ClonePostDelegationMode {
 }
 
 impl ClonePostDelegationMode {
-    pub(crate) fn actions(&self) -> Option<&[Instruction]> {
+    /// Returns the action bundle when this request activates a delegation.
+    pub(crate) fn delegation(&self) -> Option<&DelegationActions> {
         match self {
-            Self::ExecuteActions(actions) => Some(actions.actions()),
+            Self::ExecuteActions(actions) => Some(actions),
             Self::None | Self::RescueUndelegate(_) => None,
         }
     }
 
     pub(crate) fn has_actions(&self) -> bool {
-        self.actions().is_some()
-    }
-
-    pub(crate) fn is_rescue_undelegate(&self) -> bool {
-        matches!(self, Self::RescueUndelegate(_))
-    }
-
-    pub(crate) fn rescue_undelegate(self) -> Option<Self> {
-        match self {
-            Self::ExecuteActions(actions) => {
-                Some(Self::RescueUndelegate(actions.source_program()))
-            }
-            Self::None | Self::RescueUndelegate(_) => None,
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// Proves rescue fallback retains the delegation record owner from the
-    /// failed normal post-delegation action path.
-    #[test]
-    fn rescue_undelegation_preserves_source_program() {
-        let source_program = Pubkey::new_unique();
-        let mode = ClonePostDelegationMode::from(DelegationActions::new(
-            source_program,
-            vec![Instruction::new_with_bytes(
-                Pubkey::new_unique(),
-                &[],
-                vec![],
-            )],
-        ));
-
-        assert_eq!(
-            mode.rescue_undelegate(),
-            Some(ClonePostDelegationMode::RescueUndelegate(source_program))
-        );
+        self.delegation().is_some()
     }
 }
 
@@ -135,7 +113,6 @@ impl From<Option<DelegationActions>> for ClonePostDelegationMode {
     }
 }
 
-#[derive(Clone)]
 pub struct AccountCloneRequest {
     pub pubkey: Pubkey,
     pub account: AccountBuilder,
@@ -149,8 +126,87 @@ pub struct AccountCloneRequest {
     pub delegated_to_other: Option<Pubkey>,
 }
 
-fn engine_err(err: impl ToString) -> errors::ClonerError {
-    errors::ClonerError::Engine(err.to_string())
+enum Materialization {
+    Apply,
+    ApplyReadOnly,
+    Satisfied(AccountMode),
+}
+
+fn classify_materialization(
+    pubkey: Pubkey,
+    local: &AccountSharedData,
+    desired: &OwnedAccount,
+) -> ClonerResult<Materialization> {
+    let invalid = |reason| {
+        errors::ClonerError::InvalidAccountMaterialization(pubkey, reason)
+    };
+    let mode = local.mode();
+    let active_delegation = mode == AccountMode::Delegated
+        && desired.mode() == AccountMode::Delegated;
+    if mode == AccountMode::Ephemeral
+        || active_delegation
+        || local.slot() > desired.slot()
+    {
+        return Ok(Materialization::Satisfied(mode));
+    }
+    if local == desired {
+        return Ok(Materialization::Satisfied(mode));
+    }
+
+    let desired_mode = desired.mode();
+    if mode == AccountMode::Transient
+        && desired_mode == AccountMode::Placeholder
+    {
+        // Engine completes undelegation through Transient -> ReadOnly. A
+        // zero-lamport remote image is still immutable, but cannot return
+        // directly to Placeholder through the lifecycle state machine.
+        return Ok(Materialization::ApplyReadOnly);
+    }
+    if local.slot() == desired.slot() {
+        if mode == desired_mode {
+            return Err(invalid("conflicting images at the same slot".into()));
+        }
+        if !mode.allows_transition(desired_mode, local.slot(), desired.slot()) {
+            return Err(invalid(format!(
+                "invalid same-slot mode transition {mode:?} -> {desired_mode:?}"
+            )));
+        }
+        return Ok(Materialization::Apply);
+    }
+
+    if mode != desired_mode
+        && !mode.allows_transition(desired_mode, local.slot(), desired.slot())
+    {
+        return Err(invalid(format!(
+            "invalid mode transition {mode:?} -> {desired_mode:?}"
+        )));
+    }
+    Ok(Materialization::Apply)
+}
+
+pub(crate) async fn claim_materialization<'a>(
+    engine: &'a Engine,
+    request: &mut AccountCloneRequest,
+) -> ClonerResult<Option<AccountAccessor<'a>>> {
+    let accessor = engine.account(request.pubkey).await;
+    let desired = request.account.read();
+    let materialization = accessor
+        .read(|local| classify_materialization(request.pubkey, local, desired))
+        .map_err(errors::ClonerError::from)?
+        .transpose()?
+        .unwrap_or(Materialization::Apply);
+    match materialization {
+        Materialization::Apply => Ok(Some(accessor)),
+        Materialization::ApplyReadOnly => {
+            request.account =
+                mem::take(&mut request.account).mode(AccountMode::ReadOnly);
+            Ok(Some(accessor))
+        }
+        Materialization::Satisfied(mode) => {
+            accessor.satisfy(mode).await;
+            Ok(None)
+        }
+    }
 }
 
 fn undelegation_action(engine: &Engine, pubkey: Pubkey) -> Instruction {
@@ -178,9 +234,9 @@ fn undelegation_action(engine: &Engine, pubkey: Pubkey) -> Instruction {
 
 pub(crate) async fn clone_account(
     engine: &Engine,
+    accessor: &mut AccountAccessor<'_>,
     request: AccountCloneRequest,
-    materialization: AccountMaterialization,
-) -> ClonerResult<AccountMode> {
+) -> ClonerResult<()> {
     if let Some(authority) = request.delegated_to_other {
         warn!(
             pubkey = %request.pubkey,
@@ -188,15 +244,6 @@ pub(crate) async fn clone_account(
             "Cloning account delegated to another validator"
         );
     }
-    if request.post_delegation_mode.is_rescue_undelegate()
-        && materialization == AccountMaterialization::Update
-    {
-        return Err(errors::ClonerError::UndelegationSchedulingUnavailable(
-            request.pubkey,
-        ));
-    }
-
-    let mode = request.account.read().mode();
     let actions = match request.post_delegation_mode {
         ClonePostDelegationMode::None => None,
         ClonePostDelegationMode::ExecuteActions(actions) => {
@@ -210,35 +257,21 @@ pub(crate) async fn clone_account(
         }
     };
     let account = request.account;
-    let result = match materialization {
-        AccountMaterialization::Create => {
-            engine
-                .account(request.pubkey)
-                .create(account, actions)
-                .await
-        }
-        AccountMaterialization::Update => {
-            engine.account(request.pubkey).update(account).await
-        }
-    };
-    result.map_err(|err| {
+    accessor.materialize(account, actions).await.map_err(|err| {
         errors::ClonerError::FailedToCloneRegularAccount(
             request.pubkey,
-            Box::new(engine_err(err)),
+            Box::new(err.into()),
         )
-    })?;
-    Ok(mode)
+    })
 }
 
-pub(crate) async fn clone_program(
-    engine: &Engine,
+pub(crate) fn resolve_program(
     program: LoadedProgram,
-    materialization: AccountMaterialization,
-) -> ClonerResult<Option<AccountMode>> {
+) -> Option<AccountCloneRequest> {
     let program_id = program.program_id;
     if matches!(program.loader_status, LoaderV4Status::Retracted) {
         debug!(%program_id, "Program is retracted on chain");
-        return Ok(None);
+        return None;
     }
 
     let owner = match program.loader {
@@ -255,31 +288,163 @@ pub(crate) async fn clone_program(
         .executable(true)
         .slot(program.remote_slot);
 
-    let result = match materialization {
-        AccountMaterialization::Create => {
-            engine.account(program_id).create(account, None).await
-        }
-        AccountMaterialization::Update => {
-            engine.account(program_id).update(account).await
-        }
-    };
-    result.map_err(|err| {
-        errors::ClonerError::FailedToCloneProgram(
-            program_id,
-            Box::new(engine_err(err)),
-        )
-    })?;
-    Ok(Some(AccountMode::ReadOnly))
+    Some(AccountCloneRequest {
+        pubkey: program_id,
+        account,
+        commit_frequency_ms: None,
+        post_delegation_mode: ClonePostDelegationMode::None,
+        delegated_to_other: None,
+    })
+}
+
+pub(crate) async fn clone_program(
+    accessor: &mut AccountAccessor<'_>,
+    request: AccountCloneRequest,
+) -> ClonerResult<()> {
+    let program_id = request.pubkey;
+    accessor
+        .materialize(request.account, None)
+        .await
+        .map_err(|err| {
+            errors::ClonerError::FailedToCloneProgram(
+                program_id,
+                Box::new(err.into()),
+            )
+        })
 }
 
 pub(crate) async fn evict_account(
     engine: &Engine,
     pubkey: Pubkey,
 ) -> ClonerResult<()> {
-    engine.account(pubkey).delete().await.map_err(|err| {
-        errors::ClonerError::FailedToEvictAccount(
-            pubkey,
-            Box::new(engine_err(err)),
-        )
+    let Some(mut accessor) = claim_account_eviction(engine, pubkey).await?
+    else {
+        return Ok(());
+    };
+    delete_claimed_account(&mut accessor, pubkey).await
+}
+
+pub(crate) async fn delete_claimed_account(
+    accessor: &mut AccountAccessor<'_>,
+    pubkey: Pubkey,
+) -> ClonerResult<()> {
+    accessor.delete().await.map_err(|err| {
+        errors::ClonerError::FailedToEvictAccount(pubkey, Box::new(err.into()))
     })
+}
+
+/// Claims an account displaced from Engine recency, unless a later completion
+/// retained it again or changed it to an authoritative lifecycle mode. The
+/// returned value is projected from the same protected account read.
+pub(crate) async fn claim_cached_account_eviction<R>(
+    engine: &Engine,
+    pubkey: Pubkey,
+    inspect: impl Fn(&AccountSharedData) -> R,
+) -> ClonerResult<Option<(AccountAccessor<'_>, R)>> {
+    let Some((accessor, mode, value)) =
+        claim_account_eviction_inner(engine, pubkey, inspect).await?
+    else {
+        return Ok(None);
+    };
+    Ok(accessor
+        .into_cached_eviction(mode)
+        .map(|accessor| (accessor, value)))
+}
+
+/// Claims a requested account eviction unless the current state is absent or
+/// authoritative.
+pub(crate) async fn claim_account_eviction(
+    engine: &Engine,
+    pubkey: Pubkey,
+) -> ClonerResult<Option<AccountAccessor<'_>>> {
+    let Some((accessor, mode, ())) =
+        claim_account_eviction_inner(engine, pubkey, |_| ()).await?
+    else {
+        return Ok(None);
+    };
+    Ok((!mode.authoritative()).then_some(accessor))
+}
+
+async fn claim_account_eviction_inner<R>(
+    engine: &Engine,
+    pubkey: Pubkey,
+    inspect: impl Fn(&AccountSharedData) -> R,
+) -> ClonerResult<Option<(AccountAccessor<'_>, AccountMode, R)>> {
+    let accessor = engine.account(pubkey).await;
+    let state = accessor
+        .read(|account| (account.mode(), inspect(account)))
+        .map_err(|err| {
+            errors::ClonerError::FailedToEvictAccount(
+                pubkey,
+                Box::new(err.into()),
+            )
+        })?;
+    let Some((mode, value)) = state else {
+        return Ok(None);
+    };
+    Ok(Some((accessor, mode, value)))
+}
+
+#[cfg(test)]
+mod tests {
+    use engine::testkit::TestEngine;
+
+    use super::*;
+
+    /// Proves a queued cache eviction cannot claim an account after a later
+    /// materialization retained it in recency or made it authoritative.
+    #[tokio::test]
+    async fn stale_cache_eviction_does_not_claim_current_account() {
+        let engine = TestEngine::new().await;
+        let pubkey = Pubkey::new_unique();
+        engine
+            .account(pubkey)
+            .await
+            .materialize(
+                AccountBuilder::default()
+                    .lamports(1_000_000)
+                    .mode(AccountMode::ReadOnly),
+                None,
+            )
+            .await
+            .expect("read-only account is materialized");
+
+        assert!(
+            claim_cached_account_eviction(&engine, pubkey, |_| ())
+                .await
+                .expect("eviction classification succeeds")
+                .is_none(),
+            "re-admission invalidates the queued eviction"
+        );
+        assert!(
+            engine.get_account(pubkey).is_some(),
+            "stale eviction leaves the re-admitted account intact"
+        );
+
+        let authoritative = Pubkey::new_unique();
+        engine
+            .account(authoritative)
+            .await
+            .materialize(
+                AccountBuilder::default()
+                    .lamports(1_000_000)
+                    .mode(AccountMode::Ephemeral),
+                None,
+            )
+            .await
+            .expect("ephemeral account is materialized");
+        assert!(
+            claim_cached_account_eviction(&engine, authoritative, |_| ())
+                .await
+                .expect("eviction classification succeeds")
+                .is_none(),
+            "authoritative state invalidates the queued eviction"
+        );
+        assert!(
+            engine.get_account(authoritative).is_some(),
+            "stale eviction leaves the authoritative account intact"
+        );
+
+        engine.close().await;
+    }
 }

--- a/magicblock-chainlink/src/remote_account_provider/mod.rs
+++ b/magicblock-chainlink/src/remote_account_provider/mod.rs
@@ -136,6 +136,31 @@ pub(crate) async fn subscription_key_owned_guard_from_map(
     lock.lock_owned().await
 }
 
+/// Holds the per-pubkey subscription boundary across an account eviction.
+pub(crate) struct SubscriptionEvictionGuard<
+    'a,
+    T: ChainRpcClient,
+    U: ChainPubsubClient,
+> {
+    provider: &'a RemoteAccountProvider<T, U>,
+    pubkey: Pubkey,
+    _guard: tokio::sync::OwnedMutexGuard<()>,
+}
+
+impl<T: ChainRpcClient, U: ChainPubsubClient>
+    SubscriptionEvictionGuard<'_, T, U>
+{
+    /// Returns whether a subscription was acquired before this eviction began.
+    pub(crate) fn is_watching(&self) -> bool {
+        self.provider.is_watching(&self.pubkey)
+    }
+
+    /// Removes the subscription while retaining the per-pubkey boundary.
+    pub(crate) async fn unsubscribe(&self) -> RemoteAccountProviderResult<()> {
+        self.provider.unsubscribe_locked(&self.pubkey).await
+    }
+}
+
 type ChainUpdatesPubsub = (Arc<ChainUpdatesClient>, mpsc::Receiver<()>);
 
 #[allow(clippy::too_many_arguments)]
@@ -2004,24 +2029,22 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
         self.subscribed_accounts.contains(pubkey)
     }
 
-    pub(crate) async fn evict_unwatched_with_subscription_lock<F, Fut>(
+    /// Locks subscription ownership for `pubkey` until its eviction decision
+    /// and any resulting unsubscribe and account deletion have completed.
+    pub(crate) async fn lock_account_eviction(
         &self,
         pubkey: &Pubkey,
-        evict: F,
-    ) -> bool
-    where
-        F: FnOnce() -> Fut,
-        Fut: std::future::Future<Output = ()>,
-    {
-        let subscription_key_lock = self.subscription_key_lock(pubkey).await;
-        let _subscription_guard = subscription_key_lock.lock().await;
-
-        if self.is_watching(pubkey) {
-            return false;
+    ) -> SubscriptionEvictionGuard<'_, T, U> {
+        let guard = subscription_key_owned_guard_from_map(
+            &self.subscription_key_locks,
+            *pubkey,
+        )
+        .await;
+        SubscriptionEvictionGuard {
+            provider: self,
+            pubkey: *pubkey,
+            _guard: guard,
         }
-
-        evict().await;
-        true
     }
 
     async fn subscription_key_lock(
@@ -2357,7 +2380,13 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> RemoteAccountProvider<T, U> {
     ) -> RemoteAccountProviderResult<()> {
         let subscription_key_lock = self.subscription_key_lock(pubkey).await;
         let _subscription_guard = subscription_key_lock.lock().await;
+        self.unsubscribe_locked(pubkey).await
+    }
 
+    async fn unsubscribe_locked(
+        &self,
+        pubkey: &Pubkey,
+    ) -> RemoteAccountProviderResult<()> {
         if self.subscribed_accounts.is_internally_managed(pubkey) {
             warn!(pubkey = %pubkey, "Tried to unsubscribe an internally managed account");
             inc_chainlink_subscription_cleanup_accounts(

--- a/magicblock-chainlink/src/testing/context.rs
+++ b/magicblock-chainlink/src/testing/context.rs
@@ -314,7 +314,8 @@ impl TestContext {
             .expect("account exists before undelegation");
         self.bank
             .account(*pubkey)
-            .update(account)
+            .await
+            .materialize(account, None)
             .await
             .expect("mark account undelegating through engine");
     }

--- a/magicblock-chainlink/tests/01_ensure-accounts.rs
+++ b/magicblock-chainlink/tests/01_ensure-accounts.rs
@@ -21,12 +21,18 @@ async fn seed_undelegating_account(ctx: &TestContext, pubkey: Pubkey) {
     .slot(CURRENT_SLOT);
     ctx.bank
         .account(pubkey)
-        .create(delegated.clone(), None)
+        .await
+        .materialize(delegated.clone(), None)
         .await
         .unwrap();
 
     let transient = delegated.mode(AccountMode::Transient);
-    ctx.bank.account(pubkey).update(transient).await.unwrap();
+    ctx.bank
+        .account(pubkey)
+        .await
+        .materialize(transient, None)
+        .await
+        .unwrap();
 }
 
 #[tokio::test]

--- a/magicblock-chainlink/tests/09_waiter_reconciliation_race.rs
+++ b/magicblock-chainlink/tests/09_waiter_reconciliation_race.rs
@@ -1,68 +1,205 @@
+use std::time::Duration;
+
+use dlp_api::{
+    args::{
+        EncryptedBuffer, MaybeEncryptedAccountMeta, MaybeEncryptedInstruction,
+        MaybeEncryptedIxData, PostDelegationActions,
+    },
+    pda::delegation_record_pda_from_delegated_account,
+    state::DelegationRecord,
+};
 use magicblock_chainlink::{
     AccountFetchContext, assert_cloned_as_delegated, assert_not_subscribed,
-    testing::{context::TestContext, deleg::add_delegation_record_for},
+    testing::{context::TestContext, deleg::delegation_record_to_vec},
 };
-use solana_account::Account;
+use solana_account::{Account, AccountBuilder, AccountMode, ReadableAccount};
 use solana_pubkey::Pubkey;
+use v42_calculator_interface::{ID as V42_ID, builder::transfer};
 
 const CURRENT_SLOT: u64 = 11;
 
-#[tokio::test]
-async fn concurrent_delegated_ensures_share_engine_load() {
-    let TestContext {
-        chainlink,
-        rpc_client,
-        bank,
-        validator_pubkey,
-        test_engine: _test_engine,
-        ..
-    } = TestContext::init(CURRENT_SLOT).await;
-
-    let account_pubkey = Pubkey::new_unique();
-    let account_owner = Pubkey::new_unique();
-    rpc_client.add_account(
-        account_pubkey,
+fn add_increment_action(
+    ctx: &TestContext,
+    pubkey: Pubkey,
+    output: Pubkey,
+) -> Pubkey {
+    let record_pubkey = delegation_record_pda_from_delegated_account(&pubkey);
+    let record = DelegationRecord {
+        authority: ctx.validator_pubkey,
+        owner: V42_ID,
+        delegation_slot: ctx.rpc_client.get_slot(),
+        lamports: 1_000,
+        commit_frequency_ms: 2_000,
+    };
+    let mut data = delegation_record_to_vec(&record);
+    let action = transfer(pubkey, output, 1);
+    let actions = PostDelegationActions {
+        inserted_signers: 0,
+        inserted_non_signers: 0,
+        signers: vec![
+            *pubkey.as_array(),
+            *output.as_array(),
+            *V42_ID.as_array(),
+        ],
+        non_signers: vec![],
+        instructions: vec![MaybeEncryptedInstruction {
+            program_id: 2,
+            accounts: vec![
+                MaybeEncryptedAccountMeta::ClearText(
+                    dlp_api::compact::AccountMeta::new(0, false),
+                ),
+                MaybeEncryptedAccountMeta::ClearText(
+                    dlp_api::compact::AccountMeta::new(1, false),
+                ),
+            ],
+            data: MaybeEncryptedIxData {
+                prefix: action.data,
+                suffix: EncryptedBuffer::default(),
+            },
+        }],
+    };
+    data.extend_from_slice(&borsh::to_vec(&actions).unwrap());
+    ctx.rpc_client.add_account(
+        record_pubkey,
         Account {
-            lamports: 1_000_000,
-            data: vec![1, 2, 3, 4],
             owner: dlp_api::id(),
+            data,
             ..Default::default()
         },
     );
-    let deleg_record_pubkey = add_delegation_record_for(
-        &rpc_client,
-        account_pubkey,
-        validator_pubkey,
-        account_owner,
-    );
+    record_pubkey
+}
 
-    let ensure = || {
-        let chainlink = chainlink.clone();
-        tokio::spawn(async move {
-            chainlink
-                .ensure_accounts(
-                    &[account_pubkey],
-                    AccountFetchContext::rpc_get_multiple_accounts(),
-                )
-                .await
+fn seed_output(ctx: &TestContext, output: Pubkey) {
+    ctx.bank
+        .accounts()
+        .store(&[(
+            output,
+            AccountBuilder::default()
+                .lamports(1_000_000)
+                .data(0_i64.to_le_bytes().to_vec())
+                .owner(V42_ID)
+                .mode(AccountMode::Ephemeral)
+                .build(),
+        )])
+        .unwrap();
+}
+
+fn account_value(ctx: &TestContext, pubkey: Pubkey) -> i64 {
+    ctx.bank
+        .accounts()
+        .loader()
+        .read(&pubkey, |account| {
+            i64::from_le_bytes(account.data().try_into().unwrap())
         })
-    };
-    let (first, second, third) =
-        tokio::try_join!(ensure(), ensure(), ensure()).expect("join ensures");
-    first.expect("first ensure succeeds");
-    second.expect("second ensure succeeds");
-    third.expect("third ensure succeeds");
+        .unwrap()
+        .unwrap()
+}
 
-    assert_eq!(
-        chainlink.fetch_count(),
-        Some(3),
-        "delegated resolution should perform only one owner fetch sequence"
+/// Proves a forced fetch racing the greedy-discovery subscription path submits
+/// one account mutation and executes its post-delegation action exactly once.
+#[tokio::test]
+async fn fetch_and_discovery_subscription_race_materializes_once() {
+    let ctx = TestContext::init(CURRENT_SLOT).await;
+    let chainlink = ctx.chainlink.clone();
+    let rpc_client = ctx.rpc_client.clone();
+    let bank = ctx.bank.clone();
+
+    let account_pubkey = Pubkey::new_unique();
+    let output = Pubkey::new_unique();
+    seed_output(&ctx, output);
+    let remote_account = Account {
+        lamports: 1_000_000,
+        data: 10_i64.to_le_bytes().to_vec(),
+        owner: dlp_api::id(),
+        ..Default::default()
+    };
+    rpc_client.add_account(account_pubkey, remote_account.clone());
+    let deleg_record_pubkey =
+        add_increment_action(&ctx, account_pubkey, output);
+    let mut updates = bank.accounts().subscribe(account_pubkey).await;
+    let blocker = bank.account(account_pubkey).await;
+
+    let requested = [account_pubkey];
+    let ensure = chainlink.ensure_accounts(
+        &requested,
+        AccountFetchContext::rpc_get_multiple_accounts(),
     );
-    assert_cloned_as_delegated!(
-        bank,
-        &[account_pubkey],
-        CURRENT_SLOT,
-        account_owner
+    let subscription = ctx.send_and_receive_account_update(
+        account_pubkey,
+        remote_account,
+        Some(8_000),
+    );
+    let release = async move {
+        tokio::task::yield_now().await;
+        drop(blocker);
+    };
+    let (ensure_result, subscription_completed, ()) =
+        tokio::join!(ensure, subscription, release);
+    ensure_result.expect("ensure succeeds");
+    assert!(subscription_completed, "subscription update completes");
+
+    assert_cloned_as_delegated!(bank, &[account_pubkey], CURRENT_SLOT, V42_ID);
+    let target_value = account_value(&ctx, account_pubkey);
+    let output_value = account_value(&ctx, output);
+    assert_eq!(
+        (target_value, output_value),
+        (9, 1),
+        "post-delegation action executes exactly once"
+    );
+    updates.recv().await.expect("one materialization update");
+    assert!(
+        tokio::time::timeout(Duration::from_millis(100), updates.recv())
+            .await
+            .is_err(),
+        "race must not commit a second account mutation"
     );
     assert_not_subscribed!(chainlink, &[&account_pubkey, &deleg_record_pubkey]);
+}
+
+/// Proves a newer subscription-observed delegation replaces a transient bank
+/// image and executes its post-delegation action exactly once.
+#[tokio::test]
+async fn transient_redelegation_subscription_executes_action_once() {
+    let ctx = TestContext::init(CURRENT_SLOT).await;
+    let pubkey = Pubkey::new_unique();
+    let output = Pubkey::new_unique();
+    seed_output(&ctx, output);
+    ctx.bank
+        .accounts()
+        .store(&[(
+            pubkey,
+            AccountBuilder::default()
+                .lamports(1_000_000)
+                .data(10_i64.to_le_bytes().to_vec())
+                .owner(dlp_api::id())
+                .mode(AccountMode::Transient)
+                .slot(CURRENT_SLOT)
+                .build(),
+        )])
+        .unwrap();
+    ctx.chainlink.undelegation_requested(pubkey).await.unwrap();
+
+    let slot = ctx.rpc_client.set_slot(CURRENT_SLOT + 11);
+    let remote = Account {
+        lamports: 1_000_000,
+        data: 10_i64.to_le_bytes().to_vec(),
+        owner: dlp_api::id(),
+        ..Default::default()
+    };
+    ctx.rpc_client.add_account(pubkey, remote.clone());
+    let record = add_increment_action(&ctx, pubkey, output);
+
+    assert!(
+        ctx.send_and_receive_account_update(pubkey, remote, Some(8_000))
+            .await,
+        "subscription update completes"
+    );
+    assert_cloned_as_delegated!(ctx.bank, &[pubkey], slot, V42_ID);
+    assert_eq!(
+        (account_value(&ctx, pubkey), account_value(&ctx, output)),
+        (9, 1),
+        "redelegation action executes exactly once"
+    );
+    assert_not_subscribed!(ctx.chainlink, &[&pubkey, &record]);
 }

--- a/programs/magicblock/src/utils/account_actions.rs
+++ b/programs/magicblock/src/utils/account_actions.rs
@@ -13,7 +13,7 @@ pub(crate) fn set_account_mode(
     acc: &mut AccountSharedData,
     mode: AccountMode,
 ) -> Result<(), InstructionError> {
-    acc.set_mode(mode).map_err(|err| {
+    acc.set_lifecycle(mode, acc.slot()).map_err(|err| {
         ic_msg!(invoke_context, "Account mode transition rejected: {}", err);
         InstructionError::InvalidArgument
     })

--- a/test-integration/Cargo.lock
+++ b/test-integration/Cargo.lock
@@ -119,7 +119,7 @@ dependencies = [
 [[package]]
 name = "agave-transaction-view"
 version = "4.1.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.3#a5a284482fee558b77d896da0de51cb27a90c1b4"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.4.0#2dc279bd2f6fd1878ea647c27756c93263634e6b"
 dependencies = [
  "ahash 0.8.12",
  "solana-hash 4.4.0",
@@ -3519,8 +3519,8 @@ dependencies = [
 
 [[package]]
 name = "magic-root-interface"
-version = "0.3.3"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.3#a5a284482fee558b77d896da0de51cb27a90c1b4"
+version = "0.4.0"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.4.0#2dc279bd2f6fd1878ea647c27756c93263634e6b"
 dependencies = [
  "solana-account 4.3.1",
  "solana-instruction 3.4.0",
@@ -3530,8 +3530,8 @@ dependencies = [
 
 [[package]]
 name = "magic-root-program"
-version = "0.3.3"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.3#a5a284482fee558b77d896da0de51cb27a90c1b4"
+version = "0.4.0"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.4.0#2dc279bd2f6fd1878ea647c27756c93263634e6b"
 dependencies = [
  "magic-root-interface",
  "magicblock-engine-nucleus",
@@ -3546,8 +3546,8 @@ dependencies = [
 
 [[package]]
 name = "magicblock-accountsdb"
-version = "0.3.3"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.3#a5a284482fee558b77d896da0de51cb27a90c1b4"
+version = "0.4.0"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.4.0#2dc279bd2f6fd1878ea647c27756c93263634e6b"
 dependencies = [
  "ahash 0.8.12",
  "bincode",
@@ -3805,8 +3805,8 @@ dependencies = [
 
 [[package]]
 name = "magicblock-engine"
-version = "0.3.3"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.3#a5a284482fee558b77d896da0de51cb27a90c1b4"
+version = "0.4.0"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.4.0#2dc279bd2f6fd1878ea647c27756c93263634e6b"
 dependencies = [
  "agave-transaction-view",
  "derive_more",
@@ -3838,8 +3838,8 @@ dependencies = [
 
 [[package]]
 name = "magicblock-engine-nucleus"
-version = "0.3.3"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.3#a5a284482fee558b77d896da0de51cb27a90c1b4"
+version = "0.4.0"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.4.0#2dc279bd2f6fd1878ea647c27756c93263634e6b"
 dependencies = [
  "agave-transaction-view",
  "derive_more",
@@ -3870,8 +3870,8 @@ dependencies = [
 
 [[package]]
 name = "magicblock-keeper"
-version = "0.3.3"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.3#a5a284482fee558b77d896da0de51cb27a90c1b4"
+version = "0.4.0"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.4.0#2dc279bd2f6fd1878ea647c27756c93263634e6b"
 dependencies = [
  "agave-feature-set",
  "ahash 0.8.12",
@@ -3909,8 +3909,8 @@ dependencies = [
 
 [[package]]
 name = "magicblock-ledger"
-version = "0.3.3"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.3#a5a284482fee558b77d896da0de51cb27a90c1b4"
+version = "0.4.0"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.4.0#2dc279bd2f6fd1878ea647c27756c93263634e6b"
 dependencies = [
  "agave-transaction-view",
  "bitcode",
@@ -3975,8 +3975,8 @@ dependencies = [
 
 [[package]]
 name = "magicblock-processor"
-version = "0.3.3"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.3#a5a284482fee558b77d896da0de51cb27a90c1b4"
+version = "0.4.0"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.4.0#2dc279bd2f6fd1878ea647c27756c93263634e6b"
 dependencies = [
  "agave-feature-set",
  "agave-precompiles",
@@ -6123,7 +6123,7 @@ dependencies = [
 [[package]]
 name = "solana-account"
 version = "4.3.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.3#a5a284482fee558b77d896da0de51cb27a90c1b4"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.4.0#2dc279bd2f6fd1878ea647c27756c93263634e6b"
 dependencies = [
  "bincode",
  "bitflags 2.13.1",
@@ -7709,7 +7709,7 @@ dependencies = [
 [[package]]
 name = "solana-program-runtime"
 version = "4.1.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.3#a5a284482fee558b77d896da0de51cb27a90c1b4"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.4.0#2dc279bd2f6fd1878ea647c27756c93263634e6b"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -8399,7 +8399,7 @@ dependencies = [
 [[package]]
 name = "solana-svm"
 version = "4.1.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.3#a5a284482fee558b77d896da0de51cb27a90c1b4"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.4.0#2dc279bd2f6fd1878ea647c27756c93263634e6b"
 dependencies = [
  "ahash 0.8.12",
  "magic-root-interface",
@@ -8786,7 +8786,7 @@ dependencies = [
 [[package]]
 name = "solana-transaction-context"
 version = "4.1.1"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.3#a5a284482fee558b77d896da0de51cb27a90c1b4"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.4.0#2dc279bd2f6fd1878ea647c27756c93263634e6b"
 dependencies = [
  "bincode",
  "serde",
@@ -10265,8 +10265,8 @@ dependencies = [
 
 [[package]]
 name = "v42-calculator-interface"
-version = "0.3.3"
-source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.3.3#a5a284482fee558b77d896da0de51cb27a90c1b4"
+version = "0.4.0"
+source = "git+https://github.com/magicblock-labs/magicblock-engine.git?tag=0.4.0#2dc279bd2f6fd1878ea647c27756c93263634e6b"
 dependencies = [
  "solana-instruction 3.4.0",
  "solana-pubkey 4.2.0",

--- a/test-integration/Cargo.toml
+++ b/test-integration/Cargo.toml
@@ -32,14 +32,14 @@ chrono = "0.4"
 cleanass = "0.0.1"
 color-backtrace = { version = "0.7" }
 ctrlc = "3.4.7"
-engine = { package = "magicblock-engine", git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.3", features = [
+engine = { package = "magicblock-engine", git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.4.0", features = [
     "testkit"
 ] }
 ephemeral-rollups-sdk = { version = "0.14", default-features = false, features = ["modular-sdk"] }
 futures = "0.3.31"
 integration-test-tools = { path = "test-tools" }
 isocountry = "0.3.2"
-keeper = { package = "magicblock-keeper", git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.3", features = [
+keeper = { package = "magicblock-keeper", git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.4.0", features = [
     "testkit"
 ] }
 lazy_static = "1.4.0"
@@ -71,7 +71,7 @@ schedulecommit-client = { path = "schedulecommit/client" }
 serde = "1.0.217"
 serial_test = "3.2.0"
 shlex = "1.3.0"
-solana-account = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.3" }
+solana-account = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.4.0" }
 solana-address = "=2.6.1"
 solana-address-lookup-table-interface = "3.0"
 solana-clock = "=3.1.1"
@@ -114,15 +114,15 @@ toml = "0.8.13"
 tracing = "0.1"
 ureq = "2.9.6"
 url = "2.5.0"
-v42-calculator-interface = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.3", features = [
+v42-calculator-interface = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.4.0", features = [
     "builder"
 ] }
 
 [patch.crates-io]
-agave-transaction-view = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.3" }
-solana-account = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.3" }
-solana-program-runtime = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.3" }
-solana-svm = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.3" }
-solana-transaction-context = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.3.3" }
+agave-transaction-view = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.4.0" }
+solana-account = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.4.0" }
+solana-program-runtime = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.4.0" }
+solana-svm = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.4.0" }
+solana-transaction-context = { git = "https://github.com/magicblock-labs/magicblock-engine.git", tag = "0.4.0" }
 # Fix libsodium for ARM builds - upstream crates.io version breaks Linux ARM binaries
 libsodium-rs = { git = "https://github.com/jedisct1/libsodium-rs.git", rev = "0397a6c5785233f9f2ac91f3eedc3cceb74e0060" }


### PR DESCRIPTION
## What changed

- Route account, program, and eviction materialization through Engine 0.4.0's serialized per-account accessor.
- Re-evaluate raced materialization requests against the current account image so duplicate triggers converge without duplicate clone transactions.
- Preserve subscription-observed post-delegation actions and leave absent writable ER-only dependencies for PostFinalize creation.

Closes #1600

Addresses #1601

## Impact

Chainlink no longer owns a parallel missing-account materialization guard. Engine now serializes account mutations, post-delegation activation, rescue undelegation, and eviction. The root and integration workspaces require Engine 0.4.0. Existing slot ordering, subscription ownership, remote-fetch deduplication, and action provenance remain enforced.

## Reviewer notes

The highest-risk boundaries are lifecycle classification under the Engine lease, reuse of that lease for rescue undelegation after failed activation, and the subscription/account lock ordering around eviction. Equal-slot undelegation completion remains constrained to `Transient` to `ReadOnly` by Engine's lifecycle state machine.
