### PR TITLE
feat(verifier): enable replication relays

### DIFF
--- a/bins/magicblock-verifier/src/main.rs
+++ b/bins/magicblock-verifier/src/main.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result};
 use engine::Engine;
 use magicblock_config::{ConfigError, VerifierParams};
 use nucleus::shutdown::{Service, ShutdownManager, ShutdownReason};
-use replicator::ReplicationClient;
+use replicator::{ReplicationClient, ReplicationDispatcher};
 use tokio::sync::mpsc;
 use tracing::{error, info};
 
@@ -70,22 +70,41 @@ async fn run_engine(
     let engine = Engine::new(builder, Some(blocks), &mut shutdown)
         .await
         .context("failed to open verifier engine")?;
-    ReplicationClient::spawn(
-        config.engine.replication.upstream_address,
-        engine.clone(),
-        pacer,
-        &mut shutdown,
-    )
-    .context("failed to start replication client")?;
-
-    let reason = tokio::select! {
-        biased;
-        reason = metrics_shutdown.wait() => reason,
-        reason = shutdown.wait() => reason,
-    };
-    let reason = reason.combine(shutdown.terminate().await);
+    let replication = &config.engine.replication;
+    let lifecycle = async {
+        ReplicationClient::spawn(
+            replication.upstream_address,
+            engine.clone(),
+            pacer,
+            &mut shutdown,
+        )
+        .context("failed to start replication client")?;
+        if !replication.allowed_followers.is_empty() {
+            let allowed = replication
+                .allowed_followers
+                .iter()
+                .map(|follower| follower.0)
+                .collect::<Vec<_>>()
+                .into();
+            ReplicationDispatcher::spawn(
+                replication.bind_address.0,
+                engine.clone(),
+                allowed,
+                &mut shutdown,
+            )
+            .await
+            .context("failed to start replication dispatcher")?;
+        }
+        Ok(tokio::select! {
+            biased;
+            reason = metrics_shutdown.wait() => reason,
+            reason = shutdown.wait() => reason,
+        })
+    }
+    .await;
+    let shutdown_reason = shutdown.terminate().await;
     drop(engine);
-    Ok(reason)
+    lifecycle.map(|reason| reason.combine(shutdown_reason))
 }
 
 fn exit(reason: ShutdownReason) -> ExitCode {

--- a/config.verifier.example.toml
+++ b/config.verifier.example.toml
@@ -25,6 +25,9 @@ size-limit = 536_870_912
 upstream-address = "127.0.0.1:10000"
 # Replace with the leader's public authority.
 upstream-authority = "BPFLoaderUpgradeab1e11111111111111111111111"
+# A non-empty allowlist enables relaying for shared-authority verifiers.
+bind-address = "127.0.0.1:10001"
+allowed-followers = []
 
 # Programs must match the leader configuration.
 # [[programs]]

--- a/magicblock-config/src/config/engine.rs
+++ b/magicblock-config/src/config/engine.rs
@@ -46,12 +46,16 @@ pub struct LeaderReplication {
 
 /// Replication settings for a validator that follows an upstream leader.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
 pub struct FollowerReplication {
     /// TCP address of the immediate upstream validator.
     pub upstream_address: SocketAddr,
     /// Identity whose signed replication responses are accepted.
     pub upstream_authority: SerdePubkey,
+    /// TCP address on which downstream followers connect.
+    pub bind_address: BindAddress,
+    /// Local identities permitted to follow this verifier.
+    pub allowed_followers: Vec<SerdePubkey>,
 }
 
 impl<R: Default> Default for EngineConfig<R> {
@@ -72,9 +76,7 @@ impl<R: Default> Default for EngineConfig<R> {
 impl Default for LeaderReplication {
     fn default() -> Self {
         Self {
-            bind_address: consts::DEFAULT_REPLICATION_BIND_ADDRESS
-                .parse()
-                .expect("default replication bind address must be valid"),
+            bind_address: default_replication_bind_address(),
             allowed_followers: Vec::new(),
         }
     }
@@ -85,8 +87,16 @@ impl Default for FollowerReplication {
         Self {
             upstream_address: SocketAddr::from(([0, 0, 0, 0], 0)),
             upstream_authority: SerdePubkey(Default::default()),
+            bind_address: default_replication_bind_address(),
+            allowed_followers: Vec::new(),
         }
     }
+}
+
+fn default_replication_bind_address() -> BindAddress {
+    consts::DEFAULT_REPLICATION_BIND_ADDRESS
+        .parse()
+        .expect("default replication bind address must be valid")
 }
 
 impl<R: fmt::Debug> fmt::Debug for EngineConfig<R> {


### PR DESCRIPTION
## What changed

- add downstream bind-address and follower-allowlist settings to verifier replication configuration
- start a downstream replication dispatcher for each verifier Engine generation when followers are allowed
- coordinate replication startup, failure, restart, and shutdown through the Engine lifecycle manager

Closes #1617

## Impact

Existing verifier configurations remain valid through default downstream settings. Distinct-key verifiers remain terminal leaves because Engine rejects dispatcher startup before binding when the local signer does not represent the source authority. Leader-only services remain disabled.

## Reviewer notes

The relay authority boundary remains owned by `ReplicationDispatcher::spawn`. Snapshot-driven reopen reconstructs both upstream replication and the configured downstream dispatcher while the metrics endpoint retains its process lifetime.
