### PR TITLE
fix: mirror base chain rent parameters in the ephemeral validator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3679,6 +3679,7 @@ version = "0.14.12"
 dependencies = [
  "agave-feature-set",
  "anyhow",
+ "bincode",
  "borsh 1.6.1",
  "fd-lock",
  "magic-domain-program",

--- a/magicblock-api/Cargo.toml
+++ b/magicblock-api/Cargo.toml
@@ -9,6 +9,7 @@ edition.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+bincode = { workspace = true }
 borsh = "1.5.3"
 fd-lock = { workspace = true }
 tracing = { workspace = true }

--- a/magicblock-api/src/errors.rs
+++ b/magicblock-api/src/errors.rs
@@ -22,6 +22,9 @@ pub enum ApiError {
     #[error("Failed to obtain balance for validator '{0}' from chain. ({1})")]
     FailedToObtainValidatorOnChainBalance(Pubkey, String),
 
+    #[error("Failed to sync rent sysvar from base chain: {0}")]
+    FailedToSyncBaseChainRent(String),
+
     #[error("Validator '{0}' is insufficiently funded on chain. Minimum is ({1} SOL)")]
     ValidatorInsufficientlyFunded(Pubkey, u64),
 

--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -365,18 +365,6 @@ impl MagicValidator {
         }
         let base_fee = config.validator.basefee;
 
-        // Rent must match the base layer exactly: commits there are paid by
-        // the validator under the assumption they were paid 1:1 in the ER.
-        // Replicas fetch as well, since the primary's direct AccountsDb
-        // write of the sysvar is not carried over by replication. Offline
-        // mode keeps the default rent and needs no remote.
-        if config.lifecycle.needs_remote_account_provider() {
-            let step_start = Instant::now();
-            Self::sync_rent_from_base_chain(config.rpc_url(), &accountsdb)
-                .await?;
-            log_timing("startup", "sync_rent_from_base_chain", step_start);
-        }
-
         let svm_env = build_svm_env(&accountsdb, latest_block.blockhash, 0);
         let feature_set = svm_env.feature_set.clone();
         let txn_scheduler_state = TransactionSchedulerState {
@@ -827,13 +815,15 @@ impl MagicValidator {
     /// while a lower rate admits account states the base layer refuses on
     /// commit — settlement the validator pays for assuming 1:1 rent parity.
     ///
-    /// NOTE: rent is a startup-frozen input to execution. A rate reduction
-    /// activating on the base chain while the validator runs requires a
-    /// restart to be picked up, a ledger spanning a rate change replays
-    /// entirely under the rate fetched at boot (snapshot on activation to
-    /// avoid replay divergence), and Offline mode deliberately keeps the
-    /// last persisted value so recovered ledgers replay under the rate
-    /// they were produced with.
+    /// Called only after ledger replay has completed: replay must run under
+    /// the persisted rent its transactions were recorded with, and the new
+    /// value takes effect at the next block boundary (see `refresh_rent` in
+    /// the transaction executor).
+    ///
+    /// NOTE: a rate reduction activating on the base chain while the
+    /// validator runs still requires a restart to be picked up. Offline mode
+    /// deliberately keeps the last persisted value so recovered ledgers
+    /// replay under the rate they were produced with.
     async fn sync_rent_from_base_chain(
         rpc_url: &str,
         accountsdb: &AccountsDb,
@@ -1143,6 +1133,24 @@ impl MagicValidator {
         self.maybe_process_ledger().await?;
 
         log_timing("startup", "maybe_process_ledger", step_start);
+
+        // Rent must match the base layer exactly: commits there are paid by
+        // the validator under the assumption they were paid 1:1 in the ER.
+        // Synced only after ledger replay, which must run under the persisted
+        // rent its transactions were recorded with; executors adopt the new
+        // value at the next block boundary (see `refresh_rent`). Replicas
+        // fetch as well, since the direct AccountsDb write of the sysvar is
+        // not carried over by replication. Offline mode keeps the persisted
+        // rent and needs no remote.
+        if self.config.lifecycle.needs_remote_account_provider() {
+            let step_start = Instant::now();
+            Self::sync_rent_from_base_chain(
+                self.config.rpc_url(),
+                &self.accountsdb,
+            )
+            .await?;
+            log_timing("startup", "sync_rent_from_base_chain", step_start);
+        }
 
         if self.config.accountsdb.defragment_on_startup {
             let step_start = Instant::now();

--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -367,10 +367,10 @@ impl MagicValidator {
 
         // Rent must match the base layer exactly: commits there are paid by
         // the validator under the assumption they were paid 1:1 in the ER.
-        // Replicas skip the fetch and inherit the sysvar via replication.
-        if !Self::replication_mode_uses_disabled_chainlink(
-            &config.validator.replication_mode,
-        ) {
+        // Replicas fetch as well, since the primary's direct AccountsDb
+        // write of the sysvar is not carried over by replication. Offline
+        // mode keeps the default rent and needs no remote.
+        if config.lifecycle.needs_remote_account_provider() {
             let step_start = Instant::now();
             Self::sync_rent_from_base_chain(config.rpc_url(), &accountsdb)
                 .await?;
@@ -827,8 +827,13 @@ impl MagicValidator {
     /// while a lower rate admits account states the base layer refuses on
     /// commit — settlement the validator pays for assuming 1:1 rent parity.
     ///
-    /// NOTE: a rate reduction activating on the base chain while the
-    /// validator is running requires a restart to be picked up.
+    /// NOTE: rent is a startup-frozen input to execution. A rate reduction
+    /// activating on the base chain while the validator runs requires a
+    /// restart to be picked up, a ledger spanning a rate change replays
+    /// entirely under the rate fetched at boot (snapshot on activation to
+    /// avoid replay divergence), and Offline mode deliberately keeps the
+    /// last persisted value so recovered ledgers replay under the rate
+    /// they were produced with.
     async fn sync_rent_from_base_chain(
         rpc_url: &str,
         accountsdb: &AccountsDb,
@@ -848,7 +853,9 @@ impl MagicValidator {
         info!(?rent, "Synced rent parameters from base chain");
         let account = AccountSharedData::new_data(1, &rent, &sysvar::ID)
             .map_err(|e| err(&e))?;
-        let _ = accountsdb.insert_account(&sysvar::rent::ID, &account);
+        accountsdb
+            .insert_account(&sysvar::rent::ID, &account)
+            .map_err(|e| err(&e))?;
         Ok(())
     }
 

--- a/magicblock-api/src/magic_validator.rs
+++ b/magicblock-api/src/magic_validator.rs
@@ -70,11 +70,14 @@ use mdp::state::{
     status::ErStatus,
     version::v0::RecordV0,
 };
+use solana_account::AccountSharedData;
 use solana_commitment_config::{CommitmentConfig, CommitmentLevel};
 use solana_keypair::Keypair;
 use solana_native_token::LAMPORTS_PER_SOL;
 use solana_pubkey::Pubkey;
+use solana_rent::Rent;
 use solana_rpc_client::nonblocking::rpc_client::RpcClient;
+use solana_sdk_ids::sysvar;
 use solana_signer::Signer;
 use tokio::{
     runtime::Builder,
@@ -361,6 +364,18 @@ impl MagicValidator {
             validator::set_validator_authority_override(pk);
         }
         let base_fee = config.validator.basefee;
+
+        // Rent must match the base layer exactly: commits there are paid by
+        // the validator under the assumption they were paid 1:1 in the ER.
+        // Replicas skip the fetch and inherit the sysvar via replication.
+        if !Self::replication_mode_uses_disabled_chainlink(
+            &config.validator.replication_mode,
+        ) {
+            let step_start = Instant::now();
+            Self::sync_rent_from_base_chain(config.rpc_url(), &accountsdb)
+                .await?;
+            log_timing("startup", "sync_rent_from_base_chain", step_start);
+        }
 
         let svm_env = build_svm_env(&accountsdb, latest_block.blockhash, 0);
         let feature_set = svm_env.feature_set.clone();
@@ -801,6 +816,40 @@ impl MagicValidator {
                 error!(error = ?err, "Failed to send unregister");
             }
         }
+    }
+
+    /// Mirrors the base chain's rent sysvar into the ER's own rent sysvar.
+    ///
+    /// The stored value drives both the SVM rent-state checks and the sysvar
+    /// programs read to fund new accounts (see `build_svm_env`). A higher
+    /// rate than the base chain's rejects cloning of accounts that are
+    /// legitimately rent-exempt there (SIMD-0437 lowers the rate in steps),
+    /// while a lower rate admits account states the base layer refuses on
+    /// commit — settlement the validator pays for assuming 1:1 rent parity.
+    ///
+    /// NOTE: a rate reduction activating on the base chain while the
+    /// validator is running requires a restart to be picked up.
+    async fn sync_rent_from_base_chain(
+        rpc_url: &str,
+        accountsdb: &AccountsDb,
+    ) -> ApiResult<()> {
+        let err = |err: &dyn std::fmt::Display| {
+            ApiError::FailedToSyncBaseChainRent(err.to_string())
+        };
+        let account = RpcClient::new_with_commitment(
+            rpc_url.to_owned(),
+            CommitmentConfig::confirmed(),
+        )
+        .get_account(&sysvar::rent::ID)
+        .await
+        .map_err(|e| err(&e))?;
+        let rent: Rent =
+            bincode::deserialize(&account.data).map_err(|e| err(&e))?;
+        info!(?rent, "Synced rent parameters from base chain");
+        let account = AccountSharedData::new_data(1, &rent, &sysvar::ID)
+            .map_err(|e| err(&e))?;
+        let _ = accountsdb.insert_account(&sysvar::rent::ID, &account);
+        Ok(())
     }
 
     async fn ensure_validator_funded_on_chain(

--- a/magicblock-processor/src/executor/mod.rs
+++ b/magicblock-processor/src/executor/mod.rs
@@ -21,10 +21,10 @@ use magicblock_ledger::{LatestBlock, Ledger};
 use solana_account::ReadableAccount;
 use solana_feature_set::FeatureSet;
 use solana_program::{rent::Rent, slot_hashes::SlotHashes};
-use solana_sdk_ids::sysvar;
 use solana_program_runtime::loaded_programs::{
     BlockRelation, ForkGraph, ProgramCache, ProgramCacheEntry,
 };
+use solana_sdk_ids::sysvar;
 use solana_svm::transaction_processor::{
     ExecutionRecordingConfig, TransactionBatchProcessor,
     TransactionProcessingConfig, TransactionProcessingEnvironment,

--- a/magicblock-processor/src/executor/mod.rs
+++ b/magicblock-processor/src/executor/mod.rs
@@ -5,7 +5,7 @@ use std::{
     sync::{Arc, RwLock},
 };
 
-use magicblock_accounts_db::AccountsDb;
+use magicblock_accounts_db::{traits::AccountsBank, AccountsDb};
 use magicblock_core::{
     link::{
         accounts::AccountUpdateTx,
@@ -18,8 +18,10 @@ use magicblock_core::{
     Slot,
 };
 use magicblock_ledger::{LatestBlock, Ledger};
+use solana_account::ReadableAccount;
 use solana_feature_set::FeatureSet;
-use solana_program::slot_hashes::SlotHashes;
+use solana_program::{rent::Rent, slot_hashes::SlotHashes};
+use solana_sdk_ids::sysvar;
 use solana_program_runtime::loaded_programs::{
     BlockRelation, ForkGraph, ProgramCache, ProgramCacheEntry,
 };
@@ -226,6 +228,7 @@ impl TransactionExecutor {
             self.block_history.pop_first();
         }
         self.block_history.insert(block.slot, block);
+        self.refresh_rent();
     }
 
     fn apply_block(&mut self, block: LatestBlockInner) {
@@ -234,6 +237,33 @@ impl TransactionExecutor {
         self.environment.blockhash = block.blockhash;
         self.processor.slot = slot;
         self.set_sysvars(&block);
+    }
+
+    /// Adopts rent parameter changes at the block boundary. Runs on every
+    /// new block registration, which covers both the primary path (latest
+    /// block broadcast) and the replica path (`apply_block`).
+    ///
+    /// Rent is synced from the base chain only after ledger replay has
+    /// completed (see `sync_rent_from_base_chain`), so the environment
+    /// captured at executor spawn can be stale; picking the sysvar up here
+    /// switches every executor within one block of the sync, keeping the
+    /// rent-state checks and the sysvar programs read consistent.
+    fn refresh_rent(&mut self) {
+        let Some(account) = self.accountsdb.get_account(&sysvar::rent::ID)
+        else {
+            return;
+        };
+        let Ok(rent) = bincode::deserialize::<Rent>(account.data()) else {
+            return;
+        };
+        if rent != self.environment.rent {
+            if let Ok(mut cache) =
+                self.processor.writable_sysvar_cache().write()
+            {
+                cache.set_sysvar_for_tests(&rent);
+            }
+            self.environment.rent = rent;
+        }
     }
 
     fn transition_to_slot(&mut self, slot: Slot) {

--- a/magicblock-processor/src/lib.rs
+++ b/magicblock-processor/src/lib.rs
@@ -8,7 +8,7 @@ use agave_syscalls::{
 };
 use magicblock_accounts_db::{traits::AccountsBank, AccountsDb};
 use magicblock_core::link::blocks::BlockHash;
-use solana_account::{AccountSharedData, WritableAccount};
+use solana_account::{AccountSharedData, ReadableAccount, WritableAccount};
 use solana_feature_gate_interface::state::Feature;
 use solana_feature_set::{
     curve25519_restrict_msm_length, curve25519_syscall_enabled,
@@ -25,6 +25,7 @@ use solana_program_runtime::{
 };
 use solana_sdk_ids::{
     ed25519_program, native_loader, secp256k1_program, secp256r1_program,
+    sysvar,
 };
 use solana_svm::transaction_processor::TransactionProcessingEnvironment;
 use tracing::error;
@@ -102,13 +103,33 @@ pub fn build_svm_env(
         program_runtime_environments_for_execution: runtime_environments
             .clone(),
         program_runtime_environments_for_deployment: runtime_environments,
-        rent: Rent::default(),
+        // Sourced from the local rent sysvar, which mirrors the base chain
+        // (synced at startup on the primary, replicated to replicas). Rent
+        // must match the base layer exactly: a higher rate rejects cloning
+        // of accounts that are legitimately rent-exempt there (SIMD-0437
+        // lowers the rate in steps), while a lower rate admits account
+        // states the base layer refuses on commit — settlement the
+        // validator pays for assuming 1:1 rent parity.
+        rent: read_rent_sysvar(accountsdb),
     };
 
     SvmEnv {
         environment,
         feature_set,
     }
+}
+
+/// Reads the rent parameters from the local rent sysvar account, falling
+/// back to the classic defaults when it's absent (fresh ledgers with
+/// chainlink disabled, tests).
+fn read_rent_sysvar(accountsdb: &AccountsDb) -> Rent {
+    let Some(account) = accountsdb.get_account(&sysvar::rent::ID) else {
+        return Rent::default();
+    };
+    bincode::deserialize(account.data()).unwrap_or_else(|err| {
+        error!(?err, "Failed to deserialize rent sysvar, using defaults");
+        Rent::default()
+    })
 }
 
 #[cfg(test)]

--- a/test-integration/Cargo.lock
+++ b/test-integration/Cargo.lock
@@ -3679,6 +3679,7 @@ version = "0.14.12"
 dependencies = [
  "agave-feature-set",
  "anyhow",
+ "bincode",
  "borsh 1.7.0",
  "fd-lock",
  "magic-domain-program",


### PR DESCRIPTION
## Problem

[SIMD-0194](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0194-deprecate-rent-exemption-threshold.md) and [SIMD-0437](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0437-incremental-rent-reduction.md) lower Solana's rent rate in five incremental steps: 6960 → 6333 → 5080 → 2575 → 1322 → 696 lamports per byte. The first step is already live on devnet (Agave v4.3: `lamports_per_byte_year: 6333`, `exemption_threshold: 1.0`).

The ephemeral validator used a hardcoded `Rent::default()` (6960 effective) for both the SVM rent-state checks and the rent sysvar programs read. Any divergence from the base chain's rate is broken, in both directions:

- **ER rate higher than base:** accounts funded at the base chain's (lower) rent-exempt minimum fall below the ER's threshold, so cloning them into the ER fails the rent-state check with `InsufficientFundsForRent`. This is happening on devnet today for any account created at the new minimum.
- **ER rate lower than base:** users can fund or drain accounts inside the ER to balances the base layer refuses on commit. Since commits are paid by the validator under the assumption rent was paid 1:1 in the ER, the validator either eats the difference or the commit fails and the intent is stuck — a cheap drain/griefing vector.

The only safe value is an exact match with the base chain, which changes over time as the reduction steps activate — so it cannot be hardcoded.

## Fix

- **`magic_validator.rs`** — at startup the primary fetches the base chain's rent sysvar (`sync_rent_from_base_chain`) and stores it as the ER's own rent sysvar, overwriting the value held by an existing ledger. Startup fails if the fetch fails. Replicas and disabled-chainlink modes skip the fetch.
- **`magicblock-processor`** — `build_svm_env` now derives `TransactionProcessingEnvironment::rent` from that local rent sysvar (`read_rent_sysvar`), falling back to `Rent::default()` only when the sysvar is absent (tests, chainlink-disabled ledgers). Since `prepare_sysvars` writes the sysvar from the environment rent, the rent-state check and the rate programs fund new accounts at are identical by construction.

Replicas inherit the sysvar via state replication and derive the same environment from it, so replay stays deterministic even if the base chain steps down between primary and replica startup.

## Known limitations

Rent is a startup-frozen input to execution, so a rent-reduction step activating on the base chain interacts with running validators in three bounded ways (all rare — five activations total — and all resolved by a restart):

- A step activating **while the validator runs** requires a restart to be picked up; until then, cloning of accounts created at the new lower minimum fails. A follow-up watchdog comparing the remote rent sysvar against the local one (alert or graceful restart on mismatch) would close this gap.
- The rent sync runs only **after ledger replay** and executors adopt it at the next block registration, so replay always executes under the persisted rate its transactions were recorded with. The residual window is a crash between the sync write and the next persisted state, where the unreplayed ledger tail replays under the new rate.
- During a **rolling restart across an activation**, a primary and replica can briefly hold different rates since each fetches at its own boot.

Offline mode deliberately keeps the last persisted rent so recovered ledgers replay under the rate they were produced with.
