### PR TITLE
perf(chainlink): reduce resident ensure overhead

### DIFF
--- a/magicblock-aperture/src/requests/http/get_account_info.rs
+++ b/magicblock-aperture/src/requests/http/get_account_info.rs
@@ -1,4 +1,6 @@
-use magicblock_metrics::metrics::{AccountFetchContext, ENSURE_ACCOUNTS_TIME};
+use magicblock_metrics::metrics::{
+    AccountFetchEntrypoint, ENSURE_ACCOUNTS_TIME,
+};
 use solana_account::{AccountMode, AccountSharedData};
 use solana_account_decoder::{UiAccountEncoding, encode_ui_account};
 use solana_pubkey::Pubkey;
@@ -22,7 +24,7 @@ impl HttpDispatcher {
     pub(super) async fn read_account_with_ensure<R>(
         &self,
         pubkey: &Pubkey,
-        fetch_context: AccountFetchContext,
+        fetch_origin: AccountFetchEntrypoint,
         reader: impl Fn(&AccountSharedData) -> R,
     ) -> (Option<R>, u64) {
         let _timer = ENSURE_ACCOUNTS_TIME
@@ -30,7 +32,7 @@ impl HttpDispatcher {
             .start_timer();
         let claims = self
             .chainlink
-            .ensure_accounts(&[*pubkey], fetch_context)
+            .ensure_accounts(&[*pubkey], fetch_origin)
             .await
             .unwrap_or_default();
         let account = self
@@ -46,7 +48,7 @@ impl HttpDispatcher {
     pub(super) async fn read_accounts_with_ensure<R>(
         &self,
         pubkeys: &[Pubkey],
-        fetch_context: AccountFetchContext,
+        fetch_origin: AccountFetchEntrypoint,
         reader: impl Fn(&Pubkey, &AccountSharedData) -> R,
     ) -> (Vec<Option<R>>, u64) {
         let _timer = ENSURE_ACCOUNTS_TIME
@@ -54,7 +56,7 @@ impl HttpDispatcher {
             .start_timer();
         let claims = self
             .chainlink
-            .ensure_accounts(pubkeys, fetch_context)
+            .ensure_accounts(pubkeys, fetch_origin)
             .await
             .inspect_err(|error| warn!(?error, "failed to ensure accounts"))
             .unwrap_or_default();
@@ -95,7 +97,7 @@ impl HttpDispatcher {
             let (account, remote_account_claims) = self
                 .read_account_with_ensure(
                     &pubkey,
-                    AccountFetchContext::rpc_get_account(),
+                    AccountFetchEntrypoint::RpcGetAccount,
                     reader,
                 )
                 .await;

--- a/magicblock-aperture/src/requests/http/get_balance.rs
+++ b/magicblock-aperture/src/requests/http/get_balance.rs
@@ -1,4 +1,4 @@
-use magicblock_metrics::metrics::AccountFetchContext;
+use magicblock_metrics::metrics::AccountFetchEntrypoint;
 use solana_account::ReadableAccount;
 use solana_pubkey::Pubkey;
 
@@ -23,7 +23,7 @@ impl HttpDispatcher {
             let (account, remote_account_claims) = self
                 .read_account_with_ensure(
                     &pubkey,
-                    AccountFetchContext::rpc_get_account(),
+                    AccountFetchEntrypoint::RpcGetAccount,
                     |account| account.lamports(),
                 )
                 .await;

--- a/magicblock-aperture/src/requests/http/get_delegation_status.rs
+++ b/magicblock-aperture/src/requests/http/get_delegation_status.rs
@@ -1,4 +1,4 @@
-use magicblock_metrics::metrics::AccountFetchContext;
+use magicblock_metrics::metrics::AccountFetchEntrypoint;
 use solana_account::AccountMode;
 use solana_pubkey::Pubkey;
 
@@ -23,7 +23,7 @@ impl HttpDispatcher {
             let (account, remote_account_claims) = self
                 .read_account_with_ensure(
                     &pubkey,
-                    AccountFetchContext::rpc_get_account(),
+                    AccountFetchEntrypoint::RpcGetAccount,
                     |account| account.is(AccountMode::Delegated),
                 )
                 .await;

--- a/magicblock-aperture/src/requests/http/get_multiple_accounts.rs
+++ b/magicblock-aperture/src/requests/http/get_multiple_accounts.rs
@@ -1,4 +1,4 @@
-use magicblock_metrics::metrics::AccountFetchContext;
+use magicblock_metrics::metrics::AccountFetchEntrypoint;
 use solana_account::AccountSharedData;
 use solana_account_decoder::{UiAccountEncoding, encode_ui_account};
 use solana_pubkey::Pubkey;
@@ -38,7 +38,7 @@ impl HttpDispatcher {
             let (ensured_accounts, remote_account_claims) = self
                 .read_accounts_with_ensure(
                     &pubkeys,
-                    AccountFetchContext::rpc_get_multiple_accounts(),
+                    AccountFetchEntrypoint::RpcGetMultipleAccounts,
                     reader,
                 )
                 .await;

--- a/magicblock-aperture/src/requests/http/get_token_account_balance.rs
+++ b/magicblock-aperture/src/requests/http/get_token_account_balance.rs
@@ -1,4 +1,4 @@
-use magicblock_metrics::metrics::AccountFetchContext;
+use magicblock_metrics::metrics::AccountFetchEntrypoint;
 use solana_account::{AccountSharedData, ReadableAccount};
 use solana_account_decoder::{
     parse_account_data::SplTokenAdditionalDataV2,
@@ -52,7 +52,7 @@ impl HttpDispatcher {
             let (token_account, remote_account_claims) = self
                 .read_account_with_ensure(
                     &pubkey,
-                    AccountFetchContext::rpc_get_account(),
+                    AccountFetchEntrypoint::RpcGetAccount,
                     reader,
                 )
                 .await;
@@ -80,7 +80,7 @@ impl HttpDispatcher {
             let (mint_account, remote_account_claims) = self
                 .read_account_with_ensure(
                     &mint,
-                    AccountFetchContext::rpc_get_account(),
+                    AccountFetchEntrypoint::RpcGetAccount,
                     reader,
                 )
                 .await;

--- a/magicblock-aperture/src/requests/http/send_transaction.rs
+++ b/magicblock-aperture/src/requests/http/send_transaction.rs
@@ -1,9 +1,8 @@
 use std::sync::Arc;
 
 use base64::{Engine, prelude::BASE64_STANDARD};
-use magicblock_chainlink::errors::ChainlinkResult;
 use magicblock_metrics::metrics::{
-    AccountFetchContext, ENSURE_ACCOUNTS_TIME, TRANSACTION_PROCESSING_TIME,
+    AccountFetchEntrypoint, ENSURE_ACCOUNTS_TIME, TRANSACTION_PROCESSING_TIME,
     TRANSACTION_SKIP_PREFLIGHT,
 };
 use nucleus::runtime::TransactionView;
@@ -64,42 +63,28 @@ impl HttpDispatcher {
             Err(error) => return (Err(error), 0),
         };
         let signature = transaction.signatures()[0];
-        let fetch_context = match kind {
+        let fetch_origin = match kind {
             TransactionKind::Send => {
-                AccountFetchContext::send_transaction(signature)
+                AccountFetchEntrypoint::SendTransaction(signature)
             }
             TransactionKind::Simulate => {
-                AccountFetchContext::simulate_transaction(signature)
+                AccountFetchEntrypoint::SimulateTransaction(signature)
             }
         };
-        let outcome = self
-            .ensure_transaction_accounts(&transaction, fetch_context)
-            .await;
-        match outcome {
-            Ok(claims) => (Ok(transaction), claims),
-            Err(error) => (Err(RpcError::transaction_verification(error)), 0),
-        }
-    }
-
-    async fn ensure_transaction_accounts(
-        &self,
-        transaction: &TransactionView,
-        fetch_context: AccountFetchContext,
-    ) -> ChainlinkResult<u64> {
         let _timer = ENSURE_ACCOUNTS_TIME
             .with_label_values(&["transaction"])
             .start_timer();
         let outcome = self
             .chainlink
-            .ensure_transaction_accounts_with_context(
-                transaction,
-                fetch_context,
-            )
+            .ensure_accounts(transaction.static_account_keys(), fetch_origin)
             .await;
         if let Err(error) = &outcome {
             warn!(?error, "failed to ensure transaction accounts");
         }
-        outcome
+        match outcome {
+            Ok(claims) => (Ok(transaction), claims),
+            Err(error) => (Err(RpcError::transaction_verification(error)), 0),
+        }
     }
 
     pub(crate) async fn send_transaction(

--- a/magicblock-aperture/src/requests/http/simulate_transaction.rs
+++ b/magicblock-aperture/src/requests/http/simulate_transaction.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use magicblock_metrics::metrics::AccountFetchContext;
+use magicblock_metrics::metrics::AccountFetchEntrypoint;
 use solana_account::AccountSharedData;
 use solana_account_decoder::{UiAccountEncoding, encode_ui_account};
 use solana_message::inner_instruction::InnerInstructions;
@@ -130,7 +130,7 @@ impl HttpDispatcher {
                 let (current_accounts, remote_account_claims) = self
                     .read_accounts_with_ensure(
                         &pubkeys,
-                        AccountFetchContext::rpc_get_multiple_accounts(),
+                        AccountFetchEntrypoint::RpcGetMultipleAccounts,
                         reader,
                     )
                     .await;

--- a/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
+++ b/magicblock-chainlink/src/chainlink/fetch_cloner/mod.rs
@@ -28,10 +28,9 @@ use magicblock_core::token_programs::{
     TOKEN_PROGRAM_ID, is_ata, normalize_native_token_account_for_local_clone,
 };
 use magicblock_metrics::metrics::{
-    self, AccountFetchContext, AccountFetchReason, BankPrecheckOutcome,
-    BankPrecheckReason, ChainlinkCloneIntent, ChainlinkCloneOutcome,
-    ChainlinkCloneRemoteResult, ChainlinkCompanionFetchKind,
-    ChainlinkEmptyPlaceholderStage, Outcome,
+    self, AccountFetchContext, AccountFetchEntrypoint, AccountFetchReason,
+    ChainlinkCloneIntent, ChainlinkCloneOutcome, ChainlinkCloneRemoteResult,
+    ChainlinkCompanionFetchKind, ChainlinkEmptyPlaceholderStage, Outcome,
 };
 use parking_lot::Mutex as PlMutex;
 use solana_account::{
@@ -3210,24 +3209,25 @@ where
         RefreshDecision::No
     }
 
-    /// Fetches and clones accounts while the engine serializes mutations for
-    /// each target account.
+    /// Fetches requested accounts while the engine serializes target mutations.
+    /// Returns the number of requested remote accounts claimed by this call.
     #[instrument(skip(self, pubkeys))]
-    pub async fn fetch_and_clone_accounts_with_dedup(
+    pub(crate) async fn fetch_and_clone_requested_accounts(
         &self,
         pubkeys: &[Pubkey],
-        slot: Option<u64>,
-        fetch_context: AccountFetchContext,
-    ) -> ChainlinkResult<FetchAndCloneResult> {
+        fetch_origin: AccountFetchEntrypoint,
+    ) -> ChainlinkResult<u64> {
+        let fetch_context = AccountFetchContext::from(fetch_origin);
         self.fetch_and_clone_accounts_with_dedup_forced_refresh(
             pubkeys,
             Some(pubkeys),
-            slot,
-            fetch_context,
+            None,
+            fetch_context.clone(),
             &HashSet::new(),
             None,
         )
-        .await
+        .await?;
+        Ok(fetch_context.remote_account_claims_value())
     }
 
     async fn fetch_and_clone_accounts_with_dedup_forced_refresh(
@@ -3247,12 +3247,6 @@ where
 
         let mut in_bank = HashSet::new();
         let mut extra_mark_empty = Vec::new();
-        let mut bank_hit_no_fetch_non_undelegating_count = 0_u64;
-        let mut bank_hit_no_fetch_undelegating_still_valid_count = 0_u64;
-        let mut bank_hit_no_fetch_undelegating_timeout_count = 0_u64;
-        let mut bank_hit_undelegating_refresh_required_count = 0_u64;
-        let mut bank_miss_remote_required_count = 0_u64;
-        let mut forced_refresh_remote_required_count = 0_u64;
 
         // Phase 1: Sync bank check — separate undelegating accounts
         // (which need async RPC) from non-undelegating (handled
@@ -3280,13 +3274,10 @@ where
                             },
                         );
                         if !can_replace {
-                            bank_hit_no_fetch_undelegating_still_valid_count +=
-                                1;
                             in_bank.insert(**pubkey);
                             continue;
                         }
                     }
-                    forced_refresh_remote_required_count += 1;
                     continue;
                 }
                 let reader = |account: &AccountSharedData| {
@@ -3331,12 +3322,9 @@ where
                                     "Account found in bank in valid state, no fetch needed"
                                 );
                             }
-                            bank_hit_no_fetch_non_undelegating_count += 1;
                             in_bank.insert(**pubkey);
                         }
                     }
-                } else {
-                    bank_miss_remote_required_count += 1;
                 }
             }
         }
@@ -3384,7 +3372,6 @@ where
                             pubkey = %pubkey,
                             "Account completed undelegation which was missed and is fetched again"
                         );
-                        bank_hit_undelegating_refresh_required_count += 1;
                         metrics::inc_unstuck_undelegation_count();
                         if let RefreshDecision::YesAndMarkEmptyIfNotFound =
                             decision
@@ -3399,54 +3386,14 @@ where
                                 "Undelegating account still valid, no fetch needed"
                             );
                         }
-                        bank_hit_no_fetch_undelegating_still_valid_count += 1;
                         in_bank.insert(pubkey);
                     }
                     None => {
-                        bank_hit_no_fetch_undelegating_timeout_count += 1;
                         in_bank.insert(pubkey);
                     }
                 }
             }
         }
-        metrics::inc_chainlink_bank_precheck_accounts_with_context(
-            fetch_context.clone(),
-            BankPrecheckOutcome::BankHitNoFetch,
-            BankPrecheckReason::NonUndelegatingPresent,
-            bank_hit_no_fetch_non_undelegating_count,
-        );
-        metrics::inc_chainlink_bank_precheck_accounts_with_context(
-            fetch_context.clone(),
-            BankPrecheckOutcome::BankHitNoFetch,
-            BankPrecheckReason::UndelegatingStillValid,
-            bank_hit_no_fetch_undelegating_still_valid_count,
-        );
-        metrics::inc_chainlink_bank_precheck_accounts_with_context(
-            fetch_context.clone(),
-            BankPrecheckOutcome::BankHitNoFetch,
-            BankPrecheckReason::UndelegatingCheckTimeout,
-            bank_hit_no_fetch_undelegating_timeout_count,
-        );
-        metrics::inc_chainlink_bank_precheck_accounts_with_context(
-            fetch_context
-                .clone()
-                .with_reason(AccountFetchReason::UndelegatingRefresh),
-            BankPrecheckOutcome::BankHitUndelegatingRefreshRequired,
-            BankPrecheckReason::UndelegatingRefresh,
-            bank_hit_undelegating_refresh_required_count,
-        );
-        metrics::inc_chainlink_bank_precheck_accounts_with_context(
-            fetch_context.clone(),
-            BankPrecheckOutcome::BankMissRemoteRequired,
-            BankPrecheckReason::Absent,
-            bank_miss_remote_required_count,
-        );
-        metrics::inc_chainlink_bank_precheck_accounts_with_context(
-            fetch_context.clone(),
-            BankPrecheckOutcome::ForcedRefreshRemoteRequired,
-            BankPrecheckReason::ForcedRefresh,
-            forced_refresh_remote_required_count,
-        );
         pubkeys.retain(|p| !in_bank.contains(p));
 
         let mut mark_empty = mark_empty_if_not_found

--- a/magicblock-chainlink/src/chainlink/mod.rs
+++ b/magicblock-chainlink/src/chainlink/mod.rs
@@ -3,17 +3,18 @@ use std::{
     time::Duration,
 };
 
-use dlp_api::pda::ephemeral_balance_pda_from_payer;
 use engine::Engine;
 use errors::{ChainlinkError, ChainlinkResult};
 use fetch_cloner::FetchCloner;
+use keeper::error::KeeperError;
 use magicblock_aml::RiskService;
 use magicblock_config::config::ChainLinkConfig;
 use magicblock_core::token_programs::{
     is_ata, try_derive_eata_address_and_bump,
 };
-use magicblock_metrics::metrics::AccountFetchContext;
-use nucleus::runtime::TransactionView;
+use magicblock_metrics::metrics::{
+    AccountFetchContext, AccountFetchEntrypoint,
+};
 use solana_account::{AccountMode, AccountSharedData, ReadableAccount};
 use solana_commitment_config::CommitmentConfig;
 use solana_keypair::Keypair;
@@ -137,14 +138,6 @@ pub struct InnerChainlink<T: ChainRpcClient, U: ChainPubsubClient> {
 }
 
 impl<T: ChainRpcClient, U: ChainPubsubClient> InnerChainlink<T, U> {
-    fn contains_account(&self, pubkey: &Pubkey) -> bool {
-        self.engine
-            .accounts()
-            .loader()
-            .contains(pubkey)
-            .unwrap_or(false)
-    }
-
     pub fn try_new(
         engine: Engine,
         fetch_cloner: Option<Arc<FetchCloner<T, U>>>,
@@ -415,75 +408,62 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> InnerChainlink<T, U> {
         })
     }
 
-    /// Ensures all transaction accounts are materialized locally. Accounts
-    /// missing on chain are represented as placeholders.
-    #[instrument(skip(self, tx, fetch_context))]
-    pub async fn ensure_transaction_accounts_with_context(
-        &self,
-        tx: &TransactionView,
-        fetch_context: impl Into<AccountFetchContext>,
-    ) -> ChainlinkResult<u64> {
-        let fetch_context = fetch_context.into();
-        let mut pubkeys = tx.static_account_keys().to_vec();
-        let feepayer = &tx.static_account_keys()[0];
-
-        let balance_pda = ephemeral_balance_pda_from_payer(feepayer, 0);
-
-        // Determine if we need to clone the escrow account for the feepayer
-        let clone_escrow = !self.contains_account(&balance_pda);
-
-        // If cloning escrow, add the balance PDA
-        if clone_escrow {
-            trace!(
-                balance_pda = %balance_pda,
-                feepayer = %feepayer,
-                "Adding balance PDA for feepayer"
-            );
-            pubkeys.push(balance_pda);
-        }
-
-        self.ensure_accounts(&pubkeys, fetch_context).await
-    }
-
-    pub async fn ensure_transaction_accounts(
-        &self,
-        tx: &TransactionView,
-    ) -> ChainlinkResult<()> {
-        self.ensure_transaction_accounts_with_context(
-            tx,
-            AccountFetchContext::send_transaction(tx.signatures()[0]),
-        )
-        .await
-        .map(|_| ())
-    }
-
-    /// Same as fetch accounts, but does not return the accounts. Missing
-    /// requested accounts are materialized as placeholders.
+    /// Ensures requested accounts are materialized locally. Missing remote
+    /// accounts are represented as placeholders.
+    /// Returns the number of requested remote accounts claimed by this call.
     /// If we're offline and not syncing accounts then this is a no-op.
-    #[instrument(skip(self, pubkeys, fetch_context))]
     pub async fn ensure_accounts(
         &self,
         pubkeys: &[Pubkey],
-        fetch_context: impl Into<AccountFetchContext>,
+        fetch_origin: AccountFetchEntrypoint,
     ) -> ChainlinkResult<u64> {
-        let fetch_context = fetch_context.into();
         let Some(fetch_cloner) = self.fetch_cloner() else {
             return Ok(0);
         };
-        self.fetch_accounts_common(fetch_cloner, pubkeys, fetch_context)
-            .await
+
+        let pending = {
+            let accessor = self.engine.accounts();
+            let loader = accessor.loader();
+            let mut pending = None;
+            for pubkey in pubkeys {
+                let mode = loader
+                    .read(pubkey, |account| account.mode())
+                    .map_err(KeeperError::from)?;
+                if mode.is_none_or(|mode| mode == AccountMode::Transient) {
+                    pending
+                        .get_or_insert_with(|| {
+                            Vec::with_capacity(pubkeys.len())
+                        })
+                        .push(*pubkey);
+                }
+            }
+            pending
+        };
+        let Some(pending) = pending else {
+            return Ok(0);
+        };
+
+        tokio::time::timeout(
+            ENSURE_ACCOUNTS_TIMEOUT,
+            fetch_cloner
+                .fetch_and_clone_requested_accounts(&pending, fetch_origin),
+        )
+        .await
+        .unwrap_or_else(|_| {
+            Err(ChainlinkError::EnsureAccountsTimeout(
+                ENSURE_ACCOUNTS_TIMEOUT.as_secs(),
+            ))
+        })
     }
 
     /// Fetches the accounts from the bank if we're offline and not syncing accounts.
     /// Otherwise materializes requested accounts locally, using placeholders
     /// for accounts missing on chain, and returns their state from the bank.
-    #[instrument(skip(self, pubkeys, fetch_context))]
     pub async fn fetch_accounts(
         &self,
         pubkeys: &[Pubkey],
-        fetch_context: impl Into<AccountFetchContext>,
+        fetch_origin: AccountFetchEntrypoint,
     ) -> ChainlinkResult<Vec<Option<AccountSharedData>>> {
-        let fetch_context = fetch_context.into();
         if tracing::enabled!(tracing::Level::TRACE) {
             let count = pubkeys.len();
             trace!(count, "Fetching accounts");
@@ -491,17 +471,7 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> InnerChainlink<T, U> {
         let snapshot = |account: &AccountSharedData| {
             AccountSharedData::from(account.owned())
         };
-        let Some(fetch_cloner) = self.fetch_cloner() else {
-            // If we're offline and not syncing accounts then we just get them from the bank
-            let accessor = self.engine.accounts();
-            let loader = accessor.loader();
-            return Ok(pubkeys
-                .iter()
-                .map(|pubkey| loader.read(pubkey, snapshot).ok().flatten())
-                .collect());
-        };
-        self.fetch_accounts_common(fetch_cloner, pubkeys, fetch_context)
-            .await?;
+        self.ensure_accounts(pubkeys, fetch_origin).await?;
 
         let accessor = self.engine.accounts();
         let loader = accessor.loader();
@@ -517,13 +487,9 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> InnerChainlink<T, U> {
     pub async fn account_delegation_sessions(
         &self,
         pubkeys: &[Pubkey],
-        fetch_context: impl Into<AccountFetchContext>,
+        fetch_origin: AccountFetchEntrypoint,
     ) -> ChainlinkResult<Vec<Option<AccountDelegationSession>>> {
-        let fetch_context = fetch_context.into();
-        if let Some(fetch_cloner) = self.fetch_cloner() {
-            self.fetch_accounts_common(fetch_cloner, pubkeys, fetch_context)
-                .await?;
-        }
+        self.ensure_accounts(pubkeys, fetch_origin).await?;
 
         let accessor = self.engine.accounts();
         let loader = accessor.loader();
@@ -611,32 +577,6 @@ impl<T: ChainRpcClient, U: ChainPubsubClient> InnerChainlink<T, U> {
                 }
             })
             .collect())
-    }
-
-    #[instrument(skip(self, fetch_cloner, pubkeys))]
-    async fn fetch_accounts_common(
-        &self,
-        fetch_cloner: &FetchCloner<T, U>,
-        pubkeys: &[Pubkey],
-        fetch_context: AccountFetchContext,
-    ) -> ChainlinkResult<u64> {
-        // If any of the accounts was invalid and couldn't be fetched/cloned then
-        // we return an error.
-        tokio::time::timeout(
-            ENSURE_ACCOUNTS_TIMEOUT,
-            fetch_cloner.fetch_and_clone_accounts_with_dedup(
-                pubkeys,
-                None,
-                fetch_context.clone(),
-            ),
-        )
-        .await
-        .unwrap_or_else(|_| {
-            Err(ChainlinkError::EnsureAccountsTimeout(
-                ENSURE_ACCOUNTS_TIMEOUT.as_secs(),
-            ))
-        })?;
-        Ok(fetch_context.remote_account_claims_value())
     }
 
     /// This is called via the committor service when an account is about to be undelegated

--- a/magicblock-chainlink/src/lib.rs
+++ b/magicblock-chainlink/src/lib.rs
@@ -6,7 +6,9 @@ pub mod remote_account_provider;
 pub mod submux;
 
 pub use chainlink::*;
-pub use magicblock_metrics::metrics::AccountFetchContext;
+pub use magicblock_metrics::metrics::{
+    AccountFetchContext, AccountFetchEntrypoint,
+};
 
 #[cfg(any(test, feature = "dev-context"))]
 pub mod testing;

--- a/magicblock-chainlink/src/testing/context.rs
+++ b/magicblock-chainlink/src/testing/context.rs
@@ -21,7 +21,7 @@ use tracing::trace;
 
 use super::accounts::account_shared_with_owner_and_slot;
 use crate::{
-    AccountFetchContext, InnerChainlink,
+    AccountFetchEntrypoint, InnerChainlink,
     errors::ChainlinkResult,
     fetch_cloner::FetchCloner,
     remote_account_provider::{
@@ -288,7 +288,7 @@ impl TestContext {
         self.chainlink
             .ensure_accounts(
                 &[*pubkey],
-                AccountFetchContext::rpc_get_multiple_accounts(),
+                AccountFetchEntrypoint::RpcGetMultipleAccounts,
             )
             .await
             .map(|_| ())

--- a/magicblock-chainlink/tests/01_ensure-accounts.rs
+++ b/magicblock-chainlink/tests/01_ensure-accounts.rs
@@ -1,7 +1,7 @@
 use assert_matches::assert_matches;
 use dlp_api::pda::delegation_record_pda_from_delegated_account;
 use magicblock_chainlink::{
-    AccountFetchContext, assert_cloned_as_delegated,
+    AccountFetchEntrypoint, assert_cloned_as_delegated,
     assert_cloned_as_empty_placeholder, assert_cloned_as_undelegated,
     assert_not_cloned, assert_not_subscribed, assert_not_undelegating,
     assert_remain_undelegating, assert_subscribed_without_delegation_record,
@@ -38,6 +38,7 @@ async fn seed_undelegating_account(ctx: &TestContext, pubkey: Pubkey) {
 #[tokio::test]
 async fn ensure_account_scenarios() {
     let ctx = TestContext::init(CURRENT_SLOT).await;
+    resident_accounts_skip_remote_resolution(&ctx).await;
     write_non_existing_account(&ctx).await;
     existing_account_undelegated(&ctx).await;
     existing_account_missing_delegation_record(&ctx).await;
@@ -46,6 +47,59 @@ async fn ensure_account_scenarios() {
     write_undelegating_account_undelegated_to_other_validator(&ctx).await;
     write_undelegating_account_still_being_undelegated(&ctx).await;
     write_existing_account_invalid_delegation_record(&ctx).await;
+}
+
+async fn resident_accounts_skip_remote_resolution(ctx: &TestContext) {
+    let pubkeys = [
+        Pubkey::new_unique(),
+        Pubkey::new_unique(),
+        Pubkey::new_unique(),
+        Pubkey::new_unique(),
+    ];
+    let accounts = [
+        (
+            pubkeys[0],
+            AccountBuilder::default()
+                .lamports(1)
+                .mode(AccountMode::Delegated)
+                .build(),
+        ),
+        (
+            pubkeys[1],
+            AccountBuilder::default()
+                .lamports(1)
+                .mode(AccountMode::Ephemeral)
+                .build(),
+        ),
+        (
+            pubkeys[2],
+            AccountBuilder::default()
+                .lamports(1)
+                .mode(AccountMode::ReadOnly)
+                .build(),
+        ),
+        (
+            pubkeys[3],
+            AccountBuilder::default()
+                .mode(AccountMode::Placeholder)
+                .build(),
+        ),
+    ];
+    ctx.bank.accounts().store(&accounts).unwrap();
+
+    let fetches = ctx.chainlink.fetch_count().unwrap();
+    let claims = ctx
+        .chainlink
+        .ensure_accounts(
+            &pubkeys,
+            AccountFetchEntrypoint::RpcGetMultipleAccounts,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(claims, 0);
+    assert_eq!(ctx.chainlink.fetch_count().unwrap(), fetches);
+    assert_not_subscribed!(ctx.chainlink, &pubkeys);
 }
 
 // NOTE: Case comments refer to the case studies in the relevant tabs of draw.io document, i.e. Fetch
@@ -59,14 +113,15 @@ async fn write_non_existing_account(ctx: &TestContext) {
 
     let pubkey = Pubkey::new_unique();
     let pubkeys = [pubkey];
-    chainlink
+    let claims = chainlink
         .ensure_accounts(
             &pubkeys,
-            AccountFetchContext::rpc_get_multiple_accounts(),
+            AccountFetchEntrypoint::RpcGetMultipleAccounts,
         )
         .await
         .unwrap();
 
+    assert_eq!(claims, 1);
     assert_cloned_as_empty_placeholder!(bank, &pubkeys);
     let mode = bank
         .accounts()
@@ -93,7 +148,7 @@ async fn existing_account_undelegated(ctx: &TestContext) {
     chainlink
         .ensure_accounts(
             &pubkeys,
-            AccountFetchContext::rpc_get_multiple_accounts(),
+            AccountFetchEntrypoint::RpcGetMultipleAccounts,
         )
         .await
         .unwrap();
@@ -123,7 +178,7 @@ async fn existing_account_missing_delegation_record(ctx: &TestContext) {
     chainlink
         .ensure_accounts(
             &pubkeys,
-            AccountFetchContext::rpc_get_multiple_accounts(),
+            AccountFetchEntrypoint::RpcGetMultipleAccounts,
         )
         .await
         .unwrap();
@@ -165,7 +220,7 @@ async fn write_existing_account_valid_delegation_record(ctx: &TestContext) {
     chainlink
         .ensure_accounts(
             &pubkeys,
-            AccountFetchContext::rpc_get_multiple_accounts(),
+            AccountFetchEntrypoint::RpcGetMultipleAccounts,
         )
         .await
         .unwrap();
@@ -204,7 +259,7 @@ async fn write_existing_account_other_authority(ctx: &TestContext) {
     chainlink
         .ensure_accounts(
             &pubkeys,
-            AccountFetchContext::rpc_get_multiple_accounts(),
+            AccountFetchEntrypoint::RpcGetMultipleAccounts,
         )
         .await
         .unwrap();
@@ -254,7 +309,7 @@ async fn write_undelegating_account_undelegated_to_other_validator(
     chainlink
         .ensure_accounts(
             &pubkeys,
-            AccountFetchContext::rpc_get_multiple_accounts(),
+            AccountFetchEntrypoint::RpcGetMultipleAccounts,
         )
         .await
         .unwrap();
@@ -288,7 +343,7 @@ async fn write_undelegating_account_still_being_undelegated(ctx: &TestContext) {
     chainlink
         .ensure_accounts(
             &pubkeys,
-            AccountFetchContext::rpc_get_multiple_accounts(),
+            AccountFetchEntrypoint::RpcGetMultipleAccounts,
         )
         .await
         .unwrap();
@@ -325,7 +380,7 @@ async fn write_existing_account_invalid_delegation_record(ctx: &TestContext) {
     let res = chainlink
         .ensure_accounts(
             &[pubkey],
-            AccountFetchContext::rpc_get_multiple_accounts(),
+            AccountFetchEntrypoint::RpcGetMultipleAccounts,
         )
         .await;
 

--- a/magicblock-chainlink/tests/03_deleg_after_sub.rs
+++ b/magicblock-chainlink/tests/03_deleg_after_sub.rs
@@ -1,5 +1,5 @@
 use magicblock_chainlink::{
-    AccountFetchContext, assert_cloned_as_delegated,
+    AccountFetchEntrypoint, assert_cloned_as_delegated,
     assert_cloned_as_empty_placeholder, assert_cloned_as_undelegated,
     assert_not_cloned, assert_not_subscribed,
     assert_subscribed_without_delegation_record,
@@ -49,7 +49,7 @@ async fn test_deleg_after_subscribe_case2() {
         chainlink
             .ensure_accounts(
                 &[pubkey],
-                AccountFetchContext::rpc_get_multiple_accounts(),
+                AccountFetchEntrypoint::RpcGetMultipleAccounts,
             )
             .await
             .unwrap();

--- a/magicblock-chainlink/tests/08_subupdate-ordering.rs
+++ b/magicblock-chainlink/tests/08_subupdate-ordering.rs
@@ -1,5 +1,5 @@
 use magicblock_chainlink::{
-    AccountFetchContext,
+    AccountFetchEntrypoint,
     testing::{
         accounts::account_shared_with_owner_and_slot, context::TestContext,
     },
@@ -45,7 +45,7 @@ async fn test_subs_receive_out_of_order_updates() {
     chainlink
         .ensure_accounts(
             &[pubkey],
-            AccountFetchContext::rpc_get_multiple_accounts(),
+            AccountFetchEntrypoint::RpcGetMultipleAccounts,
         )
         .await
         .unwrap();

--- a/magicblock-chainlink/tests/09_waiter_reconciliation_race.rs
+++ b/magicblock-chainlink/tests/09_waiter_reconciliation_race.rs
@@ -9,7 +9,7 @@ use dlp_api::{
     state::DelegationRecord,
 };
 use magicblock_chainlink::{
-    AccountFetchContext, assert_cloned_as_delegated, assert_not_subscribed,
+    AccountFetchEntrypoint, assert_cloned_as_delegated, assert_not_subscribed,
     testing::{context::TestContext, deleg::delegation_record_to_vec},
 };
 use solana_account::{Account, AccountBuilder, AccountMode, ReadableAccount};
@@ -123,7 +123,7 @@ async fn fetch_and_discovery_subscription_race_materializes_once() {
     let requested = [account_pubkey];
     let ensure = chainlink.ensure_accounts(
         &requested,
-        AccountFetchContext::rpc_get_multiple_accounts(),
+        AccountFetchEntrypoint::RpcGetMultipleAccounts,
     );
     let subscription = ctx.send_and_receive_account_update(
         account_pubkey,

--- a/magicblock-chainlink/tests/11_ata_eata_replace.rs
+++ b/magicblock-chainlink/tests/11_ata_eata_replace.rs
@@ -1,5 +1,5 @@
 use magicblock_chainlink::{
-    AccountFetchContext,
+    AccountFetchEntrypoint,
     testing::{
         context::TestContext,
         deleg::add_delegation_record_for,
@@ -54,7 +54,7 @@ async fn ixtest_ata_eata_replace_when_delegated_to_us() {
     // Ensure account (this triggers fetch_cloner logic including ATA/eATA handling)
     let pubkeys = [ata_pubkey];
     ctx.chainlink
-        .ensure_accounts(&pubkeys, AccountFetchContext::rpc_get_account())
+        .ensure_accounts(&pubkeys, AccountFetchEntrypoint::RpcGetAccount)
         .await
         .expect("ensure_accounts ok");
     debug!("res: {:?}", ());
@@ -106,7 +106,7 @@ async fn ixtest_ata_eata_no_replace_when_not_delegated() {
     // Note: No delegation record added here
     let pubkeys = [ata_pubkey];
     ctx.chainlink
-        .ensure_accounts(&pubkeys, AccountFetchContext::rpc_get_account())
+        .ensure_accounts(&pubkeys, AccountFetchEntrypoint::RpcGetAccount)
         .await
         .expect("ensure_accounts ok");
 
@@ -160,7 +160,7 @@ async fn ixtest_ata_eata_no_replace_when_not_delegated_to_us() {
     // Ensure account (this triggers fetch_cloner logic including ATA/eATA handling)
     let pubkeys = [ata_pubkey];
     ctx.chainlink
-        .ensure_accounts(&pubkeys, AccountFetchContext::rpc_get_account())
+        .ensure_accounts(&pubkeys, AccountFetchEntrypoint::RpcGetAccount)
         .await
         .expect("ensure_accounts ok");
     debug!("res: {:?}", ());

--- a/magicblock-chainlink/tests/12_feepayer.rs
+++ b/magicblock-chainlink/tests/12_feepayer.rs
@@ -1,11 +1,8 @@
-use dlp_api::pda::{
-    delegation_record_pda_from_delegated_account,
-    ephemeral_balance_pda_from_payer,
-};
+use dlp_api::pda::ephemeral_balance_pda_from_payer;
 use engine::IntoTransactionView;
 use magicblock_chainlink::{
-    assert_cloned_as_delegated, assert_cloned_as_empty_placeholder,
-    assert_cloned_as_undelegated, assert_not_subscribed, assert_subscribed,
+    AccountFetchEntrypoint, assert_cloned_as_undelegated, assert_not_cloned,
+    assert_not_subscribed, assert_subscribed,
     testing::{
         context::TestContext, deleg::add_delegation_record_for, init_logger,
     },
@@ -35,7 +32,10 @@ fn fee_payer_transaction(
     .unwrap()
 }
 
-async fn setup_balance(delegated: bool) -> (TestContext, Keypair) {
+/// Proves transaction ensure processes only static transaction keys and never
+/// derives or materializes the retired fee-payer balance PDA.
+#[tokio::test]
+async fn transaction_ensure_ignores_ephemeral_balance_pda() {
     init_logger();
     let ctx = TestContext::init(100).await;
     let payer = Keypair::new();
@@ -51,79 +51,32 @@ async fn setup_balance(delegated: bool) -> (TestContext, Keypair) {
         balance,
         Account {
             lamports: 1_000_000,
-            owner: if delegated {
-                dlp_api::id()
-            } else {
-                solana_sdk_ids::system_program::id()
-            },
+            owner: dlp_api::id(),
             ..Default::default()
         },
     );
-    if delegated {
-        add_delegation_record_for(
-            &ctx.rpc_client,
-            balance,
-            ctx.validator_pubkey,
-            solana_sdk_ids::system_program::id(),
-        );
-    }
-    (ctx, payer)
-}
+    let record = add_delegation_record_for(
+        &ctx.rpc_client,
+        balance,
+        ctx.validator_pubkey,
+        solana_sdk_ids::system_program::id(),
+    );
+    let transaction = fee_payer_transaction(&ctx, &payer);
 
-#[tokio::test]
-async fn fee_payer_uses_delegated_ephemeral_balance() {
-    let (ctx, payer) = setup_balance(true).await;
-    let balance = ephemeral_balance_pda_from_payer(&payer.pubkey(), 0);
-    ctx.chainlink
-        .ensure_transaction_accounts(&fee_payer_transaction(&ctx, &payer))
+    let claims = ctx
+        .chainlink
+        .ensure_accounts(
+            transaction.static_account_keys(),
+            AccountFetchEntrypoint::SendTransaction(
+                transaction.signatures()[0],
+            ),
+        )
         .await
         .unwrap();
 
+    assert_eq!(claims, 1);
     assert_cloned_as_undelegated!(ctx.bank, &[payer.pubkey()]);
-    assert_cloned_as_delegated!(ctx.bank, &[balance]);
+    assert_not_cloned!(ctx.bank, &[balance, record]);
     assert_subscribed!(ctx.chainlink, &[&payer.pubkey()]);
-    assert_not_subscribed!(
-        ctx.chainlink,
-        &[
-            &balance,
-            &delegation_record_pda_from_delegated_account(&balance)
-        ]
-    );
-}
-
-#[tokio::test]
-async fn fee_payer_uses_undelegated_ephemeral_balance() {
-    let (ctx, payer) = setup_balance(false).await;
-    let balance = ephemeral_balance_pda_from_payer(&payer.pubkey(), 0);
-    ctx.chainlink
-        .ensure_transaction_accounts(&fee_payer_transaction(&ctx, &payer))
-        .await
-        .unwrap();
-
-    assert_cloned_as_undelegated!(ctx.bank, &[payer.pubkey(), balance]);
-    assert_subscribed!(ctx.chainlink, &[&payer.pubkey(), &balance]);
-}
-
-#[tokio::test]
-async fn fee_payer_without_ephemeral_balance_gets_placeholder() {
-    init_logger();
-    let ctx = TestContext::init(100).await;
-    let payer = Keypair::new();
-    let balance = ephemeral_balance_pda_from_payer(&payer.pubkey(), 0);
-    ctx.rpc_client.add_account(
-        payer.pubkey(),
-        Account {
-            lamports: 2_000_000,
-            ..Default::default()
-        },
-    );
-
-    ctx.chainlink
-        .ensure_transaction_accounts(&fee_payer_transaction(&ctx, &payer))
-        .await
-        .unwrap();
-
-    assert_cloned_as_undelegated!(ctx.bank, &[payer.pubkey()]);
-    assert_cloned_as_empty_placeholder!(ctx.bank, &[balance]);
-    assert_subscribed!(ctx.chainlink, &[&payer.pubkey(), &balance]);
+    assert_not_subscribed!(ctx.chainlink, &[&balance, &record]);
 }

--- a/magicblock-chainlink/tests/13_exceed_capacity.rs
+++ b/magicblock-chainlink/tests/13_exceed_capacity.rs
@@ -1,5 +1,5 @@
 use magicblock_chainlink::{
-    AccountFetchContext, assert_cloned_as_delegated,
+    AccountFetchEntrypoint, assert_cloned_as_delegated,
     testing::{
         context::TestContext, deleg::add_delegation_record_for, init_logger,
         utils::random_pubkeys,
@@ -31,7 +31,7 @@ async fn delegated_account_survives_readonly_cache_pressure() {
     ctx.chainlink
         .ensure_accounts(
             &[delegated],
-            AccountFetchContext::rpc_get_multiple_accounts(),
+            AccountFetchEntrypoint::RpcGetMultipleAccounts,
         )
         .await
         .unwrap();
@@ -51,7 +51,7 @@ async fn delegated_account_survives_readonly_cache_pressure() {
         ctx.chainlink
             .ensure_accounts(
                 batch,
-                AccountFetchContext::rpc_get_multiple_accounts(),
+                AccountFetchEntrypoint::RpcGetMultipleAccounts,
             )
             .await
             .unwrap();

--- a/magicblock-chainlink/tests/15_multi_account_resolution.rs
+++ b/magicblock-chainlink/tests/15_multi_account_resolution.rs
@@ -1,7 +1,7 @@
 use engine::IntoTransactionView;
 use magicblock_chainlink::{
-    assert_cloned_as_delegated, assert_cloned_as_undelegated,
-    assert_not_subscribed, assert_subscribed,
+    AccountFetchEntrypoint, assert_cloned_as_delegated,
+    assert_cloned_as_undelegated, assert_not_subscribed, assert_subscribed,
     testing::{
         context::TestContext, deleg::add_delegation_record_for, init_logger,
     },
@@ -72,7 +72,12 @@ async fn resolves_mixed_transaction_accounts_in_one_request() {
     .unwrap();
 
     ctx.chainlink
-        .ensure_transaction_accounts(&transaction)
+        .ensure_accounts(
+            transaction.static_account_keys(),
+            AccountFetchEntrypoint::SendTransaction(
+                transaction.signatures()[0],
+            ),
+        )
         .await
         .unwrap();
 

--- a/magicblock-chainlink/tests/basics.rs
+++ b/magicblock-chainlink/tests/basics.rs
@@ -1,5 +1,5 @@
 use magicblock_chainlink::{
-    AccountFetchContext, assert_cloned_as_delegated,
+    AccountFetchEntrypoint, assert_cloned_as_delegated,
     assert_cloned_as_undelegated,
     testing::{
         accounts::account_shared_with_owner_and_slot, context::TestContext,
@@ -41,7 +41,7 @@ async fn test_remote_slot_of_accounts_read_from_bank() {
     chainlink
         .ensure_accounts(
             &[pubkey],
-            AccountFetchContext::rpc_get_multiple_accounts(),
+            AccountFetchEntrypoint::RpcGetMultipleAccounts,
         )
         .await
         .unwrap();
@@ -52,7 +52,7 @@ async fn test_remote_slot_of_accounts_read_from_bank() {
     chainlink
         .ensure_accounts(
             &[pubkey],
-            AccountFetchContext::rpc_get_multiple_accounts(),
+            AccountFetchEntrypoint::RpcGetMultipleAccounts,
         )
         .await
         .unwrap();
@@ -94,7 +94,7 @@ async fn test_remote_slot_of_ensure_accounts_from_bank() {
     chainlink
         .ensure_accounts(
             &[pubkey],
-            AccountFetchContext::rpc_get_multiple_accounts(),
+            AccountFetchEntrypoint::RpcGetMultipleAccounts,
         )
         .await
         .unwrap();
@@ -108,7 +108,7 @@ async fn test_remote_slot_of_ensure_accounts_from_bank() {
     chainlink
         .ensure_accounts(
             &[pubkey],
-            AccountFetchContext::rpc_get_multiple_accounts(),
+            AccountFetchEntrypoint::RpcGetMultipleAccounts,
         )
         .await
         .unwrap();

--- a/magicblock-committor-service/src/service.rs
+++ b/magicblock-committor-service/src/service.rs
@@ -15,9 +15,7 @@ use intent_client::{
     ERIntentClient, InternalIntentClientError, ScheduledBaseIntentMeta,
 };
 use magicblock_chainlink::{ProdChainlink, errors::ChainlinkResult};
-use magicblock_metrics::metrics::{
-    self, AccountFetchContext, AccountFetchReason,
-};
+use magicblock_metrics::metrics::{self, AccountFetchEntrypoint};
 use magicblock_program::{
     Pubkey, magic_scheduled_base_intent::ScheduledIntentBundle,
 };
@@ -497,9 +495,7 @@ where
             .chainlink
             .account_delegation_sessions(
                 pubkeys,
-                AccountFetchContext::internal(
-                    AccountFetchReason::RequestedAccount,
-                ),
+                AccountFetchEntrypoint::Internal,
             )
             .await?
             .into_iter()

--- a/magicblock-metrics/src/metrics/mod.rs
+++ b/magicblock-metrics/src/metrics/mod.rs
@@ -6,8 +6,7 @@ use prometheus::{
 };
 pub use types::{
     AccountFetchContext, AccountFetchEntrypoint, AccountFetchReason,
-    BankPrecheckOutcome, BankPrecheckReason, ChainlinkCloneIntent,
-    ChainlinkCloneOutcome, ChainlinkCloneRemoteResult,
+    ChainlinkCloneIntent, ChainlinkCloneOutcome, ChainlinkCloneRemoteResult,
     ChainlinkCompanionFetchKind, ChainlinkCompanionFetchOutcome,
     ChainlinkEmptyPlaceholderStage, ChainlinkPendingFetchLayer,
     ChainlinkPendingFetchOutcome, LabelValue, Outcome,
@@ -63,15 +62,6 @@ lazy_static::lazy_static! {
         panic!("failed to create inflight_subscription_updates_gauge: {err}")
     });
 
-    static ref CHAINLINK_BANK_PRECHECK_ACCOUNTS_TOTAL: IntCounterVec =
-        IntCounterVec::new(
-            Opts::new(
-                "chainlink_bank_precheck_accounts_total",
-                "Account entries by FetchCloner bank precheck outcome before remote fetch",
-            ),
-            &["entrypoint", "fetch_reason", "outcome", "bank_reason"],
-        )
-        .unwrap();
     static ref CHAINLINK_SUBSCRIPTION_REGISTRATION_ACCOUNTS_TOTAL: IntCounterVec =
         IntCounterVec::new(
             Opts::new(
@@ -588,7 +578,6 @@ pub(crate) fn register() {
         register!(CHAIN_SLOT_GAUGE);
         register!(MONITORED_ACCOUNTS_GAUGE);
         register!(INFLIGHT_SUBSCRIPTION_UPDATES_GAUGE);
-        register!(CHAINLINK_BANK_PRECHECK_ACCOUNTS_TOTAL);
         register!(CHAINLINK_SUBSCRIPTION_REGISTRATION_ACCOUNTS_TOTAL);
         register!(CHAINLINK_SUBSCRIPTION_RELEASE_ACCOUNTS_TOTAL);
         register!(CHAINLINK_SUBSCRIPTION_CLEANUP_ACCOUNTS_TOTAL);
@@ -671,25 +660,6 @@ pub fn dec_inflight_subscription_updates() {
 pub fn set_monitored_accounts_count(count: usize) {
     MONITORED_ACCOUNTS_GAUGE.set(count as i64);
 }
-pub fn inc_chainlink_bank_precheck_accounts_with_context(
-    context: AccountFetchContext,
-    outcome: BankPrecheckOutcome,
-    bank_reason: BankPrecheckReason,
-    count: u64,
-) {
-    if count == 0 {
-        return;
-    }
-    CHAINLINK_BANK_PRECHECK_ACCOUNTS_TOTAL
-        .with_label_values(&[
-            context.entrypoint().value(),
-            context.reason().value(),
-            outcome.value(),
-            bank_reason.value(),
-        ])
-        .inc_by(count);
-}
-
 pub fn inc_chainlink_subscription_registration_accounts(
     origin: SubscriptionRegistrationOrigin,
     subscription_reason: SubscriptionReasonLabel,
@@ -1200,8 +1170,6 @@ mod fetch_context_metric_tests {
     fn fetch_context_metrics_keep_entrypoint_and_reason_separate() {
         let action_context = AccountFetchContext::rpc_get_account()
             .with_reason(AccountFetchReason::ActionDependencyMissing);
-        let forced_context = AccountFetchContext::rpc_get_account()
-            .with_reason(AccountFetchReason::ActionDependencyForcedRefresh);
         let sub_context = AccountFetchContext::subscription_update(
             AccountFetchReason::SubscriptionUpdateClone,
         );
@@ -1239,30 +1207,6 @@ mod fetch_context_metric_tests {
                 action_labels
             ),
             before_action + 1
-        );
-
-        let forced_labels = &[
-            "rpc_get_account",
-            "action_dependency_forced_refresh",
-            "forced_refresh_remote_required",
-            "forced_refresh",
-        ];
-        let before_forced = counter_value(
-            &CHAINLINK_BANK_PRECHECK_ACCOUNTS_TOTAL,
-            forced_labels,
-        );
-        inc_chainlink_bank_precheck_accounts_with_context(
-            forced_context,
-            BankPrecheckOutcome::ForcedRefreshRemoteRequired,
-            BankPrecheckReason::ForcedRefresh,
-            1,
-        );
-        assert_eq!(
-            counter_value(
-                &CHAINLINK_BANK_PRECHECK_ACCOUNTS_TOTAL,
-                forced_labels
-            ),
-            before_forced + 1
         );
 
         let sub_labels = &[

--- a/magicblock-metrics/src/metrics/types.rs
+++ b/magicblock-metrics/src/metrics/types.rs
@@ -161,31 +161,19 @@ impl AccountFetchContext {
     }
 
     pub fn rpc_get_account() -> Self {
-        Self::new(
-            AccountFetchEntrypoint::RpcGetAccount,
-            AccountFetchReason::RequestedAccount,
-        )
+        AccountFetchEntrypoint::RpcGetAccount.into()
     }
 
     pub fn rpc_get_multiple_accounts() -> Self {
-        Self::new(
-            AccountFetchEntrypoint::RpcGetMultipleAccounts,
-            AccountFetchReason::RequestedAccount,
-        )
+        AccountFetchEntrypoint::RpcGetMultipleAccounts.into()
     }
 
     pub fn send_transaction(signature: Signature) -> Self {
-        Self::new(
-            AccountFetchEntrypoint::SendTransaction(signature),
-            AccountFetchReason::RequestedAccount,
-        )
+        AccountFetchEntrypoint::SendTransaction(signature).into()
     }
 
     pub fn simulate_transaction(signature: Signature) -> Self {
-        Self::new(
-            AccountFetchEntrypoint::SimulateTransaction(signature),
-            AccountFetchReason::RequestedAccount,
-        )
+        AccountFetchEntrypoint::SimulateTransaction(signature).into()
     }
 
     pub fn subscription_update(reason: AccountFetchReason) -> Self {
@@ -241,6 +229,13 @@ impl AccountFetchContext {
 
     pub fn signature(&self) -> Option<&Signature> {
         self.entrypoint.signature()
+    }
+}
+
+/// Starts shared requested-account fetch tracking from a copyable origin.
+impl From<AccountFetchEntrypoint> for AccountFetchContext {
+    fn from(entrypoint: AccountFetchEntrypoint) -> Self {
+        Self::new(entrypoint, AccountFetchReason::RequestedAccount)
     }
 }
 
@@ -363,76 +358,6 @@ impl fmt::Display for ChainlinkCompanionFetchOutcome {
 }
 
 impl LabelValue for ChainlinkCompanionFetchOutcome {
-    fn value(&self) -> &str {
-        self.as_str()
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum BankPrecheckOutcome {
-    BankHitNoFetch,
-    BankHitUndelegatingRefreshRequired,
-    BankMissRemoteRequired,
-    ForcedRefreshRemoteRequired,
-}
-
-impl BankPrecheckOutcome {
-    fn as_str(&self) -> &str {
-        match self {
-            Self::BankHitNoFetch => "bank_hit_no_fetch",
-            Self::BankHitUndelegatingRefreshRequired => {
-                "bank_hit_undelegating_refresh_required"
-            }
-            Self::BankMissRemoteRequired => "bank_miss_remote_required",
-            Self::ForcedRefreshRemoteRequired => {
-                "forced_refresh_remote_required"
-            }
-        }
-    }
-}
-
-impl fmt::Display for BankPrecheckOutcome {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.as_str())
-    }
-}
-
-impl LabelValue for BankPrecheckOutcome {
-    fn value(&self) -> &str {
-        self.as_str()
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum BankPrecheckReason {
-    Absent,
-    NonUndelegatingPresent,
-    UndelegatingStillValid,
-    UndelegatingCheckTimeout,
-    UndelegatingRefresh,
-    ForcedRefresh,
-}
-
-impl BankPrecheckReason {
-    fn as_str(&self) -> &str {
-        match self {
-            Self::Absent => "absent",
-            Self::NonUndelegatingPresent => "non_undelegating_present",
-            Self::UndelegatingStillValid => "undelegating_still_valid",
-            Self::UndelegatingCheckTimeout => "undelegating_check_timeout",
-            Self::UndelegatingRefresh => "undelegating_refresh",
-            Self::ForcedRefresh => "forced_refresh",
-        }
-    }
-}
-
-impl fmt::Display for BankPrecheckReason {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.as_str())
-    }
-}
-
-impl LabelValue for BankPrecheckReason {
     fn value(&self) -> &str {
         self.as_str()
     }

--- a/magicblock-services/src/undelegation_request_service.rs
+++ b/magicblock-services/src/undelegation_request_service.rs
@@ -5,7 +5,9 @@ use engine::Engine;
 use magicblock_chainlink::{
     AccountStatusOnEr, ObservedUndelegationRequest, ProdChainlink,
 };
-use magicblock_metrics::metrics::AccountFetchContext;
+use magicblock_metrics::metrics::{
+    AccountFetchContext, AccountFetchEntrypoint,
+};
 use magicblock_program::instruction_utils::InstructionUtils;
 use nucleus::shutdown::{ShutdownHandle, ShutdownReason};
 use solana_transaction_error::TransactionError;
@@ -271,7 +273,7 @@ impl UndelegationRequestService {
             if let Err(err) = chainlink
                 .ensure_accounts(
                     &[request.delegated_account],
-                    AccountFetchContext::rpc_get_account(),
+                    AccountFetchEntrypoint::RpcGetAccount,
                 )
                 .await
             {


### PR DESCRIPTION
## What changed

- reduce successful resident account ensures to one synchronous AccountsDB loader scan and defer remote-fetch setup until missing or transient accounts are found
- pass transaction static account keys directly and remove the retired fee-payer balance PDA derivation
- replace eager shared fetch context construction with a copyable entrypoint and remove bank-precheck metrics while retaining end-to-end ensure and remote fetch/clone instrumentation

Closes #1626

## Impact

Resident RPC and transaction ensures avoid the generic remote-fetch pipeline setup and perform no remote fetch. Missing and transient accounts continue through the existing Engine-owned deduplication, subscription, lifecycle, and materialization paths. The `mbv_chainlink_bank_precheck_accounts_total` metric family is removed.

## Reviewer notes

The key boundary is `InnerChainlink::ensure_accounts`: every present non-transient mode is ready, while missing and transient accounts enter the existing slow path and AccountsDB loader errors propagate. The weekly documentation task should update the Chainlink transaction-ensure flow and public API description.
