### PR TITLE
fix(chainlink): extend subscription activation window

### DIFF
--- a/magicblock-chainlink/src/remote_account_provider/chain_slot.rs
+++ b/magicblock-chainlink/src/remote_account_provider/chain_slot.rs
@@ -35,8 +35,8 @@ impl ChainSlot {
 
     /// The maximum amount of slots we expect to pass from the time
     /// a subscription is requested until the point when it is
-    /// activated. ~10 secs
-    pub const MAX_SLOTS_SUB_ACTIVATION: u64 = 25;
+    /// activated. ~40 secs
+    pub const MAX_SLOTS_SUB_ACTIVATION: u64 = 100;
 
     /// Computes a `from_slot` for backfilling based on the current
     /// chain slot.


### PR DESCRIPTION
## Summary
Increase the gRPC subscription backfill window from about 10 seconds to 40 seconds so delayed activation does not miss base-layer updates.

## Breaking Changes
- [x] None
- [ ] Yes — migration path described below

## Test Plan
- make fmt
- make lint
- cargo test -p magicblock-chainlink remote_account_provider::chain_slot::tests::returns_subtracted_slot_when_slot_is_nonzero -- --exact --nocapture

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Expanded the supported backfill window for chain slot processing.
  * Increased the activation period coverage from approximately 10 seconds to 40 seconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->