### PR TITLE
fix(committor): return error when MagicContext is missing in accept loop

### DIFF
--- a/magicblock-committor-service/src/service/intent_client.rs
+++ b/magicblock-committor-service/src/service/intent_client.rs
@@ -138,10 +138,10 @@ impl<L: LatestBlockProvider> ERIntentClient for InternalIntentRpcClient<L> {
     ) -> Result<Vec<ScheduledIntentBundle>, Self::Error> {
         // If accounts were scheduled to be committed, we accept them here
         // and processs the commits
-        let magic_context_acc =
-            self.accounts_db.get_account(&MAGIC_CONTEXT_PUBKEY).expect(
-                "Validator found to be running without MagicContext account!",
-            );
+        let magic_context_acc = self
+            .accounts_db
+            .get_account(&MAGIC_CONTEXT_PUBKEY)
+            .ok_or(InternalIntentClientError::MagicContextMissing)?;
         if !MagicContext::has_scheduled_commits(magic_context_acc.data()) {
             return Ok(vec![]);
         }
@@ -253,6 +253,8 @@ fn build_sent_commit(
 
 #[derive(thiserror::Error, Debug)]
 pub enum InternalIntentClientError {
+    #[error("MagicContext account is missing from AccountsDb")]
+    MagicContextMissing,
     #[error("TransactionError: {0}")]
     TransactionError(#[from] TransactionError),
 }


### PR DESCRIPTION
## Summary
- `accept_scheduled_intents` used `.expect()` when reading `MAGIC_CONTEXT_PUBKEY` from AccountsDb
- A missing MagicContext account would panic the committor accept task on every slot tick
- Return `InternalIntentClientError::MagicContextMissing` instead; the existing loop in `service.rs` already logs and continues on `Err`

Related to #1018 (same panic-in-worker family); does not fix the transaction_preparator site.

## Test plan
- [X] `cargo check -p magicblock-committor-service`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Scheduled intent acceptance now reports a clear error when the required MagicContext account is unavailable, instead of causing a panic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->