### PR TITLE
fix(committor): harden transaction lifecycle under load

### DIFF
--- a/magicblock-committor-service/src/intent_executor/error.rs
+++ b/magicblock-committor-service/src/intent_executor/error.rs
@@ -132,8 +132,8 @@ impl IntentExecutorError {
 
     /// True when re-executing the whole intent from scratch may succeed:
     /// the failure was transport/RPC-side rather than deterministic.
-    /// Once a commit landed (two-stage finalize failures) re-execution would
-    /// commit the same state again, so those are never transient.
+    /// Once either stage exposes a submitted signature, re-execution could
+    /// duplicate work whose base-layer outcome is still ambiguous.
     pub fn is_transient(&self) -> bool {
         match self {
             Self::EmptyIntentError
@@ -144,7 +144,7 @@ impl IntentExecutorError {
             Self::FailedToFinalizeError {
                 err,
                 commit_signature: None,
-                ..
+                finalize_signature: None,
             } => err.is_transient(),
             Self::FailedToFinalizeError { .. }
             | Self::FailedFinalizePreparationError(_) => false,

--- a/magicblock-committor-service/src/service/intent_client.rs
+++ b/magicblock-committor-service/src/service/intent_client.rs
@@ -1,4 +1,7 @@
-use std::mem;
+use std::{
+    mem,
+    sync::atomic::{AtomicU64, Ordering},
+};
 
 use async_trait::async_trait;
 use engine::{Engine, IntoTransactionView};
@@ -14,7 +17,7 @@ use solana_message::Message;
 use solana_pubkey::Pubkey;
 use solana_transaction::Transaction;
 use solana_transaction_error::TransactionError;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 use crate::{
     intent_execution_manager::BroadcastedIntentExecutionResult,
@@ -63,7 +66,11 @@ pub trait ERIntentClient: Send + Sync + 'static {
         &self,
     ) -> Result<Vec<ScheduledIntentBundle>, Self::Error>;
 
-    /// Processes intent results, submitting them on chain(ER)
+    /// Registers the result payload and submits its notification on the ER.
+    ///
+    /// Fresh intents preserve their scheduling-time signature. Recovered
+    /// intents, and fresh intents whose blockhash expired before execution,
+    /// are signed against the engine's current blockhash.
     async fn notify_commit_sent(
         &self,
         meta: ScheduledBaseIntentMeta,
@@ -79,6 +86,8 @@ pub trait ERIntentClient: Send + Sync + 'static {
 pub struct InternalIntentRpcClient {
     engine: Engine,
 }
+
+static ACCEPT_NONCE: AtomicU64 = AtomicU64::new(0);
 
 impl InternalIntentRpcClient {
     pub fn new(engine: Engine) -> Self {
@@ -109,13 +118,33 @@ impl InternalIntentRpcClient {
     /// Sends transaction to move the scheduled commits from the `MagicContext`
     /// to the global ScheduledCommit store
     async fn send_accept_tx(&self) -> Result<(), InternalIntentClientError> {
+        // Consecutive accepts can share a blockhash on an otherwise idle ER.
+        // Varying a noop keeps their signatures distinct for replay protection.
         let authority = self.engine.authority();
-        let ix =
+        let accept_ix =
             InstructionUtils::accept_scheduled_commits_instruction(&authority);
-        let message = Message::new(&[ix], Some(&authority));
+        let noop_ix = InstructionUtils::noop_instruction(
+            ACCEPT_NONCE.fetch_add(1, Ordering::Relaxed),
+        );
+        let message = Message::new(&[accept_ix, noop_ix], Some(&authority));
         self.execute(message).await.inspect_err(|err| {
             error!(error = ?err, "Failed to accept scheduled commits");
         })
+    }
+
+    /// Builds and executes a notification using the engine's current blockhash.
+    async fn send_fresh_commit_sent_tx(
+        &self,
+        intent_id: u64,
+    ) -> Result<(), InternalIntentClientError> {
+        let authority = self.engine.authority();
+        let ix = InstructionUtils::scheduled_commit_sent_instruction(
+            &id(),
+            &authority,
+            intent_id,
+        );
+        let message = Message::new(&[ix], Some(&authority));
+        self.execute(message).await
     }
 }
 
@@ -157,27 +186,32 @@ impl ERIntentClient for InternalIntentRpcClient {
         let intent_id = result.id;
         let transaction = mem::take(&mut meta.sent_transaction);
         let sent_commit = build_sent_commit(meta, &result);
+        // Register once before submission. Only BlockhashNotFound permits a
+        // fallback because it occurs before the processor can consume this payload.
         register_scheduled_commit_sent(sent_commit);
-        let result = match transaction {
+        match transaction {
             IntentSentTransaction::Known(transaction) => {
-                self.execute(transaction).await
+                let signature = transaction.signatures[0];
+                match self.execute(transaction).await {
+                    Err(InternalIntentClientError::TransactionError(
+                        TransactionError::BlockhashNotFound,
+                    )) => {
+                        warn!(
+                            %signature,
+                            intent_id,
+                            "Pre-signed commit notification expired; its logged signature is best-effort"
+                        );
+                        self.send_fresh_commit_sent_tx(intent_id).await
+                    }
+                    result => result,
+                }
             }
             IntentSentTransaction::Recovered => {
-                let authority = self.engine.authority();
-                let ix = InstructionUtils::scheduled_commit_sent_instruction(
-                    &id(),
-                    &authority,
-                    intent_id,
-                );
-                let message = Message::new(&[ix], Some(&authority));
-                self.execute(message).await
+                self.send_fresh_commit_sent_tx(intent_id).await
             }
-        };
-        result
-            .inspect(|_| debug!("Sent commit signaled"))
-            .inspect_err(
-                |err| error!(error = ?err, "Failed to signal sent commit"),
-            )?;
+        }
+        .inspect(|_| debug!("Sent commit signaled"))
+        .inspect_err(|err| error!(error = ?err, "Failed to signal sent commit"))?;
 
         Ok(())
     }

--- a/magicblock-rpc-client/src/lib.rs
+++ b/magicblock-rpc-client/src/lib.rs
@@ -116,7 +116,9 @@ impl MagicBlockRpcClientError {
     /// errors are deterministic and excluded.
     pub fn is_transient(&self) -> bool {
         match self {
-            Self::LookupTableDeserialize(_) => false,
+            Self::LookupTableDeserialize(_)
+            | Self::CannotGetTransactionSignatureStatus(..)
+            | Self::CannotConfirmTransactionSignatureStatus(..) => false,
             Self::SentTransactionError(tx_err, _) => {
                 !matches!(tx_err, TransactionError::InstructionError(..))
             }

--- a/magicblock-rpc-client/src/lib.rs
+++ b/magicblock-rpc-client/src/lib.rs
@@ -205,8 +205,9 @@ impl MagicBlockSendTransactionConfig {
             check_for_processed_interval: None,
             // NOTE: we skip the processed check here and wait directly for
             //       the commitment level, trusting the confirmed result
-            //       even if an earlier processed check would have failed
-            wait_for_commitment_level: Some(Duration::from_millis(8_000)),
+            //       even if an earlier processed check would have failed.
+            //       Use the processed window for busy base-layer queues.
+            wait_for_commitment_level: Some(DEFAULT_MAX_TIME_TO_PROCESSED),
             check_for_commitment_interval: Some(Duration::from_millis(400)),
         }
     }

--- a/magicblock-rpc-client/src/utils.rs
+++ b/magicblock-rpc-client/src/utils.rs
@@ -199,9 +199,9 @@ pub fn decide_rpc_error_flow(
         | MagicBlockRpcClientError::CannotConfirmTransactionSignatureStatus(
             ..,
         ) => {
-            // if there's still time left we can retry sending tx
-            // Since [`DEFAULT_MAX_TIME_TO_PROCESSED`] is large we skip sleep as well
-            ControlFlow::Continue(Duration::ZERO)
+            // The transaction was submitted. Retrying would re-sign and send
+            // it again with a fresh blockhash.
+            ControlFlow::Break(())
         }
         MagicBlockRpcClientError::GetLatestBlockhash(err) => {
             trace!(error = ?err, "Failed to get latest blockhash during sending tx");


### PR DESCRIPTION
## What changed

- make validator-internal `AcceptScheduleCommits` transactions unique under a shared ER blockhash
- preserve the pre-signed `ScheduledCommitSent` transaction, falling back to the current blockhash only when the original blockhash has expired
- stop re-signing and re-sending submitted base-layer transactions after status timeouts, extend the confirmation window, and prevent whole-intent retries once either stage has a signature

Closes #1603
Closes #1604
Closes #1605

## Impact

No public API, instruction schema, serialized data, or persistence format changes. The accept path gains one internal noop instruction. Base-layer confirmation can wait up to 50 seconds instead of producing a duplicate submission. The scheduling-time notification signature remains exact on the normal path and becomes best-effort only after blockhash expiry.

## Reviewer notes

The completion payload is registered exactly once. A fresh notification is attempted only after `BlockhashNotFound`, which occurs before the processor can consume that payload; all ambiguous execution failures propagate without retry.
