### PR TITLE
ci: pin redsuite to 0.3.0

### DIFF
--- a/.github/workflows/ci-redsuite.yml
+++ b/.github/workflows/ci-redsuite.yml
@@ -44,7 +44,7 @@ permissions:
 
 env:
   REDSUITE_REPO: magicblock-labs/redsuite
-  REDSUITE_REV: 06c80157f8bc87c39ac48fd59367a8e9280d2db9
+  REDSUITE_REV: 0.3.0
   BENCHER_PROJECT: 019f8273-ddb4-7dc3-99f7-44e7fe7c4f36
   BENCHER_TESTBED: blacksmith-16vcpu-ubuntu-2404
 


### PR DESCRIPTION
## Summary
CI now uses 0.3.0 version of redsuite.
